### PR TITLE
[kyo-system] add a filesystem abstraction behind the Path API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,6 +389,7 @@ This is guidance for new and changed code. Existing APIs that thread byte counts
 | Kyo primitive         | Purpose                | Notes                                                                                   |
 | --------------------- | ---------------------- | --------------------------------------------------------------------------------------- |
 | `Path`                | File system operations | Immutable, cross-platform; construct with `/`, effect-tracked read/write                  |
+| `FileSystem`          | Pluggable backend      | Filesystem service, with a host implementation over the platform backends                 |
 | `Command`             | OS process launch      | Builds and runs external processes; `spawn`, `text`, `waitFor`                            |
 | `Process`             | Running process handle | `stdout`, `stderr`, `waitFor`, `destroy`                                                  |
 | `System`              | Environment/properties | Type-safe access with custom `Parser`s                                                    |

--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -12,13 +12,14 @@ The module owns these boundaries:
 
 | Surface | Safe API | Effect row |
 |---|---|---|
-| Filesystem reads | `Path` | `Sync`, `Abort[FileReadException]` |
-| Filesystem writes | `Path` | `Sync`, `Abort[FileWriteException]`, `Abort[FileStructureException]` |
+| Filesystem reads | `Path`, `FileSystem.Read` | `Sync`, `Abort[FileReadException]` |
+| Filesystem writes | `Path`, `FileSystem.Write` | `Sync`, `Abort[FileWriteException]`, `Abort[FileStructureException]` |
 | Commands and processes | `Command`, `Process` | `Sync`, `Async`, `Scope` |
 | Environment | `System` | `Sync` |
 
-A method carries the failure category it can actually raise, never a wider one. Keep the category
-visible in return types and compile-time tests.
+`FileSystem.Write[S] <: FileSystem.Read[S]`: write authority includes read authority, and a
+read-only backend intentionally cannot be passed where a write backend is required. Keep this
+negative authority law visible in return types and compile-time tests.
 
 ### Source layout
 
@@ -26,6 +27,8 @@ visible in return types and compile-time tests.
 kyo-system/
   shared/src/main/scala/kyo/
     Path.scala
+    FileSystem.scala
+    HostFileSystem.scala
     FileSystemException.scala
     Command.scala
     Process.scala
@@ -34,11 +37,32 @@ kyo-system/
   js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
 ```
 
+## Filesystem authority and selection
+
+`FileSystem.Read[S]` contains only inspection and read operations. `FileSystem.Write[S]` extends it
+with mutation and structure changes.
+
+The built-in factories are:
+
+| Factory | Authority | Purpose |
+|---|---|---|
+| `FileSystem.host` | write | Local host filesystem |
+
+A caller holds a backend as an ordinary value and calls its methods directly. Nothing routes
+`Path` through a backend yet: `Path`'s own methods go straight to `Path.Unsafe`, and `FileSystem`
+exists so a caller who wants a swappable filesystem has one contract to implement against. The
+conformance suites are the only consumers of the service in this module.
+
+Never widen a read-only factory to `FileSystem.Write`. Authority is part of the public contract.
+
 ## Path operation flow
 
 1. A safe `Path` extension bridges the matching `Path.Unsafe` operation through `Sync.Unsafe.defer`.
 2. The unsafe tier returns a `Result` carrying a precise filesystem failure marker.
 3. `Abort.get` lifts that `Result` into the method's declared `Abort` row.
+
+`FileSystem.host` follows the same three steps for every service method, so a host backend answers
+exactly what the matching `Path` method answers.
 
 Safe methods carry `Sync` plus a precise `Abort` row. Do not expose platform exceptions or widen an
 `Abort` row past what the unsafe tier can return.
@@ -99,9 +123,11 @@ throwables into expected filesystem failures.
 1. Decide whether the operation needs read or write authority.
 2. Add a focused shared test that proves behavior and its precise failure case.
 3. Add the safe `Path` surface bridging the unsafe tier, when the operation belongs on `Path`.
-4. Implement both platform leaves for host behavior.
-5. Add the safe-to-unsafe bridge with its `// Unsafe:` explanation.
-6. Compile and test JVM, JavaScript, Native, and Wasm.
+4. Add the narrowest `FileSystem` tier method and precise effect row.
+5. Implement both platform leaves for host behavior.
+6. Add the safe-to-unsafe bridge with its `// Unsafe:` explanation.
+7. Extend the reusable conformance suite when the contract applies to multiple backends.
+8. Compile and test JVM, JavaScript, Native, and Wasm.
 
 Do not add an operation to the unsafe tier without completing every layer above it.
 
@@ -109,6 +135,11 @@ Do not add an operation to the unsafe tier without completing every layer above 
 
 Shared behavior belongs in `shared/src/test`. A test file must share a prefix with its production
 source. Platform tests are reserved for genuine host integration differences.
+
+Use the reusable suites for backend laws:
+
+- `FileSystemReadTestSuite`
+- `FileSystemWriteTestSuite`
 
 Test effect rows and backend authority with `typeCheck` and `typeCheckErrors`. Never use sleeps or blocking primitives
 to make scheduling tests pass.

--- a/kyo-system/README.md
+++ b/kyo-system/README.md
@@ -18,7 +18,7 @@ val deploy =
 
 ## Filesystem failures in the type system
 
-Each `Path` method carries the failure category it can actually raise:
+Each `Path` method carries the failure category it can actually raise. There is no umbrella row to discharge and no runner to install:
 
 | Operation group | Methods | Effect row |
 |---|---|---|
@@ -27,6 +27,23 @@ Each `Path` method carries the failure category it can actually raise:
 | Structure changes | `mkDir`, `mkFile`, `list`, `walk`, `move`, `copy`, `remove`, `removeAll`, `temp`, `tempDir` | `Sync & Abort[FileStructureException]` |
 
 `isDirectory`, `isRegularFile`, and `isSymbolicLink` answer `false` for an inaccessible path and carry only `Sync`.
