### PR TITLE
[kyo-doctest] execute runtime expectations and isolate skipped blocks

### DIFF
--- a/kyo-doctest/README.md
+++ b/kyo-doctest/README.md
@@ -1,6 +1,6 @@
 # kyo-doctest
 
-kyo-doctest validates the Scala code blocks inside your Markdown by compiling them, so the examples in your docs cannot rot. `KyoDoctestPlugin` auto-enables on every JVM project. Running `sbt doctest` finds the project's `README.md`, extracts every ```` ```scala ```` block, and type-checks each one against the project's own classpath, failing the build on any unexpected outcome. A project opts out with `.disablePlugins(KyoDoctestPlugin)`. Each fenced block is treated as an independent compile unit by default, so examples stay copy-pasteable. An info-string DSL (`doctest:scope=...`, `doctest:expect=...`, `doctest:platform=...`, `doctest:setup`) lets a doc author chain blocks, declare blocks that must fail to compile, hide a setup fixture inside an HTML comment, or restrict a block to a single platform.
+kyo-doctest validates the Scala code blocks inside your Markdown by compiling them, so the examples in your docs cannot rot. `KyoDoctestPlugin` auto-enables on every JVM project. Running `sbt doctest` finds the project's `README.md`, extracts every ```` ```scala ```` block, and type-checks each one against the project's own classpath, failing the build on any unexpected outcome. A project opts out with `.disablePlugins(KyoDoctestPlugin)`. Each fenced block is treated as an independent compile unit by default, so examples stay copy-pasteable. An info-string DSL (`doctest:scope=...`, `doctest:expect=...`, `doctest:platform=...`, `doctest:timeout=...`, `doctest:setup`) lets a doc author chain blocks, declare blocks that must fail to compile, hide a setup fixture inside an HTML comment, restrict a block to a single platform, or configure its runtime limit.
 
 There are two surfaces. `kyo-doctest-plugin` is the user-facing sbt plugin: it exposes the task and setting keys that almost every user touches. `kyo-doctest` is the JVM-only runner library that the plugin forks into over a temp JSON config, never called directly by users. Anyone wiring doctest into a non-sbt build (Mill, a CI script, an editor integration) calls `kyo.doctest.Doctest.check` directly with a `Doctest.Config`.
 
@@ -99,9 +99,9 @@ lazy val myKyoLib = project
 
 ## Writing validatable Markdown
 
-The Markdown DSL lives entirely on the code block's info string (`scala doctest:KEY=VALUE`) and on optional file-level `<!-- doctest:default -->` comments. Three orthogonal axes (scope, expectation, platform) and a `setup` sugar cover the cases that come up writing real READMEs. A separate axis, the **carrier**, controls whether readers see the block at all.
+The Markdown DSL lives entirely on the code block's info string (`scala doctest:KEY=VALUE`) and on optional file-level `<!-- doctest:default -->` comments. Four orthogonal axes (scope, expectation, platform, timeout) and a `setup` sugar cover the cases that come up writing real READMEs. A separate axis, the **carrier**, controls whether readers see the block at all.
 
-The defaults you get without writing any DSL are deliberate: `scope=isolated`, `expect=compiles`, `platform=jvm,js,native` (or the subset of those the project supports). That means a bare `scala` fenced block must type-check on its own, with no leakage from prior blocks. **The default is "compiles," not "runs." A block whose body throws at runtime still passes validation unless you opt in with `expect=runs` or `expect=crashes`.**
+The defaults you get without writing any DSL are deliberate: `scope=isolated`, `expect=compiles`, `platform=jvm,js,native` (or the subset of those the project supports), and `timeout=30s`. That means a bare `scala` fenced block must type-check on its own, with no leakage from prior blocks. **The default is "compiles," not "runs." A block whose body throws at runtime still passes validation unless you opt in with `expect=runs` or `expect=crashes`.**
 
 ### Scope: what names a block sees
 
@@ -156,6 +156,18 @@ Expectation answers "what counts as a valid outcome for this block?" The default
 
 `expect=runs`: the block must type-check AND execute without throwing. Use this when the example value is the point of the example (numeric results, side effects on a fixture).
 
+Runtime blocks execute in an isolated child JVM. The default limit is 30 seconds, and `timeout=DURATION` changes it for one block. Durations must be finite and greater than zero, for example `timeout=250ms` or `timeout=45s`. A timeout, an uncaught exception, or termination through `System.exit` fails an `expect=runs` block without terminating the doctest runner. Runtime-bearing compile units are recompiled and re-executed on every validation run because their behavior can depend on ambient state.
+
+For a named environment, the deadline resets when execution enters each block and uses that block's resolved timeout. Setup and inherited code that runs before the current block starts uses the default 30-second limit.
+
+````markdown
+```scala doctest:expect=runs timeout=45s
+assert(1 + 1 == 2)
+```
+````
+
+Runtime expectations require doctest's generated object wrapper. A block whose first declaration is a top-level `package` is still supported by compile-only expectations, but `expect=runs` and `expect=crashes` report that the form cannot be executed.
+
 ```scala
 List(1, 2, 3).map(_ * 2) // doctest:expect=runs
 // The block compiles AND runs; the validator throws if execution raises.
@@ -172,6 +184,8 @@ val n: Int = "not an int"
 `expect=warns`: the block must compile and produce at least one compiler warning. Useful for showing deprecation behavior.
 
 `expect=crashes`: the block must throw at runtime. Symmetrical to `fails-compile`: the example IS the failure being demonstrated.
+
+An uncaught exception or explicit process termination satisfies `expect=crashes`. Normal completion, timeout, class-loading failure, and failure to launch the isolated JVM are reported as missed expectations or runtime infrastructure failures.
 
 `expect=skipped`: the block is parsed (so its line range surfaces in error reports) but neither compiled nor executed. Use for `scala` blocks that hold pseudocode or partial fragments you want to keep in the document.
 
@@ -222,12 +236,12 @@ alice.name
 When most blocks in a file share the same scope or expectation, repeating the modifier on every block adds noise. A single HTML comment at the top of the file sets defaults that every block inherits.
 
 ````markdown
-<!-- doctest:default scope=inherited expect=runs -->
+<!-- doctest:default scope=inherited expect=runs timeout=45s -->
 
 # My Document
 
 ```scala doctest:expect=skipped
-// Inherits scope=inherited, expect=runs from the file default.
+// Inherits scope=inherited, expect=runs, timeout=45s from the file default.
 val x = 1
 ```
 
@@ -237,7 +251,7 @@ val y: Int = x + 1
 ```
 ````
 
-The resolution rule is three-tier: per-block tokens win, then per-file defaults, then the hardcoded defaults (`Isolated`, `Compiles`, all three platforms).
+The resolution rule is three-tier: per-block tokens win, then per-file defaults, then the hardcoded defaults (`Isolated`, `Compiles`, all three platforms, 30 seconds).
 
 > **Caution:** the `<!-- doctest:default ... -->` comment must appear in the first non-blank lines of the file, before any non-comment content. A defaults block that appears after the first content line is treated as an ordinary HTML comment and silently ignored.
 
