### PR TITLE
[kyo-json] use ByteSize for JSONL limits and buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All breaking API changes to this project will be documented in this file.
 
 ### Changed
 
+- [kyo-core, kyo-schema-json, kyo-json] JSONL record limits and JSONL-adjacent streaming buffer capacities now use `ByteSize`; record offsets and cursor positions remain numeric
 - [kyo-schema] `Schema.dictSchema`: non-String-key `Dict` now serializes each entry as a two-field `key`/`value` record (the same form `mapSchema` uses) instead of a bare two-element array. BREAKING: previously-serialized MsgPack bytes for a non-String-key `Dict` cannot be read by the new code. MsgPack was the only codec that decoded the old form; the other six failed to decode and Protobuf silently emitted corrupt bytes.
 - [kyo-schema] `Schema.dictSchema` and `Schema.stringDictSchema`: a case class field holding an empty `Dict` now decodes on Protobuf instead of failing with `MissingFieldException`, matching the `Map` givens
 - [kyo-core] `Fiber.init`: use `Scope` effect to guarantee termination of forked fiber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,61 @@ You can also add these lines to your `.bashrc` or `.zshrc` file for persistent s
 
 ### How to Build Locally
 
+#### Windows toolchains
+
+Builds that reach a kyo-ffi module need a C compiler. The FFI plugin reads the
+`CC` environment variable and otherwise invokes `cc`. If GCC is installed on
+Windows as `gcc.exe` but no `cc.exe` alias exists, set `CC` before starting sbt:
+
+```powershell
+$env:CC = "gcc"
+```
+
+Some modules also use MSVC. Install the Visual Studio Build Tools C++ workload,
+then run the build from a shell initialized by `VsDevCmd.bat` so `cl.exe`,
+`link.exe`, `INCLUDE`, and `LIB` are available. For an x86_64 build:
+
+```powershell
+cmd.exe /k '"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=amd64'
+```
+
+This opens an initialized Command Prompt. Run `powershell` inside it if the
+commands below are being entered in PowerShell.
+
+Confirm the initialized shell sees both tools with `where.exe cl` and
+`where.exe link`. See [kyo-aeron's contributor guide](kyo-aeron/CONTRIBUTING.md#staging-libaeron)
+for that module's required Windows staging step.
+
+On Windows ARM64, install the native ARM64 Podman package explicitly. Scoop can
+otherwise select a package for a different architecture:
+
+```powershell
+scoop install -a arm64 podman
+podman machine init
+podman machine start
+podman info
+```
+
+Run `podman machine init` only when creating the machine. Start an existing
+machine with `podman machine start`.
+
+#### Local build runner
+
+On native Windows, invoke POSIX build scripts through Git Bash. Use the direct
+environment for diff-selected verification:
+
+```powershell
+& $env:SHELL -lc 'scripts/build.sh --env direct testDiff JVM JS'
+```
+
+Do not use `--env podman testDiff`. The container receives a clean source
+archive without `.git`, so the diff selector cannot discover the changed
+modules. Use `--env podman test` when a full Linux container run is needed:
+
+```powershell
+& $env:SHELL -lc 'scripts/build.sh --env podman test JVM JS Native'
+```
+
 Run the following commands to build and test the project locally:
 ```sh
 sbt '+kyoJVM/test' # Runs JVM tests

--- a/kyo-aeron/CONTRIBUTING.md
+++ b/kyo-aeron/CONTRIBUTING.md
@@ -165,7 +165,31 @@ sbt 'kyo-aeronJS/test'
 
 ### Staging libaeron
 
-`kyo-aeron/scripts/build-aeron.sh <os-arch>` clones Aeron at the pinned 1.50.2 tag, builds the static archives with CMake, and stages them under `kyo-aeron/build/aeron/staged/<os-arch>/` (e.g. `darwin-aarch64`, `linux-x86_64`, `linux-aarch64`). The staged tree is gitignored: the archives are build artifacts, never committed binary blobs, so they must be produced on every machine and every CI runner before the compile step. The CI "Prepare libaeron" step runs `kyo-aeron/scripts/build-aeron.sh` per arch on the JVM, Native, JS, and Wasm legs (cmake is preinstalled or installed on demand). Run the script locally once per os-arch before a Native, JS, or Wasm build.
+`kyo-aeron/scripts/build-aeron.sh <os-arch>` clones Aeron at the pinned 1.50.2 tag, builds the static archives with CMake, and stages them under `kyo-aeron/build/aeron/staged/<os-arch>/` (e.g. `darwin-aarch64`, `linux-x86_64`, `linux-aarch64`, `windows-x86_64`). The staged tree is gitignored: the archives are build artifacts, never committed binary blobs, so they must be produced on every machine and every CI runner before the compile step. The CI "Prepare libaeron" step runs `kyo-aeron/scripts/build-aeron.sh` per arch on the JVM, Native, JS, and Wasm legs (cmake is preinstalled or installed on demand). Run the script locally once per os-arch before any build whose dependency graph reaches kyo-aeron, including a JVM build, because shared FFI generation resolves the staged headers and archive.
+
+On Windows, Aeron supports MSVC rather than MinGW. Install CMake and the Visual
+Studio Build Tools C++ workload. Initialize the build shell with
+`VsDevCmd.bat` so `cl.exe`, `link.exe`, `INCLUDE`, and `LIB` are available to
+the later FFI compile. Then stage the x86_64 archive before running sbt:
+
+```powershell
+cmd.exe /k '"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=amd64'
+```
+
+The command opens an initialized Command Prompt. Run `powershell` inside it,
+then launch Git Bash for the staging script. Use a
+Windows-style temporary directory because an MSYS-style `/tmp` path can be
+passed through to native CMake tools without the required path conversion:
+
+```powershell
+New-Item -ItemType Directory -Force C:\Temp | Out-Null
+& $env:SHELL -lc 'export TMPDIR=C:/Temp; kyo-aeron/scripts/build-aeron.sh windows-x86_64'
+```
+
+The generic kyo-ffi compiler defaults to `cc`. If a separate FFI dependency
+uses MinGW GCC and only `gcc.exe` exists, set `$env:CC = "gcc"` before running
+sbt. Keep the MSVC environment initialized because kyo-aeron selects `cl.exe`
+for its Windows shim.
 
 ### The link is driver-only
 

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
@@ -39,7 +39,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
     private case class McpServerConfig(`type`: String, url: String, timeout: Int, alwaysLoad: Boolean) derives Schema
     private case class McpConfig(mcpServers: Map[String, McpServerConfig]) derives Schema
     private case class McpBridge(
-        config: String,
+        configPath: Path,
         allowedTools: Chunk[String],
         executedTools: AtomicRef[Chunk[ExecutedTool]],
         resultCapture: AtomicRef[Maybe[String]],
@@ -90,7 +90,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                     withResultBridge(config, resultTool, resultSchema) { bridge =>
                         runClaudeCommand(
                             config,
-                            claudeCommand(config, commandArgs(config, context, bridge.config, bridge.allowedTools))
+                            claudeCommand(config, commandArgs(config, context, bridge.configPath.toString, bridge.allowedTools))
                                 .stdin(input + "\n"),
                             config.timeout,
                             bridge
@@ -127,7 +127,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                     )
                     raw <- runClaudeCommand(
                         config,
-                        claudeCommand(config, commandArgs(config, context, bridge.config, bridge.allowedTools))
+                        claudeCommand(config, commandArgs(config, context, bridge.configPath.toString, bridge.allowedTools))
                             .stdin(input + "\n"),
                         config.timeout,
                         bridge
@@ -246,9 +246,9 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                 // The --max-turns 2 cap (see ClaudeCodeWire.baseCliArgs) ends a resultless invocation with
                 // error_max_turns and a non-zero exit: this backend's normal turn boundary, not a failure, so
                 // the transcript flows to readMessages and the eval loop replays and iterates (how the forced
-                // turn stays reachable). Every other non-zero exit classifies from the terminal result event's
-                // structured api_error_status (via failureStatus), never by regexing stdout. No structured
-                // status (a hard crash with no result event) -> Absent -> AIHarnessException.
+                // turn stays reachable). Every other non-zero exit classifies from the event's structured
+                // authentication error or api_error_status, never by regexing stdout. No structured signal
+                // (a hard crash with no result event) -> Absent -> AIHarnessException.
                 endedAtTurnCap(out).map {
                     case true  => Kyo.lift[String, Any](out)
                     case false =>
@@ -263,9 +263,16 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                                     Present(config.effectiveMaxOutputTokens)
                                 ))
                             case false =>
-                                failureStatus(out).map(status =>
-                                    Abort.fail(commandFailure(status, s"exited with ${code.toInt}: $out$err"))
-                                )
+                                authenticationFailed(out).map {
+                                    case true =>
+                                        Abort.fail[AIGenException](
+                                            AIProviderAuthException("Claude Code", "CLI OAuth session is not authenticated")
+                                        )
+                                    case false =>
+                                        failureStatus(out).map(status =>
+                                            Abort.fail(commandFailure(status, s"exited with ${code.toInt}: $out$err"))
+                                        )
+                                }
                         }
                 }
             case Result.Success(CliResult.TimedOut) =>
@@ -283,6 +290,26 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
       */
     private[completion] def userToolInfos(tools: Chunk[Tool.internal.Info[?, ?, LLM]]): Chunk[Tool.internal.Info[?, ?, LLM]] =
         tools.filterNot(_.name == Completion.resultToolName)
+
+    /** Writes the MCP configuration to a scoped file for the Claude CLI.
+      *
+      * Passing inline JSON is not portable on Windows: executable shims can consume the JSON's quotes while reconstructing the native
+      * command line, after which Claude treats the malformed value as a file path. A file path contains no JSON quoting and also avoids
+      * platform command-line length limits.
+      */
+    private[completion] def mcpConfigFile(config: String)(using Frame): Path < (Sync & Scope & Abort[AIGenException]) =
+        Abort.run[FileFsException | FileWriteException] {
+            for
+                path <- Path.tempScoped("kyo-ai-claude-mcp-", ".json")
+                _    <- path.write(config)
+            yield path
+        }.map {
+            case Result.Success(path) => path
+            case Result.Failure(ex) =>
+                Abort.fail(AIProviderUnavailableException("Claude Code", s"failed to write the MCP bridge config: ${ex.getMessage}"))
+            case Result.Panic(ex) => Abort.panic(ex)
+        }
+    end mcpConfigFile
 
     /** The in-process MCP server exposing kyo's tools to the CLI, the result tool included.
       *
@@ -336,8 +363,11 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
             }
             url     = s"ws://127.0.0.1:${server.port}/mcp"
             timeout = math.min(Int.MaxValue.toLong, math.max(1000L, config.timeout.toMillis)).toInt
+            configPath <- mcpConfigFile(
+                Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true))))
+            )
             bridge = McpBridge(
-                Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true)))),
+                configPath,
                 userTools.map(_.name).append(Completion.resultToolName).map(name => s"$mcpToolPrefix$name"),
                 executed,
                 resultCapture,
@@ -396,8 +426,11 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
             }
             url     = s"ws://127.0.0.1:${server.port}/mcp"
             timeout = math.min(Int.MaxValue.toLong, math.max(1000L, config.timeout.toMillis)).toInt
+            configPath <- mcpConfigFile(
+                Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true))))
+            )
             bridge = McpBridge(
-                Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true)))),
+                configPath,
                 Chunk(s"$mcpToolPrefix${Completion.resultToolName}"),
                 executed,
                 resultCapture,

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeWire.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeWire.scala
@@ -80,6 +80,14 @@ private[completion] object ClaudeCodeWire:
     private[completion] def stoppedAtOutputLimit(out: String)(using Frame): Boolean < Abort[AIGenException] =
         readEvents(out, lenient = true).map(_.exists(_.error.contains("max_output_tokens")))
 
+    /** True when the CLI emitted its structured authentication failure code.
+      *
+      * This deliberately ignores prose and terminal result text. Only the decoded `error` field can classify a failed command as an
+      * authentication problem, preserving the same no-text-scraping rule used for provider status codes and output limits.
+      */
+    private[completion] def authenticationFailed(out: String)(using Frame): Boolean < Abort[AIGenException] =
+        readEvents(out, lenient = true).map(_.exists(_.error.contains("authentication_failed")))
+
     case class ExecutedTool(name: String, arguments: Structure.Value, output: String)
 
     val mcpServerName = "kyo"

--- a/kyo-ai/shared/src/test/scala/kyo/BaseAITest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/BaseAITest.scala
@@ -251,7 +251,16 @@ abstract class BaseAITest extends kyo.test.Test[Any]:
             config <- Config.credentialed(backend.entry)
             _ <- backend.cli match
                 case Present(command) =>
-                    commandAvailable(command).map(available => assume(available, s"$command CLI is not available"))
+                    for
+                        available <- commandAvailable(command)
+                        _         <- Kyo.lift(assume(available, s"$command CLI is not available"))
+                        _ <-
+                            if command != "claude" then Kyo.unit
+                            else
+                                claudeAuthenticationAvailable.map(authenticated =>
+                                    assume(authenticated, "claude CLI is not authenticated")
+                                )
+                    yield ()
                 case Absent =>
                     Kyo.lift(assume(config.apiKey.isDefined, s"${backend.provider.keyName} is not available")).andThen(
                         apiBackendAvailable(backend, config)
@@ -339,6 +348,26 @@ abstract class BaseAITest extends kyo.test.Test[Any]:
             case _                         => false
         }
     end commandAvailable
+
+    private[kyo] def claudeAuthenticationAvailable(using Frame): Boolean < Async =
+        Abort.run[CommandException] {
+            Command("claude", "auth", "status").textWithExitCode
+        }.map {
+            case Result.Success((output, code)) => code.isSuccess && claudeAuthenticated(output)
+            case _                              => false
+        }
+    end claudeAuthenticationAvailable
+
+    private[kyo] def claudeAuthenticated(output: String): Boolean =
+        Json.decode[Structure.Value](output).toMaybe.exists {
+            case Structure.Value.Record(fields) =>
+                fields.exists {
+                    case ("loggedIn", Structure.Value.Bool(value)) => value
+                    case _                                         => false
+                }
+            case _ => false
+        }
+    end claudeAuthenticated
 
     private[kyo] def providerUnavailable(ex: Throwable): Boolean =
         val renderedUnavailable = unavailableText(ex.getMessage) || unavailableText(ex.toString)

--- a/kyo-ai/shared/src/test/scala/kyo/BaseAITestSelectionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/BaseAITestSelectionTest.scala
@@ -34,4 +34,19 @@ class BaseAITestSelectionTest extends BaseAITest:
         }
     }
 
+    "claudeAuthenticated" - {
+        "accepts an authenticated status response" in {
+            assert(claudeAuthenticated("""{"loggedIn":true,"authMethod":"oauth"}"""))
+        }
+
+        "rejects a logged-out status response" in {
+            assert(!claudeAuthenticated("""{"loggedIn":false,"authMethod":"none"}"""))
+        }
+
+        "rejects malformed and incomplete responses" in {
+            assert(!claudeAuthenticated("not json"))
+            assert(!claudeAuthenticated("""{"authMethod":"oauth"}"""))
+        }
+    }
+
 end BaseAITestSelectionTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeCompletionTest.scala
@@ -5,6 +5,15 @@ import kyo.ai.Config
 
 class ClaudeCodeCompletionTest extends kyo.test.Test[Any]:
 
+    "mcpConfigFile writes the exact config to a scoped JSON file" in Scope.run {
+        val config = """{"mcpServers":{"kyo":{"type":"ws","url":"ws://127.0.0.1:1234/mcp"}}}"""
+        ClaudeCodeCompletion.mcpConfigFile(config).map { path =>
+            path.read.map { contents =>
+                assert(contents == config, s"the CLI must read the exact MCP config from disk: $contents")
+            }
+        }
+    }
+
     "strippedEnvVars is exactly the three ambient API credential vars (subscription-guarantee isolation)" in {
         // The base URL is deliberately NOT in the set: it is routing, not a credential. Stripping it
         // made Config.apiUrl silently inert on this backend alone while the native path honored it.

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeWireTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeWireTest.scala
@@ -375,6 +375,23 @@ class ClaudeCodeWireTest extends kyo.test.Test[Any]:
         end for
     }
 
+    "authenticationFailed reads only the structured authentication error" in {
+        val authFailure =
+            """{"type":"assistant","error":"authentication_failed","message":{"role":"assistant","content":[]}}"""
+        val proseOnly =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"authentication_failed"}]}}"""
+
+        for
+            auth  <- Abort.run[AIGenException](ClaudeCodeWire.authenticationFailed(authFailure))
+            prose <- Abort.run[AIGenException](ClaudeCodeWire.authenticationFailed(proseOnly))
+            empty <- Abort.run[AIGenException](ClaudeCodeWire.authenticationFailed(""))
+        yield
+            assert(auth == Result.Success(true), s"the structured auth error must be recognized: $auth")
+            assert(prose == Result.Success(false), s"prose must never be classified as an auth error: $prose")
+            assert(empty == Result.Success(false), s"empty output has no auth error: $empty")
+        end for
+    }
+
     "turnUsage prefers the terminal result event's aggregate" in {
         // The result event sums the invocation's internal iterations (verified live), so it wins over
         // the per-message assistant events, whose output counts are message-start snapshots.

--- a/kyo-core/README.md
+++ b/kyo-core/README.md
@@ -917,8 +917,11 @@ import kyo.*
 def source: java.io.InputStream = ???
 
 val bytes: Stream[Byte, Sync & Scope] =
-    Stream.fromInputStream(source, bufferSize = 8192)
+    Stream.fromInputStream(source, bufferSize = 8.kib)
 ```
+
+Buffer capacities are `ByteSize` values. File resume offsets remain numeric byte positions, so `Path.Origin.Offset` continues to take a
+`Long`.
 
 `readStream`, `readBytesStream`, `readLinesStream`, `walk` (directory tree), `tail` (follow file updates), and `tailBytes` (follow file updates at the byte level) all return `Scope`-managed streams. `Path.ReadResult` is the typed wrapper around the raw byte count returned by low-level read operations: `ReadResult.Eof` signals end-of-file, and a positive value is the number of bytes read.
 

--- a/kyo-core/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-core/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -532,10 +532,10 @@ final private[kyo] class NodeReadHandle(fd: Int, path: Path) extends Path.ReadHa
     def position(offset: Long)(using AllowUnsafe): Unit =
         pos = offset
 
-    def size()(using AllowUnsafe, Frame): Result[FileReadException, Long] =
+    def size()(using AllowUnsafe, Frame): Result[FileReadException, ByteSize] =
         // fstat on the descriptor, not stat on the path: it answers for the file this handle holds
         // even once the name has been renamed away or unlinked. Same translation catchRead applies.
-        try Result.succeed(NodeFs.fstatSync(fd).size.toLong)
+        try Result.succeed(NodeFs.fstatSync(fd).size.toLong.bytes)
         catch
             case e: js.JavaScriptException => Result.fail(NodeError.translateRead(path, e))
             case e: Throwable              => Result.panic(e)

--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -460,12 +460,12 @@ final private[kyo] class NioReadHandle(channel: FileChannel, path: Path) extends
     def position(offset: Long)(using AllowUnsafe): Unit =
         discard(channel.position(offset))
 
-    def size()(using AllowUnsafe, Frame): Result[FileReadException, Long] =
+    def size()(using AllowUnsafe, Frame): Result[FileReadException, ByteSize] =
         // SeekableByteChannel.size reports the channel's file, so a rename or a replacement of the
         // path this channel was opened under leaves the answer unchanged. The path-resolution
         // failures catchRead separates out (not found, denied, is a directory) cannot arise from a
         // measurement of an already-open channel, which leaves the same shape NioWriteHandle uses.
-        try Result.succeed(channel.size())
+        try Result.succeed(channel.size().bytes)
         catch
             case e: IOException => Result.fail(FileIOException(path, e))
             case e: Throwable   => Result.panic(e)

--- a/kyo-core/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Path.scala
@@ -364,7 +364,7 @@ object Path extends PathPlatformSpecific:
 
         /** Tails the file, emitting new lines as they are appended, sleeping `pollDelay` between polls. */
         def tail(pollDelay: Duration)(using Frame): Stream[String, Async & Scope & Abort[FileReadException]] =
-            tail(pollDelay, 8192)
+            tail(pollDelay, 8.kib)
 
         /** Tails the file, emitting new lines as they are appended, sleeping `pollDelay` between polls, using the given read buffer size.
           *
@@ -372,7 +372,7 @@ object Path extends PathPlatformSpecific:
           * replacement, and a deletion of the name do to the stream. A truncation in place drops the pending partial line along with the
           * rest of the old content, so no line ever spans the rewind.
           */
-        def tail(pollDelay: Duration, bufferSize: Int)(using Frame): Stream[String, Async & Scope & Abort[FileReadException]] =
+        def tail(pollDelay: Duration, bufferSize: ByteSize)(using Frame): Stream[String, Async & Scope & Abort[FileReadException]] =
             // State carried between reads: leftover bytes from an incomplete UTF-8 sequence, plus the pending incomplete line text.
             // `follow` restores this initial state when the file is truncated, so neither survives a rewind.
             val emptyBytes = new Array[Byte](0)
@@ -439,7 +439,7 @@ object Path extends PathPlatformSpecific:
         def tailBytes(
             from: Origin = Origin.End,
             pollDelay: Duration = 100.millis,
-            bufferSize: Int = 8192
+            bufferSize: ByteSize = 8.kib
         )(using Frame): Stream[Byte, Async & Scope & Abort[FileReadException]] =
             follow[Byte, Unit](self, from, pollDelay, bufferSize, ()) { (_, buf, n) =>
                 // The loop reuses `buf`, so each emitted chunk gets its own copy
@@ -670,7 +670,7 @@ object Path extends PathPlatformSpecific:
         if !result.isEof then Poll.Data(result.bytesRead)
         else
             handle.size().foldError(
-                size => if size < pos then Poll.Rewound else Poll.Idle,
+                size => if size.toBytes < pos then Poll.Rewound else Poll.Idle,
                 error => Poll.Unreadable(error)
             )
         end if
@@ -698,11 +698,12 @@ object Path extends PathPlatformSpecific:
         self: Path,
         from: Origin,
         pollDelay: Duration,
-        bufferSize: Int,
+        bufferSize: ByteSize,
         initialState: St
     )(
         step: (St, Array[Byte], Int) => Step[V, St]
     )(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Stream[V, Async & Scope & Abort[FileReadException]] =
+        val capacity = readBufferCapacity(bufferSize)
         Stream {
             Scope.acquireRelease(
                 Sync.Unsafe.defer(Abort.get(self.unsafe.openRead()))
@@ -715,14 +716,14 @@ object Path extends PathPlatformSpecific:
                             case Origin.Start => Result.succeed(0L)
                             // The end of the file the handle holds, not the end of whatever the path names, so that
                             // the start position and the cursor it seeds belong to one file.
-                            case Origin.End => handle.size()
+                            case Origin.End => handle.size().map(_.toBytes)
                             // Clamped so a negative offset means the same thing everywhere: JVM and Native raise a raw
                             // IllegalArgumentException from the channel, while Node reads from the current position instead.
                             case Origin.Offset(bytes) => Result.succeed(math.max(0L, bytes))
                     Abort.get(startPos).map { start =>
                         Sync.Unsafe.defer {
                             handle.position(start)
-                            val buf = new Array[Byte](bufferSize)
+                            val buf = new Array[Byte](capacity)
                             Loop(start, initialState) { (pos, state) =>
                                 Sync.Unsafe.defer {
                                     poll(handle, buf, pos) match
@@ -751,6 +752,13 @@ object Path extends PathPlatformSpecific:
             }
         }
     end follow
+
+    private def readBufferCapacity(bufferSize: ByteSize): Int =
+        val bytes = bufferSize.toBytes
+        if bytes == 0L || bytes > Int.MaxValue then
+            throw new IllegalArgumentException(s"bufferSize must be between 1 and ${Int.MaxValue} bytes, got $bytes")
+        bytes.toInt
+    end readBufferCapacity
 
     /** Returns the number of trailing bytes that form an incomplete UTF-8 sequence. */
     private def incompleteUtf8Tail(bytes: Array[Byte], len: Int): Int =
@@ -938,7 +946,7 @@ object Path extends PathPlatformSpecific:
           * Returns a `Result` rather than raising, so a measurement failure stays in the typed `FileReadException` channel instead of
           * escaping the enclosing `Sync.Unsafe.defer` as a panic.
           */
-        def size()(using AllowUnsafe, Frame): Result[FileReadException, Long]
+        def size()(using AllowUnsafe, Frame): Result[FileReadException, ByteSize]
 
         /** Reads the current content into the handle's own retained buffer and parses the first ASCII-decimal
           * `Long` in place, with no intermediate `String` and no `Maybe` box. TOTAL: returns

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -237,8 +237,12 @@ object StreamCoreExtensions:
           * @param bufferSize
           *   read buffer size in bytes
           */
-        def fromInputStream(is: java.io.InputStream, bufferSize: Int = 8192)(using Frame): Stream[Byte, Sync & Scope] =
-            streamFromJavaInputStream(is, bufferSize)
+        def fromInputStream(is: java.io.InputStream, bufferSize: ByteSize = 8.kib)(using Frame): Stream[Byte, Sync & Scope] =
+            val bytes = bufferSize.toBytes
+            if bytes == 0L || bytes > Int.MaxValue then
+                throw new IllegalArgumentException(s"bufferSize must be between 1 and ${Int.MaxValue} bytes, got $bytes")
+            streamFromJavaInputStream(is, bytes.toInt)
+        end fromInputStream
 
         /** Merges multiple streams asynchronously. Stream stops as soon as any of the source streams complete.
           *

--- a/kyo-core/shared/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/PathTest.scala
@@ -1553,7 +1553,7 @@ class PathTest extends kyo.test.Test[Any]:
                 file = dir / "tail-utf8.txt"
                 _ <- file.mkFile
                 tailFiber <- Fiber.initUnscoped(
-                    Scope.run(file.tail(50.millis, 16).take(1).run)
+                    Scope.run(file.tail(50.millis, 16.bytes).take(1).run)
                 )
                 _     <- control.advance(50.millis)
                 _     <- file.append(multiByteContent)
@@ -1662,6 +1662,20 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
     // tailBytes
     // =========================================================================
+
+    "tailBytes rejects a zero-byte buffer before opening the file" in {
+        val ex = intercept[IllegalArgumentException](
+            (Path / "not-opened").tailBytes(bufferSize = ByteSize.Zero)
+        )
+        assert(ex.getMessage == "bufferSize must be between 1 and 2147483647 bytes, got 0")
+    }
+
+    "tailBytes rejects a buffer larger than an array can address before opening the file" in {
+        val ex = intercept[IllegalArgumentException](
+            (Path / "not-opened").tailBytes(bufferSize = (Int.MaxValue.toLong + 1L).bytes)
+        )
+        assert(ex.getMessage == "bufferSize must be between 1 and 2147483647 bytes, got 2147483648")
+    }
 
     /** Repeats `write` until `condition` holds, waking the follower between writes.
       *

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -121,8 +121,22 @@ class StreamCoreExtensionsTest extends kyo.test.Test[Any]:
                 // of the one before it all change the sequence, and none of them would change the count.
                 val data = Array.tabulate(20)(i => (i + 1).toByte)
                 val is   = new java.io.ByteArrayInputStream(data)
-                for bytes <- Scope.run(Stream.fromInputStream(is, bufferSize = 8).run)
+                for bytes <- Scope.run(Stream.fromInputStream(is, bufferSize = 8.bytes).run)
                 yield assert(bytes.toArray.toSeq == data.toSeq)
+            }
+
+            "rejects a zero-byte buffer before reading" in {
+                val is = new java.io.ByteArrayInputStream(Array[Byte](1))
+                val ex = intercept[IllegalArgumentException](Stream.fromInputStream(is, bufferSize = ByteSize.Zero))
+                assert(ex.getMessage == "bufferSize must be between 1 and 2147483647 bytes, got 0")
+            }
+
+            "rejects a buffer larger than an array can address before reading" in {
+                val is = new java.io.ByteArrayInputStream(Array[Byte](1))
+                val ex = intercept[IllegalArgumentException](
+                    Stream.fromInputStream(is, bufferSize = (Int.MaxValue.toLong + 1L).bytes)
+                )
+                assert(ex.getMessage == "bufferSize must be between 1 and 2147483647 bytes, got 2147483648")
             }
         }
     }

--- a/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/CCompiler.scala
+++ b/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/CCompiler.scala
@@ -21,7 +21,7 @@ import sys.process._
   *
   * For MSVC the flag shape is:
   * {{{
-  *   cl.exe /LD /O2 /W3 /I<dir> <sources> /Fe:<outFile> <linkFlags> <lib>.lib
+  *   cl.exe /LD /O2 /W3 /I<dir> <sources> /Fo:<objectDir> /Fe:<outFile> <linkFlags> <lib>.lib
   * }}}
   *
   * When `staticLink` is true the named `linkLibs` are folded statically into the produced
@@ -186,14 +186,16 @@ private[sbt] object CCompiler {
             val staticFlag      = if (staticLink) Seq("/MT") else Nil
             val libDirFlags     = libDirs.map(d => "/LIBPATH:" + d.getAbsolutePath)
             val libFlags        = linkLibs.map(l => l + ".lib")
-            // cl.exe builds a DLL with /LD; /Fe: sets output exe/dll name. `/LIBPATH:` is a linker
-            // option: cl silently ignores it on the compiler command line, so the search dirs and the
-            // named import libs must follow `/link`, otherwise the linker cannot find a vendored .lib
-            // (LNK1181). The libs found via the LIB env (winsock, the CRT) resolve either way.
+            val objectDirFlag   = "/Fo:" + outFile.getAbsoluteFile.getParentFile.getAbsolutePath + File.separator
+            // cl.exe builds a DLL with /LD; /Fo: keeps intermediate objects beside the target DLL and
+            // /Fe: sets its name. `/LIBPATH:` is a linker option: cl silently ignores it on the compiler
+            // command line, so the search dirs and the named import libs must follow `/link`, otherwise
+            // the linker cannot find a vendored .lib (LNK1181). The libs found via the LIB env (winsock,
+            // the CRT) resolve either way.
             val linkerArgs = linkFlags ++ libDirFlags ++ libFlags
             splitCc(cc) ++ Seq("/LD") ++ translatedFlags ++ staticFlag ++ includeFlags ++
                 sources.map(_.getAbsolutePath) ++
-                Seq("/Fe:" + outFile.getAbsolutePath) ++
+                Seq(objectDirFlag, "/Fe:" + outFile.getAbsolutePath) ++
                 (if (linkerArgs.nonEmpty) Seq("/link") ++ linkerArgs else Nil)
         case _ =>
             val includeFlags = includes.flatMap(d => Seq("-I", d.getAbsolutePath))

--- a/kyo-ffi/plugin/src/test/scala/kyo/ffi/sbt/CCompilerTest.scala
+++ b/kyo-ffi/plugin/src/test/scala/kyo/ffi/sbt/CCompilerTest.scala
@@ -207,6 +207,7 @@ class CCompilerTest extends AnyFunSuite with Matchers {
         cmd should contain("/O2")
         cmd should contain("/W3")
         cmd should contain("/I" + inc.getAbsolutePath)
+        cmd should contain("/Fo:" + out.getAbsoluteFile.getParentFile.getAbsolutePath + File.separator)
         cmd should contain("/Fe:" + out.getAbsolutePath)
         cmd should contain("ws2_32.lib")
         // -fPIC is dropped on Windows (PIC is default for DLLs):

--- a/kyo-json/CONTRIBUTING.md
+++ b/kyo-json/CONTRIBUTING.md
@@ -173,9 +173,9 @@ loop.**
 
 ---
 
-## `maxLineBytes` and the one unrecoverable failure
+## `maxLineSize` and the one unrecoverable failure
 
-`maxLineBytes` (default `Json.Lines.DefaultMaxLineBytes`, 16 MiB) exists because
+`maxLineSize` (default `Json.Lines.DefaultMaxLineSize`, `16.mib`) is a `ByteSize` value and exists because
 a byte stream containing no newline would otherwise grow the framer's residual
 without bound. `maxDepth` and `maxCollectionSize` do not cover this: both
 operate inside a single document, and a stream with no record boundary never
@@ -248,7 +248,7 @@ for the full rationale on the source.
 Nothing in this module buffers a whole stream, in either direction, and every
 entry point must keep that property.
 
-Reading: the framer holds at most one partial record, capped by `maxLineBytes`.
+Reading: the framer holds at most one partial record, capped by `maxLineSize`.
 Records complete within a chunk are emitted and dropped.
 
 Writing: `writeAll` folds the value stream chunk by chunk. Each chunk goes

--- a/kyo-json/README.md
+++ b/kyo-json/README.md
@@ -135,7 +135,7 @@ val untilShutdown =
     Scope.run(Jsonl.follow[LogEvent](logFile).takeWhilePure(_.message != "shutdown").run)
 ```
 
-`take`, `takeWhilePure`, and an interrupt of the fiber running the stream are the three ways out. A bare `.run` on a follow stream over a well-formed log waits forever. Two things do end it: `follow` aborts on the first undecodable record or record-size breach, and `followResults`, which survives both of those, ends when the pending bytes outgrow `maxLineBytes` with no newline among them (see [Limits](#limits)).
+`take`, `takeWhilePure`, and an interrupt of the fiber running the stream are the three ways out. A bare `.run` on a follow stream over a well-formed log waits forever. Two things do end it: `follow` aborts on the first undecodable record or record-size breach, and `followResults`, which survives both of those, ends when the pending bytes outgrow `maxLineSize` with no newline among them (see [Limits](#limits)).
 
 `pollDelay` is how long the follower sleeps between polls once it reaches end of file, `100.millis` by default. Raising it trades latency for fewer wakeups:
 
@@ -207,7 +207,7 @@ Both directions are available on every source, so the choice is per call site ra
 | Any `Stream[Byte, S]` | `Jsonl.pipe` | `Jsonl.pipeResults` |
 | A file still being written | `Jsonl.follow` | `Jsonl.followResults` |
 
-> **Caution:** the `Results` variants survive an undecodable record, and they survive a record longer than `maxLineBytes` (the framer's record-size ceiling, covered under [Limits](#limits)) only when that record's newline arrived. A terminated over-long record has a boundary to resume at, so it costs one failure element and framing carries on with the record after it. Pending bytes that outgrow the ceiling with no newline among them have no boundary to skip to: the stream emits every record framed before them, then that single failure element, and then it ends. Consumers that treat a `Results` stream as unbounded need to handle it ending.
+> **Caution:** the `Results` variants survive an undecodable record, and they survive a record larger than `maxLineSize` (the framer's record-size ceiling, covered under [Limits](#limits)) only when that record's newline arrived. A terminated over-long record has a boundary to resume at, so it costs one failure element and framing carries on with the record after it. Pending bytes that outgrow the ceiling with no newline among them have no boundary to skip to: the stream emits every record framed before them, then that single failure element, and then it ends. Consumers that treat a `Results` stream as unbounded need to handle it ending.
 
 ## Writing and appending
 
@@ -244,17 +244,17 @@ A failure part way through leaves the records already written on disk rather tha
 
 Three parameters bound what a decode can cost, and two of them look interchangeable and are not. All three appear on `read`, `readResults`, `pipe`, `pipeResults`, `follow`, and `followResults`, with the same defaults everywhere.
 
-`maxLineBytes` is the framer's record-size ceiling, `Json.Lines.DefaultMaxLineBytes` (16 MiB) by default. It is what keeps a byte stream containing no newline from growing the framer's pending buffer without bound:
+`maxLineSize` is the framer's `ByteSize` record ceiling, `Json.Lines.DefaultMaxLineSize` (`16.mib`) by default. It is what keeps a byte stream containing no newline from growing the framer's pending buffer without bound:
 
 ```scala
-val capped = Jsonl.read[LogEvent](logFile, maxLineBytes = 64 * 1024)
+val capped = Jsonl.read[LogEvent](logFile, maxLineSize = 64.kib)
 ```
 
-The limit counts the record's own bytes, the ones a decoder sees, and never the line terminator: a `'\n'` and any `'\r'` immediately before it are excluded. A maximum-size record therefore occupies `maxLineBytes + 1` bytes on the wire when it ends in `\n`, and `maxLineBytes + 2` when it ends in `\r\n`. A pending partial record is measured the same way, so a record is accepted or rejected identically whether its terminator arrived in the same chunk or a later one.
+The limit counts the record's own bytes, the ones a decoder sees, and never the line terminator: a `'\n'` and any `'\r'` immediately before it are excluded. A record at the ceiling therefore occupies one additional byte on the wire when it ends in `\n`, and two additional bytes when it ends in `\r\n`. A pending partial record is measured the same way, so a record is accepted or rejected identically whether its terminator arrived in the same chunk or a later one.
 
 What a breach costs depends on whether the offending line was terminated. A terminated one has a known boundary, so framing skips it and resumes at the next record: the `Results` variants report one failure for it and carry on. Pending bytes that outgrow the limit with no newline among them have nothing to skip to, and that is the case the `Results` variants end on.
 
-> **Caution:** a strict `maxLineBytes` breach aborts with a bare `LimitExceededException`, not a `RecordDecodeException`. No record was framed, so there is no record to attribute it to. Both are `DecodeException`, so the effect row does not distinguish them, and a handler that matches only on `RecordDecodeException` will miss the framing breach entirely. Match on `DecodeException`, or on both.
+> **Caution:** a strict `maxLineSize` breach aborts with a bare `LimitExceededException`, not a `RecordDecodeException`. No record was framed, so there is no record to attribute it to. Both are `DecodeException`, so the effect row does not distinguish them, and a handler that matches only on `RecordDecodeException` will miss the framing breach entirely. Match on `DecodeException`, or on both.
 
 `maxDepth` and `maxCollectionSize` bound one record's decoding: how deeply objects and arrays may nest, and how many entries a map, set, or array may hold. They default to `Json.DefaultMaxDepth` and `Json.DefaultMaxCollectionSize`:
 
@@ -262,7 +262,7 @@ What a breach costs depends on whether the offending line was terminated. A term
 val guarded = Jsonl.read[LogEvent](logFile, maxDepth = 8, maxCollectionSize = 1000)
 ```
 
-These operate inside one document and say nothing about how long a record may be. A single line of ten million characters passes any `maxDepth`; `maxLineBytes` is the parameter that rejects it. Breaching either one arrives as a `LimitExceededException` wrapped in a `RecordDecodeException.cause`, because the record was framed and only its decoding failed. Its `limit` field names which of the two was applied.
+These operate inside one document and say nothing about how long a record may be. A single line of ten million characters passes any `maxDepth`; `maxLineSize` is the parameter that rejects it. Breaching either one arrives as a `LimitExceededException` wrapped in a `RecordDecodeException.cause`, because the record was framed and only its decoding failed. Its `limit` field names which of the two was applied.
 
 ## Putting it together
 
@@ -272,7 +272,7 @@ A shipper that resumes where it stopped, watches a live log, and copies the erro
 val shipErrors =
     Jsonl.append(
         errorFile,
-        Jsonl.follow[LogEvent](logFile, Path.Origin.Offset(lastOffset), maxLineBytes = 64 * 1024)
+        Jsonl.follow[LogEvent](logFile, Path.Origin.Offset(lastOffset), maxLineSize = 64.kib)
             .filterPure(_.level == "ERROR")
             .take(100)
     )

--- a/kyo-json/shared/src/main/scala/kyo/Jsonl.scala
+++ b/kyo-json/shared/src/main/scala/kyo/Jsonl.scala
@@ -47,18 +47,18 @@ object Jsonl:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `Json.Lines.DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `Json.Lines.DefaultMaxLineSize`)
       * @return
       *   a pipe emitting one value per record, aborting with the first decode or framing failure
       */
     def pipe[A](
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = Json.Lines.DefaultMaxLineBytes
+        maxLineSize: ByteSize = Json.Lines.DefaultMaxLineSize
     )(using Json, Schema[A], Tag[Emit[Chunk[A]]], Frame): Pipe[Byte, A, Abort[DecodeException]] =
         Pipe:
-            Loop(Json.Lines.Framer.init(maxLineBytes)) { framer =>
+            Loop(Json.Lines.Framer.init(maxLineSize)) { framer =>
                 Poll.andMap[Chunk[Byte]] {
                     case Absent =>
                         framer.finish match
@@ -94,7 +94,7 @@ object Jsonl:
       * The variant for heterogeneous or partially-written logs: a truncated tail or an unrecognized record type yields one failure element
       * rather than ending the stream.
       *
-      * A record exceeding `maxLineBytes` is one failure element too when its terminator arrived: the boundary is known, so framing skips
+      * A record exceeding `maxLineSize` is one failure element too when its terminator arrived: the boundary is known, so framing skips
       * the record and the records after it are emitted normally. The one failure this cannot recover from is an oversized trailing
       * residual, which found no record boundary and has nothing to skip to. It surfaces as a final failure element after every record
       * framed before it, and then the stream ends.
@@ -103,18 +103,18 @@ object Jsonl:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `Json.Lines.DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `Json.Lines.DefaultMaxLineSize`)
       * @return
       *   a pipe emitting one result per record
       */
     def pipeResults[A](
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = Json.Lines.DefaultMaxLineBytes
+        maxLineSize: ByteSize = Json.Lines.DefaultMaxLineSize
     )(using Json, Schema[A], Tag[Emit[Chunk[Result[DecodeException, A]]]], Frame): Pipe[Byte, Result[DecodeException, A], Any] =
         Pipe:
-            Loop(Json.Lines.Framer.init(maxLineBytes)) { framer =>
+            Loop(Json.Lines.Framer.init(maxLineSize)) { framer =>
                 Poll.andMap[Chunk[Byte]] {
                     case Absent =>
                         framer.finish match
@@ -144,8 +144,8 @@ object Jsonl:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `Json.Lines.DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `Json.Lines.DefaultMaxLineSize`)
       * @return
       *   a stream of decoded values, aborting with the first decode or framing failure
       */
@@ -153,9 +153,9 @@ object Jsonl:
         path: Path,
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = Json.Lines.DefaultMaxLineBytes
+        maxLineSize: ByteSize = Json.Lines.DefaultMaxLineSize
     )(using Json, Schema[A], Tag[Emit[Chunk[A]]], Frame): Stream[A, Scope & Sync & Abort[FileReadException | DecodeException]] =
-        path.readBytesStream.into(pipe[A](maxDepth, maxCollectionSize, maxLineBytes))
+        path.readBytesStream.into(pipe[A](maxDepth, maxCollectionSize, maxLineSize))
 
     /** Reads a JSONL file as a stream of per-record `Result`s, surviving undecodable records.
       *
@@ -167,8 +167,8 @@ object Jsonl:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `Json.Lines.DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `Json.Lines.DefaultMaxLineSize`)
       * @return
       *   a stream of per-record results
       */
@@ -176,14 +176,14 @@ object Jsonl:
         path: Path,
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = Json.Lines.DefaultMaxLineBytes
+        maxLineSize: ByteSize = Json.Lines.DefaultMaxLineSize
     )(using
         Json,
         Schema[A],
         Tag[Emit[Chunk[Result[DecodeException, A]]]],
         Frame
     ): Stream[Result[DecodeException, A], Scope & Sync & Abort[FileReadException]] =
-        path.readBytesStream.into(pipeResults[A](maxDepth, maxCollectionSize, maxLineBytes))
+        path.readBytesStream.into(pipeResults[A](maxDepth, maxCollectionSize, maxLineSize))
 
     /** Streams a JSONL file's records, continuing to emit as records are appended.
       *
@@ -228,8 +228,8 @@ object Jsonl:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `Json.Lines.DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `Json.Lines.DefaultMaxLineSize`)
       * @return
       *   a stream of decoded values that runs until interrupted, aborting with the first decode or framing failure
       */
@@ -239,7 +239,7 @@ object Jsonl:
         pollDelay: Duration = 100.millis,
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = Json.Lines.DefaultMaxLineBytes
+        maxLineSize: ByteSize = Json.Lines.DefaultMaxLineSize
     )(using
         Json,
         Schema[A],
@@ -247,7 +247,7 @@ object Jsonl:
         Tag[Emit[Chunk[A]]],
         Frame
     ): Stream[A, Scope & Async & Abort[FileReadException | DecodeException]] =
-        followResults[A](path, from, pollDelay, maxDepth, maxCollectionSize, maxLineBytes).flatMapChunk { results =>
+        followResults[A](path, from, pollDelay, maxDepth, maxCollectionSize, maxLineSize).flatMapChunk { results =>
             val (values, failure) = splitAtFailure(results)
             failure match
                 case Absent => Stream[A, Any](emitNonEmpty(values)(()))
@@ -263,7 +263,7 @@ object Jsonl:
       * on. Every other property of [[follow]] holds unchanged, including the `Path.Origin.Start` default, the framer rebuilt across a
       * truncation, and the behavior under rotation by rename.
       *
-      * A record exceeding `maxLineBytes` yields one failure element and the stream carries on, as long as its terminator arrived: the
+      * A record exceeding `maxLineSize` yields one failure element and the stream carries on, as long as its terminator arrived: the
       * boundary is known, so framing skips the record and keeps following. That matters most here, because ending instead would let one
       * over-long line stop a follower on a live log permanently.
       *
@@ -283,10 +283,10 @@ object Jsonl:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `Json.Lines.DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `Json.Lines.DefaultMaxLineSize`)
       * @return
-      *   a stream of per-record results that runs until interrupted, or until the pending bytes outgrow `maxLineBytes`
+      *   a stream of per-record results that runs until interrupted, or until the pending bytes outgrow `maxLineSize`
       */
     def followResults[A](
         path: Path,
@@ -294,7 +294,7 @@ object Jsonl:
         pollDelay: Duration = 100.millis,
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = Json.Lines.DefaultMaxLineBytes
+        maxLineSize: ByteSize = Json.Lines.DefaultMaxLineSize
     )(using
         Json,
         Schema[A],
@@ -309,7 +309,7 @@ object Jsonl:
             from,
             pollDelay,
             FollowBufferSize,
-            Json.Lines.Framer.init(maxLineBytes)
+            Json.Lines.Framer.init(maxLineSize)
         ) { (framer, buffer, bytesRead) =>
             // The follow loop reuses `buffer` across reads, so the framer, which retains what it
             // cannot yet frame, is handed an array nothing else holds.
@@ -452,20 +452,20 @@ object Jsonl:
       * passed to the shared follow loop explicitly rather than inherited from [[Path.tailBytes]]'s own default, so the two are free to
       * differ and neither has to track the other.
       */
-    private inline def FollowBufferSize: Int = 8192
+    private inline def FollowBufferSize: ByteSize = 8.kib
 
     /** What framing and decoding one chunk of JSONL bytes produced.
       *
       * The two cases of `Json.Lines.Framed`, with each framed record decoded. Naming them keeps each driver's handling of them a visible
       * decision, and keeps the framer that a halt leaves behind out of reach: the case that carries a halting breach carries no framer, so
-      * there is no value to feed again by mistake. A record skipped for exceeding `maxLineBytes` is not a halt and does not appear as one:
+      * there is no value to feed again by mistake. A record skipped for exceeding `maxLineSize` is not a halt and does not appear as one:
       * it is one failure inside `results`, sitting where the record sat, and framing carried on past it.
       */
     private enum Framing[A]:
         /** Every record the chunk resolved, and the framer that frames the next chunk. */
         case Continued[A](results: Chunk[Result[DecodeException, A]], framer: Json.Lines.Framer) extends Framing[A]
 
-        /** Every record resolved before the pending bytes outgrew `maxLineBytes`, and that breach. */
+        /** Every record resolved before the pending bytes outgrew `maxLineSize`, and that breach. */
         case Halted[A](results: Chunk[Result[DecodeException, A]], breach: LimitExceededException) extends Framing[A]
     end Framing
 
@@ -482,7 +482,7 @@ object Jsonl:
       *   the next bytes of the input, of any size including empty
       * @return
       *   [[Framing.Continued]] with the chunk's results and the advanced framer, or [[Framing.Halted]] when the pending bytes outgrew
-      *   `maxLineBytes` with no boundary to skip to, carrying the records resolved before the breach
+      *   `maxLineSize` with no boundary to skip to, carrying the records resolved before the breach
       */
     private def frameChunk[A](
         framer: Json.Lines.Framer,

--- a/kyo-json/shared/src/test/scala/kyo/JsonlTest.scala
+++ b/kyo-json/shared/src/test/scala/kyo/JsonlTest.scala
@@ -19,7 +19,7 @@ class JsonlTest extends kyo.test.Test[Any]:
     private def byteStream(s: String, chunkSize: Int = 4096): Stream[Byte, Any] =
         Stream.init(Chunk.from(s.getBytes(StandardCharsets.UTF_8)), chunkSize)
 
-    /** A well-formed record of 61 bytes, over the 30-byte `maxLineBytes` every skip test below sets.
+    /** A well-formed record of 61 bytes, over the 30-byte `maxLineSize` every skip test below sets.
       *
       * It decodes cleanly at the default limit, so a test that rejects it is rejecting it for its size alone. Every call site terminates it
       * with a newline, which is what makes it a skippable breach rather than an oversized residual: the boundary is known, so framing
@@ -166,7 +166,7 @@ class JsonlTest extends kyo.test.Test[Any]:
             for
                 seen <- AtomicRef.init(Chunk.empty[Event])
                 r <- Abort.run[DecodeException](
-                    byteStream(in).into(Jsonl.pipe[Event](maxLineBytes = 30)).foreach(e =>
+                    byteStream(in).into(Jsonl.pipe[Event](maxLineSize = 30.bytes)).foreach(e =>
                         seen.updateAndGet(_ :+ e)
                     )
                 )
@@ -191,7 +191,7 @@ class JsonlTest extends kyo.test.Test[Any]:
             for
                 seen <- AtomicRef.init(Chunk.empty[Event])
                 r <- Abort.run[DecodeException](
-                    byteStream(in).into(Jsonl.pipe[Event](maxLineBytes = 30)).foreach(e => seen.updateAndGet(_ :+ e))
+                    byteStream(in).into(Jsonl.pipe[Event](maxLineSize = 30.bytes)).foreach(e => seen.updateAndGet(_ :+ e))
                 )
                 emitted <- seen.get
             yield
@@ -313,7 +313,7 @@ class JsonlTest extends kyo.test.Test[Any]:
                 _    <- file.write(in)
                 seen <- AtomicRef.init(Chunk.empty[Event])
                 r <- Abort.run[DecodeException](
-                    Scope.run(Jsonl.read[Event](file, maxLineBytes = 30).foreach(e => seen.updateAndGet(_ :+ e)))
+                    Scope.run(Jsonl.read[Event](file, maxLineSize = 30.bytes).foreach(e => seen.updateAndGet(_ :+ e)))
                 )
                 emitted <- seen.get
                 _       <- dir.removeAll
@@ -337,7 +337,7 @@ class JsonlTest extends kyo.test.Test[Any]:
                 dir <- Path.tempDir("kyo-jsonl-read-results-skip")
                 file = dir / "oversized.jsonl"
                 _  <- file.write(in)
-                rs <- Scope.run(Jsonl.readResults[Event](file, maxLineBytes = 30).run)
+                rs <- Scope.run(Jsonl.readResults[Event](file, maxLineSize = 30.bytes).run)
                 _  <- dir.removeAll
             yield
                 assert(rs.size == 3)
@@ -425,7 +425,7 @@ class JsonlTest extends kyo.test.Test[Any]:
 
         "keeps the records framed before a limit breach, then ends" in {
             val in = "{\"name\":\"a\",\"count\":1}\n{\"name\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"count\":2}\n"
-            for rs <- byteStream(in).into(Jsonl.pipeResults[Event](maxLineBytes = 30)).run
+            for rs <- byteStream(in).into(Jsonl.pipeResults[Event](maxLineSize = 30.bytes)).run
             yield
                 assert(rs.size == 2)
                 assert(rs(0).getOrThrow == Event("a", 1))
@@ -443,7 +443,7 @@ class JsonlTest extends kyo.test.Test[Any]:
             // "one failure element per bad record, carry on" applies to a breach with a boundary too.
             // Ending at the breach instead would drop Event("c", 3) and everything behind it.
             val in = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n{\"name\":\"c\",\"count\":3}\n"
-            for rs <- byteStream(in).into(Jsonl.pipeResults[Event](maxLineBytes = 30)).run
+            for rs <- byteStream(in).into(Jsonl.pipeResults[Event](maxLineSize = 30.bytes)).run
             yield
                 assert(rs.size == 3)
                 assert(rs(0).getOrThrow == Event("a", 1))
@@ -465,7 +465,7 @@ class JsonlTest extends kyo.test.Test[Any]:
             val first = "{\"name\":\"a\",\"count\":1}\n"
             val in    = first + oversizedLine + "\n{\"nope\":true}\n"
             val badAt = (first + oversizedLine + "\n").getBytes(StandardCharsets.UTF_8).length.toLong
-            for rs <- byteStream(in).into(Jsonl.pipeResults[Event](maxLineBytes = 30)).run
+            for rs <- byteStream(in).into(Jsonl.pipeResults[Event](maxLineSize = 30.bytes)).run
             yield
                 assert(rs.size == 3)
                 assert(badAt == 85L)
@@ -795,7 +795,7 @@ class JsonlTest extends kyo.test.Test[Any]:
                     seen <- AtomicRef.init(Chunk.empty[Result[DecodeException, Event]])
                     fiber <- Fiber.initUnscoped(
                         Scope.run(
-                            Jsonl.followResults[Event](file, pollDelay = pollDelay, maxLineBytes = 30)
+                            Jsonl.followResults[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
                                 .take(3)
                                 .foreach(r => seen.updateAndGet(_ :+ r))
                         )
@@ -834,7 +834,7 @@ class JsonlTest extends kyo.test.Test[Any]:
                 seen <- AtomicRef.init(Chunk.empty[Event])
                 r <- Abort.run[DecodeException](
                     Scope.run(
-                        Jsonl.follow[Event](file, pollDelay = pollDelay, maxLineBytes = 30)
+                        Jsonl.follow[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
                             .take(2)
                             .foreach(e => seen.updateAndGet(_ :+ e))
                     )
@@ -868,7 +868,7 @@ class JsonlTest extends kyo.test.Test[Any]:
                     seen <- AtomicRef.init(Chunk.empty[Result[DecodeException, Event]])
                     fiber <- Fiber.initUnscoped(
                         Scope.run(
-                            Jsonl.followResults[Event](file, pollDelay = pollDelay, maxLineBytes = 30)
+                            Jsonl.followResults[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
                                 .take(3)
                                 .foreach(r => seen.updateAndGet(_ :+ r))
                         )
@@ -909,7 +909,7 @@ class JsonlTest extends kyo.test.Test[Any]:
                 seen <- AtomicRef.init(Chunk.empty[Event])
                 r <- Abort.run[DecodeException](
                     Scope.run(
-                        Jsonl.follow[Event](file, pollDelay = pollDelay, maxLineBytes = 30)
+                        Jsonl.follow[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
                             .take(2)
                             .foreach(e => seen.updateAndGet(_ :+ e))
                     )

--- a/kyo-schema-json/shared/src/main/scala/kyo/Json.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/Json.scala
@@ -29,7 +29,7 @@ object Json:
     /** Line-delimited JSON (JSONL, also called NDJSON) support: one JSON value per line.
       *
       * Alias for [[kyo.JsonLines]], whose body lives in its own file. Reach it as `Json.Lines.Framer`,
-      * `Json.Lines.Record`, `Json.Lines.Line`, `Json.Lines.Framed`, and `Json.Lines.DefaultMaxLineBytes`.
+      * `Json.Lines.Record`, `Json.Lines.Line`, `Json.Lines.Framed`, and `Json.Lines.DefaultMaxLineSize`.
       */
     export kyo.JsonLines as Lines
 

--- a/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
@@ -32,7 +32,7 @@ object JsonLines:
       * in `'\n'`, and two more when it ends in `"\r\n"`. A pending residual is measured the same way, so a record is accepted or rejected
       * identically whether its terminator arrived in the same chunk or a later one.
       */
-    val DefaultMaxLineBytes: Int = 16 * 1024 * 1024
+    val DefaultMaxLineSize: ByteSize = 16.mib
 
     private val LimitName: String = "JSONL record length"
 
@@ -53,7 +53,7 @@ object JsonLines:
       * input was split into chunks.
       *
       * `index` is the line's position among the non-blank lines, so blank and whitespace-only lines do not consume an index while a line
-      * skipped for exceeding `maxLineBytes` does, exactly as an undecodable record does. `byteOffset` counts every byte of the overall
+      * skipped for exceeding `maxLineSize` does, exactly as an undecodable record does. `byteOffset` counts every byte of the overall
       * input, including skipped blank lines and a leading byte order mark, so it addresses the record in the original source.
       *
       * Do not compare two records with `==`. `Span` is an opaque array with no structural equality, so the derived `equals` compares
@@ -73,7 +73,7 @@ object JsonLines:
 
     /** One line a framer resolved out of the input.
       *
-      * A line is either framed as a record or rejected for exceeding `maxLineBytes`. Both travel in one ordered sequence, so a rejected
+      * A line is either framed as a record or rejected for exceeding `maxLineSize`. Both travel in one ordered sequence, so a rejected
       * line stays exactly where it sat among the records around it, which is what lets a lenient consumer report one failure for it and
       * carry on with the next record.
       */
@@ -107,7 +107,7 @@ object JsonLines:
           */
         case Continued(framer: Framer, lines: Chunk[Line])
 
-        /** Every line resolved before the pending residual outgrew `maxLineBytes`, and that breach.
+        /** Every line resolved before the pending residual outgrew `maxLineSize`, and that breach.
           *
           * No record boundary was found for the residual, so there is nothing to skip to and framing is over. There is no framer to carry
           * on with, and `finish` is not reachable either: the bytes that would have produced a trailing record are the ones that breached.
@@ -144,12 +144,12 @@ object JsonLines:
       * @param pending
       *   the bytes seen since the last record terminator, in arrival order, none of which holds a newline
       * @param pendingSize
-      *   total size of `pending`, carried so the `maxLineBytes` check never has to join anything to measure it
+      *   total size of `pending`, carried so the `maxLineSize` check never has to join anything to measure it
       * @param nextIndex
       *   index the next emitted record will carry
       * @param residualOffset
       *   overall-input offset of the first pending byte
-      * @param maxLineBytes
+      * @param maxLineSize
       *   record size ceiling
       * @param atStart
       *   true until a byte that settles the byte order mark question is consumed
@@ -159,7 +159,7 @@ object JsonLines:
         pendingSize: Int,
         nextIndex: Long,
         residualOffset: Long,
-        maxLineBytes: Int,
+        maxLineSize: ByteSize,
         atStart: Boolean
     ):
 
@@ -169,7 +169,7 @@ object JsonLines:
           *   the next bytes of the input, of any size including empty
           * @return
           *   [[Framed.Continued]] holding every line this chunk resolved and the advanced framer, or [[Framed.Halted]] when the pending
-          *   residual outgrew `maxLineBytes` with no record boundary to skip to. A terminated line over the ceiling is not a halt: it
+          *   residual outgrew `maxLineSize` with no record boundary to skip to. A terminated line over the ceiling is not a halt: it
           *   arrives as a [[Line.Skipped]] inside [[Framed.Continued]], and framing carries on after its terminator.
           */
         def feed(chunk: Span[Byte])(using Frame): Framed =
@@ -211,7 +211,7 @@ object JsonLines:
                 // Still undecided: the bytes so far are a proper prefix of the mark, and a proper prefix
                 // holds no newline, so there is nothing to emit while waiting for the rest.
                 Framed.Continued(
-                    Framer(hold(pending, chunk), total.toInt, nextIndex, residualOffset, maxLineBytes, true),
+                    Framer(hold(pending, chunk), total.toInt, nextIndex, residualOffset, maxLineSize, true),
                     Chunk.empty
                 )
             else
@@ -261,8 +261,8 @@ object JsonLines:
             val end       = heldSize + nl
             val hasReturn = if nl > 0 then chunk(nl - 1) == Return else heldSize > 0 && lastByte(held) == Return
             val lineSize  = if hasReturn then end - 1 else end
-            if lineSize > maxLineBytes then
-                (nextIndex + 1, Chunk(Line.Skipped(LimitExceededException(LimitName, lineSize, maxLineBytes))))
+            if lineSize.bytes > maxLineSize then
+                (nextIndex + 1, Chunk(Line.Skipped(LimitExceededException(LimitName, lineSize, maxLineSize.toBytes.toInt))))
             else if isBlankPrefix(held, chunk, lineSize) then (nextIndex, Chunk.empty)
             else (nextIndex + 1, Chunk(Line.Kept(Record(join(held, heldSize, chunk, lineSize), nextIndex, offset))))
             end if
@@ -281,12 +281,19 @@ object JsonLines:
             val restLine =
                 if heldSize > 0 && lastByte(held) == Return then heldSize - 1
                 else heldSize
-            if restLine > maxLineBytes || heldSize > Int.MaxValue then
+            if restLine.bytes > maxLineSize || heldSize > Int.MaxValue then
                 // No newline anywhere in the residual, so there is no boundary to resume at and no framer
                 // worth handing back. The lines resolved before it stay.
-                Framed.Halted(lines, LimitExceededException(LimitName, math.min(restLine, Int.MaxValue.toLong).toInt, maxLineBytes))
+                Framed.Halted(
+                    lines,
+                    LimitExceededException(
+                        LimitName,
+                        math.min(restLine, Int.MaxValue.toLong).toInt,
+                        maxLineSize.toBytes.toInt
+                    )
+                )
             else
-                Framed.Continued(Framer(held, heldSize.toInt, index, offset, maxLineBytes, false), lines)
+                Framed.Continued(Framer(held, heldSize.toInt, index, offset, maxLineSize, false), lines)
             end if
         end settle
 
@@ -297,7 +304,7 @@ object JsonLines:
           * chunk with allocation proportional to the output.
           *
           * `offset` is the overall-input offset of `buf(start)`, and the returned `Int` is the index where the unterminated residual
-          * begins. A line over `maxLineBytes` is recorded as a [[Line.Skipped]] and the walk continues past its terminator, since that
+          * begins. A line over `maxLineSize` is recorded as a [[Line.Skipped]] and the walk continues past its terminator, since that
           * terminator is a record boundary like any other. It consumes a record index, because it is a non-blank line that a lenient
           * consumer sees one failure for, so an index keeps naming a line's position whether or not the line was kept.
           */
@@ -315,13 +322,13 @@ object JsonLines:
                     val lineEnd    = if nl > start && buf(nl - 1) == Return then nl - 1 else nl
                     val lineSize   = lineEnd - start
                     val restOffset = offset + (nl + 1 - start)
-                    if lineSize > maxLineBytes then
+                    if lineSize.bytes > maxLineSize then
                         emitFrom(
                             buf,
                             nl + 1,
                             restOffset,
                             index + 1,
-                            acc :+ Line.Skipped(LimitExceededException(LimitName, lineSize, maxLineBytes))
+                            acc :+ Line.Skipped(LimitExceededException(LimitName, lineSize, maxLineSize.toBytes.toInt))
                         )
                     else if isBlank(buf, start, lineEnd) then emitFrom(buf, nl + 1, restOffset, index, acc)
                     else
@@ -340,13 +347,17 @@ object JsonLines:
     object Framer:
         /** Creates a framer positioned at the start of an input.
           *
-          * @param maxLineBytes
+          * @param maxLineSize
           *   the largest record the framer will emit, in bytes
           * @return
           *   a framer holding no pending bytes, at record index zero and byte offset zero
           */
-        def init(maxLineBytes: Int = DefaultMaxLineBytes): Framer =
-            Framer(Chunk.empty, 0, 0L, 0L, maxLineBytes, true)
+        def init(maxLineSize: ByteSize = DefaultMaxLineSize): Framer =
+            val bytes = maxLineSize.toBytes
+            if bytes > Int.MaxValue then
+                throw new IllegalArgumentException(s"maxLineSize must not exceed ${Int.MaxValue} bytes, got $bytes")
+            Framer(Chunk.empty, 0, 0L, 0L, maxLineSize, true)
+        end init
     end Framer
 
     /** Appends `piece` to the pending pieces, dropping it when it carries nothing.
@@ -487,8 +498,8 @@ object JsonLines:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `DefaultMaxLineSize`)
       * @return
       *   every decoded value in order, or the first decode or framing failure encountered
       */
@@ -496,13 +507,13 @@ object JsonLines:
         input: String,
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = DefaultMaxLineBytes
+        maxLineSize: ByteSize = DefaultMaxLineSize
     )(using Json, Schema[A], Frame): Result[DecodeException, Chunk[A]] =
         decodeAllBytes[A](
             Span.from(input.getBytes(StandardCharsets.UTF_8)),
             maxDepth,
             maxCollectionSize,
-            maxLineBytes
+            maxLineSize
         )
     end decodeAll
 
@@ -514,8 +525,8 @@ object JsonLines:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `DefaultMaxLineSize`)
       * @return
       *   every decoded value in order, or the first decode or framing failure encountered
       */
@@ -523,9 +534,9 @@ object JsonLines:
         input: Span[Byte],
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = DefaultMaxLineBytes
+        maxLineSize: ByteSize = DefaultMaxLineSize
     )(using Json, Schema[A], Frame): Result[DecodeException, Chunk[A]] =
-        foldResults(decodeAllBytesResults[A](input, maxDepth, maxCollectionSize, maxLineBytes))
+        foldResults(decodeAllBytesResults[A](input, maxDepth, maxCollectionSize, maxLineSize))
     end decodeAllBytes
 
     /** Decodes every record, returning one `Result` per record instead of failing the whole input.
@@ -533,7 +544,7 @@ object JsonLines:
       * The variant for heterogeneous or partially-written logs: a truncated tail or an unrecognized record type yields one failure rather
       * than discarding the whole file.
       *
-      * A record exceeding `maxLineBytes` is one failure element too, as long as its terminator arrived: the boundary is known, so framing
+      * A record exceeding `maxLineSize` is one failure element too, as long as its terminator arrived: the boundary is known, so framing
       * skips the record and the records after it decode normally. Only an oversized trailing residual, which has no boundary to skip to,
       * cannot be recovered from; it surfaces as a final failure element and ends the chunk. Either way every record decoded before the
       * breach is kept: a limit breach on record 5 of a 4-record-so-far log yields 4 successes followed by that one failure, not an empty
@@ -545,19 +556,19 @@ object JsonLines:
       *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
       * @param maxCollectionSize
       *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
-      * @param maxLineBytes
-      *   the largest record the framer will accept, in bytes (default `DefaultMaxLineBytes`)
+      * @param maxLineSize
+      *   the largest record the framer will accept (default `DefaultMaxLineSize`)
       * @return
-      *   one result per record, including one failure per record skipped for exceeding `maxLineBytes`; an oversized trailing residual,
+      *   one result per record, including one failure per record skipped for exceeding `maxLineSize`; an oversized trailing residual,
       *   which finds no record boundary, is appended as a final failure element after every record decoded before it
       */
     def decodeAllBytesResults[A](
         input: Span[Byte],
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
-        maxLineBytes: Int = DefaultMaxLineBytes
+        maxLineSize: ByteSize = DefaultMaxLineSize
     )(using Json, Schema[A], Frame): Chunk[Result[DecodeException, A]] =
-        Framer.init(maxLineBytes).feed(input) match
+        Framer.init(maxLineSize).feed(input) match
             case Framed.Continued(framer, lines) =>
                 val decoded = decodeLines[A](lines, maxDepth, maxCollectionSize)
                 framer.finish match

--- a/kyo-schema-json/shared/src/test/scala/kyo/JsonLinesTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/kyo/JsonLinesTest.scala
@@ -19,7 +19,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
 
     /** Feed `input` through a fresh framer in fixed-size chunks, returning every record.
       *
-      * Every chunk is expected to frame cleanly (`DefaultMaxLineBytes` is never exercised here), so a skipped line or a halt would
+      * Every chunk is expected to frame cleanly (`DefaultMaxLineSize` is never exercised here), so a skipped line or a halt would
       * indicate a bug unrelated to what these tests are pinning. `require`, not `assert`, surfaces that: this helper is also called from a
       * group builder (outside any `in { ... }` leaf), where `kyo.test`'s `assert` has no `AssertScope` to report through.
       */
@@ -28,7 +28,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
 
     /** The `Span[Byte]` form of [[frameAll]], for inputs that are not valid UTF-8 text. */
     private def frameAllBytes(all: Span[Byte], chunkSize: Int): Chunk[Json.Lines.Record] =
-        var f   = Json.Lines.Framer.init(Json.Lines.DefaultMaxLineBytes)
+        var f   = Json.Lines.Framer.init(Json.Lines.DefaultMaxLineSize)
         var out = Chunk.empty[Json.Lines.Record]
         var i   = 0
         while i < all.size do
@@ -71,7 +71,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
                 next
             case Json.Lines.Framed.Halted(_, breach) => throw new AssertionError(s"unexpected framing halt $breach")
 
-    /** Feeds `input` through a fresh framer of ceiling `maxLineBytes` in `chunkSize` pieces.
+    /** Feeds `input` through a fresh framer of ceiling `maxLineSize` in `chunkSize` pieces.
       *
       * Returns every line resolved along the way and the breach that ended framing, if one did. Unlike [[frameAll]] this keeps skipped
       * lines and survives a halt, which is what the limit tests are pinning.
@@ -79,10 +79,10 @@ class JsonLinesTest extends kyo.test.Test[Any]:
     private def frameLines(
         input: String,
         chunkSize: Int,
-        maxLineBytes: Int
+        maxLineSize: ByteSize
     ): (Chunk[Json.Lines.Line], Maybe[LimitExceededException]) =
         val all  = bytes(input)
-        var f    = Json.Lines.Framer.init(maxLineBytes)
+        var f    = Json.Lines.Framer.init(maxLineSize)
         var live = true
         var out  = Chunk.empty[Json.Lines.Line]
         var halt = Maybe.empty[LimitExceededException]
@@ -230,7 +230,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         }
 
         "strips a carriage return ending one chunk when its newline opens the next" in {
-            val framer = holding(holding(Json.Lines.Framer.init(Json.Lines.DefaultMaxLineBytes), "{\"a\":1}"), "\r")
+            val framer = holding(holding(Json.Lines.Framer.init(Json.Lines.DefaultMaxLineSize), "{\"a\":1}"), "\r")
             val lines  = kept(linesOf(framer, "\n{\"b\":2}\n"))
             assert(lines.map(_.text) == Chunk("{\"a\":1}", "{\"b\":2}"))
             assert(lines.map(_.index) == Chunk(0L, 1L))
@@ -238,7 +238,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         }
 
         "recognizes a blank line split across chunks as blank" in {
-            val framer = holding(holding(Json.Lines.Framer.init(Json.Lines.DefaultMaxLineBytes), "  "), " \t")
+            val framer = holding(holding(Json.Lines.Framer.init(Json.Lines.DefaultMaxLineSize), "  "), " \t")
             val lines  = kept(linesOf(framer, " \n{\"a\":1}\n"))
             assert(lines.map(_.text) == Chunk("{\"a\":1}"))
             assert(lines.map(_.index) == Chunk(0L))
@@ -248,7 +248,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         // The counterpart of the test above: the blankness walk has to read every pending piece, not just the last one, so a non-blank
         // byte sitting in an earlier piece still makes the line a record.
         "keeps a split line whose only non-blank byte arrived in an earlier chunk" in {
-            val framer = holding(holding(Json.Lines.Framer.init(Json.Lines.DefaultMaxLineBytes), "  x"), "  ")
+            val framer = holding(holding(Json.Lines.Framer.init(Json.Lines.DefaultMaxLineSize), "  x"), "  ")
             val lines  = kept(linesOf(framer, " \n"))
             assert(lines.map(_.text) == Chunk("  x   "))
             assert(lines.map(_.index) == Chunk(0L))
@@ -278,7 +278,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         // assertion that rejects backing those pieces with a growable buffer a later feed writes into: the two continuations below would
         // then see each other's bytes.
         "leaves the receiver usable after a feed, so two continuations of one framer stay independent" in {
-            val framer = holding(Json.Lines.Framer.init(Json.Lines.DefaultMaxLineBytes), "{\"a\":1")
+            val framer = holding(Json.Lines.Framer.init(Json.Lines.DefaultMaxLineSize), "{\"a\":1")
             val first  = kept(linesOf(framer, "}\n"))
             val second = kept(linesOf(framer, "23}\n"))
             assert(first.map(_.text) == Chunk("{\"a\":1}"))
@@ -289,13 +289,13 @@ class JsonLinesTest extends kyo.test.Test[Any]:
 
         // The regression guard for the cost defect this representation exists to remove: joining the bytes held on every feed makes a
         // record spanning k chunks copy O(k^2) bytes, so a newline-free run large against the read buffer burns memory bandwidth for as
-        // long as maxLineBytes allows. Timing that would be flaky, so this pins the allocation-independent shape instead: a newline-free
+        // long as maxLineSize allows. Timing that would be flaky, so this pins the allocation-independent shape instead: a newline-free
         // feed adds one piece and joins nothing, the running total tracks what is held without joining to measure it, and the join
         // happens once, when the record completes. An implementation that concatenates eagerly leaves `pending` holding one piece.
         "holds one pending piece per newline-free feed and joins only when a record completes" in {
             val piece  = "0123456789"
             val feeds  = 64
-            var framer = Json.Lines.Framer.init(Json.Lines.DefaultMaxLineBytes)
+            var framer = Json.Lines.Framer.init(Json.Lines.DefaultMaxLineSize)
             var n      = 0
             while n < feeds do
                 framer = holding(framer, piece)
@@ -315,8 +315,30 @@ class JsonLinesTest extends kyo.test.Test[Any]:
 
     "limits" - {
 
-        "rejects a complete record longer than maxLineBytes" in {
-            val lines = linesOf(Json.Lines.Framer.init(8), "{\"aaaaaaaaaaaa\":1}\n")
+        "uses a 16 MiB default record ceiling" in {
+            assert(Json.Lines.DefaultMaxLineSize == 16.mib)
+        }
+
+        "rejects a ceiling larger than a Span can address" in {
+            val ex = intercept[IllegalArgumentException](
+                Json.Lines.Framer.init((Int.MaxValue.toLong + 1L).bytes)
+            )
+            assert(ex.getMessage == "maxLineSize must not exceed 2147483647 bytes, got 2147483648")
+        }
+
+        "allows a zero-byte ceiling and rejects the first non-empty record" in {
+            val lines = linesOf(Json.Lines.Framer.init(ByteSize.Zero), "\n1\n")
+            assert(lines.size == 1)
+            lines(0) match
+                case Json.Lines.Line.Skipped(e) =>
+                    assert(e.actual == 1)
+                    assert(e.maximum == 0)
+                case other => fail(s"Expected a skipped line, got $other")
+            end match
+        }
+
+        "rejects a complete record longer than maxLineSize" in {
+            val lines = linesOf(Json.Lines.Framer.init(8.bytes), "{\"aaaaaaaaaaaa\":1}\n")
             assert(lines.size == 1)
             lines(0) match
                 case Json.Lines.Line.Skipped(e) => assert(e.maximum == 8)
@@ -324,8 +346,8 @@ class JsonLinesTest extends kyo.test.Test[Any]:
             end match
         }
 
-        "rejects a residual longer than maxLineBytes with no newline in sight" in {
-            Json.Lines.Framer.init(8).feed(bytes("aaaaaaaaaaaaaaaaaaaa")) match
+        "rejects a residual longer than maxLineSize with no newline in sight" in {
+            Json.Lines.Framer.init(8.bytes).feed(bytes("aaaaaaaaaaaaaaaaaaaa")) match
                 case Json.Lines.Framed.Halted(lines, breach) =>
                     assert(lines.isEmpty)
                     assert(breach.actual == 20)
@@ -333,18 +355,18 @@ class JsonLinesTest extends kyo.test.Test[Any]:
                 case other => fail(s"Expected a halt, got $other")
         }
 
-        "accepts a record exactly at maxLineBytes" in {
-            assert(kept(linesOf(Json.Lines.Framer.init(8), "12345678\n")).map(_.text) == Chunk("12345678"))
+        "accepts a record exactly at maxLineSize" in {
+            assert(kept(linesOf(Json.Lines.Framer.init(8.bytes), "12345678\n")).map(_.text) == Chunk("12345678"))
         }
 
         // The limit counts the record, not the line terminator, so a CRLF line carries two more
         // bytes on the wire than the limit allows for its record.
-        "accepts a CRLF record whose content is exactly maxLineBytes" in {
-            assert(kept(linesOf(Json.Lines.Framer.init(8), "12345678\r\n")).map(_.text) == Chunk("12345678"))
+        "accepts a CRLF record whose content is exactly maxLineSize" in {
+            assert(kept(linesOf(Json.Lines.Framer.init(8.bytes), "12345678\r\n")).map(_.text) == Chunk("12345678"))
         }
 
-        "rejects a CRLF record whose content exceeds maxLineBytes" in {
-            val lines = linesOf(Json.Lines.Framer.init(8), "123456789\r\n")
+        "rejects a CRLF record whose content exceeds maxLineSize" in {
+            val lines = linesOf(Json.Lines.Framer.init(8.bytes), "123456789\r\n")
             assert(lines.size == 1)
             lines(0) match
                 case Json.Lines.Line.Skipped(e) =>
@@ -357,7 +379,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         // The residual path and the completed-record path must agree: whether the '\n' arrives in
         // this chunk or the next one cannot change whether the record is accepted.
         "measures a pending CRLF residual the same way as a completed record" in {
-            Json.Lines.Framer.init(8).feed(bytes("12345678\r")) match
+            Json.Lines.Framer.init(8.bytes).feed(bytes("12345678\r")) match
                 case Json.Lines.Framed.Continued(held, lines) =>
                     assert(lines.isEmpty)
                     assert(kept(linesOf(held, "\n")).map(_.text) == Chunk("12345678"))
@@ -366,17 +388,17 @@ class JsonLinesTest extends kyo.test.Test[Any]:
 
         // The ceiling is enforced against the pending bytes as they accumulate, so where it fires cannot depend on how the record was
         // split. A record whose content is exactly the ceiling still frames when it arrives one byte per feed.
-        "accepts a record exactly at maxLineBytes when it arrives one byte at a time" in {
-            val (lines, halt) = frameLines("12345678\n", 1, 8)
+        "accepts a record exactly at maxLineSize when it arrives one byte at a time" in {
+            val (lines, halt) = frameLines("12345678\n", 1, 8.bytes)
             assert(halt.isEmpty)
             assert(kept(lines).map(_.text) == Chunk("12345678"))
         }
 
         // One byte over, the pending bytes breach before the terminator arrives, so this is a halt rather than a skip: the framer cannot
         // know a boundary is coming. Feeding the same line whole instead yields a Line.Skipped, which "rejects a complete record longer
-        // than maxLineBytes" pins.
-        "halts on a record one byte over maxLineBytes when it arrives one byte at a time" in {
-            val (lines, halt) = frameLines("123456789\n87654321\n", 1, 8)
+        // than maxLineSize" pins.
+        "halts on a record one byte over maxLineSize when it arrives one byte at a time" in {
+            val (lines, halt) = frameLines("123456789\n87654321\n", 1, 8.bytes)
             assert(lines.isEmpty)
             halt match
                 case Present(e) =>
@@ -387,7 +409,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         }
 
         "measures a pending CRLF residual by the same rule when it arrives one byte at a time" in {
-            val (lines, halt) = frameLines("12345678\r\n", 1, 8)
+            val (lines, halt) = frameLines("12345678\r\n", 1, 8.bytes)
             assert(halt.isEmpty)
             assert(kept(lines).map(_.text) == Chunk("12345678"))
         }
@@ -396,7 +418,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         // What this pins is the records AFTER the skip: halting there instead drops every record in
         // the rest of the input, which on a live log means one bad line ends the follower forever.
         "resumes framing after a terminated oversized record" in {
-            val lines = linesOf(Json.Lines.Framer.init(8), "12345678\n123456789\n87654321\n")
+            val lines = linesOf(Json.Lines.Framer.init(8.bytes), "12345678\n123456789\n87654321\n")
             assert(kept(lines).map(_.text) == Chunk("12345678", "87654321"))
             assert(lines.size == 3)
             lines(1) match
@@ -411,7 +433,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         // as an undecodable record does, and its bytes and terminator advance the offset. Lines are
         // 9 and 10 bytes, so the record after the skip sits at index 2 and byte 19.
         "counts a skipped oversized record in the index and byte offset of the records after it" in {
-            val records = kept(linesOf(Json.Lines.Framer.init(8), "12345678\n123456789\n87654321\n"))
+            val records = kept(linesOf(Json.Lines.Framer.init(8.bytes), "12345678\n123456789\n87654321\n"))
             assert(records.map(_.index) == Chunk(0L, 2L))
             assert(records.map(_.byteOffset) == Chunk(0L, 19L))
         }
@@ -420,7 +442,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         // in the same `feed` call. `emitFrom` used to fail the whole scan and drop its accumulator;
         // it must instead stop and return what it already collected.
         "preserves records framed before a mid-buffer breach in the same chunk" in {
-            val lines = linesOf(Json.Lines.Framer.init(8), "12345678\n123456789\n")
+            val lines = linesOf(Json.Lines.Framer.init(8.bytes), "12345678\n123456789\n")
             assert(kept(lines).map(_.text) == Chunk("12345678"))
             assert(lines.size == 2)
             lines(1) match
@@ -435,7 +457,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         // the lines after it are framed, and only the unterminated tail halts. Reporting the halt must
         // not cost the skip that preceded it, nor the record framed between them.
         "reports a skipped record and then halts on an oversized residual in the same chunk" in {
-            Json.Lines.Framer.init(8).feed(bytes("123456789\n12345678\naaaaaaaaaaaa")) match
+            Json.Lines.Framer.init(8.bytes).feed(bytes("123456789\n12345678\naaaaaaaaaaaa")) match
                 case Json.Lines.Framed.Halted(lines, breach) =>
                     assert(kept(lines).map(_.text) == Chunk("12345678"))
                     assert(lines.size == 2)
@@ -522,7 +544,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         // and folding those results must stop at it rather than inheriting the recovery.
         "fails on a terminated oversized record rather than skipping it" in {
             val in = "{\"name\":\"a\",\"count\":1}\n" + ("x" * 40) + "\n{\"name\":\"c\",\"count\":3}\n"
-            Json.Lines.decodeAll[Event](in, maxLineBytes = 30) match
+            Json.Lines.decodeAll[Event](in, maxLineSize = 30.bytes) match
                 case Result.Failure(e: LimitExceededException) =>
                     assert(e.actual == 40)
                     assert(e.maximum == 30)
@@ -563,7 +585,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
             val in = "aaaaaaaaaaaaaaaaaaaaaaaa"
             val rs = Json.Lines.decodeAllBytesResults[Event](
                 Span.from(in.getBytes(StandardCharsets.UTF_8)),
-                maxLineBytes = 8
+                maxLineSize = 8.bytes
             )
             assert(rs.size == 1)
             rs(0) match
@@ -580,7 +602,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
             val in = "{\"name\":\"a\",\"count\":1}\n" + ("x" * 40) + "\n{\"name\":\"c\",\"count\":3}\n"
             val rs = Json.Lines.decodeAllBytesResults[Event](
                 Span.from(in.getBytes(StandardCharsets.UTF_8)),
-                maxLineBytes = 30
+                maxLineSize = 30.bytes
             )
             assert(rs.size == 3)
             assert(rs(0).getOrThrow == Event("a", 1))
@@ -594,7 +616,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
         }
 
         // Regression test for a defect where decodeAllBytesResults, via Framer.feed, discarded every
-        // already-decoded record when a later record in the same input breached maxLineBytes. The
+        // already-decoded record when a later record in the same input breached maxLineSize. The
         // valid record must survive and precede the failure, not disappear with it.
         "keeps a valid record decoded before a later record breaches the limit" in {
             val validLine = "{\"name\":\"a\",\"count\":1}\n"
@@ -602,7 +624,7 @@ class JsonLinesTest extends kyo.test.Test[Any]:
             val in        = validLine + oversized
             val rs = Json.Lines.decodeAllBytesResults[Event](
                 Span.from(in.getBytes(StandardCharsets.UTF_8)),
-                maxLineBytes = 30
+                maxLineSize = 30.bytes
             )
             assert(rs.size == 2)
             assert(rs(0).getOrThrow == Event("a", 1))

--- a/kyo-schema/README.md
+++ b/kyo-schema/README.md
@@ -434,7 +434,7 @@ framed match
         // inside `next`, which frames the following chunk; `next.finish` closes it at end of input.
         lines.size
     case Json.Lines.Framed.Halted(lines, breach) =>
-        // Only when the pending bytes outgrew maxLineBytes with no newline among them. There is no
+        // Only when the pending bytes outgrew maxLineSize with no newline among them. There is no
         // record boundary to resume at, so framing is over and no framer comes back.
         lines.size
 end match
@@ -442,7 +442,7 @@ end match
 
 Feeding a framer never mutates it: `feed` returns the advanced framer inside `Framed.Continued` and the receiver stays usable. Each `Record` carries `bytes` (its own UTF-8 encoding, terminator removed), `index`, and `byteOffset`, and `text` decodes those bytes. Do not compare two records with `==`: `Span` has no structural equality, so the derived `equals` compares `bytes` by reference; compare `text` or `bytes.is(other.bytes)` instead.
 
-`maxLineBytes` (default `Json.Lines.DefaultMaxLineBytes`, 16 MiB) bounds a single record. Without it a byte stream that never contains a newline would grow the framer's residual without bound, and neither `maxDepth` nor `maxCollectionSize` covers that, since both operate inside one document. What a breach costs depends on whether the offending line was terminated. A terminated one has a known boundary, so it arrives as a `Line.Skipped` among the lines, framing resumes after its newline, and `decodeAllBytesResults` reports one `LimitExceededException` failure in its place and decodes the records after it. An oversized residual has no boundary to skip to, so `feed` returns `Framed.Halted` and `decodeAllBytesResults` appends that breach as its last element.
+`maxLineSize` (default `Json.Lines.DefaultMaxLineSize`, `16.mib`) is a `ByteSize` ceiling for a single record. Without it a byte stream that never contains a newline would grow the framer's residual without bound, and neither `maxDepth` nor `maxCollectionSize` covers that, since both operate inside one document. What a breach costs depends on whether the offending line was terminated. A terminated one has a known boundary, so it arrives as a `Line.Skipped` among the lines, framing resumes after its newline, and `decodeAllBytesResults` reports one `LimitExceededException` failure in its place and decodes the records after it. An oversized residual has no boundary to skip to, so `feed` returns `Framed.Halted` and `decodeAllBytesResults` appends that breach as its last element. Record indices and byte offsets remain numeric positions.
 
 All of the above is pure and takes whole inputs. Reading a JSONL file, decoding an arbitrary byte stream, and following a file that is still being written live in [kyo-json](../kyo-json), whose `Jsonl` entry point drives this same framer under `Sync` and `Async`.
 


### PR DESCRIPTION
## Summary

- replace the JSONL record ceiling APIs introduced by #1852 with `ByteSize`
- use `ByteSize` for the new tail and input-stream buffer capacities, with eager range validation before narrowing to `Int`
- keep byte offsets, cursor positions, indices, array lengths, and read counts numeric
- update JSONL tests, examples, Scaladoc, module documentation, and the changelog for the final API shape
- document the Windows toolchains exercised by the cross-platform build

## Stacking

This PR is stacked directly on #1852 at `88c23d88589ff5d95ac93063e6cff4da5a6c67ac`.

The migration is intentionally source-breaking relative to #1852. It adds no raw-`Int` compatibility overloads because it completes that API before the base PR reaches `main`.

## Windows build fixes

The Windows verification exposed two build-path defects and one CLI integration defect:

- MSVC object output did not specify `/Fo`, so `kyo_aeron.obj` leaked into the repository root. The FFI compiler now writes objects directly into the target directory.
- Claude Code inline MCP JSON lost quoting through Windows executable shims. The integration now passes a scope-managed JSON file and classifies structured authentication failures.
- Live Claude tests now preflight `claude auth status`, cancelling cleanly when the installed CLI is logged out.

## Validation

- focused JVM suites for `Path`, stream extensions, JSON lines, and JSONL
- full affected JS suites
- schema JSON and JSONL Native suites
- changed-module doctests
- Kyo FFI plugin suite, 107 tests passed
- Claude Code completion, wire, and backend-selection suites, 36 tests passed
- logged-out Claude live integration preflight, 9 test arms cancelled before model execution
- manual CI diff matrix for Linux x64 and ARM64 across JVM, JS, Native, and Wasm: [latest run](https://github.com/getkyo/kyo/actions/workflows/ci.yml)

The manual dispatch is required while this PR targets #1852's feature branch because the automatic pull-request workflows are filtered to PRs whose base is `main`.