+
+### The `FileSystem` service
+
+`FileSystem.Read[S]` describes inspection and content reads; `FileSystem.Write[S]` extends it with mutation and structure changes. `FileSystem.host` implements the write tier over the platform backends this module already uses, so a host service answers exactly what the matching `Path` method answers.
+
+A caller holds a backend as a value and calls its methods directly:
+
+```scala
+import kyo.*
+
+val backend: FileSystem.Write[Sync] = FileSystem.host
+
+val listed: Chunk[Path] < (Sync & Abort[FileReadException | FileStructureException]) =
+    backend.list(Path("var", "uploads"))
+```
+
+`Path` does not route through a backend: its methods go straight to the platform implementation. The service exists so a caller who needs a swappable filesystem has one contract to implement against, and so its behavior is pinned by the conformance suites before anything depends on it.
 
 Portable matching uses a compiled `Glob`, never a platform-specific string matcher:
 

--- a/kyo-system/js/src/test/scala/kyo/HostFileSystemSymlinkJsTest.scala
+++ b/kyo-system/js/src/test/scala/kyo/HostFileSystemSymlinkJsTest.scala
@@ -1,0 +1,25 @@
+package kyo
+
+import kyo.internal.NodeFs
+
+/** Runs the shared read contract against the host with symbolic links enabled, on Node.
+  *
+  * The JS backend is a separate implementation from the JVM one, with its own `realPath` and
+  * `isSymbolicLink`. Running the same contract here is what keeps the symlink-escape fix asserted on
+  * this platform rather than inferred from the JVM passing.
+  */
+class HostFileSystemSymlinkJsTest extends FileSystemReadTestSuite:
+
+    override protected def realPathRequiresExistence: Boolean = true
+    override protected def supportsSymbolicLinks: Boolean     = true
+
+    override protected def createSymbolicLink(link: Path, target: Path)(using Frame): Unit < (Sync & Abort[FileSystemException]) =
+        // Unsafe: creates a real symbolic link, which no Path operation exposes
+        Sync.Unsafe.defer(NodeFs.symlinkSync(target.unsafe.show, link.unsafe.show))
+
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Read[Sync], Path, String) < (Sync & Scope & Abort[FileSystemException]) =
+        FileSystemConformanceFixtures.hostRead
+
+end HostFileSystemSymlinkJsTest

--- a/kyo-system/jvm/src/test/scala/kyo/HostFileSystemSymlinkJvmTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/HostFileSystemSymlinkJvmTest.scala
@@ -1,0 +1,31 @@
+package kyo
+
+import java.nio.file.Files as JFiles
+import java.nio.file.Paths as JPaths
+
+/** Runs the shared read contract against the host with symbolic links enabled.
+  *
+  * The shared registrations cannot do this: link creation has no public operation, so it has to come
+  * from a platform source set. Without a fixture that can create one, the suite's link assertions are
+  * one-sided and a backend that stopped resolving links entirely would still pass.
+  */
+class HostFileSystemSymlinkJvmTest extends FileSystemReadTestSuite:
+
+    override protected def realPathRequiresExistence: Boolean = true
+    override protected def supportsSymbolicLinks: Boolean     = true
+
+    override protected def createSymbolicLink(link: Path, target: Path)(using Frame): Unit < (Sync & Abort[FileSystemException]) =
+        // Unsafe: creates a real symbolic link, which no Path operation exposes
+        Sync.Unsafe.defer {
+            discard(JFiles.createSymbolicLink(
+                JPaths.get(link.parts.mkString("/")),
+                JPaths.get(target.parts.mkString("/"))
+            ))
+        }
+
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Read[Sync], Path, String) < (Sync & Scope & Abort[FileSystemException]) =
+        FileSystemConformanceFixtures.hostRead
+
+end HostFileSystemSymlinkJvmTest

