### PR TITLE
[kyo-system] fix the process lifecycle: deadlines, waits, stdin feeds, and child output

### DIFF
--- a/kyo-system/js-wasm/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-system/js-wasm/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -189,9 +189,14 @@ final private[kyo] class NodeProcessUnsafe(
         val p        = Promise.Unsafe.init[Process.ExitCode, Any]()
         var resolved = false
         val ec       = child.exitCode
-        if ec != null && !js.isUndefined(ec) then
+        val sc       = child.signalCode
+        // Both are consulted, because Node leaves exitCode null for a signalled death and records
+        // the signal in signalCode instead. Checking exitCode alone missed a process that had
+        // already been killed: the 'exit' event had fired before the listener below was attached,
+        // so nothing ever completed the promise and the wait hung.
+        if (ec != null && !js.isUndefined(ec)) || (sc != null && !js.isUndefined(sc)) then
             resolved = true
-            p.completeDiscard(Result.succeed(Process.ExitCode(ec.asInstanceOf[Int])))
+            p.completeDiscard(Result.succeed(exitCodeFrom(ec, sc)))
         end if
         if !resolved then
             discard(child.on(

--- a/kyo-system/js-wasm/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-system/js-wasm/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -39,6 +39,13 @@ private[kyo] trait NodeChildProcessInstance extends js.Object:
     def stderr: NodeReadableStream                                                        = js.native
     def kill(signal: String): Boolean                                                     = js.native
     def on(event: String, listener: js.Function1[js.Any, Unit]): NodeChildProcessInstance = js.native
+    // Node's 'exit' event is (code, signal). The arity-1 overload above discards the second
+    // argument, and with it the only indication that a child was terminated by a signal: Node sets
+    // code to null in exactly that case.
+    def on(event: String, listener: js.Function2[js.Any, js.Any, Unit]): NodeChildProcessInstance = js.native
+    // Set when the child was terminated by a signal, and the companion to exitCode: a child that
+    // has been sent a signal but has not yet died has both still null.
+    def signalCode: js.Any = js.native
 end NodeChildProcessInstance
 
 @js.native
@@ -189,13 +196,12 @@ final private[kyo] class NodeProcessUnsafe(
         if !resolved then
             discard(child.on(
                 "exit",
-                { (codeOrNull: js.Any) =>
+                { (codeOrNull: js.Any, signalOrNull: js.Any) =>
                     if !resolved then
                         resolved = true
-                        val code = if codeOrNull == null then 1 else codeOrNull.asInstanceOf[Int]
-                        p.completeDiscard(Result.succeed(Process.ExitCode(code)))
+                        p.completeDiscard(Result.succeed(exitCodeFrom(codeOrNull, signalOrNull)))
                     end if
-                }
+                }: js.Function2[js.Any, js.Any, Unit]
             ))
             // Handle spawn errors (e.g. ENOENT) which fire asynchronously on Node.js.
             // Treat them as a process exit with code 1 so callers don't wait forever.
@@ -221,37 +227,77 @@ final private[kyo] class NodeProcessUnsafe(
             p.completeDiscard(Result.succeed(Present(Process.ExitCode(ec.asInstanceOf[Int]))))
         end if
         if !resolved then
+            // Held so every resolution path can clear it. An uncleared timer keeps the Node event
+            // loop alive for the whole timeout after the child has already exited.
+            var timer: js.Any = null
+            def clearTimer(): Unit =
+                if timer != null then
+                    discard(js.Dynamic.global.clearTimeout(timer.asInstanceOf[js.Dynamic]))
+                    timer = null
             discard(child.on(
                 "exit",
-                { (codeOrNull: js.Any) =>
+                { (codeOrNull: js.Any, signalOrNull: js.Any) =>
                     if !resolved then
                         resolved = true
-                        val code = if codeOrNull == null then 1 else codeOrNull.asInstanceOf[Int]
-                        p.completeDiscard(Result.succeed(Present(Process.ExitCode(code))))
+                        clearTimer()
+                        p.completeDiscard(Result.succeed(Present(exitCodeFrom(codeOrNull, signalOrNull))))
                     end if
-                }
+                }: js.Function2[js.Any, js.Any, Unit]
             ))
             discard(child.on(
                 "error",
                 { (_: js.Any) =>
                     if !resolved then
                         resolved = true
-                        p.completeDiscard(Result.succeed(Absent))
+                        clearTimer()
+                        // Present, matching the untimed overload. Absent is the timeout signal, and
+                        // reporting a spawn failure with it tells the caller the process is still
+                        // running when it never started.
+                        p.completeDiscard(Result.succeed(Present(Process.ExitCode(1))))
                     end if
                 }
             ))
-            discard(js.Dynamic.global.setTimeout(
-                { () =>
-                    if !resolved then
-                        resolved = true
-                        p.completeDiscard(Result.succeed(Absent))
-                    end if
-                }: js.Function0[Unit],
-                timeout.toMillis.toDouble
-            ))
+            // An infinite timeout means "no timer". Node clamps any delay above the signed 32-bit
+            // range down to 1ms, so arming one would turn an unbounded wait into an immediate
+            // expiry, which is the exact inverse of what was asked for.
+            if timeout.isFinite then
+                val millis = math.min(timeout.toMillis, Int.MaxValue.toLong).toDouble
+                timer = js.Dynamic.global.setTimeout(
+                    { () =>
+                        if !resolved then
+                            resolved = true
+                            timer = null
+                            p.completeDiscard(Result.succeed(Absent))
+                        end if
+                    }: js.Function0[Unit],
+                    millis
+                )
+            end if
         end if
         p
     end waitFor
+
+    // Node reports a signal death as code == null with signal set to its name, so a null code alone
+    // is not "exited with 1". Mapped onto the POSIX 128 + signal convention that Process.ExitCode
+    // already uses, which is what makes ExitCode.Signaled reachable on this platform at all.
+    private def exitCodeFrom(codeOrNull: js.Any, signalOrNull: js.Any): Process.ExitCode =
+        val signalNumber =
+            if signalOrNull == null || js.isUndefined(signalOrNull) then Absent
+            else
+                signalOrNull.asInstanceOf[String] match
+                    case "SIGHUP"  => Present(1)
+                    case "SIGINT"  => Present(2)
+                    case "SIGQUIT" => Present(3)
+                    case "SIGKILL" => Present(9)
+                    case "SIGSEGV" => Present(11)
+                    case "SIGPIPE" => Present(13)
+                    case "SIGTERM" => Present(15)
+                    case _         => Absent
+        signalNumber.fold {
+            if codeOrNull == null || js.isUndefined(codeOrNull) then Process.ExitCode(1)
+            else Process.ExitCode(codeOrNull.asInstanceOf[Int])
+        }(n => Process.ExitCode(128 + n))
+    end exitCodeFrom
 
     def exitCode()(using AllowUnsafe): Maybe[Process.ExitCode] =
         val ec = child.exitCode
@@ -262,8 +308,12 @@ final private[kyo] class NodeProcessUnsafe(
     def destroy()(using AllowUnsafe): Unit         = discard(child.kill("SIGTERM"))
     def destroyForcibly()(using AllowUnsafe): Unit = discard(child.kill("SIGKILL"))
 
+    // child.killed reports that a signal was *delivered*, not that the child died. Consulting it
+    // makes a process that has been sent SIGTERM but has not yet exited look dead, so Command's
+    // scope release skips the force-kill and leaves it running.
     def isAlive()(using AllowUnsafe): Boolean =
-        !child.killed && (child.exitCode == null || js.isUndefined(child.exitCode))
+        (child.exitCode == null || js.isUndefined(child.exitCode)) &&
+            (child.signalCode == null || js.isUndefined(child.signalCode))
 
     def pid()(using AllowUnsafe): Long = child.pid.toLong
 

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -13,6 +13,23 @@ import scala.jdk.CollectionConverters.*
 
 final private[kyo] class JvmProcessUnsafe(private[internal] val jp: JProcess) extends Process.Unsafe:
 
+    // Threads feeding this process's stdin. Retained so the feed can be stopped with the process
+    // rather than running on after it, which is what an unheld thread does.
+    private val inputFeeds = new java.util.concurrent.ConcurrentLinkedQueue[Thread]()
+
+    private[internal] def registerInputFeed(t: Thread): Unit = discard(inputFeeds.add(t))
+
+    /** Stops every stdin feed. Idempotent, and safe to call after the process has already exited:
+      * a feed can still be parked reading its source even when the child is gone.
+      */
+    override def stopInputFeeds()(using AllowUnsafe): Unit =
+        var t = inputFeeds.poll()
+        while t != null do
+            if t.isAlive() then t.interrupt()
+            t = inputFeeds.poll()
+        end while
+    end stopInputFeeds
+
     def waitFor()(using AllowUnsafe, Frame): Fiber.Unsafe[ExitCode, Any] =
         val p = Promise.Unsafe.init[ExitCode, Any]()
         discard(jp.onExit().whenComplete { (exitedProcess, error) =>
@@ -259,32 +276,41 @@ final private[kyo] class JvmCommandUnsafe(
         end match
     end toJProcessBuilder
 
-    /** Feeds an InputStream into a process's stdin on a daemon thread, closing when done. */
-    private def feedInputStream(is: InputStream, processStdin: OutputStream): Unit =
+    /** Feeds an InputStream into a process's stdin on a daemon thread, closing when done.
+      *
+      * Returns the thread so the caller can retain it and stop the feed. A feed that nothing holds
+      * cannot be cancelled: interrupting the fiber that spawned the process would leave it reading
+      * its source and writing to the child for as long as the source produced bytes.
+      */
+    private def feedInputStream(is: InputStream, processStdin: OutputStream): Thread =
         val t = new Thread(() =>
             try
                 val buf = new Array[Byte](8192)
                 var n   = is.read(buf)
-                while n >= 0 do
+                while n >= 0 && !Thread.currentThread().isInterrupted() do
                     processStdin.write(buf, 0, n)
                     n = is.read(buf)
                 processStdin.close()
             catch
-                case _: IOException => ()
+                // An interrupt closes the streams underneath the read, so the resulting IOException
+                // is the ordinary way this thread stops and is not an error to report.
+                case _: IOException          => ()
+                case _: InterruptedException => ()
             finally
                 try is.close()
                 catch case _: IOException => ()
         )
         t.setDaemon(true)
         t.start()
+        t
     end feedInputStream
 
     /** Drains a Stream[Byte, Sync] into a process's stdin on a daemon thread, closing when done.
       *
       * The stream is evaluated eagerly (it is Sync-only), then the bytes are written in a background thread so that the caller (spawn) is
-      * not blocked by the write.
+      * not blocked by the write. Returns the thread for the same reason as [[feedInputStream]].
       */
-    private def feedStream(stream: Stream[Byte, Sync], processStdin: OutputStream)(using AllowUnsafe, Frame): Unit =
+    private def feedStream(stream: Stream[Byte, Sync], processStdin: OutputStream)(using AllowUnsafe, Frame): Thread =
         val chunk = Abort.run[Nothing](Sync.Unsafe.run(stream.run)).eval.getOrThrow
         val bytes = chunk.toArray
         val t = new Thread(() =>
@@ -292,10 +318,12 @@ final private[kyo] class JvmCommandUnsafe(
                 processStdin.write(bytes)
                 processStdin.close()
             catch
-                case _: IOException => ()
+                case _: IOException          => ()
+                case _: InterruptedException => ()
         )
         t.setDaemon(true)
         t.start()
+        t
     end feedStream
 
     /** Reads all bytes from an InputStream and closes it. */
@@ -372,12 +400,13 @@ final private[kyo] class JvmCommandUnsafe(
                                 val proc = new JvmProcessUnsafe(jp)
                                 // Feed stdin if needed
                                 stdinStream match
-                                    case Present(s) => feedStream(s, jp.getOutputStream)
+                                    case Present(s) => proc.registerInputFeed(feedStream(s, jp.getOutputStream))
                                     case Absent =>
                                         stdinSource match
-                                            case Process.Input.FromStream(is) => feedInputStream(is, jp.getOutputStream)
-                                            case Process.Input.Inherit        => ()
-                                            case Process.Input.Pipe           => ()
+                                            case Process.Input.FromStream(is) =>
+                                                proc.registerInputFeed(feedInputStream(is, jp.getOutputStream))
+                                            case Process.Input.Inherit => ()
+                                            case Process.Input.Pipe    => ()
                                 end match
                                 Result.succeed(proc)
                             catch
@@ -417,12 +446,13 @@ final private[kyo] class JvmCommandUnsafe(
                         val jp   = pb.start()
                         val proc = new JvmProcessUnsafe(jp)
                         firstCmd.stdinStream match
-                            case Present(s) => feedStream(s, jp.getOutputStream)
+                            case Present(s) => proc.registerInputFeed(feedStream(s, jp.getOutputStream))
                             case Absent =>
                                 firstCmd.stdinSource match
-                                    case Process.Input.FromStream(is) => feedInputStream(is, jp.getOutputStream)
-                                    case Process.Input.Inherit        => ()
-                                    case Process.Input.Pipe           => ()
+                                    case Process.Input.FromStream(is) =>
+                                        proc.registerInputFeed(feedInputStream(is, jp.getOutputStream))
+                                    case Process.Input.Inherit => ()
+                                    case Process.Input.Pipe    => ()
                                 end match
                         end match
                         Result.succeed(proc)

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -442,15 +442,31 @@ final private[kyo] class JvmCommandUnsafe(
             case Result.Panic(ex) =>
                 p.completeDiscard(Result.panic(ex))
             case Result.Success(proc: JvmProcessUnsafe) =>
-                discard(proc.jp.onExit().whenComplete { (exitedProcess, error) =>
-                    if error != null then
-                        p.completeDiscard(Result.panic(error))
-                    else
-                        try
-                            val bytes = readAll(exitedProcess.getInputStream)
-                            p.completeDiscard(Result.succeed(new String(bytes, StandardCharsets.UTF_8)))
-                        catch
-                            case e: IOException => p.completeDiscard(Result.panic(e))
+                // Drained while the process runs, and completed at end of stream rather than at exit.
+                //
+                // Reading only after onExit deadlocks any child that writes more than the pipe
+                // buffer, roughly 64KB: the child blocks on write, so it never exits, so onExit
+                // never fires, so the read that would unblock it never starts. Process.scala
+                // documents this hazard for the stdout-plus-stderr case; it was reproduced here on
+                // a single stream.
+                //
+                // End of stream is the right completion point for this operation: it yields the
+                // output text and does not report exit status, and the child closes stdout when it
+                // exits. The onExit handler remains only to surface a spawn failure, and completing
+                // an already-completed promise is a no-op, so whichever arrives first wins.
+                val out = proc.jp.getInputStream
+                // Unsafe: bridges a blocking pipe read off the scheduler. The thread ends at end of
+                // stream, which the child reaches by exiting.
+                val reader = new Thread(
+                    () =>
+                        try p.completeDiscard(Result.succeed(new String(readAll(out), StandardCharsets.UTF_8)))
+                        catch case e: IOException => p.completeDiscard(Result.panic(e)),
+                    "kyo-command-text"
+                )
+                reader.setDaemon(true)
+                reader.start()
+                discard(proc.jp.onExit().whenComplete { (_, error) =>
+                    if error != null then p.completeDiscard(Result.panic(error))
                 })
         end match
         p

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -13,20 +13,20 @@ import scala.jdk.CollectionConverters.*
 
 final private[kyo] class JvmProcessUnsafe(private[internal] val jp: JProcess) extends Process.Unsafe:
 
-    // Threads feeding this process's stdin. Retained so the feed can be stopped with the process
-    // rather than running on after it, which is what an unheld thread does.
-    private val inputFeeds = new java.util.concurrent.ConcurrentLinkedQueue[Thread]()
+    // Stop actions for the fibers feeding this process's stdin. Retained so a feed ends with the
+    // process rather than running on after it, which is what an unheld feed does.
+    private val inputFeeds = new java.util.concurrent.ConcurrentLinkedQueue[() => Unit]()
 
-    private[internal] def registerInputFeed(t: Thread): Unit = discard(inputFeeds.add(t))
+    private[internal] def registerInputFeed(stop: () => Unit): Unit = discard(inputFeeds.add(stop))
 
     /** Stops every stdin feed. Idempotent, and safe to call after the process has already exited:
       * a feed can still be parked reading its source even when the child is gone.
       */
     override def stopInputFeeds()(using AllowUnsafe): Unit =
-        var t = inputFeeds.poll()
-        while t != null do
-            if t.isAlive() then t.interrupt()
-            t = inputFeeds.poll()
+        var stop = inputFeeds.poll()
+        while stop != null do
+            stop()
+            stop = inputFeeds.poll()
         end while
     end stopInputFeeds
 
@@ -276,54 +276,81 @@ final private[kyo] class JvmCommandUnsafe(
         end match
     end toJProcessBuilder
 
-    /** Feeds an InputStream into a process's stdin on a daemon thread, closing when done.
+    /** Closes a stream, ignoring the failure a second close or an already-broken stream reports. */
+    private def closeQuietly(closeable: java.io.Closeable): Unit =
+        try closeable.close()
+        catch case _: IOException => ()
+
+    /** Feeds an InputStream into a process's stdin on a carrier fiber, closing when done.
       *
-      * Returns the thread so the caller can retain it and stop the feed. A feed that nothing holds
-      * cannot be cancelled: interrupting the fiber that spawned the process would leave it reading
-      * its source and writing to the child for as long as the source produced bytes.
+      * Returns the stop action so the caller can retain it and end the feed. A feed that nothing
+      * holds cannot be cancelled: interrupting the fiber that spawned the process would leave it
+      * reading its source and writing to the child for as long as the source produced bytes.
+      *
+      * The read blocks, so the carrier parks in it and the scheduler's `BlockingMonitor` drains
+      * that worker's queue to the others, the sanctioned-blocking pattern kyo-net's stdio pumps
+      * use. The monitor also dispatches `Thread.interrupt()` to a parked carrier whose fiber was
+      * interrupted, so the stop action's interrupt reaches a read already parked, not only the
+      * safepoint each loop step leaves between reads. Closing the streams covers a source that
+      * ignores the interrupt, and closes what the feed owns even when the fiber ends before its
+      * own close runs.
       */
-    private def feedInputStream(is: InputStream, processStdin: OutputStream): Thread =
-        val t = new Thread(() =>
-            try
-                val buf = new Array[Byte](8192)
-                var n   = is.read(buf)
-                while n >= 0 && !Thread.currentThread().isInterrupted() do
-                    processStdin.write(buf, 0, n)
-                    n = is.read(buf)
-                processStdin.close()
-            catch
-                // An interrupt closes the streams underneath the read, so the resulting IOException
-                // is the ordinary way this thread stops and is not an error to report.
-                case _: IOException          => ()
-                case _: InterruptedException => ()
-            finally
-                try is.close()
-                catch case _: IOException => ()
-        )
-        t.setDaemon(true)
-        t.start()
-        t
+    private def feedInputStream(is: InputStream, processStdin: OutputStream)(using AllowUnsafe, Frame): () => Unit =
+        val buf = new Array[Byte](8192)
+        // Unsafe: spawns the pump from outside the effect system, where spawn() runs.
+        val feed = Fiber.Unsafe.init {
+            Loop.foreach {
+                Sync.defer {
+                    try
+                        val n = is.read(buf)
+                        if n < 0 then
+                            processStdin.close()
+                            Loop.done
+                        else
+                            processStdin.write(buf, 0, n)
+                            Loop.continue
+                        end if
+                    catch
+                        // A stop interrupts the carrier and closes the streams underneath the read
+                        // and the write, so both exceptions are the ordinary way a feed ends rather
+                        // than a failure to report. Catching the interrupt here also keeps it off
+                        // the scheduler worker the carrier is mounted on.
+                        case _: IOException          => Loop.done
+                        case _: InterruptedException => Loop.done
+                    end try
+                }
+            }.andThen(Sync.defer(closeQuietly(is)))
+        }
+        () =>
+            discard(feed.interrupt())
+            // Closing both ends releases a read or a write already parked, which no interrupt can
+            // reach, and closing the source is what the feed itself does when it ends on its own.
+            closeQuietly(is)
+            closeQuietly(processStdin)
     end feedInputStream
 
-    /** Drains a Stream[Byte, Sync] into a process's stdin on a daemon thread, closing when done.
+    /** Drains a Stream[Byte, Sync] into a process's stdin on a carrier fiber, closing when done.
       *
-      * The stream is evaluated eagerly (it is Sync-only), then the bytes are written in a background thread so that the caller (spawn) is
-      * not blocked by the write. Returns the thread for the same reason as [[feedInputStream]].
+      * The stream is evaluated eagerly (it is Sync-only), then the bytes are written on a carrier fiber so that the caller (spawn) is not
+      * blocked by the write. Returns the stop action for the same reason as [[feedInputStream]].
       */
-    private def feedStream(stream: Stream[Byte, Sync], processStdin: OutputStream)(using AllowUnsafe, Frame): Thread =
+    private def feedStream(stream: Stream[Byte, Sync], processStdin: OutputStream)(using AllowUnsafe, Frame): () => Unit =
         val chunk = Abort.run[Nothing](Sync.Unsafe.run(stream.run)).eval.getOrThrow
         val bytes = chunk.toArray
-        val t = new Thread(() =>
-            try
-                processStdin.write(bytes)
-                processStdin.close()
-            catch
-                case _: IOException          => ()
-                case _: InterruptedException => ()
-        )
-        t.setDaemon(true)
-        t.start()
-        t
+        // Unsafe: spawns the pump from outside the effect system, where spawn() runs.
+        val feed = Fiber.Unsafe.init {
+            Sync.defer {
+                try
+                    processStdin.write(bytes)
+                    processStdin.close()
+                catch
+                    case _: IOException          => ()
+                    case _: InterruptedException => ()
+            }
+        }
+        () =>
+            discard(feed.interrupt())
+            closeQuietly(processStdin)
     end feedStream
 
     /** Reads all bytes from an InputStream and closes it. */
@@ -413,8 +440,9 @@ final private[kyo] class JvmCommandUnsafe(
                                 case e: IOException => Result.fail(translateIOException(e, args.headMaybe.getOrElse("")))
                 else
                     // Pipeline spawn — delegate to `sh -c "cmd1 | cmd2 | ..."` so the OS
-                    // kernel handles inter-process piping directly. This avoids daemon thread
-                    // deadlocks on Scala Native where blocking I/O in threads is unreliable.
+                    // kernel handles inter-process piping directly. This avoids the pump-per-stage
+                    // deadlocks on Scala Native, where blocking I/O off the calling thread is
+                    // unreliable.
                     def shellEscape(a: String): String = "'" + a.replace("'", "'\\''") + "'"
                     val shellCmd                       = chain.map(_.args.map(shellEscape).mkString(" ")).mkString(" | ")
 
@@ -485,16 +513,16 @@ final private[kyo] class JvmCommandUnsafe(
                 // exits. The onExit handler remains only to surface a spawn failure, and completing
                 // an already-completed promise is a no-op, so whichever arrives first wins.
                 val out = proc.jp.getInputStream
-                // Unsafe: bridges a blocking pipe read off the scheduler. The thread ends at end of
-                // stream, which the child reaches by exiting.
-                val reader = new Thread(
-                    () =>
+                // Unsafe: bridges a blocking pipe read from outside the effect system. The carrier
+                // parks in the read and the scheduler's `BlockingMonitor` drains that worker's
+                // queue to the others; the read ends at end of stream, which the child reaches by
+                // exiting.
+                discard(Fiber.Unsafe.init {
+                    Sync.defer {
                         try p.completeDiscard(Result.succeed(new String(readAll(out), StandardCharsets.UTF_8)))
-                        catch case e: IOException => p.completeDiscard(Result.panic(e)),
-                    "kyo-command-text"
-                )
-                reader.setDaemon(true)
-                reader.start()
+                        catch case e: IOException => p.completeDiscard(Result.panic(e))
+                    }
+                })
                 discard(proc.jp.onExit().whenComplete { (_, error) =>
                     if error != null then p.completeDiscard(Result.panic(error))
                 })

--- a/kyo-system/jvm/src/test/scala/kyo/CommandStdinFeedJvmTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/CommandStdinFeedJvmTest.scala
@@ -1,0 +1,46 @@
+package kyo
+
+/** Ownership of the threads that feed a process's stdin.
+  *
+  * JVM-only, and the split is genuine rather than a way to avoid platform cost. JS feeds stdin
+  * through Node streams with no thread of its own, so there is nothing here to own. On Native the
+  * threads exist, but interrupting one parked in a blocking read is not dependable, which
+  * `ProcessPlatformSpecific` already notes where it routes pipelines through `sh -c` rather than
+  * through threads. What is asserted below is specifically that a JVM thread parked in a read is
+  * released when the scope closes.
+  */
+class CommandStdinFeedJvmTest extends kyo.test.Test[Any]:
+
+    "a stdin feed does not outlive the scope that spawned the process" in {
+        // The feed runs on a thread of its own, so nothing about the fiber's lifetime reaches it
+        // unaided: before the feed was tied to the process, closing the scope left the thread parked
+        // in read() for as long as its source withheld bytes, holding that source open with it.
+        val closed = new java.util.concurrent.atomic.AtomicBoolean(false)
+        val parked = new java.util.concurrent.CountDownLatch(1)
+
+        // A source that never yields a byte and never ends. Blocking is the point: it stands in for
+        // a pipe or socket gone quiet, which is when an unowned feed is impossible to observe.
+        val source = new java.io.InputStream:
+            override def read(): Int =
+                parked.countDown()
+                new java.util.concurrent.CountDownLatch(1).await()
+                -1
+            end read
+            override def read(b: Array[Byte], off: Int, len: Int): Int = read()
+            override def close(): Unit                                 = closed.set(true)
+
+        Scope.run {
+            Command("cat").stdin(Process.Input.FromStream(source)).spawn.map { _ =>
+                // Wait until the feed is genuinely parked in the read, so what follows is about the
+                // scope closing rather than about the feed never having started.
+                Sync.defer(parked.await())
+            }
+        }.andThen {
+            // The scope has closed. The feed is interrupted, unwinds, and closes its source.
+            assertEventually(Sync.defer(closed.get()))
+        }.andThen {
+            assert(closed.get(), "the stdin feed outlived the scope that spawned the process")
+        }
+    }
+
+end CommandStdinFeedJvmTest

--- a/kyo-system/jvm/src/test/scala/kyo/CommandStdinFeedJvmTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/CommandStdinFeedJvmTest.scala
@@ -1,20 +1,21 @@
 package kyo
 
-/** Ownership of the threads that feed a process's stdin.
+/** Ownership of the fibers that feed a process's stdin.
   *
   * JVM-only, and the split is genuine rather than a way to avoid platform cost. JS feeds stdin
-  * through Node streams with no thread of its own, so there is nothing here to own. On Native the
-  * threads exist, but interrupting one parked in a blocking read is not dependable, which
+  * through Node streams with no carrier of its own, so there is nothing here to own. On Native the
+  * carriers exist, but releasing one parked in a blocking read is not dependable, which
   * `ProcessPlatformSpecific` already notes where it routes pipelines through `sh -c` rather than
-  * through threads. What is asserted below is specifically that a JVM thread parked in a read is
-  * released when the scope closes.
+  * through feeds of its own. What is asserted below is specifically that a JVM carrier parked in a
+  * read is released when the scope closes.
   */
 class CommandStdinFeedJvmTest extends kyo.test.Test[Any]:
 
     "a stdin feed does not outlive the scope that spawned the process" in {
-        // The feed runs on a thread of its own, so nothing about the fiber's lifetime reaches it
-        // unaided: before the feed was tied to the process, closing the scope left the thread parked
-        // in read() for as long as its source withheld bytes, holding that source open with it.
+        // The feed runs on a carrier of its own, so nothing about the spawning fiber's lifetime
+        // reaches it unaided: before the feed was tied to the process, closing the scope left the
+        // carrier parked in read() for as long as its source withheld bytes, holding that source
+        // open with it.
         val closed = new java.util.concurrent.atomic.AtomicBoolean(false)
         val parked = new java.util.concurrent.CountDownLatch(1)
 

--- a/kyo-system/shared/src/main/scala/kyo/Command.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Command.scala
@@ -68,7 +68,12 @@ object Command:
             Sync.Unsafe.defer {
                 Abort.get(self.unsafe.spawn()).map { proc =>
                     Scope.acquireRelease(proc.safe) { p =>
-                        Sync.Unsafe.defer(if p.unsafe.isAlive() then p.unsafe.destroyForcibly())
+                        Sync.Unsafe.defer {
+                            // Feeds are stopped unconditionally: the process may have exited
+                            // while a feed is still parked reading its own source.
+                            p.unsafe.stopInputFeeds()
+                            if p.unsafe.isAlive() then p.unsafe.destroyForcibly()
+                        }
                     }
                 }
             }
@@ -94,7 +99,12 @@ object Command:
                     Abort.get(self.unsafe.spawn()).map { proc =>
                         val safeProc = proc.safe
                         Scope.acquireRelease(safeProc) { p =>
-                            Sync.Unsafe.defer(if p.unsafe.isAlive() then p.unsafe.destroyForcibly())
+                            Sync.Unsafe.defer {
+                                // Feeds are stopped unconditionally: the process may have exited
+                                // while a feed is still parked reading its own source.
+                                p.unsafe.stopInputFeeds()
+                                if p.unsafe.isAlive() then p.unsafe.destroyForcibly()
+                            }
                         }.map { p =>
                             p.stdout.emit
                         }
@@ -124,7 +134,12 @@ object Command:
                     proc <- Sync.Unsafe.defer {
                         Abort.get(self.unsafe.spawn()).map { p =>
                             Scope.acquireRelease(p.safe) { p =>
-                                Sync.Unsafe.defer(if p.unsafe.isAlive() then p.unsafe.destroyForcibly())
+                                Sync.Unsafe.defer {
+                                    // Feeds are stopped unconditionally: the process may have exited
+                                    // while a feed is still parked reading its own source.
+                                    p.unsafe.stopInputFeeds()
+                                    if p.unsafe.isAlive() then p.unsafe.destroyForcibly()
+                                }
                             }
                         }
                     }

--- a/kyo-system/shared/src/main/scala/kyo/Process.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Process.scala
@@ -239,6 +239,13 @@ object Process:
           */
         def waitFor(timeout: Duration)(using AllowUnsafe, Frame): Fiber.Unsafe[Maybe[ExitCode], Any]
 
+        /** Stops any background feed writing into this process's stdin.
+          *
+          * Idempotent, and safe to call after the process has exited: a feed can still be parked reading its source when the child is
+          * already gone. Platforms that feed stdin without a thread of their own do not need to do anything here.
+          */
+        def stopInputFeeds()(using AllowUnsafe): Unit = ()
+
         /** Non-blocking poll. Returns `Absent` if still running. */
         def exitCode()(using AllowUnsafe): Maybe[ExitCode]
 

--- a/kyo-system/shared/src/main/scala/kyo/Process.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Process.scala
@@ -71,9 +71,24 @@ object Process:
         /** Suspends the current fiber until the process exits or `timeout` elapses.
           *
           * Returns `Present(exitCode)` on normal exit or `Absent` on timeout.
+          *
+          * The deadline is measured against the ambient `Clock` rather than by a platform timer, so it is uniform across platforms and
+          * moves under `Clock.withTimeControl`. A timed wait that could only be driven by real elapsed time was both untestable and
+          * load-sensitive, since a busy machine could carry a process past a deadline the test believed it controlled. A non-finite
+          * timeout arms no timer at all and waits indefinitely.
+          *
+          * The process is left running when the deadline expires; only the wait is abandoned.
           */
         def waitFor(timeout: Duration)(using Frame): Maybe[ExitCode] < Async =
-            Sync.Unsafe.defer(self.unsafe.waitFor(timeout).safe.get)
+            // Bound to a local rather than calling the untimed overload: inside the extension body
+            // `waitFor` resolves to the Unsafe member, not to this extension's own no-arg version.
+            val untimed: ExitCode < Async = Sync.Unsafe.defer(self.unsafe.waitFor().safe.get)
+            Abort.run[Timeout](Async.timeout(timeout)(untimed)).map {
+                case Result.Success(code)       => Present(code)
+                case Result.Failure(_: Timeout) => Absent
+                case Result.Panic(error)        => Abort.panic(error)
+            }
+        end waitFor
 
         /** Polls the process's current exit status without suspending.
           *
@@ -217,7 +232,11 @@ object Process:
         /** Suspends until the process exits and completes the returned `Fiber.Unsafe` with the exit code. */
         def waitFor()(using AllowUnsafe, Frame): Fiber.Unsafe[ExitCode, Any]
 
-        /** Suspends until the process exits or `timeout` elapses; completes the fiber with `Absent` on timeout. */
+        /** Suspends until the process exits or `timeout` elapses; completes the fiber with `Absent` on timeout.
+          *
+          * This tier measures the deadline with a platform timer against real elapsed time. It is outside the effect system and so cannot
+          * consult the ambient `Clock`, which is why the safe `waitFor(timeout)` builds its deadline from `Clock` instead of calling this.
+          */
         def waitFor(timeout: Duration)(using AllowUnsafe, Frame): Fiber.Unsafe[Maybe[ExitCode], Any]
 
         /** Non-blocking poll. Returns `Absent` if still running. */

--- a/kyo-system/shared/src/main/scala/kyo/Process.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Process.scala
@@ -242,7 +242,7 @@ object Process:
         /** Stops any background feed writing into this process's stdin.
           *
           * Idempotent, and safe to call after the process has exited: a feed can still be parked reading its source when the child is
-          * already gone. Platforms that feed stdin without a thread of their own do not need to do anything here.
+          * already gone. Platforms that feed stdin without a carrier of their own do not need to do anything here.
           */
         def stopInputFeeds()(using AllowUnsafe): Unit = ()
 

--- a/kyo-system/shared/src/test/scala/kyo/CommandTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/CommandTest.scala
@@ -342,6 +342,25 @@ class CommandTest extends kyo.test.Test[Any]:
         ()
     }
 
+    "text drains output larger than the pipe buffer" in {
+        assumeUnix("sh -c");
+        {
+            // An OS pipe buffers roughly 64KB. Past that the child blocks on write until the parent
+            // reads, so an implementation that waits for exit before reading deadlocks: the child
+            // cannot exit, so the wait never completes, so the read that would release it never
+            // starts. Nothing smaller than the buffer can detect that, and every other case in this
+            // file stays well under it.
+            //
+            // seq 1 100000 emits roughly 580KB, comfortably past the boundary on any platform.
+            Command("sh", "-c", "seq 1 100000").text.map { out =>
+                val lines = out.trim.linesIterator.toIndexedSeq
+                assert(lines.length == 100000, s"expected 100000 lines, got ${lines.length}")
+                assert(lines.head == "1")
+                assert(lines.last == "100000")
+            }
+        }
+    }
+
     // ---------------------------------------------------------------------------
     // textWithExitCode
     // ---------------------------------------------------------------------------

--- a/kyo-system/shared/src/test/scala/kyo/ExitCodeTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/ExitCodeTest.scala
@@ -207,6 +207,52 @@ class ExitCodeTest extends kyo.test.Test[Any]:
         }
     }
 
+    "waitFor's deadline is driven by the ambient Clock, not by elapsed real time" in {
+        // The deadline used to be a platform timer, correct in wall time but impossible to drive
+        // from a test: the case above can only be written by waiting out a real 200ms, and on a
+        // loaded machine the same code can carry a process past a deadline it meant to control.
+        //
+        // Asserting only that the wait returns Absent does not distinguish the two: a platform timer
+        // reaches the same answer, just by burning the full 30 seconds of real time. What separates
+        // them is that here almost no real time passes, so the elapsed wall clock is the assertion.
+        val budget = 10.seconds
+        Clock.withTimeControl { clock =>
+            Scope.run {
+                for
+                    started <- Clock.live.now
+                    proc    <- Command("sleep", "60").spawn
+                    fiber   <- Fiber.initUnscoped(proc.waitFor(30.seconds))
+                    // Let the fiber reach the point where it arms its deadline before moving the
+                    // clock. Async.timeout arms inside the fiber it starts, so an advance that lands
+                    // first would have the deadline computed from the advanced time, putting it
+                    // permanently out of reach of the advances below.
+                    _ <- clock.advance(Duration.Zero, 100.millis)
+                    // Short of the deadline: the wait is still outstanding.
+                    _        <- clock.advance(29.seconds)
+                    pending  <- fiber.poll
+                    _        <- clock.advance(2.seconds)
+                    result   <- fiber.get
+                    finished <- Clock.live.now
+                    elapsed = finished - started
+                yield assert(
+                    pending.isEmpty && result == Absent && elapsed < budget,
+                    s"expected a clock-driven deadline; pending=$pending result=$result elapsed=$elapsed"
+                )
+            }
+        }
+    }
+
+    "waitFor with an infinite timeout waits for the process rather than expiring" in {
+        // Arming a timer for a non-finite duration is what inverted an unbounded wait into an
+        // instant expiry on JS, where Node clamps an out-of-range delay down to 1ms.
+        Scope.run {
+            for
+                proc   <- Command("true").spawn
+                result <- proc.waitFor(Duration.Infinity)
+            yield assert(result == Present(ExitCode.Success))
+        }
+    }
+
     "envAppend adds and overrides env variables preserving existing ones" in {
         Command("sh", "-c", "echo $KYO_TEST_VAR")
             .envAppend(Map("KYO_TEST_VAR" -> "appended_value"))

--- a/kyo-system/shared/src/test/scala/kyo/ProcessExitCodeTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/ProcessExitCodeTest.scala
@@ -1,6 +1,6 @@
 package kyo
 
-class ExitCodeTest extends kyo.test.Test[Any]:
+class ProcessExitCodeTest extends kyo.test.Test[Any]:
 
     "ExitCode(0) is ExitCode.Success" in {
         assert(ExitCode(0) == ExitCode.Success)
@@ -305,4 +305,4 @@ class ExitCodeTest extends kyo.test.Test[Any]:
         }
     }
 
-end ExitCodeTest
+end ProcessExitCodeTest

--- a/kyo-system/shared/src/test/scala/kyo/ProcessTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/ProcessTest.scala
@@ -68,6 +68,37 @@ class ProcessTest extends kyo.test.Test[Any]:
         }
     }
 
+    "a signalled process reports the signal, not a generic failure" in {
+        unixOnly
+        // Reachable on JVM through the exit status and on JS through the 'exit' event's second
+        // argument. The JS listener took one argument and discarded that second one, so a signal
+        // death arrived as a null code and was reported as Failure(1). Nothing caught it: every
+        // other assertion here checks only that the code is not Success, which a wrong but nonzero
+        // code satisfies.
+        Scope.run {
+            for
+                proc   <- Command("sleep", "60").spawn
+                _      <- proc.destroyForcibly
+                result <- proc.waitFor(10.seconds)
+            yield result match
+                case Present(ExitCode.Signaled(n)) => assert(n == 9, s"expected SIGKILL, got signal $n")
+                case other                         => assert(false, s"expected a signalled exit, got $other")
+        }
+    }
+
+    "waitFor with an infinite timeout waits for the process" in {
+        unixOnly
+        // An infinite timeout must not arm a timer. Node clamps any delay past the signed 32-bit
+        // range down to 1ms, so arming one turned an unbounded wait into an immediate expiry: the
+        // inverse of the request, reported as Absent, which reads as "still running".
+        Scope.run {
+            for
+                proc   <- Command("true").spawn
+                result <- proc.waitFor(Duration.Infinity)
+            yield assert(result == Present(ExitCode.Success), s"expected a completed wait, got $result")
+        }
+    }
+
     "isAlive is true before exit and false after" in {
         unixOnly
         Scope.run {
@@ -340,8 +371,12 @@ class ProcessTest extends kyo.test.Test[Any]:
         unixOnly
         Scope.run {
             for
-                stopwatch <- Clock.stopwatch
+                // Started after spawn, so the window measures only what the assertion names. On
+                // JS, spawn is synchronous (a PATH scan, then uv_spawn), so including it charges
+                // that work to the deadline and a failure reports a number that is not about
+                // waitFor at all.
                 proc      <- Command("sleep", "60").spawn
+                stopwatch <- Clock.stopwatch
                 result    <- proc.waitFor(200.millis)
                 elapsed   <- stopwatch.elapsed
                 _         <- proc.destroyForcibly
@@ -357,8 +392,9 @@ class ProcessTest extends kyo.test.Test[Any]:
         unixOnly
         Scope.run {
             for
-                stopwatch <- Clock.stopwatch
+                // Started after spawn: the assertion is about draining, not about process start.
                 proc      <- Command("echo", "fast").spawn
+                stopwatch <- Clock.stopwatch
                 out       <- proc.stdout.run
                 elapsed   <- stopwatch.elapsed
                 _         <- proc.waitFor
@@ -403,8 +439,12 @@ class ProcessTest extends kyo.test.Test[Any]:
         unixOnly
         Scope.run {
             for
-                stopwatch <- Clock.stopwatch
+                // Started after spawn, so the window measures only what the assertion names. On
+                // JS, spawn is synchronous (a PATH scan, then uv_spawn), so including it charges
+                // that work to the deadline and a failure reports a number that is not about
+                // waitFor at all.
                 proc      <- Command("sleep", "60").spawn
+                stopwatch <- Clock.stopwatch
                 result    <- proc.waitFor(200.millis)
                 elapsed   <- stopwatch.elapsed
                 _         <- proc.destroyForcibly
@@ -420,8 +460,9 @@ class ProcessTest extends kyo.test.Test[Any]:
         unixOnly
         Scope.run {
             for
-                stopwatch <- Clock.stopwatch
+                // Started after spawn: the assertion is about draining, not about process start.
                 proc      <- Command("echo", "fast").spawn
+                stopwatch <- Clock.stopwatch
                 out       <- proc.stdout.run
                 elapsed   <- stopwatch.elapsed
                 _         <- proc.waitFor


### PR DESCRIPTION
### What this fixes

Three process lifecycle defects that predate the path-capability work:

- `Process.waitFor(timeout)` built its deadline from wall arithmetic; it now derives from `Clock`, and fixing that exposed a JavaScript wait bug that is fixed with it.
- Stdin feeds were not tied to the process that owned them; a feed now belongs to its process and ends with it.
- Child output larger than the pipe buffer could deadlock `text()` on the JVM; reads now stream on a dedicated thread.

The first commit extracts prerequisites (JavaScript signal reporting via `signalCode` and `exitCodeFrom`, the infinite-timeout guard, the `isAlive` fix, and the `text()` streaming read) that the two fix commits build on. They were never isolated commits upstream; this extraction carries them with their tests. One behavior change rides with it: a spawn failure now reports `Present(ExitCode(1))` instead of `Absent`.

A fourth commit renames `ExitCodeTest.scala` to `ProcessExitCodeTest.scala` so the test file shares a prefix with the source it covers.

The last commit answers the review: the two stdin feeds and the `text()` drain spawn through `Fiber.Unsafe.init` instead of `new Thread`, so the scheduler carries the blocking reads. `BlockingMonitor` drains a parked carrier's queue to the other workers and dispatches `Thread.interrupt()` to a parked carrier whose fiber was interrupted, which is what releases a feed parked on a quiet source. A process holds a stop action per feed rather than a `Thread`; `stopInputFeeds` and its contract are unchanged.

Fixes #1815
Fixes #1816
Fixes #1817

### Stack

Part of the path-capability stack on #1859: process fixes, filesystem vocabulary, abstraction, capability flip, channels, locks, watch, durability, confinement, in-memory, zip, then overlay (#1799). Merge bottom up; GitHub retargets the stack above each merge.

Each branch carries one synthesized commit whose diff is exactly this pull request. The original incremental development history remains visible in #1799's earlier timeline and in the backup refs recorded in the working notes.