@@ -391,7 +405,9 @@ Under sbt, the plugin (`kyo-doctest-plugin`) forks a JVM running the runner (`ky
 
 Inside the fork, a single warm Dotty `Driver` is built once and reused across every block. Dotty's `ContextBase` pins a compiler context to the thread that created it, so all compiles are dispatched to one dedicated compiler thread regardless of which fiber invoked them. The cost of parsing scalac options and initialising the compiler is paid once, not once per block.
 
-Re-runs are incremental. A content-hash `BlockCache` keys each block on a SHA-256 of its body, its scope-closure bodies, the classpath fingerprint, the Scala version, and the sorted scalac options. A block whose hash matches a stored entry serves its prior outcome from disk and skips recompilation. Editing one paragraph re-validates only the blocks whose content actually changed, which is why a warm `doctest` run is faster than recompiling every block the way mdoc does.
+Re-runs are incremental for compile-only blocks. A content-hash `BlockCache` keys each block on a SHA-256 of its body, its scope-closure bodies, the classpath fingerprint, the Scala version, and the sorted scalac options. A compile-only block whose hash matches a stored entry serves its prior outcome from disk and skips recompilation. Editing one paragraph re-validates only the compile-only blocks whose content actually changed, which is why a warm `doctest` run is faster than recompiling every block the way mdoc does.
+
+Compile units containing `expect=runs` or `expect=crashes` bypass the cache. After a successful compile, doctest starts a fresh JVM with the compiler output directory first in a child-first class loader and the platform class loader as its parent. This prevents a block from resolving classes from the runner's application class loader. The child reports normal completion or the uncaught throwable through a private result file. The runner kills the child after 30 seconds, so a non-cooperative loop or `System.exit` cannot hang or terminate the validation process. Runtime stack frames are translated from synthetic source lines back to their Markdown lines. A shared `scope=env` unit executes once; if it throws, blocks before the throwing block retain their observed outcome, the throwing block receives the exception, and later runtime blocks report that they were not executed.
 
 ## Putting it together
 

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Block.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Block.scala
@@ -20,6 +20,8 @@ import kyo.*
   *   The set of platforms this block should be compiled for.
   * @param carrier
   *   How the block is embedded in the Markdown: visible (plain backtick block) or hidden (HTML comment).
+  * @param timeout
+  *   Maximum runtime after this block begins executing.
   */
 final private[kyo] case class Block(
     file: Path,
@@ -29,10 +31,14 @@ final private[kyo] case class Block(
     visibility: Block.Visibility,
     expect: Block.Expectation,
     platform: Set[Block.Target],
-    carrier: Block.Carrier
+    carrier: Block.Carrier,
+    timeout: Duration = Block.DefaultTimeout
 ) derives CanEqual
 
 private[kyo] object Block:
+
+    /** Runtime limit used when neither the block nor its README declares a timeout. */
+    val DefaultTimeout: Duration = 30.seconds
 
     /** Visibility axis: what names are in scope when this block is compiled.
       *

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/CompileUnit.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/CompileUnit.scala
@@ -43,13 +43,14 @@ private[kyo] object CompileUnit:
       *   Compile units ready to feed to Driver.compile.
       */
     def group(blocks: Chunk[Block]): Chunk[CompileUnit] =
-        if blocks.isEmpty then Chunk.empty
+        val activeBlocks = blocks.filter(_.expect != Block.Expectation.Skipped)
+        if activeBlocks.isEmpty then Chunk.empty
         else
-            val setupBlocks    = extractSetupBlocks(blocks)
-            val nonSetupBlocks = blocks.filter(f => !isSetup(f))
+            val setupBlocks    = extractSetupBlocks(activeBlocks)
+            val nonSetupBlocks = activeBlocks.filter(f => !isSetup(f))
             if nonSetupBlocks.isEmpty then
                 // Only setup blocks: compile them as a standalone Env("__doc__") unit.
-                groupEnvBlocks(blocks.filter(isSetup), Chunk.empty)
+                groupEnvBlocks(activeBlocks.filter(isSetup), Chunk.empty)
             else
                 groupNonSetup(nonSetupBlocks, setupBlocks)
             end if

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/CompileUnit.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/CompileUnit.scala
@@ -31,7 +31,9 @@ final private[kyo] case class CompileUnit(syntheticSource: Driver.Source, blocks
   */
 private[kyo] object CompileUnit:
 
-    private val Newline = "\n"
+    private val Newline          = "\n"
+    private val ProgressProperty = "kyo.doctest.progress"
+    private type RuntimeMarker = (synthLine: Int, blockLine: Int)
 
     /** Produces compile units from a file's blocks.
       *
@@ -53,6 +55,42 @@ private[kyo] object CompileUnit:
             end if
         end if
     end group
+
+    /** Inserts a progress marker immediately before each block body and adjusts its synthetic line map. */
+    def instrumentRuntime(unit: CompileUnit): CompileUnit =
+        val markers: Seq[RuntimeMarker] = unit.blocks.toSeq.filter { wrapped =>
+            wrapped.runtimeClassName match
+                case Present(_) => true
+                case Absent     => false
+        }.flatMap { wrapped =>
+            wrapped.lineMap.toSeq.collect { case (synthLine, bodyLine) if bodyLine >= 1 => synthLine }.minOption.map { synthLine =>
+                (synthLine = synthLine, blockLine = wrapped.block.lineStart)
+            }
+        }.sortBy(_.synthLine)
+
+        val markersByLine = markers.groupMap(_.synthLine)(_.blockLine)
+        val sourceLines   = unit.syntheticSource.content.split(Newline, -1).toList.dropRight(1)
+        val instrumentedContent = sourceLines.zipWithIndex.flatMap { case (line, index) =>
+            val synthLine = index + 1
+            val indent    = line.takeWhile(_.isWhitespace)
+            val inserted = markersByLine.getOrElse(synthLine, Seq.empty).map { blockLine =>
+                s"$indent val _ = java.nio.file.Files.writeString(java.nio.file.Path.of(java.lang.System.getProperty(\"$ProgressProperty\")), \"$blockLine\")$Newline"
+            }
+            inserted :+ (line + Newline)
+        }.mkString
+
+        val instrumentedBlocks = unit.blocks.map { wrapped =>
+            val adjustedMap = wrapped.lineMap.map { case (synthLine, bodyLine) =>
+                val shift = markers.count(_.synthLine <= synthLine)
+                (synthLine + shift, bodyLine)
+            }
+            wrapped.copy(syntheticContent = instrumentedContent, lineMap = adjustedMap)
+        }
+        CompileUnit(
+            Driver.Source(unit.syntheticSource.name, instrumentedContent),
+            instrumentedBlocks
+        )
+    end instrumentRuntime
 
     // Extract the setup blocks (Env("__doc__")) in document order.
     private def extractSetupBlocks(blocks: Chunk[Block]): Chunk[Block] =
@@ -101,7 +139,7 @@ private[kyo] object CompileUnit:
         // Emit env groups in first-seen order.
         val envOrder: List[String] = blockList
             .collect {
-                case b @ Block(_, _, _, _, Block.Visibility.Env(name), _, _, _) => name
+                case b @ Block(_, _, _, _, Block.Visibility.Env(name), _, _, _, _) => name
             }
             .distinct
 

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/DefaultsParser.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/DefaultsParser.scala
@@ -87,19 +87,19 @@ object DefaultsParser:
 
     /** Applies the three-tier resolution: per-block > per-file > hardcoded defaults.
       *
-      * Hardcoded defaults: Isolated, Compiles, Set(JVM, JS, Native).
+      * Hardcoded defaults: Isolated, Compiles, Set(JVM, JS, Native), and a 30-second timeout.
       *
       * @param perBlock
       *   modifiers explicitly set on the code block info string
       * @param perFile
       *   defaults from the per-README defaults block
       * @return
-      *   fully-resolved (visibility, expectation, platform) triple
+      *   fully resolved modifiers
       */
     def applyDefaults(
         perBlock: ModifierParser.Parsed,
         perFile: ModifierParser.Parsed
-    ): (Block.Visibility, Block.Expectation, Set[Block.Target]) =
+    ): (visibility: Block.Visibility, expectation: Block.Expectation, platform: Set[Block.Target], timeout: Duration) =
         ModifierParser.applyDefaults(perBlock, perFile)
 
 end DefaultsParser

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Driver.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Driver.scala
@@ -31,6 +31,7 @@ final private[kyo] class Driver private (
     ctx: Context,
     compiler: Compiler,
     outputDir: kyo.Path,
+    classpath: Chunk[kyo.Path],
     compilerThread: ExecutorService,
     freshDriver: Boolean,
     driverArgs: Array[String]
@@ -54,6 +55,20 @@ final private[kyo] class Driver private (
             )
             Async.fromCompletionStage(cf)
         }
+
+    /** Executes a compiled synthetic object in an isolated JVM. */
+    def execute(
+        wrapped: WrappedBlock,
+        blockTimeouts: Map[Int, Duration]
+    )(using Frame): RuntimeExecutor.Outcome < (Sync & Async) =
+        wrapped.runtimeClassName match
+            case Present(className) =>
+                RuntimeExecutor.execute(className, wrapped.synthFile, outputDir, classpath, blockTimeouts, Block.DefaultTimeout)
+            case Absent =>
+                Sync.defer(RuntimeExecutor.Outcome.Unsupported(
+                    "runtime expectations do not support blocks with top-level package declarations"
+                ))
+    end execute
 
     private def runOneCompile(source: Driver.Source): Driver.Outcome =
         val reporter = new Driver.CapturingReporter
@@ -283,7 +298,7 @@ private[kyo] object Driver:
                         (configuredCtx, comp)).get()
 
         val (configuredCtx, comp) = setupResult
-        new Driver(configuredCtx, comp, outputDir, compilerThread, freshDriver, allArgs)
+        new Driver(configuredCtx, comp, outputDir, classpath, compilerThread, freshDriver, allArgs)
     end buildDriver
 
 end Driver

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/MarkdownParser.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/MarkdownParser.scala
@@ -211,17 +211,18 @@ private[kyo] object MarkdownParser:
                 blockState.infoString
 
         ModifierParser.parse(combinedInfo, file, blockState.lineStart).map { perBlock =>
-            val (visibility, expect, platform) = DefaultsParser.applyDefaults(perBlock, fileDefaults)
-            val body                           = blockState.bodyLines.mkString("\n")
+            val defaults = DefaultsParser.applyDefaults(perBlock, fileDefaults)
+            val body     = blockState.bodyLines.mkString("\n")
             Block(
                 file = file,
                 lineStart = blockState.lineStart,
                 lineEnd = lineEnd,
                 body = body,
-                visibility = visibility,
-                expect = expect,
-                platform = platform,
-                carrier = carrier
+                visibility = defaults.visibility,
+                expect = defaults.expectation,
+                platform = defaults.platform,
+                carrier = carrier,
+                timeout = defaults.timeout
             )
         }
     end buildBlock

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/ModifierParser.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/ModifierParser.scala
@@ -5,9 +5,10 @@ import kyo.doctest.*
 
 /** Parses the doctest modifier DSL from a code block info string.
   *
-  * Grammar: modifier-block := token+ token := axis-key "=" axis-value | "setup" axis-key := "scope" | "expect" | "platform" scope-value :=
-  * "isolated" | "inherited" | "nested" | "env:" NAME expect-value := "compiles" | "runs" | "fails-compile" | "warns" | "crashes" |
-  * "skipped" platform-value := platform-id ("," platform-id)* platform-id := "jvm" | "js" | "native" | "all"
+  * Grammar: modifier-block := token+ token := axis-key "=" axis-value | "setup" axis-key := "scope" | "expect" | "platform" | "timeout"
+  * scope-value := "isolated" | "inherited" | "nested" | "env:" NAME expect-value := "compiles" | "runs" | "fails-compile" | "warns" |
+  * "crashes" | "skipped" platform-value := platform-id ("," platform-id)* platform-id := "jvm" | "js" | "native" | "all" timeout-value
+  * := a finite positive [[kyo.Duration]]
   *
   * The "setup" keyword (no "=") expands to scope=env:__doc__. Unknown doctest: modifier keys return a ParseError. Unknown non-doctest:
   * tokens are silently ignored.
@@ -20,11 +21,12 @@ private[kyo] object ModifierParser:
     case class Parsed(
         scope: Maybe[Block.Visibility],
         expect: Maybe[Block.Expectation],
-        platform: Maybe[Set[Block.Target]]
+        platform: Maybe[Set[Block.Target]],
+        timeout: Maybe[Duration] = Absent
     ) derives CanEqual
 
     object Parsed:
-        val empty: Parsed = Parsed(Maybe.Absent, Maybe.Absent, Maybe.Absent)
+        val empty: Parsed = Parsed(Absent, Absent, Absent, Absent)
     end Parsed
 
     private val DoctestPrefix = "doctest:"
@@ -137,10 +139,27 @@ private[kyo] object ModifierParser:
             case "scope"    => parseScope(value, file, line).map(s => acc.copy(scope = Maybe.Present(s)))
             case "expect"   => parseExpect(value, file, line).map(e => acc.copy(expect = Maybe.Present(e)))
             case "platform" => parsePlatform(value, file, line).map(p => acc.copy(platform = Maybe.Present(p)))
+            case "timeout"  => parseTimeout(value, file, line).map(t => acc.copy(timeout = Present(t)))
             case unknown =>
                 Abort.fail[Doctest.Error.ParseError](
                     Doctest.Error.ParseError(file, line, s"unknown doctest modifier key: '$unknown'")
                 )
+
+    private def parseTimeout(
+        value: String,
+        file: kyo.Path,
+        line: Int
+    )(using Frame): Duration < Abort[Doctest.Error.ParseError] =
+        Duration.parse(value) match
+            case Result.Success(duration) if duration > Duration.Zero && duration < Duration.Infinity =>
+                duration
+            case Result.Success(_) =>
+                Abort.fail(Doctest.Error.ParseError(file, line, "timeout must be finite and greater than zero"))
+            case Result.Failure(error) =>
+                Abort.fail(Doctest.Error.ParseError(file, line, s"invalid timeout '$value': ${error.getMessage}"))
+            case Result.Panic(error) =>
+                Abort.fail(Doctest.Error.ParseError(file, line, s"invalid timeout '$value': ${error.getMessage}"))
+    end parseTimeout
 
     private def parseScope(value: String, file: kyo.Path, line: Int)(using
         Frame
@@ -306,11 +325,12 @@ private[kyo] object ModifierParser:
     private[internal] def applyDefaults(
         perBlock: Parsed,
         perFile: Parsed
-    ): (Block.Visibility, Block.Expectation, Set[Block.Target]) =
+    ): (visibility: Block.Visibility, expectation: Block.Expectation, platform: Set[Block.Target], timeout: Duration) =
         val scope    = perBlock.scope.orElse(perFile.scope).getOrElse(Block.Visibility.Isolated)
         val expect   = perBlock.expect.orElse(perFile.expect).getOrElse(Block.Expectation.Compiles)
         val platform = perBlock.platform.orElse(perFile.platform).getOrElse(Set(Block.Target.JVM, Block.Target.JS, Block.Target.Native))
-        (scope, expect, platform)
+        val timeout  = perBlock.timeout.orElse(perFile.timeout).getOrElse(Block.DefaultTimeout)
+        (scope, expect, platform, timeout)
     end applyDefaults
 
 end ModifierParser

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Orchestrator.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Orchestrator.scala
@@ -73,9 +73,15 @@ private[kyo] object Orchestrator:
         scalaVer: String
     )(using Frame): Chunk[BlockOutcome] < (Sync & Async & Scope & Abort[Doctest.Error]) =
         MarkdownParser.parse(sourcePath).flatMap { blocks =>
-            val withPredef = injectPredef(blocks, config.predef, sourcePath)
-            val units      = CompileUnit.group(withPredef)
-            processUnits(units, driver, cache, fingerprint, scalaVer, config)
+            val skippedOutcomes = blocks
+                .filter(_.expect == Block.Expectation.Skipped)
+                .map(block => BlockOutcome.Skipped(block, fromCache = false))
+            val activeBlocks = blocks.filter(_.expect != Block.Expectation.Skipped)
+            val withPredef =
+                if activeBlocks.isEmpty then activeBlocks
+                else injectPredef(activeBlocks, config.predef, sourcePath)
+            val units = CompileUnit.group(withPredef)
+            processUnits(units, driver, cache, fingerprint, scalaVer, config).map(outcomes => skippedOutcomes ++ outcomes)
         }
 
     // Prepends a synthetic setup block built from the configured predef, so every block (including

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Orchestrator.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Orchestrator.scala
@@ -10,7 +10,8 @@ import kyo.doctest.*
   *   2. Open (or create) the BlockCache directory.
   *   3. Compute a classpath fingerprint (once for the whole run).
   *   4. For each source file: parse blocks, group into CompileUnits; for each unit: cache lookup, compile on miss.
-  *   5. Translate all compiler diagnostics back to README positions and assemble a Report.
+  *   5. Execute runtime-bearing units in isolated child JVMs.
+  *   6. Translate compiler diagnostics and runtime failures back to README positions, then assemble a Report.
   */
 private[kyo] object Orchestrator:
 
@@ -122,23 +123,179 @@ private[kyo] object Orchestrator:
         // EVERY block in the unit, not just the first: appending the remaining blocks' bodies to the
         // scope closure makes editing any block (not only blocks(0)) invalidate the entry. For
         // isolated/inherited/nested units `drop(1)` is empty, so their keys are unchanged.
-        val firstWrapped = unit.blocks(0)
-        val scopeClosure = firstWrapped.setupBlocks.map(_.body) ++ unit.blocks.drop(1).map(_.block.body)
-        cache.lookup(firstWrapped.block, scopeClosure, fingerprint, scalaVer, scalacOpts).flatMap {
-            case Maybe.Present(entry) =>
-                // Cache hit: build outcomes from stored result, no compile needed.
-                val posMap = PositionMap.init(unit.blocks)
-                Chunk.from(unit.blocks.toSeq.map(wb => toOutcomeFromResult(wb, entry.result, posMap, fromCache = true)))
-            case Maybe.Absent =>
-                // Cache miss: compile, record, produce outcomes.
-                driver.compile(unit.syntheticSource).flatMap { result =>
-                    cache.record(firstWrapped.block, scopeClosure, fingerprint, scalaVer, scalacOpts, result).map { _ =>
-                        val posMap = PositionMap.init(unit.blocks)
-                        Chunk.from(unit.blocks.toSeq.map(wb => toOutcomeFromResult(wb, result, posMap, fromCache = false)))
+        val firstWrapped    = unit.blocks(0)
+        val scopeClosure    = firstWrapped.setupBlocks.map(_.body) ++ unit.blocks.drop(1).map(_.block.body)
+        val requiresRuntime = unit.blocks.exists(wb => isRuntimeExpectation(wb.block.expect))
+
+        if requiresRuntime then
+            // Compile every runtime-bearing unit on every run. The cache stores diagnostics, not class files,
+            // and runtime behavior may depend on ambient state that must be observed again.
+            val runtimeUnit = CompileUnit.instrumentRuntime(unit)
+            driver.compile(runtimeUnit.syntheticSource).flatMap { result =>
+                toOutcomesFromResult(runtimeUnit, result, driver, fromCache = false)
+            }
+        else
+            cache.lookup(firstWrapped.block, scopeClosure, fingerprint, scalaVer, scalacOpts).flatMap {
+                case Maybe.Present(entry) =>
+                    toOutcomesFromResult(unit, entry.result, driver, fromCache = true)
+                case Maybe.Absent =>
+                    driver.compile(unit.syntheticSource).flatMap { result =>
+                        cache.record(firstWrapped.block, scopeClosure, fingerprint, scalaVer, scalacOpts, result).flatMap { _ =>
+                            toOutcomesFromResult(unit, result, driver, fromCache = false)
+                        }
                     }
-                }
-        }
+            }
+        end if
     end processUnit
+
+    private def toOutcomesFromResult(
+        unit: CompileUnit,
+        result: Driver.Outcome,
+        driver: Driver,
+        fromCache: Boolean
+    )(using Frame): Chunk[BlockOutcome] < (Sync & Async) =
+        val posMap = PositionMap.init(unit.blocks)
+        result match
+            case Driver.Outcome.Ok(warnings) =>
+                unit.blocks.find(wb => isRuntimeExpectation(wb.block.expect)) match
+                    case Some(runtimeBlock) =>
+                        val blockTimeouts = unit.blocks.toSeq.map(wb => wb.block.lineStart -> wb.block.timeout).toMap
+                        driver.execute(runtimeBlock, blockTimeouts).map { runtimeResult =>
+                            Chunk.from(unit.blocks.toSeq.map { wb =>
+                                if isRuntimeExpectation(wb.block.expect) then
+                                    toRuntimeOutcome(wb, unit, runtimeResult, posMap, fromCache, warnings.size)
+                                else
+                                    toOutcomeFromResult(wb, result, posMap, fromCache)
+                            })
+                        }
+                    case None =>
+                        Sync.defer(Chunk.from(unit.blocks.toSeq.map(wb => toOutcomeFromResult(wb, result, posMap, fromCache))))
+            case _: Driver.Outcome.Failed =>
+                Sync.defer(Chunk.from(unit.blocks.toSeq.map(wb => toOutcomeFromResult(wb, result, posMap, fromCache))))
+        end match
+    end toOutcomesFromResult
+
+    private def isRuntimeExpectation(expectation: Block.Expectation): Boolean =
+        expectation == Block.Expectation.Runs || expectation == Block.Expectation.Crashes
+
+    private def toRuntimeOutcome(
+        wb: WrappedBlock,
+        unit: CompileUnit,
+        result: RuntimeExecutor.Outcome,
+        posMap: PositionMap,
+        fromCache: Boolean,
+        warnings: Int
+    ): BlockOutcome =
+        val block = wb.block
+        val effectiveResult: Result.Partial[String, RuntimeExecutor.Outcome] = result match
+            case thrown: RuntimeExecutor.Outcome.Threw =>
+                posMap.translateRuntime(kyo.Path(thrown.synthFile), thrown.synthLine) match
+                    case Present((owner, ownerLine)) =>
+                        val blocks     = unit.blocks.toSeq.map(_.block)
+                        val ownerIndex = blocks.indexOf(owner)
+                        val blockIndex = blocks.indexOf(block)
+                        if ownerIndex < 0 then
+                            Result.Failure(
+                                s"block was not executed because inherited or setup code failed: ${formatRuntimeFailure(thrown, posMap)}"
+                            )
+                        else if blockIndex < ownerIndex then Result.Success(RuntimeExecutor.Outcome.Completed)
+                        else if blockIndex == ownerIndex then Result.Success(thrown)
+                        else
+                            Result.Failure(s"block was not executed because runtime failed at ${owner.file}:$ownerLine")
+                        end if
+                    case Absent => Result.Success(thrown)
+            case timedOut @ RuntimeExecutor.Outcome.TimedOut(_, progress) =>
+                attributeProcessOutcome(block, unit, timedOut, progress)
+            case exited @ RuntimeExecutor.Outcome.ProcessExited(_, _, progress) =>
+                attributeProcessOutcome(block, unit, exited, progress)
+            case other => Result.Success(other)
+
+        effectiveResult match
+            case Result.Failure(message)  => BlockOutcome.Failure(block, message, fromCache)
+            case Result.Success(observed) => toRuntimeOutcome(block, observed, posMap, fromCache, warnings)
+    end toRuntimeOutcome
+
+    private def attributeProcessOutcome(
+        block: Block,
+        unit: CompileUnit,
+        outcome: RuntimeExecutor.Outcome,
+        progress: RuntimeExecutor.Progress
+    ): Result.Partial[String, RuntimeExecutor.Outcome] =
+        progress match
+            case RuntimeExecutor.Progress.NotStarted =>
+                Result.Failure("runtime process terminated before the child runner started")
+            case RuntimeExecutor.Progress.Started =>
+                Result.Failure("block was not executed because inherited, setup, or class-loading code terminated the runtime process")
+            case RuntimeExecutor.Progress.Block(activeLine) =>
+                val blocks      = unit.blocks.toSeq.map(_.block)
+                val activeIndex = blocks.indexWhere(_.lineStart == activeLine)
+                val blockIndex  = blocks.indexOf(block)
+                if activeIndex < 0 then Result.Failure(s"runtime process reported unknown active block line $activeLine")
+                else if blockIndex < activeIndex then Result.Success(RuntimeExecutor.Outcome.Completed)
+                else if blockIndex == activeIndex then Result.Success(outcome)
+                else
+                    val active = blocks(activeIndex)
+                    Result.Failure(s"block was not executed because runtime terminated in ${active.file}:${active.lineStart}")
+                end if
+    end attributeProcessOutcome
+
+    private def toRuntimeOutcome(
+        block: Block,
+        result: RuntimeExecutor.Outcome,
+        posMap: PositionMap,
+        fromCache: Boolean,
+        warnings: Int
+    ): BlockOutcome =
+        block.expect match
+            case Block.Expectation.Runs =>
+                result match
+                    case RuntimeExecutor.Outcome.Completed =>
+                        BlockOutcome.Success(block, fromCache, warnings)
+                    case thrown: RuntimeExecutor.Outcome.Threw =>
+                        BlockOutcome.Failure(block, formatRuntimeFailure(thrown, posMap), fromCache)
+                    case RuntimeExecutor.Outcome.TimedOut(after, _) =>
+                        BlockOutcome.Failure(block, s"runtime execution timed out after ${after.show}", fromCache)
+                    case RuntimeExecutor.Outcome.ProcessExited(code, stderr, _) =>
+                        val details = if stderr.isEmpty then "" else s": ${stderr.trim}"
+                        BlockOutcome.Failure(block, s"runtime process exited with code $code$details", fromCache)
+                    case RuntimeExecutor.Outcome.LaunchFailed(message) =>
+                        BlockOutcome.Failure(block, s"runtime process could not be launched: $message", fromCache)
+                    case RuntimeExecutor.Outcome.LoadFailed(message) =>
+                        BlockOutcome.Failure(block, s"compiled block could not be loaded: $message", fromCache)
+                    case RuntimeExecutor.Outcome.Unsupported(message) =>
+                        BlockOutcome.Failure(block, message, fromCache)
+
+            case Block.Expectation.Crashes =>
+                result match
+                    case RuntimeExecutor.Outcome.Completed =>
+                        BlockOutcome.Failure(block, "expected a runtime failure but the block completed normally", fromCache)
+                    case _: RuntimeExecutor.Outcome.Threw | _: RuntimeExecutor.Outcome.ProcessExited =>
+                        BlockOutcome.Success(block, fromCache, warnings)
+                    case RuntimeExecutor.Outcome.TimedOut(after, _) =>
+                        BlockOutcome.Failure(block, s"runtime execution timed out after ${after.show}", fromCache)
+                    case RuntimeExecutor.Outcome.LaunchFailed(message) =>
+                        BlockOutcome.Failure(block, s"runtime process could not be launched: $message", fromCache)
+                    case RuntimeExecutor.Outcome.LoadFailed(message) =>
+                        BlockOutcome.Failure(block, s"compiled block could not be loaded: $message", fromCache)
+                    case RuntimeExecutor.Outcome.Unsupported(message) =>
+                        BlockOutcome.Failure(block, message, fromCache)
+
+            case _ =>
+                BlockOutcome.Failure(block, "internal error: runtime outcome for a compile-only expectation", fromCache)
+        end match
+    end toRuntimeOutcome
+
+    private def formatRuntimeFailure(thrown: RuntimeExecutor.Outcome.Threw, posMap: PositionMap): String =
+        val description =
+            if thrown.message.isEmpty then thrown.className
+            else s"${thrown.className}: ${thrown.message}"
+        posMap.translateRuntime(kyo.Path(thrown.synthFile), thrown.synthLine) match
+            case Present((block, readmeLine)) =>
+                s"${block.file}:$readmeLine: error: $description"
+            case _ =>
+                s"runtime error: $description"
+        end match
+    end formatRuntimeFailure
 
     // Translates a Driver.Outcome to a BlockOutcome for one wrapped block.
     private def toOutcomeFromResult(

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/PositionMap.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/PositionMap.scala
@@ -24,6 +24,18 @@ final private[kyo] class PositionMap private (records: Map[kyo.Path, Map[Int, (B
                     case None                       => Absent
                     case Some((block, bodyLine, _)) => Present((block, bodyLine))
 
+    /** Translates a runtime stack frame to the block and README line that supplied the executed code. */
+    def translateRuntime(synthFile: kyo.Path, synthLine: Int): Maybe[(Block, Int)] =
+        records.get(synthFile) match
+            case None => Absent
+            case Some(lineMap) =>
+                lineMap.get(synthLine) match
+                    case None => Absent
+                    case Some((block, blockBodyLine, setupBlocks)) =>
+                        if blockBodyLine >= 1 then Present((block, block.lineStart + blockBodyLine))
+                        else backMapPreludePosition(synthLine, lineMap, setupBlocks)
+    end translateRuntime
+
     /** Translates a Driver.Diagnostic to a PositionMap.MappedDiagnostic.
       *
       * Returns Absent for boilerplate lines. On Present, computes the README line from blockBodyLine.
@@ -75,34 +87,32 @@ final private[kyo] class PositionMap private (records: Map[kyo.Path, Map[Int, (B
         setupBlocks: Chunk[Block],
         originalMessage: String
     ): (Int, String) =
-        if setupBlocks.isEmpty then
-            // Fallback: cannot identify originating setup block.
-            (block.lineStart, originalMessage + " (setup prelude)")
-        else
-            // Count prelude lines (blockBodyLine == 0) up to and including targetSynthLine.
-            val prelLineIndex = lineMap
-                .toSeq
-                .filter { case (synthLine, (_, bodyLine, _)) => bodyLine == 0 && synthLine <= targetSynthLine }
-                .size - 1 // 0-indexed
-
-            if prelLineIndex < 0 then
-                (block.lineStart, originalMessage + " (setup prelude)")
-            else
-                @scala.annotation.tailrec
-                def loop(remaining: Int, sbs: List[Block]): (Int, String) =
-                    sbs match
-                        case Nil => (block.lineStart, originalMessage + " (setup prelude)")
-                        case sb :: rest =>
-                            val sbLines = sb.body.linesIterator.length
-                            if remaining < sbLines then
-                                (sb.lineStart + 1 + remaining, originalMessage)
-                            else
-                                loop(remaining - sbLines, rest)
-                            end if
-                loop(prelLineIndex, setupBlocks.toList)
-            end if
-        end if
+        backMapPreludePosition(targetSynthLine, lineMap, setupBlocks) match
+            case Present((_, readmeLine)) => (readmeLine, originalMessage)
+            case Absent                   => (block.lineStart, originalMessage + " (setup prelude)")
     end backMapPreludeLine
+
+    private def backMapPreludePosition(
+        targetSynthLine: Int,
+        lineMap: Map[Int, (Block, Int, Chunk[Block])],
+        setupBlocks: Chunk[Block]
+    ): Maybe[(Block, Int)] =
+        val preludeLineIndex = lineMap
+            .toSeq
+            .count { case (synthLine, (_, bodyLine, _)) => bodyLine == 0 && synthLine <= targetSynthLine } - 1
+
+        @scala.annotation.tailrec
+        def loop(remaining: Int, blocks: List[Block]): Maybe[(Block, Int)] =
+            blocks match
+                case Nil => Absent
+                case setupBlock :: rest =>
+                    val lineCount = setupBlock.body.linesIterator.length
+                    if remaining < lineCount then Present((setupBlock, setupBlock.lineStart + 1 + remaining))
+                    else loop(remaining - lineCount, rest)
+
+        if preludeLineIndex < 0 then Absent
+        else loop(preludeLineIndex, setupBlocks.toList)
+    end backMapPreludePosition
 
 end PositionMap
 

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/RuntimeExecutor.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/RuntimeExecutor.scala
@@ -1,0 +1,182 @@
+package kyo.doctest.internal
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.Base64
+import kyo.*
+
+/** Executes compiled doctest blocks in an isolated JVM. */
+private[kyo] object RuntimeExecutor:
+
+    private val DefaultTimeout = Block.DefaultTimeout
+    private val PollInterval   = 25.millis
+
+    sealed trait Outcome derives CanEqual
+    enum Progress derives CanEqual:
+        case NotStarted, Started
+        case Block(lineStart: Int)
+    end Progress
+
+    object Outcome:
+        case object Completed                                                                   extends Outcome
+        case class Threw(className: String, message: String, synthFile: String, synthLine: Int) extends Outcome
+        case class TimedOut(after: Duration, progress: Progress)                                extends Outcome
+        case class ProcessExited(code: Int, stderr: String, progress: Progress)                 extends Outcome
+        case class LaunchFailed(message: String)                                                extends Outcome
+        case class LoadFailed(message: String)                                                  extends Outcome
+        case class Unsupported(message: String)                                                 extends Outcome
+    end Outcome
+
+    private enum WaitResult:
+        case Exited(code: ExitCode)
+        case TimedOut(after: Duration, progress: Progress)
+    end WaitResult
+
+    def execute(
+        className: String,
+        synthFile: kyo.Path,
+        outputDir: kyo.Path,
+        classpath: Chunk[kyo.Path],
+        timeout: Duration = DefaultTimeout
+    )(using Frame): Outcome < (Sync & Async) =
+        execute(className, synthFile, outputDir, classpath, Map.empty, timeout)
+
+    def execute(
+        className: String,
+        synthFile: kyo.Path,
+        outputDir: kyo.Path,
+        classpath: Chunk[kyo.Path],
+        blockTimeouts: Map[Int, Duration],
+        defaultTimeout: Duration
+    )(using Frame): Outcome < (Sync & Async) =
+        for
+            id <- Random.uuid
+            resultPath   = outputDir / s"runtime-result-$id"
+            progressPath = outputDir / s"runtime-progress-$id"
+            stdoutPath   = outputDir / s"runtime-stdout-$id"
+            stderrPath   = outputDir / s"runtime-stderr-$id"
+            result <- Abort.run[CommandException](Scope.run {
+                for
+                    javaHome <- System.property[String]("java.home", "")
+                    javaBin = s"$javaHome${File.separator}bin${File.separator}java"
+                    cp      = classpath.map(_.toString).mkString(File.pathSeparator)
+                    process <- Command(
+                        javaBin,
+                        "-cp",
+                        cp,
+                        "kyo.doctest.internal.RuntimeExecutorMain",
+                        resultPath.toString,
+                        progressPath.toString,
+                        outputDir.toString,
+                        className,
+                        synthFile.toString
+                    ).stdoutToFile(stdoutPath).stderrToFile(stderrPath).spawn
+                    progress <- readProgress(progressPath)
+                    timeout = timeoutFor(progress, blockTimeouts, defaultTimeout)
+                    deadline   <- Clock.deadline(timeout)
+                    waitResult <- waitFor(process, progressPath, blockTimeouts, defaultTimeout, progress, timeout, deadline)
+                    outcome <- waitResult match
+                        case WaitResult.TimedOut(after, activeProgress) =>
+                            process.destroyForcibly.andThen(Sync.defer(Outcome.TimedOut(after, activeProgress)))
+                        case WaitResult.Exited(code) =>
+                            readOutcome(resultPath, progressPath, stderrPath, code.toInt)
+                yield outcome
+            })
+        yield result match
+            case Result.Success(outcome) => outcome
+            case Result.Failure(error)   => Outcome.LaunchFailed(error.toString)
+            case Result.Panic(error)     => Outcome.LaunchFailed(formatThrowable(error))
+    end execute
+
+    private def waitFor(
+        process: kyo.Process,
+        progressPath: kyo.Path,
+        blockTimeouts: Map[Int, Duration],
+        defaultTimeout: Duration,
+        progress: Progress,
+        timeout: Duration,
+        deadline: Clock.Deadline
+    )(using Frame): WaitResult < (Sync & Async) =
+        process.waitFor(PollInterval).flatMap {
+            case Present(code) =>
+                Sync.defer(WaitResult.Exited(code))
+            case Absent =>
+                readProgress(progressPath).flatMap { nextProgress =>
+                    if nextProgress != progress then
+                        val nextTimeout = timeoutFor(nextProgress, blockTimeouts, defaultTimeout)
+                        Clock.deadline(nextTimeout).flatMap { nextDeadline =>
+                            waitFor(process, progressPath, blockTimeouts, defaultTimeout, nextProgress, nextTimeout, nextDeadline)
+                        }
+                    else
+                        deadline.isOverdue.flatMap { overdue =>
+                            if overdue then Sync.defer(WaitResult.TimedOut(timeout, progress))
+                            else waitFor(process, progressPath, blockTimeouts, defaultTimeout, progress, timeout, deadline)
+                        }
+                }
+        }
+    end waitFor
+
+    private def timeoutFor(progress: Progress, blockTimeouts: Map[Int, Duration], defaultTimeout: Duration): Duration =
+        progress match
+            case Progress.Block(lineStart) => blockTimeouts.getOrElse(lineStart, defaultTimeout)
+            case _                         => defaultTimeout
+
+    private def readOutcome(
+        resultPath: kyo.Path,
+        progressPath: kyo.Path,
+        stderrPath: kyo.Path,
+        exitCode: Int
+    )(using Frame): Outcome < Sync =
+        Sync.defer {
+            val resultFile = java.nio.file.Path.of(resultPath.toString)
+            if Files.exists(resultFile) then
+                val lines = Files.readAllLines(resultFile, StandardCharsets.UTF_8)
+                if !lines.isEmpty && lines.get(0) == "completed" then Outcome.Completed
+                else if lines.size() >= 5 && lines.get(0) == "threw" then
+                    Outcome.Threw(
+                        decode(lines.get(1)),
+                        decode(lines.get(2)),
+                        decode(lines.get(3)),
+                        lines.get(4).toIntOption.getOrElse(0)
+                    )
+                else if lines.size() >= 2 && lines.get(0) == "load-failed" then
+                    Outcome.LoadFailed(decode(lines.get(1)))
+                else
+                    Outcome.ProcessExited(
+                        exitCode,
+                        s"invalid runtime result: ${lines.toArray.mkString("|")}",
+                        readProgressUnsafe(progressPath)
+                    )
+                end if
+            else
+                val stderrFile = java.nio.file.Path.of(stderrPath.toString)
+                val stderr =
+                    if Files.exists(stderrFile) then Files.readString(stderrFile, StandardCharsets.UTF_8)
+                    else ""
+                Outcome.ProcessExited(exitCode, stderr, readProgressUnsafe(progressPath))
+            end if
+        }
+    end readOutcome
+
+    private def readProgress(progressPath: kyo.Path)(using Frame): Progress < Sync =
+        Sync.defer(readProgressUnsafe(progressPath))
+
+    private def readProgressUnsafe(progressPath: kyo.Path): Progress =
+        val file = java.nio.file.Path.of(progressPath.toString)
+        if !Files.exists(file) then Progress.NotStarted
+        else
+            Files.readString(file, StandardCharsets.UTF_8).trim match
+                case "started" => Progress.Started
+                case value     => value.toIntOption.fold(Progress.Started)(Progress.Block(_))
+        end if
+    end readProgressUnsafe
+
+    private def decode(value: String): String =
+        new String(Base64.getDecoder.decode(value), StandardCharsets.UTF_8)
+
+    private def formatThrowable(error: Throwable): String =
+        val message = Option(error.getMessage).fold("")(m => s": $m")
+        s"${error.getClass.getName}$message"
+
+end RuntimeExecutor

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/RuntimeExecutorMain.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/RuntimeExecutorMain.scala
@@ -1,0 +1,75 @@
+package kyo.doctest.internal
+
+import java.net.URLClassLoader
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.Base64
+
+/** Child-process entry point used by RuntimeExecutor. */
+private[kyo] object RuntimeExecutorMain:
+
+    def main(args: Array[String]): Unit =
+        val resultPath   = java.nio.file.Path.of(args(0))
+        val progressPath = java.nio.file.Path.of(args(1))
+        val outputDir    = java.nio.file.Path.of(args(2))
+        val className    = args(3)
+        val synthFile    = args(4)
+        val _            = Files.writeString(progressPath, "started", StandardCharsets.UTF_8)
+        val _            = java.lang.System.setProperty("kyo.doctest.progress", progressPath.toString)
+        try
+            val separator = java.io.File.pathSeparator
+            val classpath = java.lang.System.getProperty("java.class.path", "")
+                .split(java.util.regex.Pattern.quote(separator))
+                .filter(_.nonEmpty)
+                .map(path => java.nio.file.Path.of(path).toUri.toURL)
+            val urls   = outputDir.toUri.toURL +: classpath
+            val loader = new ChildFirstClassLoader(urls)
+            try
+                try
+                    val _ = Class.forName(className, true, loader)
+                    val _ = Files.writeString(resultPath, "completed\n", StandardCharsets.UTF_8)
+                catch
+                    case error: ClassNotFoundException =>
+                        val result = s"load-failed\n${encode(error.getMessage)}\n"
+                        val _      = Files.writeString(resultPath, result, StandardCharsets.UTF_8)
+            finally loader.close()
+            end try
+        catch
+            case error: Throwable =>
+                val cause   = unwrap(error)
+                val frame   = cause.getStackTrace.find(_.getFileName == synthFile)
+                val file    = frame.fold("")(_.getFileName)
+                val line    = frame.fold(0)(_.getLineNumber)
+                val message = Option(cause.getMessage).getOrElse("")
+                val result =
+                    s"threw\n${encode(cause.getClass.getName)}\n${encode(message)}\n${encode(file)}\n$line\n"
+                val _ = Files.writeString(resultPath, result, StandardCharsets.UTF_8)
+        end try
+    end main
+
+    @scala.annotation.tailrec
+    private def unwrap(error: Throwable): Throwable =
+        error match
+            case e: ExceptionInInitializerError if e.getCause != null => unwrap(e.getCause)
+            case _                                                    => error
+
+    private def encode(value: String): String =
+        Base64.getEncoder.encodeToString(value.getBytes(StandardCharsets.UTF_8))
+
+    /** Loads the compiled block and its module dependencies without falling back to the runner's application class loader. */
+    private class ChildFirstClassLoader(urls: Array[java.net.URL])
+        extends URLClassLoader(urls, ClassLoader.getPlatformClassLoader):
+
+        override protected def loadClass(name: String, resolve: Boolean): Class[?] =
+            val loaded = findLoadedClass(name)
+            val result =
+                if loaded != null then loaded
+                else
+                    try findClass(name)
+                    catch case _: ClassNotFoundException => super.loadClass(name, false)
+            if resolve then resolveClass(result)
+            result
+        end loadClass
+    end ChildFirstClassLoader
+
+end RuntimeExecutorMain

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/WrappedBlock.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/WrappedBlock.scala
@@ -21,7 +21,15 @@ final private[kyo] case class WrappedBlock(
     syntheticContent: String,
     lineMap: Chunk[(Int, Int)],
     setupBlocks: Chunk[Block]
-) derives CanEqual
+) derives CanEqual:
+
+    def runtimeClassName: Maybe[String] =
+        if syntheticContent.startsWith("package _doctest_synthetic_\nobject ") then
+            val objectName = synthFile.toString.stripSuffix(".scala")
+            Present(s"_doctest_synthetic_.$objectName$$")
+        else Absent
+
+end WrappedBlock
 
 /** Wraps individual blocks into synthetic Scala sources.
   *

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/CorpusTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/CorpusTest.scala
@@ -164,7 +164,9 @@ class CorpusTest extends kyo.test.Test[Any]:
             parsedBlocks <- parseFixtureBlocks("scope-env-named.md")
             _ =
                 // Verify the two distinct env names are present
-                val envNames = parsedBlocks.toSeq.collect { case Block(_, _, _, _, Block.Visibility.Env(name), _, _, _) => name }.distinct
+                val envNames = parsedBlocks.toSeq.collect { case Block(_, _, _, _, Block.Visibility.Env(name), _, _, _, _) =>
+                    name
+                }.distinct
                 assert(
                     envNames.contains("tutorial"),
                     s"expected env:tutorial scope among parsed blocks, got env names: $envNames"

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
@@ -823,6 +823,41 @@ class OrchestratorTest extends kyo.test.Test[Any]:
         }
     }
 
+    "expect=skipped-only source does not compile configured predef" in {
+        withTempCacheDir { cacheDir =>
+            val md = """|# Test
+                        |
+                        |```scala doctest:expect=skipped
+                        |this is not valid scala at all !!!! @@@
+                        |```
+                        |""".stripMargin
+            withTempFile("README.md", md) { kyoFile =>
+                for
+                    cp    <- testClasspath
+                    nCpus <- System.availableProcessors
+                    config = Doctest.Config(
+                        sources = Chunk(kyoFile),
+                        classpath = cp,
+                        scalaOpts = Chunk.empty,
+                        cache = cacheDir,
+                        parallel = nCpus,
+                        predef = Chunk("this configured predef is invalid !!!")
+                    )
+                    result <- Abort.run(Scope.run(Doctest.check(config)))
+                yield result match
+                    case Result.Success(report) =>
+                        assert(report.totalBlocks == 1, s"expected 1 block, got ${report.totalBlocks}")
+                        assert(report.compiled == 0, s"skipped block should not be compiled, got compiled=${report.compiled}")
+                        assert(report.cacheHits == 0, s"skipped block should not use cache, got cacheHits=${report.cacheHits}")
+                        assert(report.failures.isEmpty, s"skipped block should not produce failures, got ${report.failures}")
+                    case Result.Failure(e) =>
+                        fail(s"unexpected failure: $e")
+                    case Result.Panic(t) =>
+                        fail(s"unexpected panic: ${t.getMessage}")
+            }
+        }
+    }
+
     "invalid classpath surfaces Abort DriverInitFailed" in {
         withTempCacheDir { cacheDir =>
             val md = """|# Test

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
@@ -789,8 +789,12 @@ class OrchestratorTest extends kyo.test.Test[Any]:
         withTempCacheDir { cacheDir =>
             val md = """|# Test
                         |
-                        |```scala doctest:expect=skipped
+                        |```scala doctest:scope=inherited expect=skipped
                         |this is not valid scala at all !!!! @@@
+                        |```
+                        |
+                        |```scala doctest:scope=inherited
+                        |val compiled = 42
                         |```
                         |""".stripMargin
             withTempFile("README.md", md) { kyoFile =>
@@ -807,8 +811,8 @@ class OrchestratorTest extends kyo.test.Test[Any]:
                     result <- Abort.run(Scope.run(Doctest.check(config)))
                 yield result match
                     case Result.Success(report) =>
-                        assert(report.totalBlocks == 1, s"expected 1 block, got ${report.totalBlocks}")
-                        assert(report.compiled == 0, s"skipped block should not be compiled, got compiled=${report.compiled}")
+                        assert(report.totalBlocks == 2, s"expected 2 blocks, got ${report.totalBlocks}")
+                        assert(report.compiled == 1, s"expected 1 compiled block, got compiled=${report.compiled}")
                         assert(report.cacheHits == 0, s"skipped block should not use cache, got cacheHits=${report.cacheHits}")
                         assert(report.failures.isEmpty, s"skipped block should not produce failures, got ${report.failures}")
                     case Result.Failure(e) =>

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
@@ -409,6 +409,326 @@ class OrchestratorTest extends kyo.test.Test[Any]:
         }
     }
 
+    "expect=runs and expect=crashes execute blocks" in {
+        withTempCacheDir { cacheDir =>
+            val md = """|# Runtime expectations
+                        |
+                        |```scala doctest:expect=runs
+                        |assert(1 + 1 == 2)
+                        |```
+                        |
+                        |```scala doctest:expect=runs
+                        |val message = "runs exploded"
+                        |throw new IllegalStateException(message)
+                        |```
+                        |
+                        |```scala doctest:expect=crashes
+                        |throw new IllegalArgumentException("expected crash")
+                        |```
+                        |
+                        |```scala doctest:expect=crashes
+                        |val completedNormally = true
+                        |```
+                        |""".stripMargin
+            withTempFile("README.md", md) { kyoFile =>
+                for
+                    cp    <- testClasspath
+                    nCpus <- System.availableProcessors
+                    config = Doctest.Config(
+                        sources = Chunk(kyoFile),
+                        classpath = cp,
+                        scalaOpts = Chunk.empty,
+                        cache = cacheDir,
+                        parallel = nCpus
+                    )
+                    result <- Abort.run(Scope.run(Doctest.check(config)))
+                yield result match
+                    case Result.Success(report) =>
+                        assert(report.totalBlocks == 4, s"expected 4 blocks, got ${report.totalBlocks}")
+                        assert(report.failures.size == 2, s"expected 2 failures, got ${report.failures}")
+
+                        val runsFailure = report.failures.find(_.line == 7).getOrElse(
+                            fail(s"expected expect=runs failure at line 7, got ${report.failures}")
+                        )
+                        assert(
+                            runsFailure.message.contains("java.lang.IllegalStateException: runs exploded"),
+                            s"expected runtime exception details, got: ${runsFailure.message}"
+                        )
+                        assert(
+                            runsFailure.message.contains(s"$kyoFile:9"),
+                            s"expected mapped README line 9, got: ${runsFailure.message}"
+                        )
+
+                        val crashesFailure = report.failures.find(_.line == 16).getOrElse(
+                            fail(s"expected expect=crashes failure at line 16, got ${report.failures}")
+                        )
+                        assert(
+                            crashesFailure.message.contains("expected a runtime failure but the block completed normally"),
+                            s"expected missed crash message, got: ${crashesFailure.message}"
+                        )
+                    case Result.Failure(e) =>
+                        fail(s"unexpected failure: $e")
+                    case Result.Panic(t) =>
+                        fail(s"unexpected panic: ${t.getMessage}")
+            }
+        }
+    }
+
+    "runtime expectations recompile and re-execute instead of using cached diagnostics" in {
+        withTempCacheDir { cacheDir =>
+            val md = """|# Runtime cache
+                        |
+                        |```scala doctest:expect=runs
+                        |assert(java.lang.System.nanoTime() > 0L)
+                        |```
+                        |""".stripMargin
+            withTempFile("README.md", md) { kyoFile =>
+                for
+                    cp    <- testClasspath
+                    nCpus <- System.availableProcessors
+                    config = Doctest.Config(
+                        sources = Chunk(kyoFile),
+                        classpath = cp,
+                        scalaOpts = Chunk.empty,
+                        cache = cacheDir,
+                        parallel = nCpus
+                    )
+                    first  <- Abort.run(Scope.run(Doctest.check(config)))
+                    second <- Abort.run(Scope.run(Doctest.check(config)))
+                yield (first, second) match
+                    case (Result.Success(firstReport), Result.Success(secondReport)) =>
+                        assert(firstReport.compiled == 1, s"expected first run to compile: $firstReport")
+                        assert(secondReport.compiled == 1, s"expected second run to recompile: $secondReport")
+                        assert(secondReport.cacheHits == 0, s"runtime blocks must not use cache: $secondReport")
+                        assert(secondReport.failures.isEmpty, s"expected second execution to pass: $secondReport")
+                    case other =>
+                        fail(s"unexpected runtime-cache results: $other")
+            }
+        }
+    }
+
+    "runtime expectations in one env are attributed to the block that throws" in {
+        withTempCacheDir { cacheDir =>
+            val md = """|# Runtime environment
+                        |
+                        |```scala doctest:scope=env:runtime expect=runs
+                        |val first = 1
+                        |```
+                        |
+                        |```scala doctest:scope=env:runtime expect=crashes
+                        |throw new IllegalStateException("env crash")
+                        |```
+                        |
+                        |```scala doctest:scope=env:runtime expect=runs
+                        |val neverReached = first + 1
+                        |```
+                        |""".stripMargin
+            withTempFile("README.md", md) { kyoFile =>
+                for
+                    cp    <- testClasspath
+                    nCpus <- System.availableProcessors
+                    config = Doctest.Config(
+                        sources = Chunk(kyoFile),
+                        classpath = cp,
+                        scalaOpts = Chunk.empty,
+                        cache = cacheDir,
+                        parallel = nCpus
+                    )
+                    result <- Abort.run(Scope.run(Doctest.check(config)))
+                yield result match
+                    case Result.Success(report) =>
+                        assert(report.failures.size == 1, s"expected only the unexecuted block to fail: $report")
+                        val failure = report.failures(0)
+                        assert(failure.line == 11, s"expected third block failure, got $failure")
+                        assert(
+                            failure.message.contains("block was not executed because runtime failed"),
+                            s"expected unexecuted-block message, got $failure"
+                        )
+                    case other =>
+                        fail(s"unexpected env runtime result: $other")
+            }
+        }
+    }
+
+    "runtime environments reset and apply each block timeout" in {
+        withTempCacheDir { cacheDir =>
+            val md =
+                """|# Runtime timeouts
+                        |
+                        |```scala doctest:scope=env:timeouts expect=runs timeout=500ms
+                        |val until = java.lang.System.nanoTime() + 120_000_000L; while java.lang.System.nanoTime() < until do java.lang.Thread.onSpinWait()
+                        |```
+                        |
+                        |```scala doctest:scope=env:timeouts expect=runs timeout=75ms
+                        |while true do java.lang.Thread.onSpinWait()
+                        |```
+                        |
+                        |```scala doctest:scope=env:timeouts expect=runs
+                        |val neverReached = true
+                        |```
+                        |""".stripMargin
+            withTempFile("README.md", md) { kyoFile =>
+                for
+                    cp    <- testClasspath
+                    nCpus <- System.availableProcessors
+                    config = Doctest.Config(
+                        sources = Chunk(kyoFile),
+                        classpath = cp,
+                        scalaOpts = Chunk.empty,
+                        cache = cacheDir,
+                        parallel = nCpus
+                    )
+                    result <- Abort.run(Scope.run(Doctest.check(config)))
+                yield result match
+                    case Result.Success(report) =>
+                        assert(report.failures.size == 2, s"expected timeout and unexecuted block failures: $report")
+                        val timeoutFailure = report.failures.find(_.line == 7).getOrElse(
+                            fail(s"expected timeout failure at line 7, got ${report.failures}")
+                        )
+                        assert(
+                            timeoutFailure.message.contains("timed out after 75.millis"),
+                            s"expected the second block's timeout, got $timeoutFailure"
+                        )
+                        val unexecutedFailure = report.failures.find(_.line == 11).getOrElse(
+                            fail(s"expected unexecuted failure at line 11, got ${report.failures}")
+                        )
+                        assert(
+                            unexecutedFailure.message.contains("runtime terminated in"),
+                            s"expected unexecuted-block attribution, got $unexecutedFailure"
+                        )
+                    case other =>
+                        fail(s"unexpected env timeout result: $other")
+            }
+        }
+    }
+
+    "System.exit in one env block is attributed without terminating the runner" in {
+        withTempCacheDir { cacheDir =>
+            val md = """|# Runtime process exit
+                        |
+                        |```scala doctest:scope=env:exit expect=runs
+                        |val completed = true
+                        |```
+                        |
+                        |```scala doctest:scope=env:exit expect=crashes
+                        |java.lang.System.exit(23)
+                        |```
+                        |
+                        |```scala doctest:scope=env:exit expect=runs
+                        |val neverReached = completed
+                        |```
+                        |""".stripMargin
+            withTempFile("README.md", md) { kyoFile =>
+                for
+                    cp    <- testClasspath
+                    nCpus <- System.availableProcessors
+                    config = Doctest.Config(
+                        sources = Chunk(kyoFile),
+                        classpath = cp,
+                        scalaOpts = Chunk.empty,
+                        cache = cacheDir,
+                        parallel = nCpus
+                    )
+                    result <- Abort.run(Scope.run(Doctest.check(config)))
+                yield result match
+                    case Result.Success(report) =>
+                        assert(report.failures.size == 1, s"expected only the unexecuted block to fail: $report")
+                        val failure = report.failures(0)
+                        assert(failure.line == 11, s"expected third block failure, got $failure")
+                        assert(
+                            failure.message.contains("runtime terminated in"),
+                            s"expected active-block exit attribution, got $failure"
+                        )
+                    case other =>
+                        fail(s"unexpected env System.exit result: $other")
+            }
+        }
+    }
+
+    "a crash in inherited code does not satisfy the current block's crashes expectation" in {
+        withTempCacheDir { cacheDir =>
+            val md = """|# Inherited runtime
+                        |
+                        |```scala doctest:scope=inherited
+                        |throw new IllegalStateException("inherited crash")
+                        |```
+                        |
+                        |```scala doctest:scope=inherited expect=crashes
+                        |val currentBlockCompletes = true
+                        |```
+                        |""".stripMargin
+            withTempFile("README.md", md) { kyoFile =>
+                for
+                    cp    <- testClasspath
+                    nCpus <- System.availableProcessors
+                    config = Doctest.Config(
+                        sources = Chunk(kyoFile),
+                        classpath = cp,
+                        scalaOpts = Chunk.empty,
+                        cache = cacheDir,
+                        parallel = nCpus
+                    )
+                    result <- Abort.run(Scope.run(Doctest.check(config)))
+                yield result match
+                    case Result.Success(report) =>
+                        assert(report.failures.size == 1, s"expected one inherited-runtime failure: $report")
+                        val failure = report.failures(0)
+                        assert(failure.line == 7, s"expected current block failure, got $failure")
+                        assert(
+                            failure.message.contains("block was not executed because inherited or setup code failed"),
+                            s"expected inherited-code attribution, got $failure"
+                        )
+                        assert(
+                            failure.message.contains(s"$kyoFile:4"),
+                            s"expected inherited crash mapped to README line 4, got $failure"
+                        )
+                    case other =>
+                        fail(s"unexpected inherited runtime result: $other")
+            }
+        }
+    }
+
+    "runtime expectations reject top-level package blocks with a precise failure" in {
+        withTempCacheDir { cacheDir =>
+            val md = """|# Package runtime
+                        |
+                        |```scala doctest:expect=runs
+                        |package runsPackage
+                        |val value = 1
+                        |```
+                        |
+                        |```scala doctest:expect=crashes
+                        |package crashesPackage
+                        |val value = 2
+                        |```
+                        |""".stripMargin
+            withTempFile("README.md", md) { kyoFile =>
+                for
+                    cp    <- testClasspath
+                    nCpus <- System.availableProcessors
+                    config = Doctest.Config(
+                        sources = Chunk(kyoFile),
+                        classpath = cp,
+                        scalaOpts = Chunk.empty,
+                        cache = cacheDir,
+                        parallel = nCpus
+                    )
+                    result <- Abort.run(Scope.run(Doctest.check(config)))
+                yield result match
+                    case Result.Success(report) =>
+                        assert(report.failures.size == 2, s"expected both package runtime blocks to fail: $report")
+                        assert(
+                            report.failures.forall(_.message.contains(
+                                "runtime expectations do not support blocks with top-level package declarations"
+                            )),
+                            s"expected precise unsupported-runtime messages: $report"
+                        )
+                    case other =>
+                        fail(s"unexpected package runtime result: $other")
+            }
+        }
+    }
+
     "expect=warns behaviour" in {
         withTempCacheDir { cacheDir =>
             // This test needs a block that actually emits a warning.

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
@@ -789,12 +789,16 @@ class OrchestratorTest extends kyo.test.Test[Any]:
         withTempCacheDir { cacheDir =>
             val md = """|# Test
                         |
+                        |```scala doctest:scope=inherited
+                        |val shared = 41
+                        |```
+                        |
                         |```scala doctest:scope=inherited expect=skipped
                         |this is not valid scala at all !!!! @@@
                         |```
                         |
                         |```scala doctest:scope=inherited
-                        |val compiled = 42
+                        |val compiled = shared + 1
                         |```
                         |""".stripMargin
             withTempFile("README.md", md) { kyoFile =>
@@ -811,8 +815,8 @@ class OrchestratorTest extends kyo.test.Test[Any]:
                     result <- Abort.run(Scope.run(Doctest.check(config)))
                 yield result match
                     case Result.Success(report) =>
-                        assert(report.totalBlocks == 2, s"expected 2 blocks, got ${report.totalBlocks}")
-                        assert(report.compiled == 1, s"expected 1 compiled block, got compiled=${report.compiled}")
+                        assert(report.totalBlocks == 3, s"expected 3 blocks, got ${report.totalBlocks}")
+                        assert(report.compiled == 2, s"expected 2 compiled blocks, got compiled=${report.compiled}")
                         assert(report.cacheHits == 0, s"skipped block should not use cache, got cacheHits=${report.cacheHits}")
                         assert(report.failures.isEmpty, s"skipped block should not produce failures, got ${report.failures}")
                     case Result.Failure(e) =>

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/CompileUnitTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/CompileUnitTest.scala
@@ -9,7 +9,8 @@ class CompileUnitTest extends kyo.test.Test[Any]:
         body: String,
         visibility: Block.Visibility = Block.Visibility.Isolated,
         file: String = "README.md",
-        lineStart: Int = 1
+        lineStart: Int = 1,
+        expect: Block.Expectation = Block.Expectation.Compiles
     ): Block =
         Block(
             file = kyo.Path(file),
@@ -17,7 +18,7 @@ class CompileUnitTest extends kyo.test.Test[Any]:
             lineEnd = lineStart + 3,
             body = body,
             visibility = visibility,
-            expect = Block.Expectation.Compiles,
+            expect = expect,
             platform = Set(Block.Target.JVM, Block.Target.JS, Block.Target.Native),
             carrier = Block.Carrier.Visible
         )
@@ -132,6 +133,53 @@ class CompileUnitTest extends kyo.test.Test[Any]:
     "empty block list produces empty Chunk of compile units" in {
         val units = CompileUnit.group(Chunk.empty)
         assert(units.isEmpty, s"expected empty Chunk but got ${units.size} units")
+    }
+
+    "Skipped blocks never contribute to compile units or preludes" in {
+        val inherited = makeBlock("val inherited = 1", Block.Visibility.Inherited, lineStart = 1)
+        val skippedInherited = makeBlock(
+            "this is invalid skipped inherited pseudocode",
+            Block.Visibility.Inherited,
+            lineStart = 10,
+            expect = Block.Expectation.Skipped
+        )
+        val inheritedUse = makeBlock("val inheritedUse = inherited", Block.Visibility.Inherited, lineStart = 20)
+        val skippedSetup = makeBlock(
+            "this is invalid skipped setup pseudocode",
+            Block.Visibility.Env("__doc__"),
+            lineStart = 30,
+            expect = Block.Expectation.Skipped
+        )
+        val skippedEnv = makeBlock(
+            "this is invalid skipped env pseudocode",
+            Block.Visibility.Env("shared"),
+            lineStart = 40,
+            expect = Block.Expectation.Skipped
+        )
+        val env = makeBlock("val envValue = 1", Block.Visibility.Env("shared"), lineStart = 50)
+
+        val units            = CompileUnit.group(Chunk(inherited, skippedInherited, inheritedUse, skippedSetup, skippedEnv, env))
+        val plannedBlocks    = units.flatMap(_.blocks.map(_.block))
+        val syntheticSources = units.map(_.syntheticSource.content)
+
+        assert(!plannedBlocks.contains(skippedInherited), "skipped inherited block must not be planned")
+        assert(!plannedBlocks.contains(skippedSetup), "skipped setup block must not be planned")
+        assert(!plannedBlocks.contains(skippedEnv), "skipped env block must not be planned")
+        assert(
+            syntheticSources.forall(!_.contains("this is invalid skipped inherited pseudocode")),
+            "skipped inherited body must not appear in synthetic sources"
+        )
+        assert(
+            syntheticSources.forall(!_.contains("this is invalid skipped setup pseudocode")),
+            "skipped setup body must not appear in synthetic sources"
+        )
+        assert(
+            syntheticSources.forall(!_.contains("this is invalid skipped env pseudocode")),
+            "skipped env body must not appear in synthetic sources"
+        )
+        assert(syntheticSources.exists(_.contains("val inherited = 1")), "active inherited body must be planned")
+        assert(syntheticSources.exists(_.contains("val inheritedUse = inherited")), "active inherited use must be planned")
+        assert(syntheticSources.exists(_.contains("val envValue = 1")), "active env body must be planned")
     }
 
     // Additional: Env("tutorial") blocks in a file with a setup block carry the setup block in WrappedBlock.setupBlocks.

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/DefaultsParserTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/DefaultsParserTest.scala
@@ -79,4 +79,27 @@ class DefaultsParserTest extends kyo.test.Test[Any]:
         }
     }
 
+    "per-block timeout overrides the per-README timeout default" in {
+        val content = """|<!-- doctest:default expect=runs timeout=2s -->
+                           |
+                           |```scala
+                           |val inheritedTimeout = true
+                           |```
+                           |
+                           |```scala doctest:timeout=75ms
+                           |val overriddenTimeout = true
+                           |```
+                           |""".stripMargin
+        Abort.run(MarkdownParser.parseString(content, dummyFile)).map {
+            case Result.Success(blocks) =>
+                assert(blocks.size == 2)
+                assert(blocks(0).timeout == 2.seconds)
+                assert(blocks(1).timeout == 75.millis)
+            case Result.Failure(err) =>
+                fail(s"unexpected parse error: $err")
+            case Result.Panic(t) =>
+                fail(s"unexpected panic: ${t.getMessage}")
+        }
+    }
+
 end DefaultsParserTest

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/ModifierParserTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/ModifierParserTest.scala
@@ -33,6 +33,32 @@ class ModifierParserTest extends kyo.test.Test[Any]:
         }
     }
 
+    "doctest:timeout=250ms parses to a finite positive Duration" in {
+        Abort.run(ModifierParser.parse("scala doctest:expect=runs timeout=250ms", dummyFile, 1)).map {
+            case Result.Success(mods) =>
+                assert(mods.timeout == Present(250.millis))
+            case Result.Failure(err) =>
+                fail(s"unexpected parse error: $err")
+            case Result.Panic(t) =>
+                fail(s"unexpected panic: ${t.getMessage}")
+        }
+    }
+
+    "timeout rejects zero, infinity, and malformed durations" in {
+        Kyo.foreach(Chunk("0s", "infinity", "later")) { value =>
+            Abort.run(ModifierParser.parse(s"scala doctest:timeout=$value", dummyFile, 9)).map {
+                case Result.Success(mods) =>
+                    fail(s"expected invalid timeout '$value' to fail, got $mods")
+                case Result.Failure(Doctest.Error.ParseError(file, line, message)) =>
+                    assert(file == dummyFile)
+                    assert(line == 9)
+                    assert(message.contains("timeout"), s"expected timeout error, got: $message")
+                case Result.Panic(t) =>
+                    fail(s"unexpected panic: ${t.getMessage}")
+            }
+        }.unit
+    }
+
     "doctest:scope=inherited parses to Block.Visibility.Inherited" in {
         Abort.run(ModifierParser.parse("scala doctest:scope=inherited", dummyFile, 1)).map {
             case Result.Success(mods) =>

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/RuntimeExecutorTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/RuntimeExecutorTest.scala
@@ -52,7 +52,8 @@ class RuntimeExecutorTest extends kyo.test.Test[Any]:
                     kyo.Path("RuntimeExecutorTest.scala"),
                     outputDir,
                     cp,
-                    250.millis
+                    Map(7 -> 250.millis),
+                    5.seconds
                 )
             yield result match
                 case RuntimeExecutor.Outcome.TimedOut(after, RuntimeExecutor.Progress.Block(7)) =>

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/RuntimeExecutorTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/RuntimeExecutorTest.scala
@@ -1,0 +1,117 @@
+package kyo.doctest.internal
+
+import kyo.*
+
+object RuntimeExecutorTimeoutTarget:
+    val _ = java.nio.file.Files.writeString(
+        java.nio.file.Path.of(java.lang.System.getProperty("kyo.doctest.progress")),
+        "7"
+    )
+    while true do java.lang.Thread.onSpinWait()
+end RuntimeExecutorTimeoutTarget
+
+object RuntimeExecutorExitTarget:
+    val _ = java.nio.file.Files.writeString(
+        java.nio.file.Path.of(java.lang.System.getProperty("kyo.doctest.progress")),
+        "42"
+    )
+    java.lang.System.exit(23)
+end RuntimeExecutorExitTarget
+
+object RuntimeExecutorPerBlockTimeoutTarget:
+    val progress = java.nio.file.Path.of(java.lang.System.getProperty("kyo.doctest.progress"))
+    val _        = java.nio.file.Files.writeString(progress, "11")
+    val until    = java.lang.System.nanoTime() + 120_000_000L
+    while java.lang.System.nanoTime() < until do java.lang.Thread.onSpinWait()
+    val _ = java.nio.file.Files.writeString(progress, "22")
+    while true do java.lang.Thread.onSpinWait()
+end RuntimeExecutorPerBlockTimeoutTarget
+
+class RuntimeExecutorTest extends kyo.test.Test[Any]:
+
+    private def testClasspath(using Frame): Chunk[kyo.Path] < Sync =
+        for
+            cp  <- System.property[String]("java.class.path", "")
+            sep <- System.property[String]("path.separator", ":")
+        yield Chunk.from(cp.split(sep).filter(_.nonEmpty).map(kyo.Path(_)))
+
+    private def withOutputDir[A, S](f: kyo.Path => A < (Sync & Async & S))(using Frame): A < (Sync & Async & Scope & S) =
+        for
+            id <- Random.uuid
+            dir = Path.basePaths.tmp / s"runtime-executor-test-$id"
+            _      <- Abort.run[FileFsException](dir.mkDir).unit
+            result <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileFsException](dir.removeAll).unit).flatMap(f)
+        yield result
+
+    "times out and terminates a non-cooperative block process" in {
+        withOutputDir { outputDir =>
+            for
+                cp <- testClasspath
+                result <- RuntimeExecutor.execute(
+                    "kyo.doctest.internal.RuntimeExecutorTimeoutTarget$",
+                    kyo.Path("RuntimeExecutorTest.scala"),
+                    outputDir,
+                    cp,
+                    250.millis
+                )
+            yield result match
+                case RuntimeExecutor.Outcome.TimedOut(after, RuntimeExecutor.Progress.Block(7)) =>
+                    assert(after == 250.millis)
+                case other => fail(s"expected timeout in block 7, got $other")
+        }
+    }
+
+    "contains System.exit inside the block process" in {
+        withOutputDir { outputDir =>
+            for
+                cp <- testClasspath
+                result <- RuntimeExecutor.execute(
+                    "kyo.doctest.internal.RuntimeExecutorExitTarget$",
+                    kyo.Path("RuntimeExecutorTest.scala"),
+                    outputDir,
+                    cp,
+                    5.seconds
+                )
+            yield result match
+                case RuntimeExecutor.Outcome.ProcessExited(23, _, RuntimeExecutor.Progress.Block(42)) =>
+                    succeed("captured child exit")
+                case other => fail(s"expected exit code 23 in block 42, got $other")
+        }
+    }
+
+    "resets the deadline and applies the active block timeout" in {
+        withOutputDir { outputDir =>
+            for
+                cp <- testClasspath
+                result <- RuntimeExecutor.execute(
+                    "kyo.doctest.internal.RuntimeExecutorPerBlockTimeoutTarget$",
+                    kyo.Path("RuntimeExecutorTest.scala"),
+                    outputDir,
+                    cp,
+                    Map(11 -> 500.millis, 22 -> 75.millis),
+                    5.seconds
+                )
+            yield result match
+                case RuntimeExecutor.Outcome.TimedOut(after, RuntimeExecutor.Progress.Block(22)) =>
+                    assert(after == 75.millis)
+                case other => fail(s"expected block 22 to time out after 75 milliseconds, got $other")
+        }
+    }
+
+    "distinguishes child bootstrap failure from block execution" in {
+        withOutputDir { outputDir =>
+            RuntimeExecutor.execute(
+                "missing.Target$",
+                kyo.Path("Missing.scala"),
+                outputDir,
+                Chunk.empty,
+                5.seconds
+            ).map {
+                case RuntimeExecutor.Outcome.ProcessExited(_, _, RuntimeExecutor.Progress.NotStarted) =>
+                    succeed("child runner did not start")
+                case other => fail(s"expected pre-start process exit, got $other")
+            }
+        }
+    }
+
+end RuntimeExecutorTest


### PR DESCRIPTION
## Summary

- execute `expect=runs` and `expect=crashes` blocks in isolated child JVMs
- attribute exceptions, timeouts, and process exits to the correct Markdown block
- support finite positive per-block and per-README runtime timeouts
- keep `expect=skipped` blocks out of compilation, execution, cache keys, and inherited/setup/environment scopes while preserving report totals

## Root causes

Runtime expectations were parsed but shared the compile-only result path, so their bodies were never executed.

Skipped outcomes were applied only while reducing compiler results. Their bodies still entered compile units and could leak into later inherited preludes, setup preludes, or named environments.

## Runtime examples

````markdown
```scala doctest:expect=runs timeout=45s
assert(computeValue() == 42)
```

```scala doctest:expect=crashes
throw new IllegalStateException("expected")
```
````

Runtime-bearing units now compile on every validation run and execute in an isolated child JVM. Progress markers identify the active block, allowing named environments to reset and apply each block's timeout:

```scala
val blockTimeouts =
    unit.blocks.toSeq.map(wrapped => wrapped.block.lineStart -> wrapped.block.timeout).toMap

driver.execute(runtimeBlock, blockTimeouts)
```

## Skipped-block isolation

A skipped block can contain illustrative pseudocode without affecting later inherited examples:

````markdown
```scala doctest:scope=inherited
val shared = 41
```

```scala doctest:scope=inherited expect=skipped
illustrative pseudocode that is not valid Scala
```

```scala doctest:scope=inherited
val answer = shared + 1
```
````

The compile planner defensively removes skipped blocks before every grouping path:

```scala
val activeBlocks =
    blocks.filter(_.expect != Block.Expectation.Skipped)
```

The orchestrator separately produces skipped report outcomes, so skipped blocks remain counted without creating compiler or runtime work:

```scala
val skippedOutcomes = blocks
    .filter(_.expect == Block.Expectation.Skipped)
    .map(block => BlockOutcome.Skipped(block, fromCache = false))
```

## Validation

- `sbt 'kyo-doctestJVM/test'`: 144 passed, 0 failed
- `sbt 'kyo-doctest-readme/doctestFresh'`: 23 blocks, 0 failures
- focused skipped-block and runtime regression suites
- independent specification and code-quality reviews

Closes #1844
Closes #1847