--- a/kyo-system/native/src/test/scala/kyo/HostFileSystemSymlinkNativeTest.scala
+++ b/kyo-system/native/src/test/scala/kyo/HostFileSystemSymlinkNativeTest.scala
@@ -1,0 +1,31 @@
+package kyo
+
+import java.nio.file.Files as JFiles
+import java.nio.file.Paths as JPaths
+
+/** Runs the shared read contract against the host with symbolic links enabled, on Native.
+  *
+  * Native shares the jvm-native path implementation but not its test coverage: before this, no
+  * Native test created a symbolic link, so the symlink-escape fix was asserted on one platform
+  * and assumed on this one.
+  */
+class HostFileSystemSymlinkNativeTest extends FileSystemReadTestSuite:
+
+    override protected def realPathRequiresExistence: Boolean = true
+    override protected def supportsSymbolicLinks: Boolean     = true
+
+    override protected def createSymbolicLink(link: Path, target: Path)(using Frame): Unit < (Sync & Abort[FileSystemException]) =
+        // Unsafe: creates a real symbolic link, which no Path operation exposes
+        Sync.Unsafe.defer {
+            discard(JFiles.createSymbolicLink(
+                JPaths.get(link.parts.mkString("/")),
+                JPaths.get(target.parts.mkString("/"))
+            ))
+        }
+
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Read[Sync], Path, String) < (Sync & Scope & Abort[FileSystemException]) =
+        FileSystemConformanceFixtures.hostRead
+
+end HostFileSystemSymlinkNativeTest

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -1,0 +1,130 @@
+package kyo
+
+import java.nio.charset.Charset
+
+/** Filesystem backend tiers, effect-polymorphic in the backend effect `S`. [[Read]] exposes
+  * inspection and content reads. [[Write]] extends it with mutation and structure operations.
+  * Each public operation records the applicable typed failure category in its effect row and
+  * accepts a call-site [[Frame]].
+  *
+  * @see [[FileSystem.host]] for the backend over the platform implementations in this module
+  */
+object FileSystem:
+
+    trait Read[S]:
+        def defaultCaseSensitivity(using Frame): Glob.CaseSensitivity < S
+
+        // inspection
+        def exists(path: Path)(using Frame): Boolean < (S & Abort[FileReadException])
+        def exists(path: Path, followLinks: Boolean)(using Frame): Boolean < (S & Abort[FileReadException])
+        def isDirectory(path: Path)(using Frame): Boolean < (S & Abort[FileReadException])
+        def isRegularFile(path: Path)(using Frame): Boolean < (S & Abort[FileReadException])
+        def isSymbolicLink(path: Path)(using Frame): Boolean < (S & Abort[FileReadException])
+        def realPath(path: Path)(using
+            Frame
+        ): Path < (S & Abort[
+            FileInvalidPathException | FileNotFoundException | FileAccessDeniedException | FileIOException
+        ])
+
+        /** Resolves the longest existing prefix of `path` and re-appends the segments below it.
+          *
+          * Unlike [[realPath]] this does not fail when `path` is absent. A path that does not exist
+          * yet still has a determined location: the links on the part of it that does exist fix
+          * where it will land. A path with no existing ancestor resolves to itself.
+          *
+          * This exists for callers that need the canonical location of a path they are about to
+          * create: raising on the common case of "the target does not exist yet" would make the
+          * method unusable for exactly the callers who need it, so absence is answered rather than
+          * raised.
+          *
+          * The default resolves the deepest ancestor [[realPath]] accepts.
+          */
+        def realPathPrefix(path: Path)(using
+            Frame
+        ): Path < (S & Abort[
+            FileInvalidPathException | FileAccessDeniedException | FileIOException
+        ]) =
+            Abort.run[FileNotFoundException](realPath(path)).map {
+                case Result.Success(resolved) => resolved
+                case _ =>
+                    (path.parent, path.name) match
+                        case (Present(parent), Present(name)) => realPathPrefix(parent).map(resolved => resolved / name)
+                        case _                                => path
+            }
+
+        // read
+        def read(path: Path)(using Frame): String < (S & Abort[FileReadException])
+        def read(path: Path, charset: Charset)(using Frame): String < (S & Abort[FileReadException])
+        def readBytes(path: Path)(using Frame): Span[Byte] < (S & Abort[FileReadException])
+        def readLines(path: Path)(using Frame): Chunk[String] < (S & Abort[FileReadException])
+        def readLines(path: Path, charset: Charset)(using Frame): Chunk[String] < (S & Abort[FileReadException])
+        def size(path: Path)(using Frame): Long < (S & Abort[FileReadException])
+        def stat(path: Path)(using Frame): Path.PathStat < (S & Abort[FileReadException])
+
+        // read handles (internal handle types; back the streaming reads and walk)
+        def openRead(path: Path)(using Frame): Path.ReadHandle < (S & Abort[FileReadException])
+        def openReadLines(path: Path, charset: Charset)(using Frame): Path.LineReadHandle < (S & Abort[FileReadException])
+        def openWalk(path: Path, maxDepth: Int, followLinks: Boolean)(using
+            Frame
+        ): Path.WalkHandle < (S & Abort[FileReadException | FileStructureException])
+        def list(path: Path)(using Frame): Chunk[Path] < (S & Abort[FileReadException | FileStructureException])
+        def list(path: Path, glob: Glob)(using Frame): Chunk[Path] < (S & Abort[FileReadException | FileStructureException]) =
+            defaultCaseSensitivity.map(list(path, glob, _))
+        def list(path: Path, glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using
+            Frame
+        ): Chunk[Path] < (S & Abort[FileReadException | FileStructureException])
+    end Read
+
+    trait Write[S] extends Read[S]:
+
+        // write
+        def write(path: Path, value: String, options: Path.WriteOptions)(using Frame): Unit < (S & Abort[FileWriteException])
+        def writeBytes(path: Path, value: Span[Byte], options: Path.WriteOptions)(using Frame): Unit < (S & Abort[FileWriteException])
+        def writeLines(path: Path, value: Chunk[String], options: Path.WriteOptions)(using Frame): Unit < (S & Abort[FileWriteException])
+        def append(path: Path, value: String, options: Path.WriteOptions)(using
+            Frame
+        ): Unit < (S & Abort[FileReadException | FileWriteException])
+        def appendBytes(path: Path, value: Span[Byte], options: Path.WriteOptions)(using
+            Frame
+        ): Unit < (S & Abort[FileReadException | FileWriteException])
+        def appendLines(path: Path, value: Chunk[String], options: Path.WriteOptions)(using
+            Frame
+        ): Unit < (S & Abort[FileReadException | FileWriteException])
+        def truncate(path: Path, size: Long)(using Frame): Unit < (S & Abort[FileReadException | FileWriteException])
+        def setLastModified(path: Path, epochMs: Long)(using Frame): Unit < (S & Abort[FileReadException | FileWriteException])
+
+        // write handle
+        def openWrite(path: Path, append: Boolean, options: Path.WriteOptions)(using
+            Frame
+        ): Path.WriteHandle < (S & Abort[FileReadException | FileWriteException])
+        def writeChunk(handle: Path.WriteHandle, chunk: Chunk[Byte])(using Frame): Unit < (S & Abort[FileWriteException])
+        def writeString(handle: Path.WriteHandle, value: String, charset: Charset)(using Frame): Unit < (S & Abort[FileWriteException])
+
+        // directory / structure
+        def mkDir(path: Path)(using Frame): Unit < (S & Abort[FileReadException | FileStructureException])
+        def mkFile(path: Path)(using Frame): Unit < (S & Abort[FileWriteException | FileStructureException])
+        def move(
+            from: Path,
+            to: Path,
+            options: Path.MoveOptions
+        )(using Frame): Unit < (S & Abort[FileReadException | FileWriteException | FileStructureException])
+        def copy(
+            from: Path,
+            to: Path,
+            options: Path.CopyOptions
+        )(using Frame): Unit < (S & Abort[FileReadException | FileWriteException | FileStructureException])
+        def remove(path: Path)(using Frame): Boolean < (S & Abort[FileReadException | FileStructureException])
+        def removeExisting(path: Path)(using Frame): Unit < (S & Abort[FileReadException | FileStructureException])
+        def removeAll(path: Path)(using Frame): Unit < (S & Abort[FileReadException | FileStructureException])
+
+        // scoped temp: vends a service-correct removal handle so cleanup runs through the creating service
+        def tempDir(prefix: String)(using Frame): Path.TempDirHandle < (S & Abort[FileStructureException])
+
+    end Write
+
+    /** Default host backend: delegates every operation to [[Path.Unsafe]], so it answers exactly what
+      * the [[Path]] methods answer.
+      */
+    def host: FileSystem.Write[Sync] = HostFileSystem()
+
+end FileSystem

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -11,7 +11,7 @@ import java.nio.charset.Charset
   */
 object FileSystem:
 
-    trait Read[S]:
+    abstract class Read[S]:
         def defaultCaseSensitivity(using Frame): Glob.CaseSensitivity < S
 
         // inspection
@@ -75,7 +75,7 @@ object FileSystem:
         ): Chunk[Path] < (S & Abort[FileReadException | FileStructureException])
     end Read
 
-    trait Write[S] extends Read[S]:
+    abstract class Write[S] extends Read[S]:
 
         // write
         def write(path: Path, value: String, options: Path.WriteOptions)(using Frame): Unit < (S & Abort[FileWriteException])

--- a/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
@@ -1,0 +1,201 @@
+package kyo
+
+import java.nio.charset.Charset
+import kyo.internal.Platform
+
+private[kyo] object HostFileSystem:
+
+    def apply(): FileSystem.Write[Sync] = new HostFileSystem
+
+    /** Determines case sensitivity by asking the volume rather than the operating system.
+      *
+      * The two are not the same question. macOS default volumes are case-insensitive while the
+      * platform is not Windows, so inferring from the operating system reports the wrong policy on
+      * every such machine, and the value feeds `list(path, glob)`.
+      *
+      * Probed against the filesystem's own temporary directory, so a host instance answers for its
+      * own volume rather than for the process temp volume. The result is cached per instance: it is
+      * a property of the volume, not of the call.
+      *
+      * A probe that cannot run falls back to the platform inference, which is right for Windows and
+      * the best available guess elsewhere.
+      */
+    private def probeCaseSensitivity(fileSystem: FileSystem.Write[Sync])(using Frame): Glob.CaseSensitivity < Sync =
+        val inferred = if Platform.isWindows then Glob.CaseSensitivity.Insensitive else Glob.CaseSensitivity.Sensitive
+        Abort.run[FileSystemException] {
+            fileSystem.tempDir("kyo-case-probe").map { handle =>
+                val probe = handle.path / "KyoCaseProbe"
+                fileSystem.write(probe, "probe", Path.WriteOptions()).andThen {
+                    fileSystem.exists(handle.path / "kyocaseprobe").map { foundLowercased =>
+                        // Unsafe: removes the probe directory created just above
+                        Sync.Unsafe.defer(handle.remove()).andThen {
+                            if foundLowercased then Glob.CaseSensitivity.Insensitive else Glob.CaseSensitivity.Sensitive
+                        }
+                    }
+                }
+            }
+        }.map {
+            case Result.Success(sensitivity) => sensitivity
+            case _                           => inferred
+        }
+    end probeCaseSensitivity
+
+    final class HostFileSystem extends FileSystem.Write[Sync]:
+
+        // Memo cell for the one-off volume probe below. A plain atomic rather than Kyo's: the cell
+        // has to exist at construction, outside any Sync context, and it carries no effect of its
+        // own. A racing pair of first calls both probe and agree, since they are asking the volume
+        // the same question.
+        private val caseSensitivity = new java.util.concurrent.atomic.AtomicReference[Glob.CaseSensitivity]()
+
+        def defaultCaseSensitivity(using Frame): Glob.CaseSensitivity < Sync =
+            Sync.defer(caseSensitivity.get()).map { cached =>
+                if cached ne null then cached
+                else
+                    probeCaseSensitivity(this).map { probed =>
+                        Sync.defer {
+                            caseSensitivity.compareAndSet(null, probed)
+                            caseSensitivity.get()
+                        }
+                    }
+            }
+
+        def exists(path: Path)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.exists into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.exists()))
+        def exists(path: Path, followLinks: Boolean)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.exists(followLinks) into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.exists(followLinks)))
+        def isDirectory(path: Path)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.isDirectory into the safe tier
+            Sync.Unsafe.defer(path.unsafe.isDirectory())
+        def isRegularFile(path: Path)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.isRegularFile into the safe tier
+            Sync.Unsafe.defer(path.unsafe.isRegularFile())
+        def isSymbolicLink(path: Path)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.isSymbolicLink into the safe tier
+            Sync.Unsafe.defer(path.unsafe.isSymbolicLink())
+        def realPath(path: Path)(using
+            Frame
+        ): Path < (Sync & Abort[
+            FileInvalidPathException | FileNotFoundException | FileAccessDeniedException | FileIOException
+        ]) =
+            // Unsafe: bridges Path.Unsafe.realPath; the Result maps to Abort[FileSystemException]
+            Sync.Unsafe.defer(Abort.get(path.unsafe.realPath()))
+        def read(path: Path)(using Frame): String < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.read into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.read()))
+        def read(path: Path, charset: Charset)(using Frame): String < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.read(charset) into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.read(charset)))
+        def readBytes(path: Path)(using Frame): Span[Byte] < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.readBytes into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.readBytes()))
+        def readLines(path: Path)(using Frame): Chunk[String] < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.readLines into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.readLines()))
+        def readLines(path: Path, charset: Charset)(using Frame): Chunk[String] < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.readLines(charset) into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.readLines(charset)))
+        def size(path: Path)(using Frame): Long < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.size into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.size()))
+        def stat(path: Path)(using Frame): Path.PathStat < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.stat into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.stat()))
+        def openRead(path: Path)(using Frame): Path.ReadHandle < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.openRead into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.openRead()))
+        def openReadLines(path: Path, charset: Charset)(using Frame): Path.LineReadHandle < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges Path.Unsafe.openReadLines into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.openReadLines(charset)))
+        def openWalk(path: Path, maxDepth: Int, followLinks: Boolean)(using
+            Frame
+        ): Path.WalkHandle < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.openWalk into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.openWalk(maxDepth, followLinks)))
+        def write(path: Path, value: String, options: Path.WriteOptions)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.write into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.write(value, options)))
+        def writeBytes(path: Path, value: Span[Byte], options: Path.WriteOptions)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.writeBytes into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.writeBytes(value, options)))
+        def writeLines(path: Path, value: Chunk[String], options: Path.WriteOptions)(using
+            Frame
+        ): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.writeLines into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.writeLines(value, options)))
+        def append(path: Path, value: String, options: Path.WriteOptions)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.append into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.append(value, options)))
+        def appendBytes(path: Path, value: Span[Byte], options: Path.WriteOptions)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.appendBytes into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.appendBytes(value, options)))
+        def appendLines(path: Path, value: Chunk[String], options: Path.WriteOptions)(using
+            Frame
+        ): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.appendLines into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.appendLines(value, options)))
+        def truncate(path: Path, size: Long)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.truncate into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.truncate(size)))
+        def setLastModified(path: Path, epochMs: Long)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.setLastModified into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.setLastModified(epochMs)))
+        def openWrite(path: Path, append: Boolean, options: Path.WriteOptions)(using
+            Frame
+        ): Path.WriteHandle < (Sync & Abort[FileWriteException]) =
+            // Unsafe: bridges Path.Unsafe.openWrite into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.openWrite(append, options)))
+        def writeChunk(handle: Path.WriteHandle, chunk: Chunk[Byte])(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: pumps a vended write handle into the safe tier
+            Sync.Unsafe.defer(Abort.get[FileWriteException](handle.writeBytes(chunk)))
+        def writeString(handle: Path.WriteHandle, value: String, charset: Charset)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            // Unsafe: pumps a vended write handle into the safe tier
+            Sync.Unsafe.defer(Abort.get[FileWriteException](handle.writeString(value, charset)))
+        def mkDir(path: Path)(using Frame): Unit < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.mkDir into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.mkDir()))
+        def mkFile(path: Path)(using Frame): Unit < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.mkFile into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.mkFile()))
+        def list(path: Path)(using Frame): Chunk[Path] < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.list into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.list()))
+        def list(path: Path, glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using
+            Frame
+        ): Chunk[Path] < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.list(glob) into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.list(glob, caseSensitivity)))
+        def move(
+            from: Path,
+            to: Path,
+            options: Path.MoveOptions
+        )(using Frame): Unit < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.move into the safe tier
+            Sync.Unsafe.defer(Abort.get(from.unsafe.move(to, options)))
+        def copy(
+            from: Path,
+            to: Path,
+            options: Path.CopyOptions
+        )(using Frame): Unit < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.copy into the safe tier
+            Sync.Unsafe.defer(Abort.get(from.unsafe.copy(to, options)))
+        def remove(path: Path)(using Frame): Boolean < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.remove into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.remove()))
+        def removeExisting(path: Path)(using Frame): Unit < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.removeExisting into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.removeExisting()))
+        def removeAll(path: Path)(using Frame): Unit < (Sync & Abort[FileStructureException]) =
+            // Unsafe: bridges Path.Unsafe.removeAll into the safe tier
+            Sync.Unsafe.defer(Abort.get(path.unsafe.removeAll()))
+        def tempDir(prefix: String)(using Frame): Path.TempDirHandle < (Sync & Abort[FileStructureException]) =
+            Path.tempDirUnscoped(prefix).map { dir =>
+                new Path.TempDirHandle:
+                    def path: Path = dir
+                    // Unsafe: recursive host delete of the created temp dir at Scope exit
+                    def remove()(using AllowUnsafe): Unit = discard(dir.unsafe.removeAll())
+            }
+    end HostFileSystem
+end HostFileSystem

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -177,6 +177,14 @@ object Path extends PathPlatformSpecific:
     infix def /(part: Path.Part)(using Frame): Path =
         make(flattenParts(Seq(part)))
 
+    /** A handle to a service-created temporary directory. Vended by `FileSystem.Write.tempDir` so a
+      * caller removes the directory through the service that created it. Internal.
+      */
+    abstract private[kyo] class TempDirHandle:
+        def path: Path
+        def remove()(using AllowUnsafe): Unit
+    end TempDirHandle
+
     // --- Safe extension methods ---
 
     extension (self: Path)

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
@@ -1,0 +1,24 @@
+package kyo
+
+import scala.compiletime.testing.typeCheckErrors
+
+/** Compile-time contract for the public filesystem conformance suite declarations. */
+class FileSystemConformanceDeclarationTest extends kyo.test.Test[Any]:
+
+    "all declared conformance suites are public shared types" in {
+        val suites = Chunk(
+            classOf[FileSystemReadTestSuite],
+            classOf[FileSystemWriteTestSuite]
+        )
+        assert(suites.size == 2)
+    }
+
+    "a read-only fixture cannot select write members" in {
+        val errors = typeCheckErrors("""
+            def check(read: kyo.FileSystem.Read[kyo.Sync])(using kyo.Frame) =
+                read.writeBytes(kyo.Path("file"), kyo.Span.empty[Byte], kyo.Path.WriteOptions())
+            """)
+        assert(errors.exists(_.message.contains("writeBytes")))
+    }
+
+end FileSystemConformanceDeclarationTest

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
@@ -1,0 +1,50 @@
+package kyo
+
+private object FileSystemConformanceFixtures:
+
+    private given Frame = Frame.internal
+
+    def host(prefix: String)(using
+        Frame
+    ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
+        Scope.acquireRelease(FileSystem.host.tempDir(prefix))(handle => Sync.Unsafe.defer(handle.remove())).map { handle =>
+            (FileSystem.host, handle.path)
+        }
+
+    def hostRead(using Frame): (FileSystem.Read[Sync], Path, String) < (Sync & Scope & Abort[FileSystemException]) =
+        host("kyo-host-read-suite").map { (fileSystem, root) =>
+            val file = root / "read.txt"
+            fileSystem.write(file, "read-value", Path.WriteOptions()).map(_ => (fileSystem, file, "read-value"))
+        }
+
+end FileSystemConformanceFixtures
+
+class HostFileSystemReadConformanceTest extends FileSystemReadTestSuite:
+    override protected def realPathRequiresExistence: Boolean = true
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Read[Sync], Path, String) < (Sync & Scope & Abort[FileSystemException]) =
+        FileSystemConformanceFixtures.hostRead
+end HostFileSystemReadConformanceTest
+
+class HostFileSystemWriteConformanceTest extends FileSystemWriteTestSuite:
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
+        FileSystemConformanceFixtures.host("kyo-host-write-suite")
+end HostFileSystemWriteConformanceTest
+
+/** Minimal user-defined backend fixture that deliberately exposes only the read tier. */
+final class UserReadOnlyFileSystemFixture(delegate: FileSystem.Read[Sync]) extends FileSystem.Read[Sync]:
+    export delegate.*
+end UserReadOnlyFileSystemFixture
+
+class UserReadOnlyFileSystemConformanceTest extends FileSystemReadTestSuite:
+    override protected def realPathRequiresExistence: Boolean = true
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Read[Sync], Path, String) < (Sync & Scope & Abort[FileSystemException]) =
+        FileSystemConformanceFixtures.hostRead.map { (fileSystem, path, expected) =>
+            (UserReadOnlyFileSystemFixture(fileSystem), path, expected)
+        }
+end UserReadOnlyFileSystemConformanceTest

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemReadTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemReadTestSuite.scala
@@ -1,0 +1,163 @@
+package kyo
+
+/** Reusable behavioral contract for readable filesystem backends.
+  *
+  * Implementations provide a fresh backend, a populated file, and its expected UTF-8 value for
+  * each assertion.
+  */
+abstract class FileSystemReadTestSuite extends kyo.test.Test[Any]:
+
+    private given Frame = Frame.internal
+
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Read[Sync], Path, String) < (Sync & Scope & Abort[FileSystemException])
+
+    /** Declares whether this backend resolves paths against a store that tracks existence.
+      *
+      * Backends over a real filesystem (host) fail with [[FileNotFoundException]] when asked to
+      * resolve an absent path. A backend whose paths are pure keys with no link topology could
+      * return the path unchanged instead. Each fixture states which it is, so `realPath` carries
+      * an asserted contract on every backend rather than an untested one.
+      */
+    protected def realPathRequiresExistence: Boolean = false
+
+    /** Declares whether this fixture can create a symbolic link, and creates one when it can.
+      *
+      * Symbolic links are the one filesystem behaviour this suite cannot exercise from shared code:
+      * there is no public link-creation operation, so each platform supplies its own. A backend
+      * whose paths are pure keys with no links at all leaves this declared false.
+      *
+      * Without this the suite asserts only that a regular file is not a link, which every backend
+      * satisfies by answering false to everything, including a backend that has stopped resolving
+      * links entirely. That one-sided assertion is what let a symlink-escape defect pass a green
+      * four-platform CI once already.
+      */
+    protected def supportsSymbolicLinks: Boolean = false
+
+    /** Creates a symbolic link at `link` pointing at `target`. Only called when
+      * [[supportsSymbolicLinks]] is true.
+      */
+    protected def createSymbolicLink(link: Path, target: Path)(using Frame): Unit < (Sync & Abort[FileSystemException]) =
+        Abort.panic(new UnsupportedOperationException("fixture declares supportsSymbolicLinks but does not implement it"))
+
+    "read suite reports a symbolic link as a link" in {
+        if !supportsSymbolicLinks then succeed
+        else
+            createFileSystem.map { (fileSystem, file, _) =>
+                val link = file.parent.getOrElse(Path()) / "link-to-file"
+                createSymbolicLink(link, file).andThen {
+                    fileSystem.isSymbolicLink(link).map { isLink =>
+                        assert(isLink, "a symbolic link must report as one")
+                        // The target must still report as a regular file, so a backend cannot pass
+                        // by answering true to everything any more than by answering false.
+                        fileSystem.isSymbolicLink(file).map(targetIsLink => assert(!targetIsLink))
+                    }
+                }
+            }
+    }
+
+    "read suite resolves a symbolic link to its target" in {
+        if !supportsSymbolicLinks then succeed
+        else
+            createFileSystem.map { (fileSystem, file, expected) =>
+                val link = file.parent.getOrElse(Path()) / "link-for-resolution"
+                createSymbolicLink(link, file).andThen {
+                    fileSystem.realPath(link).map { resolved =>
+                        fileSystem.realPath(file).map { target =>
+                            assert(resolved == target, s"link resolved to $resolved, target is $target")
+                            // Reading through the link must reach the same content, so resolution is
+                            // asserted against observable behaviour and not only against itself.
+                            fileSystem.read(link).map(value => assert(value == expected))
+                        }
+                    }
+                }
+            }
+    }
+
+    "read suite resolves an existing path idempotently" in {
+        createFileSystem.map { (fileSystem, file, _) =>
+            fileSystem.realPath(file).map { resolved =>
+                fileSystem.realPath(resolved).map(again => assert(again == resolved))
+            }
+        }
+    }
+
+    "read suite reports a regular file as not a symbolic link" in {
+        createFileSystem.map { (fileSystem, file, _) =>
+            fileSystem.isSymbolicLink(file).map(isLink => assert(!isLink))
+        }
+    }
+
+    "read suite resolves an absent path per its declared existence contract" in {
+        createFileSystem.map { (fileSystem, file, _) =>
+            val missing = file.parent.getOrElse(Path()) / "missing-for-realpath"
+            Abort.run[FileReadException](fileSystem.realPath(missing)).map { result =>
+                if realPathRequiresExistence then
+                    result match
+                        case Result.Failure(_: FileNotFoundException) => assert(true)
+                        case other => assert(false, s"expected FileNotFoundException for an absent path, got $other")
+                else
+                    result match
+                        case Result.Success(resolved) => assert(resolved == missing)
+                        case other                    => assert(false, s"expected the path returned unchanged, got $other")
+            }
+        }
+    }
+
+    "read suite resolves an absent path to itself via realPathPrefix" in {
+        createFileSystem.map { (fileSystem, file, _) =>
+            val parent  = file.parent.getOrElse(Path())
+            val missing = parent / "missing-for-prefix"
+            // Absence is not a failure here, unlike realPath: the resolved parent fixes where the
+            // path would land, and the segment below it is re-appended unchanged.
+            fileSystem.realPathPrefix(missing).map { resolved =>
+                fileSystem.realPathPrefix(parent).map { resolvedParent =>
+                    assert(resolved == resolvedParent / "missing-for-prefix", s"got $resolved")
+                }
+            }
+        }
+    }
+
+    "read suite resolves a path with several absent segments via realPathPrefix" in {
+        createFileSystem.map { (fileSystem, file, _) =>
+            val parent  = file.parent.getOrElse(Path())
+            val missing = parent / "absent-a" / "absent-b"
+            fileSystem.realPathPrefix(missing).map { resolved =>
+                fileSystem.realPathPrefix(parent).map { resolvedParent =>
+                    assert(resolved == resolvedParent / "absent-a" / "absent-b", s"got $resolved")
+                }
+            }
+        }
+    }
+
+    "read suite agrees between realPath and realPathPrefix on an existing path" in {
+        createFileSystem.map { (fileSystem, file, _) =>
+            fileSystem.realPath(file).map { viaRealPath =>
+                fileSystem.realPathPrefix(file).map(viaPrefix => assert(viaPrefix == viaRealPath))
+            }
+        }
+    }
+
+    "read suite returns the concrete stored value" in {
+        createFileSystem.map { (fileSystem, file, expected) =>
+            fileSystem.read(file).map(value => assert(value == expected))
+        }
+    }
+
+    "read suite reports a precise missing-file failure" in {
+        createFileSystem.map { (fileSystem, file, _) =>
+            Abort.run[FileReadException](fileSystem.read(file.parent.getOrElse(Path()) / "missing-file")).map {
+                case Result.Failure(_: FileNotFoundException) => assert(true)
+                case other                                    => assert(false, s"expected FileNotFoundException, got $other")
+            }
+        }
+    }
+
+    "read suite supports deterministic concurrent reads" in {
+        createFileSystem.map { (fileSystem, file, expected) =>
+            Async.zip(fileSystem.read(file), fileSystem.read(file)).map(values => assert(values == (expected, expected)))
+        }
+    }
+
+end FileSystemReadTestSuite

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemTest.scala
@@ -1,0 +1,79 @@
+package kyo
+
+import java.nio.charset.Charset
+
+/** Tests for the top-level [[FileSystem]] surface: the read and write tiers as types, and a
+  * user-defined backend answering through the same service methods the host backend implements.
+  */
+class FileSystemTest extends kyo.test.Test[Any]:
+
+    /** Rebases `write` and `read`, the only two ops this suite exercises, under `root`. Two instances
+      * backed by the real host filesystem then behave as independent stores addressable through the
+      * same literal `Path` value, which is what a backend test needs: the store a read reaches must
+      * depend only on which service it is asked of.
+      */
+    final private class IsolatedFileSystem(root: Path) extends FileSystem.Write[Sync]:
+        private val delegate = FileSystem.host
+        export delegate.{read as _, write as _, *}
+        def write(path: Path, value: String, options: Path.WriteOptions)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            delegate.write(root / path, value, options)
+        def read(path: Path)(using Frame): String < (Sync & Abort[FileReadException]) =
+            delegate.read(root / path)
+        def read(path: Path, charset: Charset)(using Frame): String < (Sync & Abort[FileReadException]) =
+            delegate.read(root / path, charset)
+    end IsolatedFileSystem
+
+    private def isolatedFileSystem(prefix: String)(using Frame): FileSystem.Write[Sync] < (Sync & Scope & Abort[FileSystemException]) =
+        Scope.acquireRelease(FileSystem.host.tempDir(prefix))(handle => Sync.Unsafe.defer(handle.remove())).map { handle =>
+            IsolatedFileSystem(handle.path)
+        }
+
+    "Read exposes no write member" in {
+        typeCheckFailure(
+            "def check(read: kyo.FileSystem.Read[kyo.Sync]) = read.writeBytes(kyo.Path(\"a\"), kyo.Span.empty[Byte], kyo.Path.WriteOptions())"
+        )(
+            "value writeBytes is not a member"
+        )
+    }
+
+    "Write satisfies Read" in {
+        typeCheck("def check(write: kyo.FileSystem.Write[kyo.Sync]): kyo.FileSystem.Read[kyo.Sync] = write")
+    }
+
+    "a Read-only backend does not satisfy Write" in {
+        typeCheckFailure("def check(read: kyo.FileSystem.Read[kyo.Sync]): kyo.FileSystem.Write[kyo.Sync] = read")(
+            "Found"
+        )
+    }
+
+    "public rows use precise categories" in {
+        typeCheck(
+            "def check(fs: kyo.FileSystem.Read[kyo.Sync]): kyo.Span[Byte] < (kyo.Sync & kyo.Abort[kyo.FileReadException]) = fs.readBytes(kyo.Path(\"a\"))"
+        )
+        typeCheck(
+            "def check(fs: kyo.FileSystem.Write[kyo.Sync]): Unit < (kyo.Sync & kyo.Abort[kyo.FileWriteException]) = fs.writeBytes(kyo.Path(\"a\"), kyo.Span.empty[Byte], kyo.Path.WriteOptions())"
+        )
+    }
+
+    "a user-defined backend serves reads and writes through the service methods" in {
+        isolatedFileSystem("kyo-fs-top-level").map { service =>
+            val p = Path("a")
+            service.write(p, "x", Path.WriteOptions()).andThen {
+                service.read(p).map(v => assert(v == "x"))
+            }
+        }
+    }
+
+    "two backends addressed by the same path reach independent stores" in {
+        for
+            outer <- isolatedFileSystem("kyo-fs-outer")
+            inner <- isolatedFileSystem("kyo-fs-inner")
+            selected = Path("selected.txt")
+            _         <- outer.write(selected, "outer", Path.WriteOptions())
+            _         <- inner.write(selected, "inner", Path.WriteOptions())
+            fromOuter <- outer.read(selected)
+            fromInner <- inner.read(selected)
+        yield assert((fromOuter, fromInner) == ("outer", "inner"))
+    }
+
+end FileSystemTest

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemWriteTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemWriteTestSuite.scala
@@ -1,0 +1,83 @@
+package kyo
+
+/** Reusable behavioral contract for mutable filesystem backends. */
+abstract class FileSystemWriteTestSuite extends kyo.test.Test[Any]:
+
+    private given Frame = Frame.internal
+
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException])
+
+    "write suite round-trips a concrete value" in {
+        createFileSystem.map { (fileSystem, root) =>
+            val file = root / "value.txt"
+            fileSystem.write(file, "value", Path.WriteOptions()).andThen(fileSystem.read(file)).map(value => assert(value == "value"))
+        }
+    }
+
+    "write suite reports missing parents" in {
+        createFileSystem.map { (fileSystem, root) =>
+            val file = root / "missing" / "value.txt"
+            Abort.run[FileWriteException](fileSystem.write(file, "value", Path.WriteOptions(createFolders = false))).map {
+                case Result.Failure(_: FileNotFoundException) => assert(true)
+                case other                                    => assert(false, s"expected FileNotFoundException, got $other")
+            }
+        }
+    }
+
+    "write suite preserves concurrent sibling writes" in {
+        createFileSystem.map { (fileSystem, root) =>
+            val first  = root / "first.txt"
+            val second = root / "second.txt"
+            for
+                gate   <- Latch.init(1)
+                left   <- Fiber.initUnscoped(gate.await.andThen(fileSystem.write(first, "left", Path.WriteOptions())))
+                right  <- Fiber.initUnscoped(gate.await.andThen(fileSystem.write(second, "right", Path.WriteOptions())))
+                _      <- gate.release
+                _      <- left.get
+                _      <- right.get
+                values <- Async.zip(fileSystem.read(first), fileSystem.read(second))
+            yield assert(values == ("left", "right"))
+            end for
+        }
+    }
+
+    "write suite gives distinct temporary directories for one prefix" in {
+        createFileSystem.map { (fileSystem, _) =>
+            // Two calls with the same prefix, which is the ordinary case: Path.tempDir defaults its
+            // prefix to a literal, and literals are interned, so both calls receive the identical
+            // String instance. A name derived from that instance is the same name twice, and the
+            // first handle's removal then destroys the second caller's directory.
+            Scope.run {
+                fileSystem.tempDir("conformance-temp").map { first =>
+                    fileSystem.tempDir("conformance-temp").map { second =>
+                        assert(first.path != second.path, s"both calls returned ${first.path}")
+                    }
+                }
+            }
+        }
+    }
+
+    "write suite agrees with its declared case sensitivity" in {
+        createFileSystem.map { (fileSystem, root) =>
+            // Asserted against observed behaviour rather than against the declared value, which is
+            // what makes this two-sided: a backend that reports the wrong policy fails here no
+            // matter which value it reports. Checking a policy by branching on that same policy is
+            // satisfied by any self-consistent answer, including a wrong one.
+            val file = root / "CaseProbe.txt"
+            fileSystem.write(file, "probe", Path.WriteOptions()).andThen {
+                fileSystem.defaultCaseSensitivity.map { declared =>
+                    fileSystem.exists(root / "caseprobe.txt").map { lowerFound =>
+                        declared match
+                            case Glob.CaseSensitivity.Insensitive =>
+                                assert(lowerFound, "declared case-insensitive, but a differently-cased name was not found")
+                            case Glob.CaseSensitivity.Sensitive =>
+                                assert(!lowerFound, "declared case-sensitive, but a differently-cased name resolved to the same file")
+                    }
+                }
+            }
+        }
+    }
+
+end FileSystemWriteTestSuite

--- a/kyo-system/shared/src/test/scala/kyo/PathSnapshotTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathSnapshotTest.scala
@@ -27,7 +27,9 @@ class PathSnapshotTest extends kyo.test.Test[Any]:
                     (root / "nested" / "b.txt").write("b").andThen {
                         root.list.map { top =>
                             (root / "nested").list.map { nested =>
-                                assert(top == Chunk(root / "a.txt", root / "nested"))
+                                // list order is unspecified: Files.list and readdirSync both report entries
+                                // in filesystem order, which differs between platforms and architectures.
+                                assert(top.toList.sortBy(_.parts.last) == List(root / "a.txt", root / "nested"))
                                 assert(nested == Chunk(root / "nested" / "b.txt"))
                                 val normalized = Chunk("root/", "root/a.txt=a", "root/nested/", "root/nested/b.txt=b")
                                 assert(normalized.mkString("\n") == PathSnapshotValues.normalizedTree)


### PR DESCRIPTION
### What this adds

`FileSystem.Read` and `FileSystem.Write` describe filesystem access as a service, and `HostFileSystem` implements them over the platform backends already in the module. The read and write conformance suites pin the contract against the host backend.

Nothing calls the new service yet, deliberately: no public `Path` signature changes and no module outside `kyo-system` changes in this pull request. That is what lets the capability flip arrive as its own reviewable change directly above.

One note for reviewers: `p.list(glob)` uses `Sensitive` matching while `FileSystem.host.list(p, glob)` probes the volume, so the two can disagree on a case-insensitive volume. The divergence lasts exactly one pull request and closes when the flip routes `Path` through the service.

### Stack

Part of the path-capability stack on #1859: process fixes, filesystem vocabulary, abstraction, capability flip, channels, locks, watch, durability, confinement, in-memory, zip, then overlay (#1799). Merge bottom up; GitHub retargets the stack above each merge.

Each branch carries one synthesized commit whose diff is exactly this pull request. The original incremental development history remains visible in #1799's earlier timeline and in the backup refs recorded in the working notes.
