### PR TITLE
[kyo-system] track filesystem access in the type system

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,8 +389,8 @@ This is guidance for new and changed code. Existing APIs that thread byte counts
 
 | Kyo primitive         | Purpose                | Notes                                                                                   |
 | --------------------- | ---------------------- | --------------------------------------------------------------------------------------- |
-| `Path`                | File system operations | Immutable, cross-platform; construct with `/`, effect-tracked read/write                  |
-| `FileSystem`          | Pluggable backend      | Filesystem service, with a host implementation over the platform backends                 |
+| `Path`                | File system operations | Immutable, cross-platform; construct with `/`, reads carry `PathRead`, writes `PathWrite` |
+| `FileSystem`          | Pluggable backend      | Host filesystem service the runners install                                               |
 | `Command`             | OS process launch      | Builds and runs external processes; `spawn`, `text`, `waitFor`                            |
 | `Process`             | Running process handle | `stdout`, `stderr`, `waitFor`, `destroy`                                                  |
 | `System`              | Environment/properties | Type-safe access with custom `Parser`s                                                    |

--- a/build.sbt
+++ b/build.sbt
@@ -365,7 +365,6 @@ lazy val kyoJVM: Project = project
         `kyo-prelude`.jvm,
         `kyo-parse`.jvm,
         `kyo-core`.jvm,
-        `kyo-system`.jvm,
         `kyo-offheap`.jvm,
         `kyo-ffi`.jvm,
         `kyo-ffi-codegen`,
@@ -396,6 +395,7 @@ lazy val kyoJVM: Project = project
         `kyo-sql-postgres`.jvm,
         `kyo-sql-mysql`.jvm,
         `kyo-sql-tests`.jvm,
+        `kyo-system`.jvm,
         `kyo-http`.jvm,
         `kyo-flow`.jvm,
         `kyo-ai`.jvm,
@@ -453,7 +453,6 @@ lazy val kyoJS = project
         `kyo-prelude`.js,
         `kyo-parse`.js,
         `kyo-core`.js,
-        `kyo-system`.js,
         `kyo-ffi`.js,
         `kyo-ffi-it`.js,
         `kyo-net`.js,
@@ -483,6 +482,7 @@ lazy val kyoJS = project
         `kyo-sql-postgres`.js,
         `kyo-sql-mysql`.js,
         `kyo-sql-tests`.js,
+        `kyo-system`.js,
         `kyo-http`.js,
         `kyo-aeron`.js,
         `kyo-flow`.js,
@@ -525,7 +525,6 @@ lazy val kyoNative = project
         `kyo-config`.native,
         `kyo-scheduler`.native,
         `kyo-core`.native,
-        `kyo-system`.native,
         `kyo-offheap`.native,
         `kyo-ffi`.native,
         `kyo-ffi-it`.native,
@@ -549,6 +548,7 @@ lazy val kyoNative = project
         `kyo-sql-postgres`.native,
         `kyo-sql-mysql`.native,
         `kyo-sql-tests`.native,
+        `kyo-system`.native,
         `kyo-http`.native,
         `kyo-aeron`.native,
         `kyo-flow`.native,
@@ -606,9 +606,9 @@ lazy val kyoWasm = project
         `kyo-sql-postgres`.wasm,
         `kyo-sql-mysql`.wasm,
         `kyo-sql-tests`.wasm,
+        `kyo-system`.wasm,
         `kyo-scheduler`.wasm,
         `kyo-core`.wasm,
-        `kyo-system`.wasm,
         `kyo-ffi`.wasm,
         `kyo-direct`.wasm,
         `kyo-stm`.wasm,
@@ -811,6 +811,7 @@ lazy val `kyo-schema` =
         .crossType(CrossType.Full)
         .dependsOn(`kyo-data` % "test->test;compile->compile")
         .dependsOn(`kyo-core` % "test->compile")
+        .dependsOn(`kyo-system` % "test->compile")
         .in(file("kyo-schema"))
         .withKyoTest
         .settings(`kyo-settings`)
@@ -820,6 +821,18 @@ lazy val `kyo-schema` =
         .jvmConfigure(_.settings(doctestSources := Seq.empty))
         .nativeSettings(`native-settings`)
         .jsSettings(`js-settings`, Test / scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))
+        .wasmSettings(`wasm-settings`)
+
+lazy val `kyo-system` =
+    crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-system"))
+        .dependsOn(`kyo-core`)
+        .withKyoTest
+        .settings(`kyo-settings`)
+        .jvmSettings(mimaCheck(false))
+        .nativeSettings(`native-settings`)
+        .jsSettings(`js-settings`, scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))
         .wasmSettings(`wasm-settings`)
 
 lazy val `kyo-schema-json` =
@@ -913,7 +926,6 @@ lazy val `kyo-schema-ion` =
         .crossType(CrossType.Full)
         .dependsOn(`kyo-schema` % "test->test;compile->compile")
         .dependsOn(`kyo-core` % "test->compile")
-        .dependsOn(`kyo-system` % "test->compile")
         .in(file("kyo-schema-ion"))
         .withKyoTest
         .settings(`kyo-settings`)
@@ -947,7 +959,6 @@ lazy val `kyo-sql` =
         .dependsOn(`kyo-schema-json`)
         .dependsOn(`kyo-net`)
         .dependsOn(`kyo-pod` % "test->compile")
-        .dependsOn(`kyo-system` % "test->compile")
         .in(file("kyo-sql"))
         .withKyoTest
         .settings(`kyo-settings`)
@@ -973,7 +984,6 @@ lazy val `kyo-sql-postgres` =
         .crossType(CrossType.Full)
         .dependsOn(`kyo-sql` % "test->test;compile->compile")
         .dependsOn(`kyo-pod` % "test->compile")
-        .dependsOn(`kyo-system` % "test->compile")
         .in(file("kyo-sql-postgres"))
         .withKyoTest
         .settings(`kyo-settings`)
@@ -993,7 +1003,6 @@ lazy val `kyo-sql-mysql` =
         .crossType(CrossType.Full)
         .dependsOn(`kyo-sql` % "test->test;compile->compile")
         .dependsOn(`kyo-pod` % "test->compile")
-        .dependsOn(`kyo-system` % "test->compile")
         .in(file("kyo-sql-mysql"))
         .withKyoTest
         .settings(`kyo-settings`)
@@ -1062,18 +1071,6 @@ lazy val `kyo-core` =
             // Same java.util.logging shim as JS.
             libraryDependencies += ("org.scala-js" %%% "scalajs-java-logging" % "1.0.0").cross(CrossVersion.for3Use2_13)
         )
-
-lazy val `kyo-system` =
-    crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .crossType(CrossType.Full)
-        .in(file("kyo-system"))
-        .dependsOn(`kyo-core`)
-        .withKyoTest
-        .settings(`kyo-settings`)
-        .jvmSettings(mimaCheck(false))
-        .nativeSettings(`native-settings`)
-        .jsSettings(`js-settings`, scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) })
-        .wasmSettings(`wasm-settings`)
 
 lazy val `kyo-offheap` =
     crossProject(JVMPlatform, NativePlatform)
@@ -1386,8 +1383,7 @@ lazy val `kyo-tasty` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-tasty"))
-        .dependsOn(`kyo-core`, `kyo-schema`)
-        .dependsOn(`kyo-system`)
+        .dependsOn(`kyo-core`, `kyo-schema`, `kyo-system`)
         .dependsOn(`kyo-schema-json` % "test->compile")
         .withKyoTest
         .settings(
@@ -1522,8 +1518,7 @@ lazy val `kyo-stats-machine` =
         .crossType(CrossType.Full)
         .in(file("kyo-stats-machine"))
         .enablePlugins(KyoFfiPlugin)
-        .dependsOn(`kyo-ffi`)
-        .dependsOn(`kyo-system`)
+        .dependsOn(`kyo-ffi`, `kyo-system`)
         .withKyoTest
         .settings(
             `kyo-settings`,
@@ -1851,8 +1846,7 @@ lazy val `kyo-net` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
         .crossType(CrossType.Full)
         .enablePlugins(KyoFfiPlugin)
-        .dependsOn(`kyo-core`, `kyo-config`)
-        .dependsOn(`kyo-system`)
+        .dependsOn(`kyo-core`, `kyo-config`, `kyo-system`)
         .dependsOn(`kyo-ffi`)
         .in(file("kyo-net"))
         .withKyoTest
@@ -2306,8 +2300,7 @@ lazy val `kyo-compiler` =
     crossProject(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compiler"))
-        .dependsOn(`kyo-core`, `kyo-aeron`, `kyo-ai` % Test)
-        .dependsOn(`kyo-system`)
+        .dependsOn(`kyo-core`, `kyo-aeron`, `kyo-ai` % Test, `kyo-system`)
         .withKyoTest
         .settings(
             `kyo-settings`,
@@ -2326,7 +2319,6 @@ lazy val `kyo-http` =
         .crossType(CrossType.Full)
         .in(file("kyo-http"))
         .dependsOn(`kyo-core`, `kyo-config`, `kyo-schema-json`)
-        .dependsOn(`kyo-system` % Test)
         .dependsOn(`kyo-net` % "compile->compile;test->test")
         .withKyoTest
         .settings(
@@ -2366,8 +2358,7 @@ lazy val `kyo-ai` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-ai"))
-        .dependsOn(`kyo-core`, `kyo-schema-json`, `kyo-http`, `kyo-actor`, `kyo-jsonrpc`, `kyo-jsonrpc-http`, `kyo-mcp`)
-        .dependsOn(`kyo-system`)
+        .dependsOn(`kyo-core`, `kyo-schema-json`, `kyo-http`, `kyo-actor`, `kyo-jsonrpc`, `kyo-jsonrpc-http`, `kyo-mcp`, `kyo-system`)
         .withKyoTest
         .settings(`kyo-settings`)
         .jvmSettings(mimaCheck(false))
@@ -2439,7 +2430,6 @@ lazy val `kyo-mcp` =
         .in(file("kyo-mcp"))
         .withKyoTest
         .dependsOn(`kyo-jsonrpc`)
-        .dependsOn(`kyo-system` % Test)
         .settings(`kyo-settings`)
         .jvmSettings(mimaCheck(false))
         // Test-only dep so the JVM demo MCP servers (jvm/src/test/scala/demo) can drive
@@ -2455,6 +2445,7 @@ lazy val `kyo-lsp` =
         .in(file("kyo-lsp"))
         .withKyoTest
         .dependsOn(`kyo-jsonrpc`)
+        .dependsOn(`kyo-system`)
         .settings(`kyo-settings`)
         .jvmSettings(mimaCheck(false))
         .nativeSettings(`native-settings`)
@@ -2849,8 +2840,7 @@ lazy val `kyo-browser` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-browser"))
-        .dependsOn(`kyo-http`, `kyo-jsonrpc`, `kyo-jsonrpc-http`)
-        .dependsOn(`kyo-system`)
+        .dependsOn(`kyo-http`, `kyo-jsonrpc`, `kyo-jsonrpc-http`, `kyo-system`)
         .withKyoTest
         .settings(
             `kyo-settings`
@@ -2919,7 +2909,6 @@ lazy val `kyo-slack` =
         .crossType(CrossType.Full)
         .in(file("kyo-slack"))
         .dependsOn(`kyo-http`, `kyo-schema-json`)
-        .dependsOn(`kyo-system` % Test)
         .withKyoTest
         .settings(
             `kyo-settings`
@@ -2959,8 +2948,7 @@ lazy val `kyo-i18n` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-i18n"))
-        .dependsOn(`kyo-core`)
-        .dependsOn(`kyo-system`)
+        .dependsOn(`kyo-core`, `kyo-system`)
         .withKyoTest
         .settings(`kyo-settings`)
         .jvmSettings(mimaCheck(false))
@@ -2974,7 +2962,6 @@ lazy val `kyo-ui` =
         .in(file("kyo-ui"))
         .dependsOn(`kyo-core`, `kyo-http`)
         .dependsOn(`kyo-browser` % Test)
-        .dependsOn(`kyo-system` % Test)
         .withKyoTest
         .settings(
             `kyo-settings`
@@ -3081,11 +3068,11 @@ lazy val `kyo-examples` =
         .crossType(CrossType.Full)
         .in(file("kyo-examples"))
         .dependsOn(`kyo-http`)
-        .dependsOn(`kyo-system`)
         .dependsOn(`kyo-schema-json`)
         .dependsOn(`kyo-direct`)
         .dependsOn(`kyo-core`)
         .dependsOn(`kyo-actor`)
+        .dependsOn(`kyo-system`)
         .disablePlugins(MimaPlugin)
         .settings(
             `kyo-settings`,
@@ -3178,10 +3165,10 @@ lazy val `kyo-doctest` =
         .crossType(CrossType.Full)
         .in(file("kyo-doctest"))
         .dependsOn(`kyo-core`)
-        .dependsOn(`kyo-system`)
         .dependsOn(`kyo-schema-json`)
         .dependsOn(`kyo-parse`)
         .dependsOn(`kyo-direct` % Test)
+        .dependsOn(`kyo-system`)
         .withKyoTest
         .disablePlugins(MimaPlugin)
         .jvmConfigure(_.disablePlugins(KyoDoctestPlugin))

--- a/kyo-aeron/shared/src/main/scala/kyo/Topic.scala
+++ b/kyo-aeron/shared/src/main/scala/kyo/Topic.scala
@@ -109,7 +109,7 @@ object Topic:
         v: A < (Topic & S)
     )(using Frame): A < (Async & S) =
         Scope.run {
-            Abort.run[FileStructureException](Path.tempDir("kyo-aeron-embedded")).map {
+            Abort.run[FileSystemException](Path.run(Path.tempDir("kyo-aeron-embedded"))).map {
                 case Result.Success(dir) =>
                     AeronPlatform.embedded(dir.unsafe.show, clientLivenessNs, publicationUnblockNs).map { runtime =>
                         // The driver deletes its own directory on close, once its conductor has

--- a/kyo-aeron/shared/src/test/scala/kyo/AeronClientTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/AeronClientTest.scala
@@ -47,7 +47,7 @@ class AeronClientTest extends Test:
         )(client => Sync.Unsafe.defer(client.unsafe.close()))
 
     "connect + single Topic.run(client) round-trip: received == Chunk(1L,2L)" in {
-        Path.tempDir("kyo-aeron-client-l1").map { dir =>
+        Path.run(Path.tempDir("kyo-aeron-client-l1")).map { dir =>
             Scope.run {
                 withExternalDriver(dir) {
                     AeronClient.connect(dir).map { client =>
@@ -70,7 +70,7 @@ class AeronClientTest extends Test:
 
     // run(client) does NOT close the client, so one connect backs both scopes.
     "one shared client backs multiple run(client) scopes: Chunk(10L,20L)" in {
-        Path.tempDir("kyo-aeron-client-l2").map { dir =>
+        Path.run(Path.tempDir("kyo-aeron-client-l2")).map { dir =>
             Scope.run {
                 withExternalDriver(dir) {
                     AeronClient.connect(dir).map { client =>
@@ -92,7 +92,7 @@ class AeronClientTest extends Test:
     }
 
     "client closes exactly once on normal Scope exit (close-count == 1)" in {
-        Path.tempDir("kyo-aeron-client-l3").map { dir =>
+        Path.run(Path.tempDir("kyo-aeron-client-l3")).map { dir =>
             AtomicInt.init(0).map { closeCount =>
                 Scope.run {
                     withExternalDriver(dir) {
@@ -126,7 +126,7 @@ class AeronClientTest extends Test:
 
     // The timeout interrupts the stream; the Scope finalizer must still fire and close the client.
     "cancellation/timeout releases the client; close-count == 1" in {
-        Path.tempDir("kyo-aeron-client-l4").map { dir =>
+        Path.run(Path.tempDir("kyo-aeron-client-l4")).map { dir =>
             AtomicInt.init(0).map { closeCount =>
                 Scope.run {
                     withExternalDriver(dir) {
@@ -150,7 +150,7 @@ class AeronClientTest extends Test:
     // A fresh empty tempDir has no driver, so the connect waits out the ~10 s driver-timeout before
     // failing. Same typed failure as Topic.run(absentDir): both go through the shared external primitive.
     "absent-driver connect aborts TopicTransportFailedException (JVM/JS/Native)" in {
-        Path.tempDir("kyo-aeron-absent-client").map { absentDir =>
+        Path.run(Path.tempDir("kyo-aeron-absent-client")).map { absentDir =>
             Scope.run {
                 Abort.run[TopicException] {
                     AeronClient.connect(absentDir).map { client =>

--- a/kyo-aeron/shared/src/test/scala/kyo/AeronTransportTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/AeronTransportTest.scala
@@ -258,7 +258,7 @@ class AeronTransportTest extends Test:
     "round-trip a known byte payload through AeronPlatform.embedded" in {
         val payload = Array[Byte](1, 2, 3, 4)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, roundTripStreamId))
@@ -285,7 +285,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(
             java.util.Arrays.equals(bytes, payload),
             s"payload mismatch: ${bytes.toList} != ${payload.toList}"
@@ -295,7 +295,7 @@ class AeronTransportTest extends Test:
 
     "offer to not-connected publication takes the not-connected path" in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, notConnectedStreamId))
@@ -318,7 +318,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield
             assert(notConnectedInitially, "Expected publication to be not-connected with no subscriber")
             assert(connectedPosition > 0, s"Expected a positive position after connection; got $connectedPosition")
@@ -326,7 +326,7 @@ class AeronTransportTest extends Test:
 
     "pollOne with zero fragments returns Absent" in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, absentStreamId))
@@ -349,13 +349,13 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(result.isEmpty, s"Expected Absent when no message published; got $result")
     }
 
     "close releases resources without leak" in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, closeStreamId))
@@ -373,9 +373,9 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(subMaybe.get)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
             // A second embedded() confirms the close was clean.
-            dir2 <- Path.tempDir("kyo-aeron-embedded-test")
+            dir2 <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt2  <- AeronPlatform.embedded(dir2.unsafe.show)
             transport2 = rt2.transport
             pub2TokMaybe <- Sync.Unsafe.defer(transport2.asyncAddPublication(ipcUri, closeStreamId))
@@ -385,7 +385,7 @@ class AeronTransportTest extends Test:
                 transport2.freeAsyncPub(pub2TokMaybe.get)
                 rt2.close()
             }
-            _ <- dir2.removeAll
+            _ <- Path.run(dir2.removeAll)
         // Reaching here without a crash proves the close-and-reopen cycle succeeded.
         yield succeed
     }
@@ -395,7 +395,7 @@ class AeronTransportTest extends Test:
         // single impl. TopicInvariantsTest defers its offer-sentinel coverage here, keeping only a
         // `.onlyJs` leaf for the koffi BigInt->Long sign-marshalling guard.
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubMaybeResult <- Abort.run[TopicTransportException] {
@@ -414,7 +414,7 @@ class AeronTransportTest extends Test:
                 transport.closePublication(pub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield
             assert(
                 result < 0,
@@ -434,7 +434,7 @@ class AeronTransportTest extends Test:
         val stringId = Tag[String].hash.abs
         val payload  = Array[Byte](99)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubIntTokMaybe    <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, intId))
@@ -468,7 +468,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(subString)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(
             stringResult.isEmpty,
             s"Expected Absent on String subscription after publishing to Int stream; got $stringResult"
@@ -482,7 +482,7 @@ class AeronTransportTest extends Test:
         val multiFragId = 98 // distinct stream-id; no cross-test bleed
         val payload     = Array.tabulate[Byte](4096)(i => (i & 0xff).toByte)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, multiFragId))
@@ -508,7 +508,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(
             java.util.Arrays.equals(received.get, payload),
             s"multi-fragment payload mismatch: expected 4096 bytes, got ${received.get.length}"
@@ -521,7 +521,7 @@ class AeronTransportTest extends Test:
         val largeFragId = 99 // distinct stream-id; no cross-test bleed
         val large       = Array.tabulate[Byte](2 * 1024 * 1024)(i => (i & 0xff).toByte)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, largeFragId))
@@ -547,7 +547,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(
             java.util.Arrays.equals(received.get, large),
             s"2 MiB payload mismatch: expected ${large.length} bytes, got ${received.get.length}"
@@ -561,7 +561,7 @@ class AeronTransportTest extends Test:
         val large         = Array.tabulate[Byte](256 * 1024)(i => ((i * 31) & 0xff).toByte)
         val small         = Array[Byte](9, 8, 7, 6, 5)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, reuseStreamId))
@@ -595,7 +595,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(
             java.util.Arrays.equals(receivedSmall.get, small),
             s"small payload mismatch after large: expected ${small.toList}, got ${receivedSmall.get.toList}"
@@ -611,7 +611,7 @@ class AeronTransportTest extends Test:
         Loop.indexed { i =>
             if i >= 20 then Loop.done(succeed)
             else
-                Path.tempDir("kyo-aeron-embedded-test").flatMap { dir =>
+                Path.run(Path.tempDir("kyo-aeron-embedded-test")).flatMap { dir =>
                     AeronPlatform.embedded(dir.unsafe.show).map { rt =>
                         Sync.Unsafe.defer {
                             val transport = rt.transport
@@ -748,7 +748,7 @@ class AeronTransportTest extends Test:
     // interruptible.
     "an interrupt during a pending add is honored and does not hang" in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             result <- Abort.run[Timeout | TopicTransportException] {
@@ -759,14 +759,14 @@ class AeronTransportTest extends Test:
             // The runtime close cleans up any publication the add produced; the Sync.ensure inside
             // addPublicationDeadline frees the async token if interrupted mid-poll.
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield succeed
     }
 
     "a normal add via addPublicationDeadline completes and round-trips bytes" in {
         val payload = Array[Byte](42, 43, 44)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubMaybeResult <- Abort.run[TopicTransportException] {
@@ -800,7 +800,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(
             java.util.Arrays.equals(received.get, payload),
             s"round-trip payload mismatch: got ${received.get.toList}"
@@ -885,7 +885,7 @@ class AeronTransportTest extends Test:
             bindings <- Sync.Unsafe.defer(Ffi.load[AeronBindings])
             // A unique per-instance dir rather than null, which would route to Aeron's single
             // shared default directory and risk colliding with a concurrent run.
-            dir <- Path.tempDir("kyo-aeron-uaf-reads")
+            dir <- Path.run(Path.tempDir("kyo-aeron-uaf-reads"))
             // driverStart/clientConnect are @Ffi.blocking, so each yields a Fiber.Unsafe bridged
             // via .safe.get.
             driver   <- Sync.Unsafe.defer(bindings.driverStart(dir.unsafe.show, 0L, 0L)).flatMap(_.safe.get)
@@ -914,7 +914,7 @@ class AeronTransportTest extends Test:
                 bindings.subscriptionClose(sub)
                 bindings.driverClose(driver)
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield
             assert(pubConnected == 0, s"publicationIsConnected after close must be 0 (not connected); got $pubConnected")
             assert(subConnected == 0, s"subscriptionIsConnected after close must be 0 (not connected); got $subConnected")
@@ -930,7 +930,7 @@ class AeronTransportTest extends Test:
     "UAF-sentinel: an offer on a publication after a concurrent client close returns the safe sentinel" in {
         val payload = Array[Byte](1, 2, 3, 4)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubMaybeResult <- Abort.run[TopicTransportException] {
@@ -949,7 +949,7 @@ class AeronTransportTest extends Test:
             // Release the publication bundle's client-bundle ref (closing=1, so it skips the freed
             // handle and frees the bundle).
             _ <- Sync.Unsafe.defer(transport.closePublication(pub))
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(
             offerResult == AeronSentinels.Closed,
             s"expected offer on a closed-client publication to return AeronSentinels.Closed (-4); got $offerResult"
@@ -970,7 +970,7 @@ class AeronTransportTest extends Test:
         val oversizeUri = "aeron:ipc?term-length=65536"
         val oversize    = Array.fill[Byte](8193)(0)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(oversizeUri, oversizeJvmStreamId))
@@ -991,7 +991,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield result match
             case Result.Success(r) =>
                 assert(
@@ -1010,7 +1010,7 @@ class AeronTransportTest extends Test:
         val oversizeUri = "aeron:ipc?term-length=65536"
         val oversize    = Array.fill[Byte](8193)(0)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(oversizeUri, oversizeCrossStreamId))
@@ -1031,7 +1031,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield result match
             case Result.Success(r) =>
                 assert(
@@ -1054,7 +1054,7 @@ class AeronTransportTest extends Test:
     // exit() the process.
     "an injected fatal error is recorded in the slot and the process survives" in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             _        <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
@@ -1064,7 +1064,7 @@ class AeronTransportTest extends Test:
                 s"fatalError expected Present('driver timeout') after inject; got $recorded"
             )
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield succeed
         end for
     }
@@ -1072,7 +1072,7 @@ class AeronTransportTest extends Test:
     // The next offer boundary checks fatalError and aborts, never exits the process.
     "a publish after a recorded fatal error aborts TopicTransportFailedException" in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             _ <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
@@ -1082,7 +1082,7 @@ class AeronTransportTest extends Test:
                 }
             }
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield result match
             case Result.Failure(f: TopicTransportFailedException) =>
                 assert(
@@ -1101,7 +1101,7 @@ class AeronTransportTest extends Test:
     // Symmetric to the publish path, at the stream's poll boundary.
     "a stream after a recorded fatal error aborts TopicTransportFailedException" in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             _ <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
@@ -1111,7 +1111,7 @@ class AeronTransportTest extends Test:
                 }
             }
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield result match
             case Result.Failure(f: TopicTransportFailedException) =>
                 assert(
@@ -1131,7 +1131,7 @@ class AeronTransportTest extends Test:
     "no recorded error means normal operation, fatalError stays Absent" in {
         val payload = Array[Byte](10, 20, 30)
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             beforeOp <- Sync.Unsafe.defer(transport.fatalError)
@@ -1159,7 +1159,7 @@ class AeronTransportTest extends Test:
                 transport.closeSubscription(sub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield assert(
             java.util.Arrays.equals(received.get, payload),
             s"round-trip payload mismatch: got ${received.get.toList}"
@@ -1173,7 +1173,7 @@ class AeronTransportTest extends Test:
     // Were presence not the key, an empty-message fatal error would map to Absent and retry forever.
     "empty-message fatal error inject surfaces TopicTransportFailedException with non-empty detail" in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             _        <- Sync.Unsafe.defer(transport.injectError(42, ""))
@@ -1192,7 +1192,7 @@ class AeronTransportTest extends Test:
                 }
             }
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield result match
             case Result.Failure(f: TopicTransportFailedException) =>
                 assert(

--- a/kyo-aeron/shared/src/test/scala/kyo/TopicInvariantsTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/TopicInvariantsTest.scala
@@ -112,14 +112,14 @@ class TopicInvariantsTest extends Test:
     // (aeron_driver_static) and resolve at runtime with no system libaeron.
     "runtime: symbols resolve and driver starts without system libaeron".onlyNative in {
         for
-            dir     <- Path.tempDir("kyo-aeron-embedded-test")
+            dir     <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             runtime <- AeronPlatform.embedded(dir.unsafe.show)
             result <- Sync.Unsafe.defer {
                 assert(runtime.transport != null, "runtime.transport is null after embedded()")
                 runtime.close()
                 succeed
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield result
         end for
     }
@@ -173,7 +173,7 @@ class TopicInvariantsTest extends Test:
     // must survive with its sign intact; JVM/Native never exercise that path (primitive long / C long).
     "JS koffi int64 sentinel marshalling: negative offer sentinel survives BigInt round-trip".onlyJs in {
         for
-            dir <- Path.tempDir("kyo-aeron-embedded-test")
+            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pubMaybeR <- Abort.run[TopicTransportException] {
@@ -195,7 +195,7 @@ class TopicInvariantsTest extends Test:
                 transport.closePublication(pub)
                 rt.close()
             }
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield
             assert(result < 0, s"Expected a negative sentinel from a not-connected JS FFI publication; got $result")
             assert(

--- a/kyo-aeron/shared/src/test/scala/kyo/TopicUniformInvariantsTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/TopicUniformInvariantsTest.scala
@@ -64,8 +64,8 @@ class TopicUniformInvariantsTest extends Test:
         val settleAttempts = 100
         // Inability to list the temp dir is a platform limitation, not a leak.
         def embeddedDirs(using Frame): Set[Path] < Async =
-            Abort.recover[FileStructureException](_ => Chunk.empty[Path]) {
-                Path.basePaths.tmp.list(glob"kyo-aeron-embedded*")
+            Abort.recover[FileSystemException](_ => Chunk.empty[Path]) {
+                Path.runReadOnly(Path.basePaths.tmp.list(glob"kyo-aeron-embedded*"))
             }.map(_.toSet)
         for
             before <- embeddedDirs
@@ -132,7 +132,7 @@ class TopicUniformInvariantsTest extends Test:
     "Topic.run(aeronDir) present-driver round-trip: received == Chunk(a,b)" in {
         // Type-level invariant: run(aeronDir) carries Abort[TopicException].
         val _: Int < (Async & Abort[TopicException]) = Topic.run(Path("/nonexistent-type-probe"))(42)
-        Path.tempDir("kyo-aeron-external-present").map { dir =>
+        Path.run(Path.tempDir("kyo-aeron-external-present")).map { dir =>
             withExternalDriver(dir) {
                 Topic.run(dir) {
                     for
@@ -166,7 +166,7 @@ class TopicUniformInvariantsTest extends Test:
                     received <- fiber.get
                 yield received
             }
-        Path.tempDir("kyo-aeron-external-reuse").map { dir =>
+        Path.run(Path.tempDir("kyo-aeron-external-reuse")).map { dir =>
             withExternalDriver(dir) {
                 for
                     first  <- roundTrip(dir, Seq("a", "b"), 1)
@@ -185,7 +185,7 @@ class TopicUniformInvariantsTest extends Test:
     // differently per backend: JVM throws DriverTimeoutException, FFI's clientConnect returns NULL and
     // yields FfiNullPointer. The shared external primitive maps both to the one typed failure.
     "absent-driver Topic.run(aeronDir) aborts a uniform TopicTransportFailedException (JVM/JS/Native)" in {
-        Path.tempDir("kyo-aeron-absent-driver").map { absentDir =>
+        Path.run(Path.tempDir("kyo-aeron-absent-driver")).map { absentDir =>
             Abort.run[TopicException] {
                 Topic.run(absentDir)(Topic.stream[String]("aeron:ipc").take(1).run)
             }.map { result =>
@@ -204,7 +204,7 @@ class TopicUniformInvariantsTest extends Test:
     // never lands the final release, so the leaf hangs into the per-leaf timeout rather than racing a count.
     "a concurrent ticker keeps advancing during a slow absent-driver connect (JVM/JS/Native)" in {
         val targetTicks = 50
-        Path.tempDir("kyo-aeron-absent-ticker").map { absentDir =>
+        Path.run(Path.tempDir("kyo-aeron-absent-ticker")).map { absentDir =>
             Latch.init(targetTicks).map { ticked =>
                 for
                     tickerFiber <- Fiber.initUnscoped {
@@ -235,7 +235,7 @@ class TopicUniformInvariantsTest extends Test:
                 Topic.run(c)(42)
         })
         val _: Int < (Async & Abort[TopicTransportFailedException]) = Topic.run(Path("/nonexistent-inv001-probe"))(42)
-        Path.tempDir("kyo-aeron-inv001").map { dir =>
+        Path.run(Path.tempDir("kyo-aeron-inv001")).map { dir =>
             Scope.run {
                 withExternalDriver(dir) {
                     for
@@ -300,7 +300,7 @@ class TopicUniformInvariantsTest extends Test:
     // The message comes from the upstream AeronPlatform.external catch, single-sourced in
     // TopicException.scala; AeronClient.scala adds no message string of its own.
     "connect failure is TopicTransportFailedException (TopicException leaf); message single-sourced" in {
-        Path.tempDir("kyo-aeron-inv010-absent").map { absentDir =>
+        Path.run(Path.tempDir("kyo-aeron-inv010-absent")).map { absentDir =>
             Scope.run {
                 Abort.run[TopicException] {
                     AeronClient.connect(absentDir).map { client =>
@@ -351,7 +351,7 @@ class TopicUniformInvariantsTest extends Test:
     "offer after the caller's own closePublication returns the safe Closed sentinel, no UAF (JVM/JS/Native)" in {
         val payload = Array[Byte](1, 2, 3, 4)
         for
-            dir <- Path.tempDir("kyo-aeron-offer-after-close")
+            dir <- Path.run(Path.tempDir("kyo-aeron-offer-after-close"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             offerResult <- Abort.run[TopicTransportException] {
@@ -368,7 +368,7 @@ class TopicUniformInvariantsTest extends Test:
                 }
             }
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield offerResult match
             case Result.Success((offered, connected, maxMsgLen)) =>
                 assert(
@@ -393,7 +393,7 @@ class TopicUniformInvariantsTest extends Test:
     // closes, since the runtime owns the transport's client handle.
     "client-close after a caller-closed publication is clean: no double-free, fatalError Absent (JVM/JS/Native)" in {
         for
-            dir <- Path.tempDir("kyo-aeron-client-close")
+            dir <- Path.run(Path.tempDir("kyo-aeron-client-close"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             fatalAfterClose <- Abort.run[TopicTransportException] {
@@ -407,7 +407,7 @@ class TopicUniformInvariantsTest extends Test:
             // Close the client: the sweep frees the deferred bundle. A double-free would
             // crash here; reaching the assertion proves it did not.
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield fatalAfterClose match
             case Result.Success(fatal) =>
                 assert(
@@ -437,7 +437,7 @@ class TopicUniformInvariantsTest extends Test:
     // reports itself closed so the poll never hands the shim the receive buffer closeSubscription released.
     "poll after the caller's own closeSubscription returns no fragment and a second close is a no-op, no UAF (JVM/JS/Native)" in {
         for
-            dir <- Path.tempDir("kyo-aeron-poll-after-close")
+            dir <- Path.run(Path.tempDir("kyo-aeron-poll-after-close"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             pollResult <- Abort.run[TopicTransportException] {
@@ -454,7 +454,7 @@ class TopicUniformInvariantsTest extends Test:
                 }
             }
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield pollResult match
             case Result.Success(polled) =>
                 assert(
@@ -469,7 +469,7 @@ class TopicUniformInvariantsTest extends Test:
     // Mirror of the publication client-close leaf above, for the subscription sweep.
     "client-close after a caller-closed subscription is clean: no double-free, fatalError Absent (JVM/JS/Native)" in {
         for
-            dir <- Path.tempDir("kyo-aeron-sub-client-close")
+            dir <- Path.run(Path.tempDir("kyo-aeron-sub-client-close"))
             rt  <- AeronPlatform.embedded(dir.unsafe.show)
             transport = rt.transport
             fatalAfterClose <- Abort.run[TopicTransportException] {
@@ -483,7 +483,7 @@ class TopicUniformInvariantsTest extends Test:
             // Close the client: the subscription sweep frees the deferred bundle. A double-free
             // would crash here; reaching the assertion proves it did not.
             _ <- Sync.Unsafe.defer(rt.close())
-            _ <- dir.removeAll
+            _ <- Path.run(dir.removeAll)
         yield fatalAfterClose match
             case Result.Success(fatal) =>
                 assert(
@@ -540,7 +540,7 @@ class TopicUniformInvariantsTest extends Test:
     // the single connect-failure catch, so neither diverges into a panic, null, or backend-specific outcome;
     // Async.zip runs them concurrently since both wait the same ~10 s driver-timeout.
     "cross-entry-point: BOTH AeronClient.connect AND Topic.run(aeronDir) abort TopicTransportFailedException from the same absent dir (JVM/JS/Native)" in {
-        Path.tempDir("kyo-aeron-inv014-cross").map { absentDir =>
+        Path.run(Path.tempDir("kyo-aeron-inv014-cross")).map { absentDir =>
             val connectViaClient =
                 Scope.run {
                     Abort.run[TopicException] {
@@ -572,7 +572,7 @@ class TopicUniformInvariantsTest extends Test:
     // runs. Same latch barrier: a frozen carrier never lands the final release and the leaf times out.
     "via AeronClient.connect: a concurrent ticker keeps advancing during a slow absent-driver connect (JVM/JS/Native)" in {
         val targetTicks = 50
-        Path.tempDir("kyo-aeron-inv015-client").map { absentDir =>
+        Path.run(Path.tempDir("kyo-aeron-inv015-client")).map { absentDir =>
             Latch.init(targetTicks).map { ticked =>
                 for
                     tickerFiber <- Fiber.initUnscoped {

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
@@ -298,11 +298,16 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
       * platform command-line length limits.
       */
     private[completion] def mcpConfigFile(config: String)(using Frame): Path < (Sync & Scope & Abort[AIGenException]) =
-        Abort.run[FileStructureException | FileWriteException] {
-            for
-                path <- Path.temp("kyo-ai-claude-mcp-", ".json")
-                _    <- path.write(config)
-            yield path
+        Abort.run[FileSystemException] {
+            // The temp file and the write are the only filesystem authority this needs, and both are
+            // discharged here so the config file stays an implementation detail rather than a capability
+            // the caller must grant.
+            Path.run {
+                for
+                    path <- Path.temp("kyo-ai-claude-mcp-", ".json")
+                    _    <- path.write(config)
+                yield path
+            }
         }.map {
             case Result.Success(path) => path
             case Result.Failure(ex) =>

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexCompletion.scala
@@ -79,7 +79,7 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
         Kyo.lift(Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] {
             AtomicRef.init("").map { stderrTail =>
                 Abort.run[
-                    CommandException | FileStructureException | FileReadException | FileWriteException | JsonRpcError | AIGenException | Closed
+                    CommandException | FileSystemException | JsonRpcError | AIGenException | Closed
                 ] {
                     for
                         bridge <- initBridge
@@ -140,7 +140,7 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
                     meter      <- Meter.initMutex
                     stderrTail <- AtomicRef.init("")
                     result <- Abort.run[
-                        CommandException | FileStructureException | FileReadException | FileWriteException | JsonRpcError | AIGenException | Closed
+                        CommandException | FileSystemException | JsonRpcError | AIGenException | Closed
                     ] {
                         withSession(Seq(toolCallRoute(tools, stateRef, meter, bridge)), stderrTail) {
                             (workDir, handler, events, stderrTail) =>
@@ -182,25 +182,25 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
         f: (Path, JsonRpcHandler, Channel[RpcEvent], AtomicRef[String]) => A < S
     )(using
         Frame
-    ): A < (S & Async & Scope & Abort[
-        CommandException | FileStructureException | FileReadException | FileWriteException | JsonRpcError | Closed
-    ]) =
-        for
-            workDir   <- Path.tempDir("kyo-ai-codex-cwd")
-            codexHome <- isolatedCodexHome
-            proc      <- appServerCommand(workDir, codexHome).spawn
-            _         <- Fiber.init(Scope.run(captureStderr(proc, stderrTail)))
-            events    <- Channel.init[RpcEvent](1024)
-            transport <- JsonRpcTransport.fromWire(processWire(proc), JsonRpcFramer.lineDelimited)
-            handler   <- JsonRpcHandler.init(transport, (eventRoutes(events) ++ toolRoutes)*)
-            _ <- requestAs[Structure.Value, InitializeParams](
-                handler,
-                "initialize",
-                InitializeParams(ClientInfo("kyo-ai", "0"), ClientCapabilities(experimentalApi = true))
-            )
-            _      <- handler.notify("initialized", Structure.Value.Record(Chunk.empty))
-            result <- f(workDir, handler, events, stderrTail)
-        yield result
+    ): A < (S & Async & Scope & Abort[CommandException | FileSystemException | JsonRpcError | Closed]) =
+        Path.run {
+            for
+                workDir   <- Path.tempDir("kyo-ai-codex-cwd")
+                codexHome <- isolatedCodexHome
+                proc      <- appServerCommand(workDir, codexHome).spawn
+                _         <- Fiber.init(Scope.run(captureStderr(proc, stderrTail)))
+                events    <- Channel.init[RpcEvent](1024)
+                transport <- JsonRpcTransport.fromWire(processWire(proc), JsonRpcFramer.lineDelimited)
+                handler   <- JsonRpcHandler.init(transport, (eventRoutes(events) ++ toolRoutes)*)
+                _ <- requestAs[Structure.Value, InitializeParams](
+                    handler,
+                    "initialize",
+                    InitializeParams(ClientInfo("kyo-ai", "0"), ClientCapabilities(experimentalApi = true))
+                )
+                _      <- handler.notify("initialized", Structure.Value.Record(Chunk.empty))
+                result <- f(workDir, handler, events, stderrTail)
+            yield result
+        }
     end withSession
 
     private def captureStderr(proc: Process, tail: AtomicRef[String])(using Frame): Unit < (Sync & Scope) =
@@ -219,17 +219,19 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
 
     private def isolatedCodexHome(using
         Frame
-    ): Path < (Sync & Scope & Abort[FileStructureException | FileReadException | FileWriteException]) =
-        for
-            isolated <- Path.tempDir("kyo-ai-codex-home")
-            real     <- realCodexHome
-            auth   = real / "auth.json"
-            config = real / "config.toml"
-            hasAuth   <- auth.exists
-            hasConfig <- config.exists
-            _         <- if hasAuth then auth.copy(isolated / "auth.json") else Kyo.unit
-            _         <- if hasConfig then config.copy(isolated / "config.toml") else Kyo.unit
-        yield isolated
+    ): Path < (Sync & Scope & Abort[FileSystemException]) =
+        Path.run {
+            for
+                isolated <- Path.tempDir("kyo-ai-codex-home")
+                real     <- realCodexHome
+                auth   = real / "auth.json"
+                config = real / "config.toml"
+                hasAuth   <- auth.exists
+                hasConfig <- config.exists
+                _         <- if hasAuth then auth.copy(isolated / "auth.json") else Kyo.unit
+                _         <- if hasConfig then config.copy(isolated / "config.toml") else Kyo.unit
+            yield isolated
+        }
     end isolatedCodexHome
 
     private def realCodexHome(using Frame): Path < Sync =

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeCompletionTest.scala
@@ -8,7 +8,7 @@ class ClaudeCodeCompletionTest extends kyo.test.Test[Any]:
     "mcpConfigFile writes the exact config to a scoped JSON file" in Scope.run {
         val config = """{"mcpServers":{"kyo":{"type":"ws","url":"ws://127.0.0.1:1234/mcp"}}}"""
         ClaudeCodeCompletion.mcpConfigFile(config).map { path =>
-            path.read.map { contents =>
+            Path.runReadOnly(path.read).map { contents =>
                 assert(contents == config, s"the CLI must read the exact MCP config from disk: $contents")
             }
         }

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/CodexWireTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/CodexWireTest.scala
@@ -84,14 +84,14 @@ class CodexWireTest extends kyo.test.Test[Any]:
         val resultSchema = Thought.internal.resultJson(Chunk.empty, Json.jsonSchema[CodexWireResultProbe])
         val specs        = CodexWire.dynamicToolSpecs(Tool.internal.resultToolDefinition.infos, resultSchema)
 
-        Path.tempDir("codex-wire-test").map { dir =>
+        Path.run(Path.tempDir("codex-wire-test").map { dir =>
             val params = CodexWire.threadStartParams(Config.Codex.gpt_5_5, ctx, dir, specs)
             assert(params.baseInstructions == "AMBIENT PROMPT", s"baseInstructions is the leading system alone: $params")
             assert(
                 params.dynamicTools.map(_.name) == List(Completion.resultToolName),
                 s"the registered tools ride thread/start.dynamicTools: ${params.dynamicTools}"
             )
-        }
+        })
     }
 
     "historyItems renders a non-leading system message IN PLACE as a system-reminder user item" in {

--- a/kyo-browser/shared/src/main/scala/kyo/internal/BrowserLauncher.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/BrowserLauncher.scala
@@ -37,8 +37,8 @@ private[kyo] object BrowserLauncher:
       */
     private def removeTmpDir(tmpDir: Path, removalSchedule: Schedule)(using Frame): Unit < Async =
         tmpDir.name.fold(Kyo.unit)(name => killOrphans(pattern = name, command = "pgrep")).andThen {
-            Abort.run[FileStructureException] {
-                Retry[FileStructureException](removalSchedule)(tmpDir.removeAll)
+            Abort.run[FileSystemException] {
+                Retry[FileSystemException](removalSchedule)(Path.run(tmpDir.removeAll))
             }.map {
                 case Result.Failure(err) =>
                     // Leaked tmp dirs are not a hard failure (they are cleaned up by `killOrphans` next launch),
@@ -58,16 +58,16 @@ private[kyo] object BrowserLauncher:
       * JVM/JS/Native.
       */
     private[kyo] def createTempDir(using Frame): Path < (Sync & Scope & Abort[BrowserSetupException]) =
-        Abort.recover[FileStructureException] { (ex: FileStructureException) =>
+        Abort.recover[FileSystemException] { (ex: FileSystemException) =>
             Abort.fail[BrowserSetupException](
                 BrowserSetupFailedException("failed to create Chrome user-data temp dir", ex)
             )
         } {
-            Path.tempDir("kyo-browser-")
+            Path.run(Path.tempDir("kyo-browser-"))
         }
 
     private[kyo] def createTempDir(parent: Path)(using Frame): Path < (Sync & Abort[BrowserSetupException]) =
-        Abort.recover[FileStructureException] { (ex: FileStructureException) =>
+        Abort.recover[FileSystemException] { (ex: FileSystemException) =>
             Abort.fail[BrowserSetupException](
                 BrowserSetupFailedException("failed to create Chrome user-data temp dir", ex)
             )
@@ -75,7 +75,7 @@ private[kyo] object BrowserLauncher:
             Random.nextLong.map { n =>
                 val childName = f"kyo-browser-$n%016x"
                 val target    = parent / childName
-                target.mkDir.andThen(target)
+                Path.run(target.mkDir).andThen(target)
             }
         }
 
@@ -187,7 +187,7 @@ private[kyo] object BrowserLauncher:
         val portFile = tmpDir / devToolsActivePortFile
         val poll: String < (Async & Abort[BrowserSetupException]) =
             Loop(()) { _ =>
-                Abort.run[FileReadException](portFile.read).map {
+                Abort.run[FileSystemException](Path.runReadOnly(portFile.read)).map {
                     case Result.Success(content) =>
                         parseDevToolsActivePort(content) match
                             case Present(url) => Loop.done(url)

--- a/kyo-browser/shared/src/main/scala/kyo/internal/ChromeDownloader.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/ChromeDownloader.scala
@@ -77,7 +77,7 @@ private[kyo] object ChromeDownloader:
             root     <- cacheRoot
             versionDir = root / s"${artifactName(build)}-$v-$platform"
             exec       = executablePath(versionDir, platform, build)
-            cached <- Abort.recover[FileReadException](_ => false)(exec.exists)
+            cached <- Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(exec.exists))
             _ <-
                 if cached then Kyo.unit
                 else download(build, v, platform, versionDir)
@@ -182,12 +182,12 @@ private[kyo] object ChromeDownloader:
     end downloadAndExtract
 
     private def createTempDir(using Frame): Path < (Scope & Sync & Abort[BrowserSetupException]) =
-        Abort.recover[FileStructureException] { (ex: FileStructureException) =>
+        Abort.recover[FileSystemException] { (ex: FileSystemException) =>
             Abort.fail[BrowserSetupException](
                 BrowserSetupFailedException("failed to create Chrome download temp dir", ex)
             )
         } {
-            Path.tempDir("kyo-browser-dl-")
+            Path.run(Path.tempDir("kyo-browser-dl-"))
         }
 
     private[kyo] def downloadZip(url: String, dest: Path, downloadTimeout: Duration)(using
@@ -207,11 +207,11 @@ private[kyo] object ChromeDownloader:
                 // memory bounded by `HttpClientConfig.maxResponseLength` (100 MiB), which rejects the full-Chrome zip
                 // (~200 MiB). `getStreamBytes` has no such cap; `writeTo` sinks each network chunk through a scoped write
                 // handle and removes the partial file if the download fails midway.
-                Scope.run {
+                Path.run(Scope.run {
                     HttpClient.getStreamBytes(url)
                         .mapChunkPure(_.map(span => Chunk.from(span.toArray)).flattenChunk)
                         .writeTo(dest)
-                }
+                })
             }
         }
 
@@ -242,12 +242,12 @@ private[kyo] object ChromeDownloader:
         yield ()
 
     private def createDir(dir: Path)(using Frame): Unit < (Sync & Abort[BrowserSetupException]) =
-        Abort.recover[FileStructureException] { (ex: FileStructureException) =>
+        Abort.recover[FileSystemException] { (ex: FileSystemException) =>
             Abort.fail[BrowserSetupException](
                 BrowserSetupFailedException(s"failed to create dir $dir", ex)
             )
         } {
-            dir.mkDir
+            Path.run(dir.mkDir)
         }
 
     private def makeExecutable(exec: Path)(using Frame): Unit < (Async & Abort[BrowserSetupException]) =

--- a/kyo-browser/shared/src/main/scala/kyo/internal/Image.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/Image.scala
@@ -39,20 +39,20 @@ final case class Image private (data: Span[Byte]) derives CanEqual:
         XXHash.hash32(data)
 
     /** Writes the image to a file in raw binary format. */
-    def writeFileBinary(path: String)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+    def writeFileBinary(path: String)(using Frame): Unit < (Sync & Abort[FileSystemException]) =
         writeFileBinary(Path(path))
 
     /** Writes the image to a file in raw binary format. */
-    def writeFileBinary(path: Path)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
-        path.writeBytes(data)
+    def writeFileBinary(path: Path)(using Frame): Unit < (Sync & Abort[FileSystemException]) =
+        Path.run(path.writeBytes(data))
 
     /** Writes the image to a file as a Base64-encoded text payload. */
-    def writeFileBase64(path: String)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+    def writeFileBase64(path: String)(using Frame): Unit < (Sync & Abort[FileSystemException]) =
         writeFileBase64(Path(path))
 
     /** Writes the image to a file as a Base64-encoded text payload. */
-    def writeFileBase64(path: Path)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
-        path.write(base64)
+    def writeFileBase64(path: Path)(using Frame): Unit < (Sync & Abort[FileSystemException]) =
+        Path.run(path.write(base64))
 
     /** The raw image bytes as an immutable [[Span]]. */
     def binary: Span[Byte] = data

--- a/kyo-browser/shared/src/test/scala/demo/BrowserDemo.scala
+++ b/kyo-browser/shared/src/test/scala/demo/BrowserDemo.scala
@@ -54,11 +54,11 @@ abstract class BrowserDemo[Result](val demoName: String):
             writeOrLog(logFile.append(s"[$ts] $msg\n"), s"log write failed for: $msg")
         }
 
-    /** Performs a file-write effect, logging any `FileWriteException` failure as a warning rather than silently dropping it. */
-    private def writeOrLog(write: => Unit < (Sync & Abort[FileWriteException]), context: String)(using Frame): Unit < Sync =
-        Abort.recover[FileWriteException] { e =>
+    /** Performs a file-write effect, logging any `FileSystemException` failure as a warning rather than silently dropping it. */
+    private def writeOrLog(write: => Unit < PathWrite, context: String)(using Frame): Unit < Sync =
+        Abort.recover[FileSystemException] { e =>
             Log.warn(s"$context: $e")
-        }(write)
+        }(Path.run(write))
 
     private[demo] def step(n: Int, desc: String)(using Frame): Unit < Async =
         for

--- a/kyo-browser/shared/src/test/scala/demo/WikipediaKitDemo.scala
+++ b/kyo-browser/shared/src/test/scala/demo/WikipediaKitDemo.scala
@@ -21,7 +21,7 @@ final class WikipediaKitDemo extends BrowserDemo[WikipediaKitDemo.KitResult]("wi
 
     def flow(using Frame): KitResult < (Browser & Async & Scope & Abort[Throwable]) =
         for
-            outputDir <- Path.tempDir("kyo-browser-wikipedia-kit-")
+            outputDir <- Path.run(Path.tempDir("kyo-browser-wikipedia-kit-"))
 
             _ <- step(1, s"Navigate to $articleUrl")
             _ <- Browser.goto(articleUrl)
@@ -41,9 +41,9 @@ final class WikipediaKitDemo extends BrowserDemo[WikipediaKitDemo.KitResult]("wi
             _   <- log(s"pdf bytes    = ${pdf.size}")
 
             _ <- step(5, s"Write artifacts to ${outputDir.toString}/")
-            _ <- (outputDir / "summary.txt").write(content.take(4000))
+            _ <- Path.run((outputDir / "summary.txt").write(content.take(4000)))
             _ <- infoboxImg.writeFileBinary(outputDir / "infobox.png")
-            _ <- (outputDir / "article.pdf").writeBytes(pdf)
+            _ <- Path.run((outputDir / "article.pdf").writeBytes(pdf))
             _ <- log(s"wrote three artifacts to ${outputDir.toString}/")
 
             _        <- step(6, "Render infobox PNG inline to the terminal")

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserDownloadTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserDownloadTest.scala
@@ -22,7 +22,7 @@ class BrowserDownloadTest extends BrowserTest:
         Loop(0) { i =>
             if i >= samples then Loop.done(())
             else
-                Abort.recover[FileReadException](_ => false)(path.exists).map {
+                Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(path.exists)).map {
                     case true =>
                         Abort.fail[BrowserAssertionException](
                             BrowserAssertionTimedOutException(
@@ -56,7 +56,7 @@ class BrowserDownloadTest extends BrowserTest:
     "allowDownloads(toPath = Present(absoluteTmp)) lands a downloaded file at the requested path" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-dl-allow-")
+                tempPath <- Path.run(Path.tempDir("kyo-dl-allow-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 fileName = s"hello-${now.toNanos}.txt"
@@ -69,7 +69,7 @@ class BrowserDownloadTest extends BrowserTest:
                 result <- Browser.onDownload(collectEvents(events, done)) {
                     Browser.goto(html).andThen(Browser.click(Browser.Selector.id("dl"))).andThen(done.get)
                 }
-                downloaded <- (tempPath / fileName).readBytes
+                downloaded <- Path.runReadOnly((tempPath / fileName).readBytes)
             yield
                 val bytes = downloaded.toArray
                 assert(new String(bytes, "UTF-8") == "Hello", s"expected 'Hello' but got ${new String(bytes, "UTF-8")}")
@@ -109,7 +109,7 @@ class BrowserDownloadTest extends BrowserTest:
     "denyDownloads drops the download (no file lands at the previously-set toPath)" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-dl-deny-")
+                tempPath <- Path.run(Path.tempDir("kyo-dl-deny-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 fileName = s"hello-deny-${now.toNanos}.bin"
@@ -122,7 +122,7 @@ class BrowserDownloadTest extends BrowserTest:
                 // Inverse poll: loop exits cleanly iff file never landed; Abort.fail = file landed.
                 _ <- assertNeverLands(tempPath / fileName, s"denyDownloads-no-landing-at-$fileName", 10, 50.millis)
                 // Confirm the file is absent after the full poll window (the deny contract was upheld).
-                absent <- Abort.recover[FileReadException](_ => false)((tempPath / fileName).exists)
+                absent <- Abort.recover[FileSystemException](_ => false)(Path.runReadOnly((tempPath / fileName).exists))
             yield assert(!absent, s"Expected file to remain absent after denyDownloads but it landed at ${tempPath / fileName}")
             end for
         }
@@ -135,7 +135,7 @@ class BrowserDownloadTest extends BrowserTest:
     "setDownloadBehavior(Default) resets to Chrome's default after a previous Allow" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-dl-default-")
+                tempPath <- Path.run(Path.tempDir("kyo-dl-default-"))
                 tempDir = tempPath.toString
                 dataUrl = "data:application/octet-stream;base64,SGVsbG8="
                 // Phase A: Allow → file lands at tmp. Use onDownload+collectEvents so Chrome drives the
@@ -149,7 +149,7 @@ class BrowserDownloadTest extends BrowserTest:
                 _ <- Browser.onDownload(collectEvents(eventsA, doneA)) {
                     Browser.goto(htmlA).andThen(Browser.click(Browser.Selector.id("dl"))).andThen(doneA.get)
                 }
-                landedA <- (tempPath / fileNameA).exists
+                landedA <- Path.runReadOnly((tempPath / fileNameA).exists)
                 // Phase B: Default → file does NOT land at tmp. Mirror the denyDownloads shape:
                 // goto + click + short sleep + check file. Under Default with no toPath the file doesn't
                 // land at our tempDir; we don't observe a "completed" event so no onDownload here.
@@ -170,7 +170,7 @@ class BrowserDownloadTest extends BrowserTest:
                 _ <- Browser.onDownload(collectEvents(eventsC, doneC)) {
                     Browser.goto(htmlC).andThen(Browser.click(Browser.Selector.id("dl"))).andThen(doneC.get)
                 }
-                landedC <- (tempPath / fileNameC).exists
+                landedC <- Path.runReadOnly((tempPath / fileNameC).exists)
             yield
                 assert(landedA, s"Phase A (Allow): expected file at $tempDir/$fileNameA")
                 // Phase B's no-landing contract is enforced inside the for-comprehension by `assertNeverLands`.
@@ -182,7 +182,7 @@ class BrowserDownloadTest extends BrowserTest:
     "onDownload(f)(trigger) fires f with DownloadEvent.WillBegin(guid, url, suggestedFilename)" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-dl-willbegin-")
+                tempPath <- Path.run(Path.tempDir("kyo-dl-willbegin-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 fileName = s"will-begin-${now.toNanos}.txt"
@@ -237,7 +237,7 @@ class BrowserDownloadTest extends BrowserTest:
         withLocalhostServer(handler) { (host, port) =>
             withBrowser {
                 for
-                    tempPath <- Path.tempDir("kyo-dl-big-")
+                    tempPath <- Path.run(Path.tempDir("kyo-dl-big-"))
                     tempDir = tempPath.toString
                     now <- Clock.nowMonotonic
                     fileName = s"big-${now.toNanos}.bin"
@@ -277,7 +277,7 @@ class BrowserDownloadTest extends BrowserTest:
     "onDownload(f)(action1).andThen(action2) - f is called for action1's downloads only" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-dl-unsub-")
+                tempPath <- Path.run(Path.tempDir("kyo-dl-unsub-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 fileName1 = s"in-scope-${now.toNanos}.bin"
@@ -360,7 +360,7 @@ class BrowserDownloadTest extends BrowserTest:
     "Two concurrent tabs each running onDownload do not cross-talk" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-dl-tabs-")
+                tempPath <- Path.run(Path.tempDir("kyo-dl-tabs-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 fileName1 = s"tab1-${now.toNanos}.bin"
@@ -425,7 +425,7 @@ class BrowserDownloadTest extends BrowserTest:
     "withDownloads(toPath) allows downloads in the body and reverts to Deny on exit" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-dl-with-")
+                tempPath <- Path.run(Path.tempDir("kyo-dl-with-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 fileNameInside  = s"inside-${now.toNanos}.txt"
@@ -441,7 +441,7 @@ class BrowserDownloadTest extends BrowserTest:
                         Browser.goto(html).andThen(Browser.click(Browser.Selector.id("dl1"))).andThen(done.get)
                     }
                 }
-                downloaded <- (tempPath / fileNameInside).readBytes
+                downloaded <- Path.runReadOnly((tempPath / fileNameInside).readBytes)
                 // Click dl2 AFTER the withDownloads block. Policy is now Deny so no file should land.
                 // We don't observe an event for the second click; we just confirm the path does not exist.
                 _ <- Browser.click(Browser.Selector.id("dl2"))
@@ -462,7 +462,7 @@ class BrowserDownloadTest extends BrowserTest:
     "download-event capture records every WillBegin in click order" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-dl-record-")
+                tempPath <- Path.run(Path.tempDir("kyo-dl-record-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 fileA   = s"a-${now.toNanos}.txt"

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserMutationTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserMutationTest.scala
@@ -1126,10 +1126,10 @@ class BrowserMutationTest extends BrowserTest:
             ).andThen {
                 Scope.run {
                     for
-                        tmp1 <- Path.temp("kyo-setFiles-a-", ".txt")
-                        tmp2 <- Path.temp("kyo-setFiles-b-", ".txt")
-                        _    <- tmp1.write("alpha")
-                        _    <- tmp2.write("beta")
+                        tmp1 <- Path.run(Path.temp("kyo-setFiles-a-", ".txt"))
+                        tmp2 <- Path.run(Path.temp("kyo-setFiles-b-", ".txt"))
+                        _    <- Path.run(tmp1.write("alpha"))
+                        _    <- Path.run(tmp2.write("beta"))
                         paths = Chunk(tmp1, tmp2)
                         _ <- Browser.setFiles(Browser.Selector.css("#fileInput"), paths)
                         // Single multi-field eval: one CDP round-trip returning length and both basenames.
@@ -1185,10 +1185,10 @@ class BrowserMutationTest extends BrowserTest:
             ).andThen {
                 Scope.run {
                     for
-                        tmp1 <- Path.temp("kyo-setFiles-seq-a-", ".txt")
-                        tmp2 <- Path.temp("kyo-setFiles-seq-b-", ".txt")
-                        _    <- tmp1.write("alpha")
-                        _    <- tmp2.write("beta")
+                        tmp1 <- Path.run(Path.temp("kyo-setFiles-seq-a-", ".txt"))
+                        tmp2 <- Path.run(Path.temp("kyo-setFiles-seq-b-", ".txt"))
+                        _    <- Path.run(tmp1.write("alpha"))
+                        _    <- Path.run(tmp2.write("beta"))
                         // Use an explicit List[Path] to exercise the widened Seq parameter type.
                         paths: Seq[Path] = List(tmp1, tmp2)
                         _ <- Browser.setFiles(Browser.Selector.css("#fileInput"), paths)

--- a/kyo-browser/shared/src/test/scala/kyo/ImageTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/ImageTest.scala
@@ -63,10 +63,10 @@ class ImageTest extends BaseBrowserTest:
 
     "Image.writeFileBinary(path: String) writes binary; re-reading yields identical bytes" in {
         Scope.run {
-            Path.temp("kyo-image-test", ".bin").map { tmp =>
+            Path.run(Path.temp("kyo-image-test", ".bin")).map { tmp =>
                 val pathStr = tmp.unsafe.show
                 fixtureImage.writeFileBinary(pathStr).andThen {
-                    Path(pathStr).readBytes.map { read =>
+                    Path.runReadOnly(Path(pathStr).readBytes).map { read =>
                         assert(read.toArrayUnsafe.sameElements(fixtureBytes))
                     }
                 }
@@ -78,9 +78,9 @@ class ImageTest extends BaseBrowserTest:
 
     "Image.writeFileBinary(path: Path) writes binary; re-reading yields identical bytes" in {
         Scope.run {
-            Path.temp("kyo-image-test", ".bin").map { tmp =>
+            Path.run(Path.temp("kyo-image-test", ".bin")).map { tmp =>
                 fixtureImage.writeFileBinary(tmp).andThen {
-                    tmp.readBytes.map { read =>
+                    Path.runReadOnly(tmp.readBytes).map { read =>
                         assert(read.toArrayUnsafe.sameElements(fixtureBytes))
                     }
                 }
@@ -92,10 +92,10 @@ class ImageTest extends BaseBrowserTest:
 
     "Image.writeFileBase64(path: String) writes base64; re-reading yields original base64 string" in {
         Scope.run {
-            Path.temp("kyo-image-test", ".b64").map { tmp =>
+            Path.run(Path.temp("kyo-image-test", ".b64")).map { tmp =>
                 val pathStr = tmp.unsafe.show
                 fixtureImage.writeFileBase64(pathStr).andThen {
-                    Path(pathStr).read.map { text =>
+                    Path.runReadOnly(Path(pathStr).read).map { text =>
                         assert(text == fixtureBase64)
                     }
                 }
@@ -107,9 +107,9 @@ class ImageTest extends BaseBrowserTest:
 
     "Image.writeFileBase64(path: Path) writes base64; re-reading yields original base64 string" in {
         Scope.run {
-            Path.temp("kyo-image-test", ".b64").map { tmp =>
+            Path.run(Path.temp("kyo-image-test", ".b64")).map { tmp =>
                 fixtureImage.writeFileBase64(tmp).andThen {
-                    tmp.read.map { text =>
+                    Path.runReadOnly(tmp.read).map { text =>
                         assert(text == fixtureBase64)
                     }
                 }

--- a/kyo-browser/shared/src/test/scala/kyo/internal/BrowserLauncherTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/internal/BrowserLauncherTest.scala
@@ -176,7 +176,7 @@ class BrowserLauncherTest extends BaseChromeTest:
         val timeout = 200.millis
         Scope.run {
             for
-                tmp <- Path.tempDir("kyo-browser-pollDevTools-test-")
+                tmp <- Path.run(Path.tempDir("kyo-browser-pollDevTools-test-"))
                 outcome <- Abort.run[BrowserSetupException] {
                     BrowserLauncher.pollDevToolsActivePort(tmp, timeout, 50.millis)
                 }
@@ -197,8 +197,8 @@ class BrowserLauncherTest extends BaseChromeTest:
     "pollDevToolsActivePort returns the URL when DevToolsActivePort exists and is well-formed" in {
         Scope.run {
             for
-                tmp <- Path.tempDir("kyo-browser-pollDevTools-happy-")
-                _   <- (tmp / BrowserLauncher.devToolsActivePortFile).write("9222\n/devtools/browser/test-uuid\n")
+                tmp <- Path.run(Path.tempDir("kyo-browser-pollDevTools-happy-"))
+                _   <- Path.run((tmp / BrowserLauncher.devToolsActivePortFile).write("9222\n/devtools/browser/test-uuid\n"))
                 url <- BrowserLauncher.pollDevToolsActivePort(tmp, 5.seconds, 50.millis)
             yield assert(url == "ws://127.0.0.1:9222/devtools/browser/test-uuid")
         }

--- a/kyo-browser/shared/src/test/scala/kyo/internal/ChromeDownloaderTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/internal/ChromeDownloaderTest.scala
@@ -77,13 +77,17 @@ class ChromeDownloaderTest extends BaseBrowserTest:
 
     // ---- version override path is reflected in the cached directory ----
 
+    /** Creates a temp directory on the host filesystem that auto-deletes when the enclosing scope closes. */
+    private def hostTempDir(prefix: String)(using Frame): Path < (Scope & Sync & Abort[FileSystemException]) =
+        Path.run(Path.tempDir(prefix))
+
     /** Builds a [[System]] override whose env returns `KYO_BROWSER_CACHE = cacheDir.unsafe.show`. OS/arch fall back to the host. */
     private def systemWithCache(cacheDir: Path)(os: OS, arch: Arch): System =
         fakeSystem(envOverrides = Map("KYO_BROWSER_CACHE" -> cacheDir.unsafe.show), os = os, arch = arch)
 
     "ensure(version) resolves a cacheDir that embeds the requested version (no download required)" in {
         Scope.run {
-            Path.tempDir("kyo-cd-vover-").map { tmp =>
+            hostTempDir("kyo-cd-vover-").map { tmp =>
                 // Pre-create a fake executable for whichever platform this host is on so that `ensure` short-circuits
                 // (no network access).
                 for
@@ -94,7 +98,7 @@ class ChromeDownloaderTest extends BaseBrowserTest:
                     build         = Browser.ChromeForTestingBuild.HeadlessShell
                     versionDir    = tmp / s"chrome-headless-shell-$customVersion-$platform"
                     exec          = ChromeDownloader.executablePath(versionDir, platform, build)
-                    _ <- exec.write("fake-exec") // createFolders=true creates the full ancestor chain
+                    _ <- Path.run(exec.write("fake-exec")) // createFolders=true creates the full ancestor chain
                     sys = systemWithCache(tmp)(os, arch)
                     resolved <- System.let(sys)(ChromeDownloader.ensure(
                         Present(customVersion),
@@ -114,7 +118,7 @@ class ChromeDownloaderTest extends BaseBrowserTest:
 
     "ensure(Chrome build) resolves a cacheDir under 'chrome-{v}-{platform}' (separate from chrome-headless-shell)" in {
         Scope.run {
-            Path.tempDir("kyo-cd-fullchrome-").map { tmp =>
+            hostTempDir("kyo-cd-fullchrome-").map { tmp =>
                 for
                     os       <- System.operatingSystem
                     arch     <- System.architecture
@@ -123,7 +127,7 @@ class ChromeDownloaderTest extends BaseBrowserTest:
                     build         = Browser.ChromeForTestingBuild.Chrome
                     versionDir    = tmp / s"chrome-$customVersion-$platform"
                     exec          = ChromeDownloader.executablePath(versionDir, platform, build)
-                    _ <- exec.write("fake-full-chrome")
+                    _ <- Path.run(exec.write("fake-full-chrome"))
                     sys = systemWithCache(tmp)(os, arch)
                     resolved <- System.let(sys)(ChromeDownloader.ensure(
                         Present(customVersion),
@@ -314,7 +318,7 @@ class ChromeDownloaderTest extends BaseBrowserTest:
         // 127.0.0.1:0 is reserved as 'no port' and refuses connection immediately.
         val url = "http://127.0.0.1:0/nonexistent"
         Scope.run {
-            Path.temp("kyo-cd-dl-", ".zip").map { dest =>
+            Path.run(Path.temp("kyo-cd-dl-", ".zip")).map { dest =>
                 Abort.run[BrowserSetupException](ChromeDownloader.downloadZip(url, dest, 5.minutes)).map {
                     case Result.Failure(ex: BrowserSetupFailedException) => assert(ex.getMessage.contains("failed to download Chrome"))
                     case other => fail(s"expected Failure(BrowserSetupFailedException) but got $other")
@@ -343,13 +347,13 @@ class ChromeDownloaderTest extends BaseBrowserTest:
         Scope.run {
             for
                 server <- HttpServer.init(0, "127.0.0.1")(handler)
-                dest   <- Path.temp("kyo-cd-stream-", ".zip")
+                dest   <- Path.run(Path.temp("kyo-cd-stream-", ".zip"))
                 url = s"http://${server.host}:${server.port}/chrome.zip"
                 // Force the buffered ceiling below the body size: getBinary would reject, the streamed path must not.
                 result <- HttpClient.withConfig(_.maxResponseLength(64 * 1024)) {
                     Abort.run[BrowserSetupException](ChromeDownloader.downloadZip(url, dest, 1.minute))
                 }
-                size <- dest.size
+                size <- Path.runReadOnly(dest.size)
             yield
                 assert(result.isSuccess, s"streamed download should succeed past the 64 KiB buffered cap, got: $result")
                 assert(size == bodySize.toLong, s"expected the full $bodySize-byte body on disk, got $size")
@@ -362,9 +366,9 @@ class ChromeDownloaderTest extends BaseBrowserTest:
     "extractZip on a garbage-bytes archive raises BrowserSetupFailedException" in {
         Scope.run {
             for
-                tmp <- Path.temp("kyo-cd-zip-", ".zip")
+                tmp <- Path.run(Path.temp("kyo-cd-zip-", ".zip"))
                 garbage = Span[Byte](0x00.toByte, 0xff.toByte, 0x00.toByte, 0xff.toByte, 0xde.toByte, 0xad.toByte, 0xbe.toByte, 0xef.toByte)
-                _ <- tmp.writeBytes(garbage)
+                _ <- Path.run(tmp.writeBytes(garbage))
                 dest = Path(tmp.unsafe.show + "-extract")
                 result <- Abort.run[BrowserSetupException](ChromeDownloader.extractZip(tmp, dest))
             yield result match
@@ -377,7 +381,7 @@ class ChromeDownloaderTest extends BaseBrowserTest:
 
     "ensure() reuses the cached binary on the second call (downloader counter does not advance)" in {
         Scope.run {
-            Path.tempDir("kyo-cd-reuse-").map { tmp =>
+            hostTempDir("kyo-cd-reuse-").map { tmp =>
                 for
                     os       <- System.operatingSystem
                     arch     <- System.architecture
@@ -395,10 +399,10 @@ class ChromeDownloaderTest extends BaseBrowserTest:
                             val target = ChromeDownloader.executablePath(vDir, _p, _b)
                             for
                                 _ <- counter.updateAndGet(_ + 1)
-                                _ <- Abort.run[FileStructureException](target.parent match
+                                _ <- Abort.run[FileSystemException](Path.run(target.parent match
                                     case Present(par) => par.mkDir
-                                    case Absent       => Kyo.unit).map(_.getOrThrow)
-                                _ <- Abort.run[FileWriteException](target.write("fake-exec")).map(_.getOrThrow)
+                                    case Absent       => Kyo.unit)).map(_.getOrThrow)
+                                _ <- Abort.run[FileSystemException](Path.run(target.write("fake-exec"))).map(_.getOrThrow)
                             yield ()
                             end for
                     first <- System.let(sys)(ChromeDownloader.ensureWith(

--- a/kyo-browser/shared/src/test/scala/kyo/internal/cdp/PageDownloadTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/internal/cdp/PageDownloadTest.scala
@@ -43,7 +43,7 @@ class PageDownloadTest extends kyo.BrowserTest:
     "setDownloadBehavior(Allow) causes CDP to emit Page.downloadWillBegin on a download" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-cdp-test-will-begin-")
+                tempPath <- Path.run(Path.tempDir("kyo-cdp-test-will-begin-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 unique  = s"kyo-dl-${now.toNanos}.txt"
@@ -70,7 +70,7 @@ class PageDownloadTest extends kyo.BrowserTest:
     "downloadWillBegin and downloadProgress share the same guid and reach state=completed" in {
         withBrowser {
             for
-                tempPath <- Path.tempDir("kyo-cdp-test-guid-")
+                tempPath <- Path.run(Path.tempDir("kyo-cdp-test-guid-"))
                 tempDir = tempPath.toString
                 now <- Clock.nowMonotonic
                 unique  = s"kyo-dl-${now.toNanos}.txt"

--- a/kyo-core/CONTRIBUTING.md
+++ b/kyo-core/CONTRIBUTING.md
@@ -4,25 +4,26 @@ This file documents the internal design contracts, invariants, and conventions
 specific to `kyo-core`. Read the root `CONTRIBUTING.md` first; everything there
 applies here, and this file extends it with module-local rules.
 
+File and OS-signal capabilities live in `kyo-system`; see `kyo-system/CONTRIBUTING.md` for those conventions.
+
 ---
 
 ## Architecture overview
 
 `kyo-core` is the primary effect module. It provides:
 
-- **Concurrency**: `Async`, `Fiber`, `Channel`, `Queue`, `Hub`, `Latch`, `Barrier`, `Meter`, `Gate`
-- **Time and scheduling**: `Clock`, `Duration`, `Deadline`
-- **Streams**: `Stream`, `Pipe`, `Sink` (in `kyo-prelude`; `StreamCoreExtensions.scala` adds core-specific combinators)
+- **Concurrency**: `Async`, `Fiber`, `Channel`, `Queue`, `Hub`, `Latch`, `Barrier`, `Meter`, `Gate`, `Exchange`
+- **Time and scheduling**: `Clock`, `Duration`, `Deadline`, `Retry`, `Timeout`
+- **Streams**: `StreamCoreExtensions` (core-specific combinators; `Stream`, `Pipe`, and `Sink` live in `kyo-prelude`)
 - **Atomic primitives**: `AtomicInt`, `AtomicLong`, `AtomicBoolean`, `AtomicRef`, `Adder`
-- **Environment**: `Console`, `Log`, `Signal`
+- **Environment and process**: `Console`, `Log`, `Signal` (reactive)
 - **Application entry**: `KyoApp`, `KyoAppInterrupts`
 - **Resource management**: `Scope`, `Sync`, `Sync.Unsafe`
-- **Data types**: `Chunk`, `Span` (in `kyo-data`; re-exported here)
 - **Observability**: `Stat`
 
 Every API in this module is cross-platform (JVM, Scala.js / Node, Scala Native)
-unless it is in a `jvm/`, `js/`, or `native/` source tree and explicitly
-documented as platform-specific.
+unless it is in a `jvm/`, `jvm-native/`, `native/`, or `js-wasm/` source tree and
+explicitly documented as platform-specific.
 
 ---
 
@@ -46,7 +47,227 @@ expose a fast-arraycopy path for partial buffer slices.
 
 ## Safe-by-default tier
 
-Every public API is in the safe tier. The unsafe tier (`Channel.Unsafe`,
-`Sync.Unsafe`) exists for integrators and performance-critical bridging only.
+Every public API is in the safe tier. The unsafe tier (`Sync.Unsafe`)
+exists for integrators and performance-critical bridging only.
 Every site that calls `AllowUnsafe` or `Sync.Unsafe.defer` must have a
 `// Unsafe:` comment explaining which safe-tier contract it is bridging.
+
+---
+
+## Concurrency model
+
+### Async vs Sync in the effect row
+
+`Sync` (`Sync.scala:23`) is a type-level marker meaning "this computation has side
+effects but runs to completion without parking or locking." `Async`
+(`Async.scala:47`) extends `Sync` and means "this computation may park the current
+fiber or involve the scheduler." Every method that can suspend a fiber must declare
+`Async` in its pending effects. A method with only `Sync` in its row is guaranteed
+to run to completion without scheduler involvement and without any possibility of
+fiber requeuing.
+
+This distinction is useful for reasoning about performance. A call chain showing
+only `Sync` effects is free of scheduler interactions. Once `Async` appears, the
+current fiber may park and another may run.
+
+### The no-blocking rule in kyo-core
+
+No kyo-core code may block a thread. Forbidden in non-stub shared or platform code:
+`Thread.sleep`, `synchronized`, `Future.await`, `CountDownLatch.await`, or any
+other blocking primitive. Use Async suspension instead:
+
+- Wait for channel space: `Channel.put` / `Channel.take`
+- Wait for a count to reach zero: `Latch.await`
+- Wait for elapsed time: `Clock.sleep`
+- Join a forked fiber: `Fiber.get`
+- Synchronize a group of fibers: `Gate.enter` / `Barrier.await`
+
+The js-wasm stub for `LockSupport` (`js-wasm/src/main/scala/kyo/AsyncStubs.scala`)
+throws `UnsupportedOperationException` on any `park` or `unpark` call. That throw
+is the enforcement mechanism: any accidental call to a blocking primitive that
+reaches JS will fail loudly at runtime rather than silently no-op.
+
+### Adding a new concurrent primitive
+
+Follow the four-layer pattern used by `Channel`, `Queue`, and `Latch`.
+
+**Layer 1: opaque type aliased to Unsafe.** The public type is the safe surface and
+the underlying value is the Unsafe object:
+
+```scala
+opaque type Foo[A] = Foo.Unsafe[A]   // Channel.scala:58
+```
+
+**Layer 2: safe-tier extension block.** Each public operation delegates into Unsafe
+via `Sync.Unsafe.defer`. Non-suspending operations use `Abort.get(self.method())`
+to surface typed failures; suspending operations use `self.fooFiber().safe.get` to
+convert `Fiber.Unsafe` to `Fiber` and park the current fiber:
+
+```scala
+def offer(v: A)(using Frame): Boolean < (Abort[Closed] & Sync) =
+    Sync.Unsafe.defer(Abort.get(self.offer(v)))
+
+def put(v: A)(using Frame): Unit < (Abort[Closed] & Async) =
+    Sync.Unsafe.defer(self.putFiber(v).safe.get)
+```
+
+**Layer 3: Unsafe tier.** A `sealed abstract class Unsafe[A]` whose methods take
+`(using AllowUnsafe)` and return bare values or `Fiber.Unsafe` for suspending
+operations. Include `def safe: Foo[A] = this` so the Unsafe object is addressable
+as the safe opaque type. Prefix the class and its companion with the standard
+warning comment (`Channel.scala:391-392`, `Latch.scala:72`):
+
+```scala
+/** WARNING: Low-level API meant for integrations, libraries, and
+  * performance-sensitive code. See AllowUnsafe for more details. */
+sealed abstract class Unsafe[A] extends Serializable:
+    def safe: Foo[A] = this
+```
+
+**Layer 4: init pattern.** Provide `init` and `initWith`; `init` delegates to
+`initWith(identity)`. `initWith` is `inline`, constructs the Unsafe object inside
+`Sync.Unsafe.defer`, and registers cleanup with `Scope.ensure`. Also provide
+`initUnscoped` and `initUnscopedWith` for callers that manage lifecycle manually.
+See `Channel.scala:325-389` for the full pattern. The Scope-managed `init` is the
+default: users reach for it first and it must never leak resources.
+
+`Hub` is a `final class` rather than an opaque type (`Hub.scala:22-26`) because it
+aggregates a `Channel` plus a long-running broadcast `Fiber`. Use a `final class`
+when the primitive holds composite state that does not map cleanly to a single Unsafe
+object.
+
+### The `kyo.async.concurrency.default` knob
+
+`Async.defaultConcurrency` (`Async.scala:84-91`) caps the number of fibers that
+collection operations (`Async.foreach`, `Async.collect`, and their variants) will
+fork. The default is `Runtime.availableProcessors() * 2`. It can be overridden
+per-call or globally via the `kyo.async.concurrency.default` JVM system property.
+
+The property is read once at module initialization. A malformed value throws
+`IllegalArgumentException` immediately with a message naming the property and the
+offending string (`Async.scala:75-82`). A misconfigured knob should fail loud at
+startup rather than silently fall back to the default.
+
+`kyo.System` lives in `kyo-system`, which depends on `kyo-core`, so the init-time
+read uses `java.lang.System.getProperty` directly (`Async.scala:87-88`). This is the
+only sanctioned place in kyo-core where `java.lang.System` appears instead of
+`kyo.System`. The `// Unsafe:` comment at that line names the reason.
+
+---
+
+## Platform-split discipline
+
+Source defaults to `shared/src`. Use a platform-specific tree only when a JVM,
+Native, or JS library primitive has no cross-platform Kyo wrapper.
+
+### What lives where
+
+**`jvm-native/`** (JVM and Native share, JS diverges):
+- `AsyncPlatformSpecific`: `fromCompletionStage` and `fromCompletableFuture`
+  bridging Java's `CompletionStage`/`CompletableFuture`; absent on JS.
+- `KyoAppPlatformSpecific`: OS-level exit hook (`exit(code)`) via
+  `KyoAppRunnerWithInterrupts`.
+- `LogPlatformSpecific`: platform-specific log backend wiring.
+
+**`jvm/`** (JVM only):
+- `OsSignalPlatformSpecific`: installs signal handlers via `sun.misc.Signal` through
+  reflection, with a graceful `Handler.Noop` fallback when the class is absent
+  (`jvm/src/main/scala/kyo/internal/OSSignalPlatformSpecific.scala:18-34`).
+- `IOPromisePlatformSpecific`: JVM-specific promise scheduling.
+- `StreamCompression`: deflate/inflate via `java.util.zip`, which has no equivalent
+  in Scala Native or JS standard libraries.
+
+**`native/`** (Scala Native only):
+- `OsSignalPlatformSpecific`: installs handlers via POSIX `signal()` using
+  `scala.scalanative.posix.signal`.
+- `hubsStubs.scala`: stub for `CopyOnWriteArraySet`, a Java class absent on Native.
+
+**`js-wasm/`** (JS and WASM):
+- `AsyncPlatformSpecific`: empty trait; `CompletionStage` does not exist on JS.
+- `AsyncStubs.scala`: `LockSupport` stub that throws `UnsupportedOperationException`
+  on any call; parking has no meaning on a single-threaded platform.
+- `OsSignalPlatformSpecific`: `Handler.Noop`; JS has no OS signals.
+- `hubsStubs.scala`: `CopyOnWriteArraySet` stub backed by `HashSet`.
+- `addersStubs.scala`, `timersSubs.scala`: stubs for absent JVM classes.
+- `VarHandle`, `JSServiceLoaderRegistry`, `ServiceLoader`: JS-specific
+  implementations for services and memory-model primitives.
+
+### The OsSignal pattern as a template
+
+`OsSignal` (`shared/src/main/scala/kyo/internal/OSSignal.scala`) defines the
+abstract shape and the `Handler.Noop` fallback. Three platform leaves implement
+`OsSignalPlatformSpecific`: JVM uses `sun.misc.Signal` via reflection with a `Noop`
+fallback on missing classes, Native uses POSIX signals, JS-WASM is `Noop`. New OS
+capabilities should follow this same three-leaf pattern.
+
+### Rule for placing new code
+
+Place new code in `shared/` unless a specific external library or OS primitive is
+required. Use `jvm-native/` when JVM and Native share behavior that JS cannot
+express. Use `jvm/` or `native/` only when the behavior is exclusive to one
+platform. Never move a test into a platform-specific tree to avoid a cross-platform
+failure; fix the failure instead.
+
+---
+
+## Test patterns
+
+### Test base class
+
+All kyo-core tests extend `kyo.test.Test[Any]`, not ScalaTest directly:
+
+```scala
+class ChannelTest extends kyo.test.Test[Any]:
+```
+
+`kyo.test.Test` is provided by the `kyo-test` module. Do not mix in raw ScalaTest
+traits.
+
+### Deterministic concurrency testing
+
+Never use `Thread.sleep` as a readiness witness in a test. Use Kyo's own
+synchronization primitives to drive deterministic rendezvous:
+
+- `Latch.init(n)` and `latch.await` to wait for n fibers to reach a point.
+- `Channel.put` / `Channel.take` to pass a signal between fibers without real time.
+- `Clock.run(...)` to control virtual time in tests for `Clock.sleep` or
+  `Retry` backoff scenarios.
+- `Fiber.get` to join a forked computation before asserting its result.
+
+A test that depends on real elapsed time to avoid a race is a flaky test. Drive
+events with latches and channels; let virtual clocks advance time.
+
+### The initWith pattern in tests
+
+Prefer the `initWith` and `use` factory variants over `init` followed by manual
+`close`. The `initWith` variants register cleanup automatically via `Scope.ensure`
+and keep the test body clean:
+
+```scala
+Channel.initWith[Int](10) { c =>
+    c.put(1).andThen(c.take)
+}
+```
+
+Use `initUnscoped` or `initUnscopedWith` only when the test explicitly exercises
+post-close behavior and must observe that the channel is still open after the block.
+
+### Where JVM-only tests may live
+
+A test may go in `jvm/src/test/scala/kyo/` only when it tests genuinely JVM-only
+behavior. Current examples: `StreamCompressionTest.scala` (tests `StreamCompression`
+which wraps `java.util.zip`) and `GateJvmTest.scala` (JVM-specific scheduler
+behavior). Every other test belongs in `shared/src/test/scala/kyo/` and must pass
+on JVM, Scala.js, and Scala Native.
+
+---
+
+## Pre-submission checklist (kyo-core-specific)
+
+- [ ] New concurrent primitives follow the four-layer pattern: opaque type, safe-tier extension block, `sealed abstract class Unsafe`, and `init`/`initWith`.
+- [ ] Every `Sync.Unsafe.defer` bridging site carries a `// Unsafe:` comment.
+- [ ] New platform-specific code is in the narrowest tree that fits (`shared/` first, then `jvm-native/`, then `jvm/`, `native/`, or `js-wasm/`).
+- [ ] No `Thread.sleep`, `synchronized`, or blocking primitive in non-stub code.
+- [ ] Tests extend `kyo.test.Test`, not raw ScalaTest.
+- [ ] Concurrency tests use `Latch`, `Channel`, or `Clock` for determinism, not real-time sleeps.
+- [ ] Any change to `Async.defaultConcurrency` or the `kyo.async.concurrency.default` path preserves the loud-failure behavior for malformed values (`Async.scala:75-82`).

--- a/kyo-core/README.md
+++ b/kyo-core/README.md
@@ -790,6 +790,12 @@ val withTimeout: Result[Timeout, Int] < (Async & Sync) =
 
 `Async.timeoutWithError(d, error)(v)` lets you raise a domain-specific error on expiry instead.
 
+## Files, processes, and the OS
+
+> **File system, processes, and environment:** `Path`, `Command`, `Process`, `System`, and the
+> `FileSystemException` hierarchy live in [`kyo-system`](../kyo-system/README.md); add it to your
+> dependencies to use them.
+
 ## Ambient services
 
 `Console`, `Random`, `UUIDGenerator`, and `Log` are dynamically scoped context services. Their defaults target the platform console, a non-cryptographic `java.util.Random`, secure UUID entropy, and the console logger respectively. Tests can swap them out per scope without threading them as arguments.

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -865,13 +865,6 @@ class AsyncTest extends kyo.test.Test[Any]:
         succeed("compile-time subtyping check: Abort[Nothing] <: Async")
     }
 
-    "defaultConcurrency flag key matches the documented -D property" in {
-        // StaticFlag derives its key from the enclosing objects' JVM class name, so renaming or
-        // renesting `async.concurrency.default` would silently change the key and break the
-        // -Dkyo.async.concurrency.default override documented in kyo-core/README.md.
-        assert(async.concurrency.default.name == "kyo.async.concurrency.default")
-    }
-
     "collectAll concurrency" - {
         "empty sequence" in {
             Async.collectAll(Seq(), 2).map { r =>
@@ -1885,6 +1878,17 @@ class AsyncTest extends kyo.test.Test[Any]:
                     Async.timeout(Duration.Zero)(Async.sleep(1.day))
                 }
             yield assert(result.isFailure)
+        }
+    }
+
+    "defaultConcurrency knob" - {
+        val computedDefault = Runtime.getRuntime().availableProcessors() * 2
+
+        "is backed by the kyo.async.concurrency.default StaticFlag" in {
+            val flag: StaticFlag[Int] = kyo.async.concurrency.default
+            assert(flag.name == "kyo.async.concurrency.default")
+            assert(flag.default == computedDefault)
+            assert(Async.defaultConcurrency == flag())
         }
     }
 

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/BlockCache.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/BlockCache.scala
@@ -43,29 +43,31 @@ final private[kyo] class BlockCache private (root: kyo.Path):
         val key      = cacheKey(block, scopeClosure, classpathFingerprint, scalaVersion, scalacOpts)
         val okFile   = root / s"$key.ok"
         val failFile = root / s"$key.fail"
-        // Cache files may be truncated or corrupted by a crashed prior run; treat any read failure as a cache
-        // miss so the block re-runs rather than serving stale or corrupt data. One Abort.run covers all four ops
-        // (exists and read for both files) because every failure routes to Maybe.empty regardless of which op
-        // raised it.
-        Abort.run[FileReadException] {
-            okFile.exists.flatMap {
-                case true =>
-                    okFile.read.map { content =>
-                        try Maybe(BlockCache.Entry(Driver.Outcome.Ok(deserializeDiagnostics(content))))
-                        catch case _: Throwable => Maybe.empty
-                    }
-                case false =>
-                    failFile.exists.flatMap {
-                        case true =>
-                            failFile.read.map { content =>
-                                try
-                                    val (errors, warnings) = deserializeErrorsAndWarnings(content)
-                                    Maybe(BlockCache.Entry(Driver.Outcome.Failed(errors, warnings)))
-                                catch case _: Throwable => Maybe.empty
-                            }
-                        case false =>
-                            Maybe.empty
-                    }
+        // Cache files may be truncated or corrupted by a crashed prior run; treat any IO error as a cache miss so
+        // the block re-runs rather than serving stale or corrupt data. A single boundary runner with one outer
+        // Abort.run captures all four ops (exists/read for ok and fail files); all errors route to Maybe.empty,
+        // so no per-op IoError label is needed here.
+        Abort.run[FileSystemException] {
+            Path.runReadOnly {
+                okFile.exists.flatMap {
+                    case true =>
+                        okFile.read.map { content =>
+                            try Maybe(BlockCache.Entry(Driver.Outcome.Ok(deserializeDiagnostics(content))))
+                            catch case _: Throwable => Maybe.empty
+                        }
+                    case false =>
+                        failFile.exists.flatMap {
+                            case true =>
+                                failFile.read.map { content =>
+                                    try
+                                        val (errors, warnings) = deserializeErrorsAndWarnings(content)
+                                        Maybe(BlockCache.Entry(Driver.Outcome.Failed(errors, warnings)))
+                                    catch case _: Throwable => Maybe.empty
+                                }
+                            case false =>
+                                Maybe.empty
+                        }
+                }
             }
         }.map {
             case Result.Success(v) => v
@@ -103,7 +105,7 @@ final private[kyo] class BlockCache private (root: kyo.Path):
             case Driver.Outcome.Failed(errors, warnings) =>
                 (root / s"$key.fail", serializeErrorsAndWarnings(errors, warnings))
         // Swallow write errors: a failed cache write means the next run recompiles. Not fatal.
-        Abort.run[FileWriteException](filePath.write(content)).unit
+        Abort.run[FileSystemException](Path.run(filePath.write(content))).unit
     end record
 
     /** Cache key: SHA-256 of all components fed with length-prefix delimiters to prevent preimage collisions. */
@@ -207,11 +209,14 @@ private[kyo] object BlockCache:
       *   A ready-to-use BlockCache.
       */
     def init(path: kyo.Path)(using Frame): BlockCache < (Sync & Abort[Doctest.Error]) =
+        // Single boundary runner covering both ops (exists + mkDir); Path.run subsumes runReadOnly.
         // Both ops fail for the same reason (cache-dir setup failure), so a combined error label is accurate.
-        Abort.recover[FileReadException | FileStructureException](e => Abort.fail(Doctest.Error.IoError(path, "exists/mkDir", e))) {
-            path.exists.flatMap { exists =>
-                if !exists then path.mkDir.andThen(new BlockCache(path))
-                else new BlockCache(path)
+        Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(path, "exists/mkDir", e))) {
+            Path.run {
+                path.exists.flatMap { exists =>
+                    if !exists then path.mkDir.andThen(new BlockCache(path))
+                    else new BlockCache(path)
+                }
             }
         }
 

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/ClasspathFingerprint.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/ClasspathFingerprint.scala
@@ -53,18 +53,24 @@ private[kyo] object ClasspathFingerprint:
 
     // Produce a raw-bytes hash for a single classpath entry.
     private def hashEntry(entry: kyo.Path)(using Frame): Array[Byte] < (Sync & Async & Abort[Doctest.Error]) =
-        Abort.recover[FileReadException](e => Abort.fail(Doctest.Error.IoError(entry, "exists", e))) {
-            entry.exists
+        // Per-operation runner: each Abort.recover here carries a distinct IoError op label; one runner
+        // per op is required to keep the label accurate to the failing operation.
+        Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(entry, "exists", e))) {
+            Path.runReadOnly(entry.exists)
         }.flatMap { exists =>
             if !exists then
                 // Missing entry: hash the path string itself so presence vs absence is detectable.
                 sha256Bytes(entry.toString.getBytes("UTF-8"))
             else
-                entry.isDirectory.flatMap { isDir =>
+                // Per-operation runner: the IoError message must carry the "isDirectory" op label.
+                Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(entry, "isDirectory", e))) {
+                    Path.runReadOnly(entry.isDirectory)
+                }.flatMap { isDir =>
                     if isDir then hashDirectory(entry)
                     else
-                        Abort.recover[FileReadException](e => Abort.fail(Doctest.Error.IoError(entry, "read", e))) {
-                            entry.readBytes.map(span => sha256Bytes(span.toArray))
+                        // Per-operation runner: the IoError message must carry the "read" op label.
+                        Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(entry, "read", e))) {
+                            Path.runReadOnly(entry.readBytes).map(span => sha256Bytes(span.toArray))
                         }
                 }
         }
@@ -74,8 +80,9 @@ private[kyo] object ClasspathFingerprint:
     // Walk requires Scope; we run that scope locally (Scope.run introduces Async in the row).
     private def hashDirectory(dir: kyo.Path)(using Frame): Array[Byte] < (Sync & Async & Abort[Doctest.Error]) =
         Scope.run {
-            Abort.recover[FileStructureException](e => Abort.fail(Doctest.Error.IoError(dir, "walk", e))) {
-                dir.walk.run
+            // Per-operation runner: the IoError message must carry the "walk" op label.
+            Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(dir, "walk", e))) {
+                Path.runReadOnly(dir.walk.run)
             }
         }.flatMap { allPaths =>
             // TASTy for everything the Scala compiler produced, because that is what a downstream
@@ -106,8 +113,9 @@ private[kyo] object ClasspathFingerprint:
             // Sort by path string for stable hashing.
             val sortedFiles = selected.toSeq.sortBy(_.toString)
             Kyo.foreach(sortedFiles) { f =>
-                Abort.recover[FileReadException](e => Abort.fail(Doctest.Error.IoError(f, "read", e))) {
-                    f.readBytes.map(span => (f.toString, span.toArray))
+                // Per-operation runner: the IoError message must carry the "read" op label.
+                Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(f, "read", e))) {
+                    Path.runReadOnly(f.readBytes).map(span => (f.toString, span.toArray))
                 }
             }.map { entries =>
                 val digest = MessageDigest.getInstance("SHA-256")

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Driver.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Driver.scala
@@ -131,7 +131,7 @@ final private[kyo] class Driver private (
       */
     def close(using Frame): Unit < Sync =
         // Swallow removeAll errors: if cleanup fails the OS temp cleaner will handle it.
-        Abort.run[FileStructureException](outputDir.removeAll).andThen(Sync.defer(compilerThread.shutdown()))
+        Abort.run[FileSystemException](Path.run(outputDir.removeAll)).andThen(Sync.defer(compilerThread.shutdown()))
 
 end Driver
 
@@ -243,8 +243,8 @@ private[kyo] object Driver:
         for
             id <- Random.uuid
             dir = Path.basePaths.tmp / s"doctest-out-$id"
-            _ <- Abort.run[FileStructureException](dir.mkDir).flatMap {
-                (r: Result[FileStructureException, Unit]) =>
+            _ <- Abort.run[FileSystemException](Path.run(dir.mkDir)).flatMap {
+                (r: Result[FileSystemException, Unit]) =>
                     r match
                         case Result.Success(_) => Sync.defer(())
                         case Result.Failure(e) =>

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/LinkValidator.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/LinkValidator.scala
@@ -32,8 +32,10 @@ private[kyo] object LinkValidator:
       * touched. Cross-document anchor checks read each referenced README at most once (memoised across the call).
       */
     def validate(file: Path)(using Frame): Chunk[Doctest.Failure] < (Sync & Abort[Doctest.Error]) =
-        Abort.recover[FileReadException](e => Abort.fail(Doctest.Error.IoError(file, "read", e))) {
-            file.read.map { raw =>
+        // Per-operation runner: the IoError message must carry the "read" op label; a single boundary
+        // runner at validate() entry would lose the distinction between "read" here and "exists" in validateLink.
+        Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(file, "read", e))) {
+            Path.runReadOnly(file.read).map { raw =>
                 val content      = raw.replace("\r\n", "\n")
                 val headingSlugs = extractHeadings(content).map(_.slug).toSet
                 val links        = extractLinks(content)
@@ -60,8 +62,9 @@ private[kyo] object LinkValidator:
         else
             val (pathPart, anchorPart) = splitAnchor(target)
             val resolved               = file.parent.map(_ / pathPart).getOrElse(Path(pathPart))
-            Abort.recover[FileReadException](e => Abort.fail(Doctest.Error.IoError(resolved, "exists", e))) {
-                resolved.exists
+            // Per-operation runner: the IoError message must carry the "exists" op label.
+            Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(resolved, "exists", e))) {
+                Path.runReadOnly(resolved.exists)
             }.map {
                 case false => Chunk(failure(
                         file,
@@ -83,8 +86,9 @@ private[kyo] object LinkValidator:
         targetFile: Path,
         anchor: String
     )(using Frame): Chunk[Doctest.Failure] < (Sync & Abort[Doctest.Error]) =
-        Abort.recover[FileReadException](e => Abort.fail(Doctest.Error.IoError(targetFile, "read", e))) {
-            targetFile.read.map { raw =>
+        // Per-operation runner: the IoError message must carry the "read" op label.
+        Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(targetFile, "read", e))) {
+            Path.runReadOnly(targetFile.read).map { raw =>
                 val slugs = extractHeadings(raw.replace("\r\n", "\n")).map(_.slug).toSet
                 if slugs.contains(anchor) then Chunk.empty
                 else Chunk(failure(sourceFile, link, s"unresolved anchor in $targetFile: #$anchor"))

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/MarkdownParser.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/MarkdownParser.scala
@@ -52,8 +52,8 @@ private[kyo] object MarkdownParser:
       *   a Chunk of Block objects representing every extracted scala code block
       */
     def parse(path: kyo.Path)(using Frame): Chunk[Block] < (Sync & Abort[Doctest.Error]) =
-        Abort.recover[FileReadException](e => Abort.fail(Doctest.Error.IoError(path, "read", e))) {
-            path.read.flatMap { raw =>
+        Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(path, "read", e))) {
+            Path.runReadOnly(path.read).flatMap { raw =>
                 parseString(raw.replace("\r\n", "\n"), path)
             }
         }

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Orchestrator.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/Orchestrator.scala
@@ -57,8 +57,10 @@ private[kyo] object Orchestrator:
         scalaVer: String
     )(using Frame): Chunk[BlockOutcome] < (Sync & Async & Scope & Abort[Doctest.Error]) =
         Kyo.foreach(config.sources) { sourcePath =>
-            Abort.recover[FileReadException](e => Abort.fail(Doctest.Error.IoError(sourcePath, "exists", e))) {
-                sourcePath.exists
+            // Per-operation runner: the IoError message must carry the "exists" op label for this source
+            // path; the Abort.recover must wrap the runner to catch the FileSystemException it surfaces.
+            Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(sourcePath, "exists", e))) {
+                Path.runReadOnly(sourcePath.exists)
             }.flatMap { exists =>
                 if !exists then Abort.fail(Doctest.Error.SourceNotFound(sourcePath))
                 else processOneSource(sourcePath, config, driver, cache, fingerprint, scalaVer)

--- a/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/cli/Main.scala
+++ b/kyo-doctest/jvm/src/main/scala/kyo/doctest/internal/cli/Main.scala
@@ -24,31 +24,34 @@ object Main extends KyoApp:
         else
             val configPathStr = args(0).toString
             val resultPathStr = args(1).toString
-            // The two Abort.recover wrappers each translate a filesystem failure into a
-            // context-specific IOException message.
-            for
-                configJson <-
-                    Abort.recover[FileReadException](e =>
-                        Abort.fail(new java.io.IOException(s"failed to read config: $e"))
-                    )(Path(configPathStr).read)
+            // Single boundary runner for the entire for-comprehension: Path.run subsumes runReadOnly,
+            // so one runner covers both the config read and the result write. The two Abort.recover
+            // wrappers each translate FileSystemException to a context-specific IOException message.
+            Path.run {
+                for
+                    configJson <-
+                        Abort.recover[FileSystemException](e =>
+                            Abort.fail(new java.io.IOException(s"failed to read config: $e"))
+                        )(Path(configPathStr).read)
 
-                config <- decodeConfig(configJson)
-                report <- runDoctest(config)
+                    config <- decodeConfig(configJson)
+                    report <- runDoctest(config)
 
-                _ <-
-                    Abort.recover[FileWriteException](e =>
-                        Abort.fail(new java.io.IOException(s"failed to write result: $e"))
-                    )(Path(resultPathStr).write(Json.encode(report)))
+                    _ <-
+                        Abort.recover[FileSystemException](e =>
+                            Abort.fail(new java.io.IOException(s"failed to write result: $e"))
+                        )(Path(resultPathStr).write(Json.encode(report)))
 
-                _ <-
-                    if report.failures.nonEmpty then
-                        // useAnsi=false: output is captured by the sbt plugin, not displayed directly in a terminal.
-                        Console.printLineErr(ErrorReporter.renderAll(report.failures, useAnsi = false))
-                            .andThen(Sync.defer { scala.sys.exit(1) })
-                    else
-                        Kyo.unit
-            yield ()
-            end for
+                    _ <-
+                        if report.failures.nonEmpty then
+                            // useAnsi=false: output is captured by the sbt plugin, not displayed directly in a terminal.
+                            Console.printLineErr(ErrorReporter.renderAll(report.failures, useAnsi = false))
+                                .andThen(Sync.defer { scala.sys.exit(1) })
+                        else
+                            Kyo.unit
+                yield ()
+                end for
+            }
         end if
     }
 

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/CorpusTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/CorpusTest.scala
@@ -37,12 +37,12 @@ class CorpusTest extends kyo.test.Test[Any]:
             cp    <- testClasspath
             nCpus <- System.availableProcessors
             cacheDir = Path.basePaths.tmp / s"kyo-doctest-corpus-cache-$id"
-            _ <- Abort.recover[FileStructureException](e => Abort.fail(Doctest.Error.IoError(cacheDir, "mkDir", e)))(
-                cacheDir.mkDir
+            _ <- Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(cacheDir, "mkDir", e)))(
+                Path.run(cacheDir.mkDir)
             )
             _ <- Scope.acquireRelease(cacheDir)(dir =>
                 // Release must not fail; swallow removeAll errors.
-                Abort.run[FileStructureException](dir.removeAll).unit
+                Abort.run[FileSystemException](Path.run(dir.removeAll)).unit
             )
             report <- Doctest.check(Doctest.Config(
                 sources = Chunk(filePath),
@@ -308,7 +308,7 @@ class CorpusTest extends kyo.test.Test[Any]:
     "kyo-doctest README.md self-validates with zero failures" in {
         // Locate the README.md at the project root relative to the module.
         // In sbt, baseDirectory for kyo-doctest is kyo-doctest/. The README lives there.
-        Abort.run[FileReadException](findReadme).flatMap {
+        Abort.run[FileSystemException](findReadme).flatMap {
             case Result.Success(readmePath) =>
                 Abort.run(Scope.run(runCheck(readmePath))).map {
                     case Result.Success(report) =>
@@ -334,7 +334,7 @@ class CorpusTest extends kyo.test.Test[Any]:
     // We walk parent directories looking for a directory named "kyo-doctest" that contains README.md.
     // Failing that, fall back to user.dir itself (in case the test runs from the kyo-doctest dir directly).
     // NOTE: override via the kyo.doctest.readme system property for non-standard build layouts.
-    private def findReadme(using Frame): kyo.Path < (Sync & Abort[FileReadException]) =
+    private def findReadme(using Frame): kyo.Path < (Sync & Abort[FileSystemException]) =
         System.property[String]("kyo.doctest.readme").flatMap { overrideProp =>
             overrideProp match
                 case Present(p) => kyo.Path(p)
@@ -342,16 +342,16 @@ class CorpusTest extends kyo.test.Test[Any]:
                     kyo.System.property[String]("user.dir").flatMap { maybeCwd =>
                         val cwdStr = maybeCwd.getOrElse(".")
                         val cwd    = kyo.Path(cwdStr)
-                        def loop(dir: kyo.Path): kyo.Path < (Sync & Abort[FileReadException]) =
+                        def loop(dir: kyo.Path): kyo.Path < (Sync & Abort[FileSystemException]) =
                             // Check if this dir contains kyo-doctest/README.md as a sibling subdir.
                             val sibling = dir / "kyo-doctest" / "README.md"
                             // Check if this dir IS named kyo-doctest and directly contains README.md.
                             val direct  = dir / "README.md"
                             val dirName = dir.name.getOrElse("")
-                            sibling.exists.flatMap { siblingExists =>
+                            Path.runReadOnly(sibling.exists).flatMap { siblingExists =>
                                 if siblingExists then sibling
                                 else
-                                    direct.exists.flatMap { directExists =>
+                                    Path.runReadOnly(direct.exists).flatMap { directExists =>
                                         if dirName == "kyo-doctest" && directExists then direct
                                         else
                                             dir.parent match

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/DoctestCheckTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/DoctestCheckTest.scala
@@ -24,12 +24,10 @@ class DoctestCheckTest extends kyo.test.Test[Any]:
         for
             id <- Random.uuid
             dir = Path.basePaths.tmp / s"doctest-check-test-$id"
-            _ <- Abort.run[FileStructureException](dir.mkDir).unit
-            res <- Scope.acquireRelease(Sync.defer(dir))(_ =>
-                Abort.run[FileStructureException](dir.removeAll).unit
-            ).flatMap { dir =>
+            _ <- Abort.run[FileSystemException](Path.run(dir.mkDir)).unit
+            res <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileSystemException](Path.run(dir.removeAll)).unit).flatMap { dir =>
                 val file = dir / name
-                Abort.run[FileWriteException](file.write(content)).flatMap { _ => f(file) }
+                Abort.run[FileSystemException](Path.run(file.write(content))).flatMap { _ => f(file) }
             }
         yield res
 
@@ -39,10 +37,8 @@ class DoctestCheckTest extends kyo.test.Test[Any]:
         for
             id <- Random.uuid
             dir = Path.basePaths.tmp / s"doctest-cache-check-$id"
-            _ <- Abort.run[FileStructureException](dir.mkDir).unit
-            res <- Scope.acquireRelease(Sync.defer(dir))(_ =>
-                Abort.run[FileStructureException](dir.removeAll).unit
-            ).flatMap(f)
+            _   <- Abort.run[FileSystemException](Path.run(dir.mkDir)).unit
+            res <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileSystemException](Path.run(dir.removeAll)).unit).flatMap(f)
         yield res
 
     // Doctest.check opens and closes the Driver via Scope.acquireRelease.
@@ -59,8 +55,8 @@ class DoctestCheckTest extends kyo.test.Test[Any]:
             withTempFile("README.md", md) { kyoFile =>
                 // Count temp dirs named doctest-out* BEFORE the run using kyo.Path.list.
                 val tempDirBase = Path.basePaths.tmp
-                def countOutDirs()(using Frame): Int < (Sync & Abort[FileStructureException]) =
-                    tempDirBase.list.map { entries =>
+                def countOutDirs()(using Frame): Int < (Sync & Abort[FileSystemException]) =
+                    Path.runReadOnly(tempDirBase.list).map { entries =>
                         entries.count(p => p.name.getOrElse("").startsWith("doctest-out"))
                     }
                 end countOutDirs
@@ -75,10 +71,10 @@ class DoctestCheckTest extends kyo.test.Test[Any]:
                         cache = cacheDir,
                         parallel = nCpus
                     )
-                    beforeCount <- Abort.run[FileStructureException](countOutDirs()).map(_.getOrElse(0))
+                    beforeCount <- Abort.run[FileSystemException](countOutDirs()).map(_.getOrElse(0))
                     // Run with Scope.run, which triggers all finalizers.
                     result     <- Abort.run(Scope.run(Doctest.check(config)))
-                    afterCount <- Abort.run[FileStructureException](countOutDirs()).map(_.getOrElse(0))
+                    afterCount <- Abort.run[FileSystemException](countOutDirs()).map(_.getOrElse(0))
                 yield result match
                     case Result.Success(_) =>
                         // Scope.run must have cleaned up the temp output dir.

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/OrchestratorTest.scala
@@ -24,12 +24,10 @@ class OrchestratorTest extends kyo.test.Test[Any]:
         for
             id <- Random.uuid
             dir = Path.basePaths.tmp / s"kyo-doctest-orch-test-$id"
-            _ <- Abort.run[FileStructureException](dir.mkDir).unit
-            res <- Scope.acquireRelease(Sync.defer(dir))(_ =>
-                Abort.run[FileStructureException](dir.removeAll).unit
-            ).flatMap { dir =>
+            _ <- Abort.run[FileSystemException](Path.run(dir.mkDir)).unit
+            res <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileSystemException](Path.run(dir.removeAll)).unit).flatMap { dir =>
                 val file = dir / name
-                Abort.run[FileWriteException](file.write(content)).flatMap { _ => f(file) }
+                Abort.run[FileSystemException](Path.run(file.write(content))).flatMap { _ => f(file) }
             }
         yield res
 
@@ -39,10 +37,8 @@ class OrchestratorTest extends kyo.test.Test[Any]:
         for
             id <- Random.uuid
             dir = Path.basePaths.tmp / s"doctest-cache-test-$id"
-            _ <- Abort.run[FileStructureException](dir.mkDir).unit
-            res <- Scope.acquireRelease(Sync.defer(dir))(_ =>
-                Abort.run[FileStructureException](dir.removeAll).unit
-            ).flatMap(f)
+            _   <- Abort.run[FileSystemException](Path.run(dir.mkDir)).unit
+            res <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileSystemException](Path.run(dir.removeAll)).unit).flatMap(f)
         yield res
 
     "empty sources raises NoSourcesConfigured" in {
@@ -235,10 +231,10 @@ class OrchestratorTest extends kyo.test.Test[Any]:
             for
                 id <- Random.uuid
                 editDir = Path.basePaths.tmp / s"kyo-doctest-edit-test-$id"
-                _ <- Abort.run[FileStructureException](editDir.mkDir).unit
+                _ <- Abort.run[FileSystemException](Path.run(editDir.mkDir)).unit
                 res <-
                     Scope.acquireRelease(Sync.defer(editDir))(_ =>
-                        Abort.run[FileStructureException](editDir.removeAll).unit
+                        Abort.run[FileSystemException](Path.run(editDir.removeAll)).unit
                     ).flatMap {
                         dir =>
                             val file    = dir / "README.md"
@@ -273,13 +269,13 @@ class OrchestratorTest extends kyo.test.Test[Any]:
                                     cache = cacheDir,
                                     parallel = nCpus
                                 )
-                                _        <- Abort.run[FileWriteException](file.write(md1))
+                                _        <- Abort.run[FileSystemException](Path.run(file.write(md1)))
                                 r1Result <- Abort.run(Scope.run(Doctest.check(config)))
                                 result <- r1Result match
                                     case Result.Success(r1) =>
                                         assert(r1.compiled == 2, s"first run: expected 2 compiled, got ${r1.compiled}")
                                         // Edit one block
-                                        Abort.run[FileWriteException](file.write(md2)).flatMap { _ =>
+                                        Abort.run[FileSystemException](Path.run(file.write(md2))).flatMap { _ =>
                                             Abort.run(Scope.run(Doctest.check(config))).map {
                                                 case Result.Success(r2) =>
                                                     assert(r2.totalBlocks == 2, s"second run: expected 2 total, got ${r2.totalBlocks}")
@@ -308,10 +304,10 @@ class OrchestratorTest extends kyo.test.Test[Any]:
             for
                 id <- Random.uuid
                 editDir = Path.basePaths.tmp / s"kyo-doctest-env-cache-test-$id"
-                _ <- Abort.run[FileStructureException](editDir.mkDir).unit
+                _ <- Abort.run[FileSystemException](Path.run(editDir.mkDir)).unit
                 res <-
                     Scope.acquireRelease(Sync.defer(editDir))(_ =>
-                        Abort.run[FileStructureException](editDir.removeAll).unit
+                        Abort.run[FileSystemException](Path.run(editDir.removeAll)).unit
                     ).flatMap {
                         dir =>
                             val file = dir / "README.md"
@@ -347,13 +343,13 @@ class OrchestratorTest extends kyo.test.Test[Any]:
                                     cache = cacheDir,
                                     parallel = nCpus
                                 )
-                                _        <- Abort.run[FileWriteException](file.write(md1))
+                                _        <- Abort.run[FileSystemException](Path.run(file.write(md1)))
                                 r1Result <- Abort.run(Scope.run(Doctest.check(config)))
                                 result <- r1Result match
                                     case Result.Success(r1) =>
                                         assert(r1.compiled == 2, s"first run: expected 2 compiled, got ${r1.compiled}")
                                         assert(r1.cacheHits == 0, s"first run: expected 0 cache hits, got ${r1.cacheHits}")
-                                        Abort.run[FileWriteException](file.write(md2)).flatMap { _ =>
+                                        Abort.run[FileSystemException](Path.run(file.write(md2))).flatMap { _ =>
                                             Abort.run(Scope.run(Doctest.check(config))).map {
                                                 case Result.Success(r2) =>
                                                     assert(r2.totalBlocks == 2, s"second run: expected 2 total, got ${r2.totalBlocks}")

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/BlockCacheTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/BlockCacheTest.scala
@@ -27,19 +27,19 @@ class BlockCacheTest extends kyo.test.Test[Any]:
         for
             id <- Random.uuid
             dir = Path.basePaths.tmp / s"doctest-cache-test-$id"
-            _   <- Abort.run[FileStructureException](dir.mkDir).unit
-            res <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileStructureException](dir.removeAll).unit).flatMap(f)
+            _   <- Abort.run[FileSystemException](Path.run(dir.mkDir)).unit
+            res <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileSystemException](Path.run(dir.removeAll)).unit).flatMap(f)
         yield res
 
     "BlockCache.init creates the cache directory if missing" in {
         withTempDir { dir =>
             val subDir = dir / "new-subdir"
-            subDir.exists.flatMap { existsBefore =>
+            Path.runReadOnly(subDir.exists).flatMap { existsBefore =>
                 assert(!existsBefore, "subdir should not exist before init")
                 BlockCache.init(subDir).flatMap { _ =>
-                    subDir.exists.flatMap { existsAfter =>
+                    Path.runReadOnly(subDir.exists).flatMap { existsAfter =>
                         assert(existsAfter, "subdir should exist after init")
-                        subDir.isDirectory.map { isDir =>
+                        Path.runReadOnly(subDir.isDirectory).map { isDir =>
                             assert(isDir, "subdir should be a directory")
                         }
                     }

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/ClasspathFingerprintTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/ClasspathFingerprintTest.scala
@@ -9,8 +9,8 @@ class ClasspathFingerprintTest extends kyo.test.Test[Any]:
     // Create a temporary file with given contents and return it as a kyo.Path.
     private def makeTempFile(dir: kyo.Path, name: String, content: Array[Byte])(using Frame): kyo.Path < (Sync & Abort[Doctest.Error]) =
         val file = dir / name
-        Abort.recover[FileWriteException](e => Abort.fail(Doctest.Error.IoError(file, "write", e))) {
-            file.writeBytes(Span.from(content)).andThen(file)
+        Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(file, "write", e))) {
+            Path.run(file.writeBytes(Span.from(content)).andThen(file))
         }
     end makeTempFile
 
@@ -19,10 +19,8 @@ class ClasspathFingerprintTest extends kyo.test.Test[Any]:
         for
             id <- Random.uuid
             dir = Path.basePaths.tmp / s"kyo-doctest-fp-test-$id"
-            _ <- Abort.run[FileStructureException](dir.mkDir).unit
-            res <- Scope.acquireRelease(Sync.defer(dir))(_ =>
-                Abort.run[FileStructureException](dir.removeAll).unit
-            ).flatMap(f)
+            _   <- Abort.run[FileSystemException](Path.run(dir.mkDir)).unit
+            res <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileSystemException](Path.run(dir.removeAll)).unit).flatMap(f)
         yield res
 
     "compute returns stable hash for unchanged jars" in {
@@ -46,8 +44,8 @@ class ClasspathFingerprintTest extends kyo.test.Test[Any]:
             makeTempFile(dir, "lib.jar", Array[Byte](1, 2, 3, 4)).flatMap { jar =>
                 ClasspathFingerprint.compute(Chunk(jar)).flatMap { hash1 =>
                     // Overwrite the jar with different content.
-                    Abort.recover[FileWriteException](e => Abort.fail(Doctest.Error.IoError(jar, "write", e))) {
-                        jar.writeBytes(Span.from(Array[Byte](9, 8, 7, 6)))
+                    Abort.recover[FileSystemException](e => Abort.fail(Doctest.Error.IoError(jar, "write", e))) {
+                        Path.run(jar.writeBytes(Span.from(Array[Byte](9, 8, 7, 6))))
                     }.flatMap { _ =>
                         ClasspathFingerprint.compute(Chunk(jar)).map { hash2 =>
                             assert(hash1 != hash2, s"expected different hashes after content change, but both were '$hash1'")

--- a/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/RuntimeExecutorTest.scala
+++ b/kyo-doctest/jvm/src/test/scala/kyo/doctest/internal/RuntimeExecutorTest.scala
@@ -39,8 +39,8 @@ class RuntimeExecutorTest extends kyo.test.Test[Any]:
         for
             id <- Random.uuid
             dir = Path.basePaths.tmp / s"runtime-executor-test-$id"
-            _      <- Abort.run[FileStructureException](dir.mkDir).unit
-            result <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileStructureException](dir.removeAll).unit).flatMap(f)
+            _      <- Abort.run[FileSystemException](Path.run(dir.mkDir)).unit
+            result <- Scope.acquireRelease(Sync.defer(dir))(_ => Abort.run[FileSystemException](Path.run(dir.removeAll)).unit).flatMap(f)
         yield result
 
     "times out and terminates a non-cooperative block process" in {

--- a/kyo-ffi/jvm/src/test/scala/kyo/ffi/internal/NativeLoaderConcurrencyTest.scala
+++ b/kyo-ffi/jvm/src/test/scala/kyo/ffi/internal/NativeLoaderConcurrencyTest.scala
@@ -22,10 +22,10 @@ class NativeLoaderConcurrencyTest extends Test:
     // alone: under the default parallel leaf execution a sibling leaf observes the mutated global.
     override def config = super.config.sequential
 
-    // Path.tempDir carries Sync & Scope & Abort[FileStructureException].
+    // Path.tempDir carries PathWrite & Sync & Scope; Path.run discharges PathWrite and adds Abort[FileSystemException].
     // A temp-dir failure is test-infra breakage, surfaced as a defect. Scope propagates so it lives until the test ends.
     private def freshDir()(using Frame): Path < (Sync & Scope) =
-        Abort.run[FileStructureException](Path.tempDir("kyo-ffi-f11-")).map {
+        Abort.run[FileSystemException](Path.run(Path.tempDir("kyo-ffi-f11-"))).map {
             case Result.Success(d)   => d
             case Result.Failure(err) => throw err
             case panic: Result.Panic => throw panic.exception

--- a/kyo-ffi/jvm/src/test/scala/kyo/ffi/internal/NativeLoaderForkStressTest.scala
+++ b/kyo-ffi/jvm/src/test/scala/kyo/ffi/internal/NativeLoaderForkStressTest.scala
@@ -51,8 +51,8 @@ class NativeLoaderForkStressTest extends Test:
         val payload = ("F11-fork-stress-payload-" + java.util.UUID.randomUUID()).getBytes()
         val libId   = s"forkstress_${java.lang.System.currentTimeMillis()}"
         val hex     = hexEncode(payload)
-        // Path.tempDir carries Sync & Scope & Abort[FileStructureException].
-        Abort.run[FileStructureException](Path.tempDir("kyo-ffi-fork-")).map {
+        // Path.tempDir carries PathWrite & Sync & Scope; Path.run discharges PathWrite and adds Abort[FileSystemException].
+        Abort.run[FileSystemException](Path.run(Path.tempDir("kyo-ffi-fork-"))).map {
             case Result.Success(dir) =>
                 val pool                   = Executors.newFixedThreadPool(forkN).nn
                 given ec: ExecutionContext = ExecutionContext.fromExecutorService(pool)

--- a/kyo-http/shared/src/test/scala/demo/ServeSite.scala
+++ b/kyo-http/shared/src/test/scala/demo/ServeSite.scala
@@ -55,19 +55,19 @@ object ServeSite extends KyoApp:
     /** Load every regular file under `root` into memory, keyed by its forward-slash path relative to
       * `root` (so `root/latest/kyo-core/index.html` is keyed `latest/kyo-core/index.html`).
       */
-    private def loadDir(root: Path)(using Frame): Map[String, Span[Byte]] < (Async & Abort[FileStructureException | FileReadException]) =
+    private def loadDir(root: Path)(using Frame): Map[String, Span[Byte]] < (Async & Abort[FileSystemException]) =
         val depth = root.parts.size
-
-        Scope.run(root.walk.run).map { entries =>
-            Kyo.foreach(entries) { entry =>
-                entry.isDirectory.map {
-                    case true => Absent
-                    case false =>
-                        entry.readBytes.map(bytes => Present(entry.parts.drop(depth).mkString("/") -> bytes))
-                }
-            }.map(pairs => pairs.collect { case Present(kv) => kv }.toMap)
-        }
-
+        Path.runReadOnly(
+            Scope.run(root.walk.run).map { entries =>
+                Kyo.foreach(entries) { entry =>
+                    entry.isDirectory.map {
+                        case true => Absent
+                        case false =>
+                            entry.readBytes.map(bytes => Present(entry.parts.drop(depth).mkString("/") -> bytes))
+                    }
+                }.map(pairs => pairs.collect { case Present(kv) => kv }.toMap)
+            }
+        )
     end loadDir
 
     /** Resolve a request path to a stored file key: empty/`/` and trailing-slash paths map to `index.html`;
@@ -108,7 +108,7 @@ object ServeSite extends KyoApp:
         args.toList match
             case dir :: rest =>
                 val port = rest.headOption.flatMap(_.toIntOption).getOrElse(defaultPort)
-                Abort.run[FileStructureException | FileReadException](loadDir(Path(dir))).map {
+                Abort.run[FileSystemException](loadDir(Path(dir))).map {
                     case Result.Success(store) =>
                         for
                             server <- HttpServer.init(HttpServerConfig.default.port(port))(rootHandler(store), restHandler(store))

--- a/kyo-i18n/README.md
+++ b/kyo-i18n/README.md
@@ -107,15 +107,17 @@ end for
 On the JVM, Scala Native, and Node the bundles usually sit on disk, so `init` also takes a directory in place of the loader and reads `<locale>.ftl` from it:
 
 ```scala doctest:expect=skipped
-for
-    start <- Locale.preferred(supported, Locale("en"))
-    i18n  <- I18n.init(supported, start)(Path("resources") / "i18n")
-yield i18n
-end for
+Path.run {
+    for
+        start <- Locale.preferred(supported, Locale("en"))
+        i18n  <- I18n.init(supported, start)(Path("resources") / "i18n")
+    yield i18n
+    end for
+}
 // reads resources/i18n/en.ftl and resources/i18n/de.ftl
 ```
 
-That overload's reads carry `Abort[FileReadException]`, so a missing or unreadable bundle surfaces at the caller. A browser build never links it, since nothing there calls it.
+That overload's reads carry `PathRead`, so the caller chooses the filesystem they run against and where the failure surfaces: `Path.run` reads the host, `Path.runReadOnlyWith` reads a custom backend supplied in a test. A browser build never links it, since nothing there calls it.
 
 `let` provides the handle as the ambient source for its body. A `t` leaf built anywhere resolves against whichever handle is ambient when it is sampled; a leaf sampled outside any `let` renders miss markers.
 

--- a/kyo-i18n/jvm-native/src/test/scala/kyo/I18nPathTest.scala
+++ b/kyo-i18n/jvm-native/src/test/scala/kyo/I18nPathTest.scala
@@ -15,14 +15,16 @@ class I18nPathTest extends kyo.test.Test[Any]:
         "reads <locale>.ftl per locale" in {
             // Path.tempDir registers its own recursive removal with the enclosing Scope, so the
             // directory no longer needs removing by hand at the end of the comprehension.
-            for
-                dir <- Path.tempDir("kyo-i18n")
-                _   <- (dir / "en.ftl").write("hello = Hello")
-                _   <- (dir / "de.ftl").write("hello = Hallo")
-                h   <- I18n.init(Seq(en, de), en)(dir)
-                a   <- I18n.let(h)(I18n.at(en, "hello"))
-                b   <- I18n.let(h)(I18n.at(de, "hello"))
-            yield assert(a == "Hello" && b == "Hallo")
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-i18n")
+                    _   <- (dir / "en.ftl").write("hello = Hello")
+                    _   <- (dir / "de.ftl").write("hello = Hallo")
+                    h   <- I18n.init(Seq(en, de), en)(dir)
+                    a   <- I18n.let(h)(I18n.at(en, "hello"))
+                    b   <- I18n.let(h)(I18n.at(de, "hello"))
+                yield assert(a == "Hello" && b == "Hallo")
+            }
         }
     }
 end I18nPathTest

--- a/kyo-i18n/shared/src/main/scala/kyo/I18n.scala
+++ b/kyo-i18n/shared/src/main/scala/kyo/I18n.scala
@@ -131,8 +131,12 @@ object I18n:
 
     /** Builds a handle by reading `<locale>.ftl` from `dir`, starting at `start`. The filesystem counterpart to
       * the loader overload, for the JVM, Scala Native, and Node; a browser build simply never links it.
+      *
+      * The reads carry `PathRead`, so the caller picks the filesystem the bundles come from: `Path.run` or
+      * `Path.runReadOnly` for the host, `Path.runReadOnlyWith` for a custom backend supplied in a
+      * test. The read failure surfaces at that runner rather than here.
       */
-    def init(locales: Seq[Locale], start: Locale)(dir: Path)(using Frame): I18n < (Sync & Abort[FileReadException]) =
+    def init(locales: Seq[Locale], start: Locale)(dir: Path)(using Frame): I18n < (PathRead & Sync) =
         Kyo.foreach(locales)(loc => (dir / s"${loc.code}.ftl").read.map(ftl => Bundle.parse(ftl).map(loc -> _)))
             .map(parsed => handle(parsed, start))
 

--- a/kyo-jsonrpc/shared/src/main/scala/kyo/internal/transport/UdsBackend.scala
+++ b/kyo-jsonrpc/shared/src/main/scala/kyo/internal/transport/UdsBackend.scala
@@ -29,7 +29,7 @@ private[kyo] object UdsBackend:
                 Scope.ensure {
                     wire.close
                         .andThen(Sync.Unsafe.defer(listener.close()))
-                        .andThen(Abort.run[FileStructureException](sockPath.remove).unit)
+                        .andThen(Abort.run[FileSystemException](Path.run(sockPath.remove)).unit)
                 }.andThen {
                     JsonRpcTransport.fromWire(wire, framer, codec)
                 }

--- a/kyo-jsonrpc/shared/src/test/scala/kyo/JsonRpcTransportUnixTest.scala
+++ b/kyo-jsonrpc/shared/src/test/scala/kyo/JsonRpcTransportUnixTest.scala
@@ -26,7 +26,7 @@ class JsonRpcTransportUnixTest extends JsonRpcTest:
 
     "unixDomain binds and accepts a connection" in {
         assumeUnixSockets()
-        Path.tempDir("kyo-jsonrpc-uds-").map { tempDir =>
+        Path.run(Path.tempDir("kyo-jsonrpc-uds-").map { tempDir =>
             val sock = Path(tempDir, "test.sock")
             Scope.run {
                 JsonRpcTransport.unixDomain(sock).map { _ =>
@@ -41,12 +41,12 @@ class JsonRpcTransportUnixTest extends JsonRpcTest:
                     }
                 }
             }
-        }
+        })
     }
 
     "unixDomain round-trips one envelope" in {
         assumeUnixSockets()
-        Path.tempDir("kyo-jsonrpc-uds-").map { tempDir =>
+        Path.run(Path.tempDir("kyo-jsonrpc-uds-").map { tempDir =>
             val sock = Path(tempDir, "test.sock")
             Scope.run {
                 JsonRpcTransport.unixDomain(sock).map { t =>
@@ -60,24 +60,24 @@ class JsonRpcTransportUnixTest extends JsonRpcTest:
                     }
                 }
             }
-        }
+        })
     }
 
     "unixDomain Scope cleanup deletes socket file" in {
         assumeUnixSockets()
-        Path.tempDir("kyo-jsonrpc-uds-").map { tempDir =>
+        Path.run(Path.tempDir("kyo-jsonrpc-uds-").map { tempDir =>
             val sock = Path(tempDir, "test.sock")
             Scope.run {
                 JsonRpcTransport.unixDomain(sock).map(_ => ())
             }.andThen {
                 sock.exists.map(exists => assert(!exists))
             }
-        }
+        })
     }
 
     "unixDomain framer override changes wire shape" in {
         assumeUnixSockets()
-        Path.tempDir("kyo-jsonrpc-uds-").map { tempDir =>
+        Path.run(Path.tempDir("kyo-jsonrpc-uds-").map { tempDir =>
             val sock = Path(tempDir, "test.sock")
             Scope.run {
                 JsonRpcTransport.unixDomain(sock, framer = JsonRpcFramer.contentLength).map { t =>
@@ -92,7 +92,7 @@ class JsonRpcTransportUnixTest extends JsonRpcTest:
                     }
                 }
             }
-        }
+        })
     }
 
 end JsonRpcTransportUnixTest

--- a/kyo-markdown/shared/src/test/scala/kyo/MarkdownTest.scala
+++ b/kyo-markdown/shared/src/test/scala/kyo/MarkdownTest.scala
@@ -86,11 +86,11 @@ class MarkdownTest extends kyo.test.Test[Any]:
     // ---- Lists ----
 
     "two-space nested list stays nested rather than flattening" in {
-        val source = "- Exception\n  - FileException\n  - TimeoutException\n"
+        val source = "- Exception\n  - FileSystemException\n  - TimeoutException\n"
         for html <- renderMd(source)
         yield
             assert(html.contains("<ul"), s"Expected ul: $html")
-            assert(html.contains("FileException"), s"Expected sub-item: $html")
+            assert(html.contains("FileSystemException"), s"Expected sub-item: $html")
             // Two <ul> tags means the list is nested.
             assert(html.indexOf("<ul") != html.lastIndexOf("<ul"), s"Expected nested ul: $html")
         end for

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixStructs.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixStructs.scala
@@ -2,7 +2,6 @@ package kyo.net.internal.posix
 
 import kyo.*
 import kyo.ffi.Buffer
-import kyo.internal.SystemPlatformSpecific
 
 /** POSIX / io_uring struct types bound through kyo-ffi.
   *
@@ -40,10 +39,9 @@ private[net] case class EpollEvent(events: Int, data: Long) derives CanEqual
   *   - x86_64: `__attribute__((packed))`, 12 bytes, `events` (`uint32_t`) at offset 0 and `data` (`__u64`) at offset 4 with no padding.
   *   - aarch64 (and other naturally-aligned ABIs): 16 bytes, `events` at offset 0 then 4 bytes of padding and `data` at offset 8.
   *
-  * Host architecture is detected once via [[kyo.internal.SystemPlatformSpecific.osArch]] (the same accessor `kyo.System` uses): it returns a
-  * Java-style token on every backend (`os.arch` on JVM/Native, normalised `process.arch` on JS). x86_64 (`x86_64` / `amd64` / `x64`) selects
-  * the packed 12-byte layout; every other arch uses the naturally-aligned 16-byte layout. Encoding is little-endian, matching all current
-  * Linux epoll targets and the byte-addressed [[Buffer]] primitives.
+  * Host architecture is detected once through the public `kyo.System` unsafe integration boundary. x86_64 selects the packed 12-byte
+  * layout; every other architecture uses the naturally-aligned 16-byte layout. Encoding is little-endian, matching all current Linux epoll
+  * targets and the byte-addressed [[Buffer]] primitives.
   */
 private[net] object EpollEvent:
 
@@ -51,9 +49,7 @@ private[net] object EpollEvent:
     val isX86_64: Boolean =
         // Unsafe: this is module-init arch detection running outside any effect, so there is no AllowUnsafe in scope to thread through.
         import AllowUnsafe.embrace.danger
-        SystemPlatformSpecific.osArch().toLowerCase match
-            case "x86_64" | "amd64" | "x64" => true
-            case _                          => false
+        System.live.unsafe.architecture() == System.Arch.X86_64
     end isX86_64
 
     /** Byte offset of the 8-byte `data` field: 4 on packed x86_64, 8 on naturally-aligned arches. */

--- a/kyo-net/shared/src/test/scala/kyo/net/TlsTestCertShared.scala
+++ b/kyo-net/shared/src/test/scala/kyo/net/TlsTestCertShared.scala
@@ -83,7 +83,7 @@ ZqiUNiukltim2BOCW/KEsI8mbg==
         val nano     = java.lang.System.nanoTime()
         val certPath = s"/tmp/kyo-tls-$nano-cert.pem"
         val keyPath  = s"/tmp/kyo-tls-$nano-key.pem"
-        Abort.run[FileWriteException](Path(certPath).write(certPem).andThen(Path(keyPath).write(keyPem))).map {
+        Abort.run[FileSystemException](Path.run(Path(certPath).write(certPem).andThen(Path(keyPath).write(keyPem)))).map {
             case Result.Success(_) => (certPath, keyPath)
             case other             => throw new RuntimeException(s"failed to write shared TLS test cert: $other")
         }
@@ -154,7 +154,7 @@ OnBE4RP7UrqA7cRm1tkCj+Y=
         val nano     = java.lang.System.nanoTime()
         val certPath = s"/tmp/kyo-tls-wrong-$nano-cert.pem"
         val keyPath  = s"/tmp/kyo-tls-wrong-$nano-key.pem"
-        Abort.run[FileWriteException](Path(certPath).write(wrongHostCertPem).andThen(Path(keyPath).write(wrongHostKeyPem))).map {
+        Abort.run[FileSystemException](Path.run(Path(certPath).write(wrongHostCertPem).andThen(Path(keyPath).write(wrongHostKeyPem)))).map {
             case Result.Success(_) => (certPath, keyPath)
             case other             => throw new RuntimeException(s"failed to write wrong-host TLS test cert: $other")
         }

--- a/kyo-pod/shared/src/main/scala/kyo/Container.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/Container.scala
@@ -2220,7 +2220,9 @@ object Container:
         short.nonEmpty && cgroup.contains(short)
 
     private def hostPidBelongsTo(id: Id, pid: Int)(using Frame): Boolean < Sync =
-        Abort.run[FileReadException](Path("/proc", pid.toString, "cgroup").read).map {
+        // The cgroup entry is the only filesystem authority this needs, and it is discharged here so the
+        // host-process check stays an implementation detail rather than a capability the caller must grant.
+        Abort.run[FileSystemException](Path.runReadOnly(Path("/proc", pid.toString, "cgroup").read)).map {
             case Result.Success(cgroup) => cgroupNamesContainer(cgroup, id)
             case _                      => false
         }

--- a/kyo-pod/shared/src/main/scala/kyo/internal/ContainerBackend.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/internal/ContainerBackend.scala
@@ -418,14 +418,14 @@ private[kyo] object ContainerBackend:
                         if paths.isEmpty then Absent
                         else
                             val head = paths.head
-                            Abort.recover[FileReadException](_ => false)(Path(head).exists).map { exists =>
+                            Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(Path(head).exists)).map { exists =>
                                 if exists then Present(head)
                                 else findExisting(paths.tail)
                             }
 
                     findExisting(configPaths).map {
                         case Present(configPath) =>
-                            Abort.run[FileReadException](Path(configPath).read).map {
+                            Abort.run[FileSystemException](Path.runReadOnly(Path(configPath).read)).map {
                                 case Result.Success(content) =>
                                     Json.decode[ContainerBackend.AuthConfigJson](content) match
                                         case Result.Success(dto) =>

--- a/kyo-pod/shared/src/main/scala/kyo/internal/HttpContainerBackend.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/internal/HttpContainerBackend.scala
@@ -1035,15 +1035,15 @@ final private[kyo] class HttpContainerBackend(
         val containerFile = containerPath.name.getOrElse(containerPath.toString)
 
         Scope.run {
-            Abort.run[FileStructureException](Path.tempDir(s"kyo-copyto-$uniqueSuffix-")).map {
+            Abort.run[FileSystemException](Path.run(Path.tempDir(s"kyo-copyto-$uniqueSuffix-"))).map {
                 case Result.Failure(e) =>
                     Abort.fail(ContainerOperationException(s"copyTo: failed to create temp dir for ${id.value}", e))
                 case Result.Panic(t) =>
                     Abort.fail(ContainerBackendException(s"copyTo: panic creating temp dir for ${id.value}", t))
                 case Result.Success(tempDir) =>
                     val target = tempDir / containerFile
-                    Abort.run[FileStructureException](
-                        source.copy(target, Path.CopyOptions(replace = Path.Replace.Existing))
+                    Abort.run[FileSystemException](
+                        Path.run(source.copy(target, Path.CopyOptions(replace = Path.Replace.Existing)))
                     ).map {
                         case Result.Failure(e) =>
                             Abort.fail(ContainerOperationException(
@@ -3039,7 +3039,7 @@ private[kyo] object HttpContainerBackend:
                             xp.toList ++ Seq(defaultSocket) ++ hd.toList
                     // Filter to paths that exist on disk
                     Kyo.filter(candidates)(path =>
-                        Abort.recover[FileReadException](_ => false)(Path(path).exists)
+                        Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(Path(path).exists))
                     ).map {
                         staticPaths =>
                             if staticPaths.nonEmpty then staticPaths

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
@@ -198,19 +198,21 @@ class ContainerItTest extends BasePodTest:
 
         "connection refused to valid-looking socket gives clear error" - runBackends {
             val fakePath = Path(s"/tmp/kyo-fake-${java.lang.System.currentTimeMillis}.sock")
-            fakePath.write("not a socket").andThen {
-                Abort.run[ContainerException] {
-                    Container.withBackendConfig(_.UnixSocket(fakePath)) {
-                        Container.init(alpine)
-                    }
-                }.map { result =>
-                    fakePath.remove.andThen {
-                        result match
-                            case Result.Failure(_: ContainerBackendException) =>
-                                succeed(
-                                    "the operation fails with a typed ContainerBackendException (transport message is environment-dependent)"
-                                )
-                            case other => fail(s"Expected backend connection error, got $other")
+            Path.run {
+                fakePath.write("not a socket").andThen {
+                    Abort.run[ContainerException] {
+                        Container.withBackendConfig(_.UnixSocket(fakePath)) {
+                            Container.init(alpine)
+                        }
+                    }.map { result =>
+                        fakePath.remove.andThen {
+                            result match
+                                case Result.Failure(_: ContainerBackendException) =>
+                                    succeed(
+                                        "the operation fails with a typed ContainerBackendException (transport message is environment-dependent)"
+                                    )
+                                case other => fail(s"Expected backend connection error, got $other")
+                        }
                     }
                 }
             }
@@ -1002,32 +1004,34 @@ class ContainerItTest extends BasePodTest:
             val volName = Container.Volume.Id(uniqueName("kyo-mount-type"))
             val hostDir = Path("/tmp/" + uniqueName("kyo-bind-type"))
             Scope.run {
-                for
-                    _ <- Container.Volume.init(Container.Volume.Config.default.copy(name = Present(volName)))
-                    _ <- hostDir.mkDir
-                    info <- Container.initWith(
-                        alpine
-                            .bind(hostDir, Path("/mnt/bind-target"))
-                            .volume(volName, Path("/mnt/vol-target"))
-                    ) { c =>
-                        c.inspect
-                    }
-                    _ <- hostDir.removeAll
-                yield
-                    assert(info.mounts.size >= 2, s"Expected at least 2 mounts, got ${info.mounts.size}")
-                    val hasBind = info.mounts.exists {
-                        case Container.Config.Mount.Bind(_, target, _) =>
-                            target == Path("/mnt/bind-target")
-                        case _ => false
-                    }
-                    val hasVolume = info.mounts.exists {
-                        case Container.Config.Mount.Volume(_, target, _) =>
-                            target == Path("/mnt/vol-target")
-                        case _ => false
-                    }
-                    assert(hasBind, s"Expected a Bind mount for /mnt/bind-target, got: ${info.mounts}")
-                    assert(hasVolume, s"Expected a Volume mount for /mnt/vol-target, got: ${info.mounts}")
-                end for
+                Path.run {
+                    for
+                        _ <- Container.Volume.init(Container.Volume.Config.default.copy(name = Present(volName)))
+                        _ <- hostDir.mkDir
+                        info <- Container.initWith(
+                            alpine
+                                .bind(hostDir, Path("/mnt/bind-target"))
+                                .volume(volName, Path("/mnt/vol-target"))
+                        ) { c =>
+                            c.inspect
+                        }
+                        _ <- hostDir.removeAll
+                    yield
+                        assert(info.mounts.size >= 2, s"Expected at least 2 mounts, got ${info.mounts.size}")
+                        val hasBind = info.mounts.exists {
+                            case Container.Config.Mount.Bind(_, target, _) =>
+                                target == Path("/mnt/bind-target")
+                            case _ => false
+                        }
+                        val hasVolume = info.mounts.exists {
+                            case Container.Config.Mount.Volume(_, target, _) =>
+                                target == Path("/mnt/vol-target")
+                            case _ => false
+                        }
+                        assert(hasBind, s"Expected a Bind mount for /mnt/bind-target, got: ${info.mounts}")
+                        assert(hasVolume, s"Expected a Volume mount for /mnt/vol-target, got: ${info.mounts}")
+                    end for
+                }
             }
         }
     }
@@ -1462,28 +1466,32 @@ class ContainerItTest extends BasePodTest:
         "copies a local file into the container and content matches" - runBackends {
             val localPath = Path("/tmp/" + uniqueName("kyo-copyto"))
             Container.init(alpine).map { c =>
-                for
-                    _      <- localPath.write("test content 12345")
-                    _      <- c.copyTo(localPath, Path("/tmp/copied"))
-                    result <- c.exec("cat", "/tmp/copied")
-                    _      <- localPath.remove
-                yield
-                    assert(result.isSuccess)
-                    assert(result.stdout.trim == "test content 12345")
+                Path.run {
+                    for
+                        _      <- localPath.write("test content 12345")
+                        _      <- c.copyTo(localPath, Path("/tmp/copied"))
+                        result <- c.exec("cat", "/tmp/copied")
+                        _      <- localPath.remove
+                    yield
+                        assert(result.isSuccess)
+                        assert(result.stdout.trim == "test content 12345")
+                }
             }
         }
 
         "handles empty file" - runBackends {
             val localPath = Path("/tmp/" + uniqueName("kyo-empty"))
             Container.init(alpine).map { c =>
-                for
-                    _      <- localPath.write("")
-                    _      <- c.copyTo(localPath, Path("/tmp/empty"))
-                    result <- c.exec("wc", "-c", "/tmp/empty")
-                    _      <- localPath.remove
-                yield
-                    assert(result.isSuccess)
-                    assert(result.stdout.trim.startsWith("0"))
+                Path.run {
+                    for
+                        _      <- localPath.write("")
+                        _      <- c.copyTo(localPath, Path("/tmp/empty"))
+                        result <- c.exec("wc", "-c", "/tmp/empty")
+                        _      <- localPath.remove
+                    yield
+                        assert(result.isSuccess)
+                        assert(result.stdout.trim.startsWith("0"))
+                }
             }
         }
     }
@@ -1492,12 +1500,14 @@ class ContainerItTest extends BasePodTest:
         "copies a file from container to local and content matches" - runBackends {
             val localPath = Path("/tmp/" + uniqueName("kyo-copyfrom"))
             Container.init(alpine).map { c =>
-                for
-                    _       <- c.exec("sh", "-c", "echo container-data-67890 > /tmp/source")
-                    _       <- c.copyFrom(Path("/tmp/source"), localPath)
-                    content <- localPath.read
-                    _       <- localPath.remove
-                yield assert(content.trim == "container-data-67890")
+                Path.run {
+                    for
+                        _       <- c.exec("sh", "-c", "echo container-data-67890 > /tmp/source")
+                        _       <- c.copyFrom(Path("/tmp/source"), localPath)
+                        content <- localPath.read
+                        _       <- localPath.remove
+                    yield assert(content.trim == "container-data-67890")
+                }
             }
         }
 
@@ -2092,129 +2102,139 @@ class ContainerItTest extends BasePodTest:
         "streams multi-step build progress with each step's output delivered in order" - runBackends {
             val dir     = Path("/tmp/" + uniqueName("kyo-build-inc"))
             val imgName = uniqueName("kyo-built-inc")
-            for
-                _ <- dir.mkDir
-                // Two RUN steps with distinct markers; the streamed output must carry both, step1 before step2.
-                _ <- (dir / "Dockerfile").write(
-                    "FROM alpine:latest\n" +
-                        "RUN echo step1\n" +
-                        "RUN echo step2\n"
-                )
-                // Consume to completion; closing a streaming response early wedges kyo-http's pool.
-                result <- Scope.run {
-                    for
-                        texts <- AtomicRef.init(Chunk.empty[String])
-                        _ <- ContainerImage.buildFromPath(
-                            dir,
-                            tags = Chunk(s"$imgName:latest"),
-                            noCache = true
-                        ).foreach { progress =>
-                            texts.updateAndGet(_.append(progress.stream.getOrElse(""))).unit
-                        }
-                        ts <- texts.get
-                    yield ts
-                }
-                _ <- Abort.run[ContainerException](ContainerImage.remove(ContainerImage(imgName, "latest"), force = true))
-                _ <- (dir / "Dockerfile").remove
-                _ <- dir.removeAll
-            yield
-                val texts = result
-                assert(texts.size >= 2, s"Expected multiple build progress events for a multi-step build, got: ${texts.size}")
-                val joined   = texts.mkString("\n")
-                val step1Idx = joined.indexOf("step1")
-                val step2Idx = joined.indexOf("step2")
-                assert(step1Idx >= 0, s"Expected step1 output in the streamed build, got: $joined")
-                assert(step2Idx >= 0, s"Expected step2 output in the streamed build, got: $joined")
-                assert(step1Idx < step2Idx, s"Expected step1 output before step2 in the streamed build, got: $joined")
-            end for
+            Path.run {
+                for
+                    _ <- dir.mkDir
+                    // Two RUN steps with distinct markers; the streamed output must carry both, step1 before step2.
+                    _ <- (dir / "Dockerfile").write(
+                        "FROM alpine:latest\n" +
+                            "RUN echo step1\n" +
+                            "RUN echo step2\n"
+                    )
+                    // Consume to completion; closing a streaming response early wedges kyo-http's pool.
+                    result <- Scope.run {
+                        for
+                            texts <- AtomicRef.init(Chunk.empty[String])
+                            _ <- ContainerImage.buildFromPath(
+                                dir,
+                                tags = Chunk(s"$imgName:latest"),
+                                noCache = true
+                            ).foreach { progress =>
+                                texts.updateAndGet(_.append(progress.stream.getOrElse(""))).unit
+                            }
+                            ts <- texts.get
+                        yield ts
+                    }
+                    _ <- Abort.run[ContainerException](ContainerImage.remove(ContainerImage(imgName, "latest"), force = true))
+                    _ <- (dir / "Dockerfile").remove
+                    _ <- dir.removeAll
+                yield
+                    val texts = result
+                    assert(texts.size >= 2, s"Expected multiple build progress events for a multi-step build, got: ${texts.size}")
+                    val joined   = texts.mkString("\n")
+                    val step1Idx = joined.indexOf("step1")
+                    val step2Idx = joined.indexOf("step2")
+                    assert(step1Idx >= 0, s"Expected step1 output in the streamed build, got: $joined")
+                    assert(step2Idx >= 0, s"Expected step2 output in the streamed build, got: $joined")
+                    assert(step1Idx < step2Idx, s"Expected step1 output before step2 in the streamed build, got: $joined")
+                end for
+            }
         }
 
         "builds from local directory and image is inspectable" - runBackends {
             val dir     = Path("/tmp/" + uniqueName("kyo-build"))
             val imgName = uniqueName("kyo-built")
-            for
-                _ <- dir.mkDir
-                _ <- (dir / "Dockerfile").write("FROM alpine:latest\nRUN echo built\n")
-                _ <- Scope.run {
-                    ContainerImage.buildFromPath(dir, tags = Chunk(s"$imgName:latest")).run
-                }
-                i <- ContainerImage.inspect(ContainerImage(imgName, "latest"))
-                _ <- ContainerImage.remove(ContainerImage(imgName, "latest"), force = true)
-                _ <- (dir / "Dockerfile").remove
-                _ <- dir.removeAll
-            yield assert(i.repoTags.exists(_.reference.contains(imgName)))
-            end for
+            Path.run {
+                for
+                    _ <- dir.mkDir
+                    _ <- (dir / "Dockerfile").write("FROM alpine:latest\nRUN echo built\n")
+                    _ <- Scope.run {
+                        ContainerImage.buildFromPath(dir, tags = Chunk(s"$imgName:latest")).run
+                    }
+                    i <- ContainerImage.inspect(ContainerImage(imgName, "latest"))
+                    _ <- ContainerImage.remove(ContainerImage(imgName, "latest"), force = true)
+                    _ <- (dir / "Dockerfile").remove
+                    _ <- dir.removeAll
+                yield assert(i.repoTags.exists(_.reference.contains(imgName)))
+                end for
+            }
         }
 
         "passes buildArgs to the Dockerfile" - runBackends {
             val dir      = Path("/tmp/" + uniqueName("kyo-build-args"))
             val imgName  = uniqueName("kyo-built-args")
             val sentinel = "KYO_ARG_SENTINEL_" + uniqueName("v").replaceAll("[^A-Za-z0-9]", "")
-            for
-                _ <- dir.mkDir
-                _ <- (dir / "Dockerfile").write(
-                    "FROM alpine:latest\n" +
-                        "ARG KYO_VAL\n" +
-                        "RUN echo build-arg=${KYO_VAL}\n"
-                )
-                events <- Scope.run {
-                    ContainerImage.buildFromPath(
-                        dir,
-                        tags = Chunk(s"$imgName:latest"),
-                        buildArgs = Dict("KYO_VAL" -> sentinel)
-                    ).run
-                }
-                _ <- Abort.run[ContainerException](ContainerImage.remove(ContainerImage(imgName, "latest"), force = true))
-                _ <- (dir / "Dockerfile").remove
-                _ <- dir.removeAll
-            yield
-                // The RUN step echoes the build-arg value; it appears in the stream events.
-                assert(
-                    events.exists(_.stream.getOrElse("").contains(sentinel)),
-                    s"expected build-arg sentinel '$sentinel' in stream events; got: ${events.map(_.stream)}"
-                )
-            end for
+            Path.run {
+                for
+                    _ <- dir.mkDir
+                    _ <- (dir / "Dockerfile").write(
+                        "FROM alpine:latest\n" +
+                            "ARG KYO_VAL\n" +
+                            "RUN echo build-arg=${KYO_VAL}\n"
+                    )
+                    events <- Scope.run {
+                        ContainerImage.buildFromPath(
+                            dir,
+                            tags = Chunk(s"$imgName:latest"),
+                            buildArgs = Dict("KYO_VAL" -> sentinel)
+                        ).run
+                    }
+                    _ <- Abort.run[ContainerException](ContainerImage.remove(ContainerImage(imgName, "latest"), force = true))
+                    _ <- (dir / "Dockerfile").remove
+                    _ <- dir.removeAll
+                yield
+                    // The RUN step echoes the build-arg value; it appears in the stream events.
+                    assert(
+                        events.exists(_.stream.getOrElse("").contains(sentinel)),
+                        s"expected build-arg sentinel '$sentinel' in stream events; got: ${events.map(_.stream)}"
+                    )
+                end for
+            }
         }
 
         "failed build (non-zero RUN) surfaces a typed ContainerException" - runBackends {
             val dir     = Path("/tmp/" + uniqueName("kyo-build-err"))
             val imgName = uniqueName("kyo-built-err")
-            for
-                _ <- dir.mkDir
-                _ <- (dir / "Dockerfile").write("FROM alpine:latest\nRUN false\n")
-                result <- Abort.run[ContainerException] {
-                    Scope.run(ContainerImage.buildFromPath(dir, tags = Chunk(s"$imgName:latest")).run)
-                }
-                _ <- Abort.run[ContainerException](ContainerImage.remove(ContainerImage(imgName, "latest"), force = true))
-                _ <- (dir / "Dockerfile").remove
-                _ <- dir.removeAll
-            yield result match
-                case Result.Failure(_: ContainerException) =>
-                    succeed("the operation fails with a typed ContainerException (message is daemon-dependent)")
-                case Result.Success(events) => fail(s"expected build to fail, got success with events: $events")
-                case Result.Panic(e)        => fail(s"expected typed ContainerException, got panic: $e")
-            end for
+            Path.run {
+                for
+                    _ <- dir.mkDir
+                    _ <- (dir / "Dockerfile").write("FROM alpine:latest\nRUN false\n")
+                    result <- Abort.run[ContainerException] {
+                        Scope.run(ContainerImage.buildFromPath(dir, tags = Chunk(s"$imgName:latest")).run)
+                    }
+                    _ <- Abort.run[ContainerException](ContainerImage.remove(ContainerImage(imgName, "latest"), force = true))
+                    _ <- (dir / "Dockerfile").remove
+                    _ <- dir.removeAll
+                yield result match
+                    case Result.Failure(_: ContainerException) =>
+                        succeed("the operation fails with a typed ContainerException (message is daemon-dependent)")
+                    case Result.Success(events) => fail(s"expected build to fail, got success with events: $events")
+                    case Result.Panic(e)        => fail(s"expected typed ContainerException, got panic: $e")
+                end for
+            }
         }
 
         "buildFromPath with non-existent --target stage fails with ContainerBuildFailedException" - runBackends {
             val dir = Path("/tmp/" + uniqueName("kyo-build-fail"))
             val tag = uniqueName("kyo-built-fail") + ":latest"
-            for
-                _ <- dir.mkDir
-                _ <- (dir / "Dockerfile").write("FROM alpine:latest as base\n")
-                r <- Abort.run[ContainerException](
-                    Scope.run {
-                        ContainerImage.buildFromPath(dir, tags = Chunk(tag), target = Present("nonexistent-stage")).discard
-                    }
-                )
-                _ <- dir.removeAll
-            yield r match
-                case Result.Failure(e: ContainerBuildFailedException) =>
-                    assert(e.getMessage.contains("Build failed"))
-                case Result.Failure(_: ContainerOperationException) =>
-                    succeed("the daemon rejected the operation with a typed ContainerOperationException (message is daemon-dependent)")
-                case other => fail(s"expected ContainerBuildFailedException or ContainerOperationException, got $other")
-            end for
+            Path.run {
+                for
+                    _ <- dir.mkDir
+                    _ <- (dir / "Dockerfile").write("FROM alpine:latest as base\n")
+                    r <- Abort.run[ContainerException](
+                        Scope.run {
+                            ContainerImage.buildFromPath(dir, tags = Chunk(tag), target = Present("nonexistent-stage")).discard
+                        }
+                    )
+                    _ <- dir.removeAll
+                yield r match
+                    case Result.Failure(e: ContainerBuildFailedException) =>
+                        assert(e.getMessage.contains("Build failed"))
+                    case Result.Failure(_: ContainerOperationException) =>
+                        succeed("the daemon rejected the operation with a typed ContainerOperationException (message is daemon-dependent)")
+                    case other => fail(s"expected ContainerBuildFailedException or ContainerOperationException, got $other")
+                end for
+            }
         }
     }
 
@@ -2697,55 +2717,61 @@ class ContainerItTest extends BasePodTest:
     "container with mounts" - {
         "bind mount — host file visible in container" - runBackends {
             val hostDir = Path("/tmp/" + uniqueName("kyo-bind"))
-            for
-                _ <- hostDir.mkDir
-                _ <- (hostDir / "data.txt").write("from-host-12345")
-                content <- Scope.run {
-                    Container.initWith(alpine.bind(hostDir, Path("/mnt/data"), readOnly = true)) { c =>
-                        c.exec("cat", "/mnt/data/data.txt").map(_.stdout.trim)
+            Path.run {
+                for
+                    _ <- hostDir.mkDir
+                    _ <- (hostDir / "data.txt").write("from-host-12345")
+                    content <- Scope.run {
+                        Container.initWith(alpine.bind(hostDir, Path("/mnt/data"), readOnly = true)) { c =>
+                            c.exec("cat", "/mnt/data/data.txt").map(_.stdout.trim)
+                        }
                     }
-                }
-                _ <- (hostDir / "data.txt").remove
-                _ <- hostDir.removeAll
-            yield assert(content == "from-host-12345")
-            end for
+                    _ <- (hostDir / "data.txt").remove
+                    _ <- hostDir.removeAll
+                yield assert(content == "from-host-12345")
+                end for
+            }
         }
 
         "bind mount — readOnly prevents writes" - runBackends {
             val hostDir = Path("/tmp/" + uniqueName("kyo-bind-ro"))
-            for
-                _ <- hostDir.mkDir
-                result <- Scope.run {
-                    Container.initWith(alpine.bind(hostDir, Path("/mnt/data"), readOnly = true)) { c =>
-                        c.exec("touch", "/mnt/data/test")
+            Path.run {
+                for
+                    _ <- hostDir.mkDir
+                    result <- Scope.run {
+                        Container.initWith(alpine.bind(hostDir, Path("/mnt/data"), readOnly = true)) { c =>
+                            c.exec("touch", "/mnt/data/test")
+                        }
                     }
-                }
-                _ <- hostDir.removeAll
-            yield assert(!result.isSuccess)
-            end for
+                    _ <- hostDir.removeAll
+                yield assert(!result.isSuccess)
+                end for
+            }
         }
 
         "bind mount from /tmp works on macOS" - runBackends {
             val hostDir  = Path("/tmp/" + uniqueName("kyo-tmp-bind"))
             val filename = "test-data.txt"
-            for
-                _ <- hostDir.mkDir
-                _ <- (hostDir / filename).write("from-tmp-host-path")
-                content <- Scope.run {
-                    Container.initWith(alpine.bind(hostDir, Path("/mnt/tmpdata"), readOnly = true)) { c =>
-                        c.exec("cat", s"/mnt/tmpdata/$filename").map(_.stdout.trim)
+            Path.run {
+                for
+                    _ <- hostDir.mkDir
+                    _ <- (hostDir / filename).write("from-tmp-host-path")
+                    content <- Scope.run {
+                        Container.initWith(alpine.bind(hostDir, Path("/mnt/tmpdata"), readOnly = true)) { c =>
+                            c.exec("cat", s"/mnt/tmpdata/$filename").map(_.stdout.trim)
+                        }
                     }
-                }
-                _ <- (hostDir / filename).remove
-                _ <- hostDir.removeAll
-            yield
-                // On macOS, readlink -f is not available. If the implementation uses readlink -f
-                // to resolve /tmp -> /private/tmp, this test would fail.
-                assert(
-                    content == "from-tmp-host-path",
-                    s"Expected 'from-tmp-host-path' from /tmp bind mount, got '$content'"
-                )
-            end for
+                    _ <- (hostDir / filename).remove
+                    _ <- hostDir.removeAll
+                yield
+                    // On macOS, readlink -f is not available. If the implementation uses readlink -f
+                    // to resolve /tmp -> /private/tmp, this test would fail.
+                    assert(
+                        content == "from-tmp-host-path",
+                        s"Expected 'from-tmp-host-path' from /tmp bind mount, got '$content'"
+                    )
+                end for
+            }
         }
 
         "named volume persists across container recreations" - runBackends {
@@ -3062,14 +3088,16 @@ class ContainerItTest extends BasePodTest:
         "copy file with unicode name roundtrip" - runBackends {
             val localPath = Path("/tmp/" + uniqueName("kyo-unicode"))
             Container.init(alpine).map { c =>
-                for
-                    _      <- localPath.write("unicode content")
-                    _      <- c.copyTo(localPath, Path("/tmp/файл"))
-                    result <- c.exec("cat", "/tmp/файл")
-                    _      <- localPath.remove
-                yield
-                    assert(result.isSuccess)
-                    assert(result.stdout.trim == "unicode content")
+                Path.run {
+                    for
+                        _      <- localPath.write("unicode content")
+                        _      <- c.copyTo(localPath, Path("/tmp/файл"))
+                        result <- c.exec("cat", "/tmp/файл")
+                        _      <- localPath.remove
+                    yield
+                        assert(result.isSuccess)
+                        assert(result.stdout.trim == "unicode content")
+                }
             }
         }
 
@@ -3077,8 +3105,10 @@ class ContainerItTest extends BasePodTest:
             Container.init(alpine.readOnlyFilesystem(true)).map { c =>
                 Abort.run[ContainerException] {
                     val localPath = Path("/tmp/" + uniqueName("kyo-ro"))
-                    localPath.write("data").andThen {
-                        c.copyTo(localPath, Path("/usr/test"))
+                    Path.run {
+                        localPath.write("data").andThen {
+                            c.copyTo(localPath, Path("/usr/test"))
+                        }
                     }
                 }.map {
                     case Result.Failure(_: ContainerException) =>
@@ -3092,14 +3122,16 @@ class ContainerItTest extends BasePodTest:
             val localPath = Path("/tmp/" + uniqueName("kyo-large"))
             val content   = "x" * (128 * 1024) // 128KB
             Container.init(alpine).map { c =>
-                for
-                    _      <- localPath.write(content)
-                    _      <- c.copyTo(localPath, Path("/tmp/large"))
-                    result <- c.exec("wc", "-c", "/tmp/large")
-                    _      <- localPath.remove
-                yield
-                    assert(result.isSuccess)
-                    assert(result.stdout.trim.split("\\s+").head.toInt == 128 * 1024)
+                Path.run {
+                    for
+                        _      <- localPath.write(content)
+                        _      <- c.copyTo(localPath, Path("/tmp/large"))
+                        result <- c.exec("wc", "-c", "/tmp/large")
+                        _      <- localPath.remove
+                    yield
+                        assert(result.isSuccess)
+                        assert(result.stdout.trim.split("\\s+").head.toInt == 128 * 1024)
+                }
             }
         }
     }
@@ -3589,39 +3621,41 @@ class ContainerItTest extends BasePodTest:
 
     "attachById preserves ports, labels, and mounts in returned Config" - runBackends {
         val hostDir = Path("/tmp/" + uniqueName("kyo-attach-bind"))
-        for
-            _ <- hostDir.mkDir
-            result <- Scope.run {
-                Container.initWith(
-                    alpine
-                        .port(80, 18080)
-                        .label("kyo-attach-key", "kyo-attach-value")
-                        .bind(hostDir, Path("/mnt/attach-bind"))
-                ) { created =>
-                    Container.attach(created.id).map { attached =>
-                        val cfg = attached.config
-                        assert(
-                            cfg.ports.exists(_.containerPort == 80),
-                            s"Expected port 80 in reattached config, got: ${cfg.ports}"
-                        )
-                        assert(
-                            cfg.labels.get("kyo-attach-key").contains("kyo-attach-value"),
-                            s"Expected label kyo-attach-key=kyo-attach-value in reattached config, got: ${cfg.labels}"
-                        )
-                        assert(
-                            cfg.mounts.exists {
-                                case Container.Config.Mount.Bind(_, target, _) =>
-                                    target == Path("/mnt/attach-bind")
-                                case _ => false
-                            },
-                            s"Expected bind mount /mnt/attach-bind in reattached config, got: ${cfg.mounts}"
-                        )
+        Path.run {
+            for
+                _ <- hostDir.mkDir
+                result <- Scope.run {
+                    Container.initWith(
+                        alpine
+                            .port(80, 18080)
+                            .label("kyo-attach-key", "kyo-attach-value")
+                            .bind(hostDir, Path("/mnt/attach-bind"))
+                    ) { created =>
+                        Container.attach(created.id).map { attached =>
+                            val cfg = attached.config
+                            assert(
+                                cfg.ports.exists(_.containerPort == 80),
+                                s"Expected port 80 in reattached config, got: ${cfg.ports}"
+                            )
+                            assert(
+                                cfg.labels.get("kyo-attach-key").contains("kyo-attach-value"),
+                                s"Expected label kyo-attach-key=kyo-attach-value in reattached config, got: ${cfg.labels}"
+                            )
+                            assert(
+                                cfg.mounts.exists {
+                                    case Container.Config.Mount.Bind(_, target, _) =>
+                                        target == Path("/mnt/attach-bind")
+                                    case _ => false
+                                },
+                                s"Expected bind mount /mnt/attach-bind in reattached config, got: ${cfg.mounts}"
+                            )
+                        }
                     }
                 }
-            }
-            _ <- hostDir.removeAll
-        yield result
-        end for
+                _ <- hostDir.removeAll
+            yield result
+            end for
+        }
     }
 
     "logs preserves stdout/stderr emission order" - runBackends {

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerOrchestrationItTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerOrchestrationItTest.scala
@@ -496,18 +496,21 @@ class ContainerOrchestrationItTest extends BasePodTest:
             .stopSignal(Container.Signal.SIGUSR1)
             .stopTimeout(10.seconds)
             .autoRemove(false)
-        for
-            _ <- hostDir.mkDir
-            // Scope.run runs the container and tears it down (stopSignal, then the graceful self-exit). Its completion is the barrier; a cleanup
-            // that hangs is caught by the suite's per-leaf cap.
-            _         <- Scope.run(Container.init(config).unit)
-            delivered <- marker.exists
-            _         <- Abort.run[FileStructureException](hostDir.removeAll)
-        yield assert(
-            delivered,
-            "scope cleanup completed but the stopSignal never reached the container; the trap left no marker on the host"
-        )
-        end for
+        Path.run {
+            for
+                _ <- hostDir.mkDir
+                // Scope.run runs the container and tears it down (stopSignal, then the graceful self-exit). Its completion is the barrier; a cleanup
+                // that hangs is caught by the suite's per-leaf cap.
+                _         <- Scope.run(Container.init(config).unit)
+                delivered <- marker.exists
+                // The cleanup runs its own runner so a removal failure is reported here rather than failing the test.
+                _ <- Abort.run[FileSystemException](Path.run(hostDir.removeAll))
+            yield assert(
+                delivered,
+                "scope cleanup completed but the stopSignal never reached the container; the trap left no marker on the host"
+            )
+            end for
+        }
     }
 
     "runOnce" - {

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
@@ -759,39 +759,43 @@ class ContainerTest extends BasePodTest:
         "XDG_RUNTIME_DIR/containers/auth.json is consulted when present" in {
             val tmpRoot    = Path("/tmp/kyo-xdg-" + java.util.UUID.randomUUID)
             val containers = tmpRoot / "containers"
-            for
-                _ <- containers.mkDir
-                _ <- (containers / "auth.json").write("""{"auths":{"ghcr.io":"dGVzdA=="}}""")
-                auth <- kyo.System.let(systemWith(
-                    envOverrides = Map("XDG_RUNTIME_DIR" -> tmpRoot.toString, "DOCKER_CONFIG" -> ""),
-                    propsOverrides = Map("user.home" -> "/nonexistent")
-                )) {
-                    kyo.internal.ContainerBackend.registryAuthFromConfig
-                }
-                _ <- tmpRoot.removeAll
-            yield assert(
-                auth.auths.toMap.nonEmpty,
-                s"expected XDG path to be consulted, got empty auth: $auth"
-            )
-            end for
+            Path.run {
+                for
+                    _ <- containers.mkDir
+                    _ <- (containers / "auth.json").write("""{"auths":{"ghcr.io":"dGVzdA=="}}""")
+                    auth <- kyo.System.let(systemWith(
+                        envOverrides = Map("XDG_RUNTIME_DIR" -> tmpRoot.toString, "DOCKER_CONFIG" -> ""),
+                        propsOverrides = Map("user.home" -> "/nonexistent")
+                    )) {
+                        kyo.internal.ContainerBackend.registryAuthFromConfig
+                    }
+                    _ <- tmpRoot.removeAll
+                yield assert(
+                    auth.auths.toMap.nonEmpty,
+                    s"expected XDG path to be consulted, got empty auth: $auth"
+                )
+                end for
+            }
         }
 
         "malformed JSON yields empty auth Dict (no panic)" in {
             val tmpRoot    = Path("/tmp/kyo-xdg-bad-" + java.util.UUID.randomUUID)
             val containers = tmpRoot / "containers"
-            for
-                _ <- containers.mkDir
-                _ <- (containers / "auth.json").write("not json")
-                auth <- kyo.System.let(systemWith(
-                    envOverrides = Map("XDG_RUNTIME_DIR" -> tmpRoot.toString, "DOCKER_CONFIG" -> ""),
-                    propsOverrides = Map("user.home" -> "/nonexistent")
-                )) { kyo.internal.ContainerBackend.registryAuthFromConfig }
-                _ <- tmpRoot.removeAll
-            yield assert(
-                auth.auths.toMap.isEmpty,
-                s"expected empty Dict on malformed JSON, got: $auth"
-            )
-            end for
+            Path.run {
+                for
+                    _ <- containers.mkDir
+                    _ <- (containers / "auth.json").write("not json")
+                    auth <- kyo.System.let(systemWith(
+                        envOverrides = Map("XDG_RUNTIME_DIR" -> tmpRoot.toString, "DOCKER_CONFIG" -> ""),
+                        propsOverrides = Map("user.home" -> "/nonexistent")
+                    )) { kyo.internal.ContainerBackend.registryAuthFromConfig }
+                    _ <- tmpRoot.removeAll
+                yield assert(
+                    auth.auths.toMap.isEmpty,
+                    s"expected empty Dict on malformed JSON, got: $auth"
+                )
+                end for
+            }
         }
 
         "missing file yields empty auth Dict (no panic)" in {

--- a/kyo-pod/shared/src/test/scala/kyo/internal/HttpContainerBackendTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/internal/HttpContainerBackendTest.scala
@@ -17,24 +17,24 @@ class HttpContainerBackendTest extends BasePodTest:
             Sync.defer(value)
     end FixedUUIDGenerator
 
-    private def claimLegacyFixture(using Frame): (UUID, Path, Path) < (Sync & Scope & Abort[FileReadException | FileStructureException]) =
+    private def claimLegacyFixture(using Frame): (UUID, Path, Path) < (Sync & Scope & Abort[FileSystemException]) =
         val uuid = UUID.v5(
             UUID.nil,
             Span.fromUnsafe(uniqueName("copyto-legacy-fixture").getBytes("UTF-8"))
         )
-        Path.tempDir("kyo-copyto-claim-").map { claimed =>
+        Path.run(Path.tempDir("kyo-copyto-claim-").map { claimed =>
             val parent        = claimed.parent.getOrElse(throw new IllegalStateException("temporary directory must have a parent"))
             val exact         = parent / s"kyo-copyto-${uuid.show}"
             val missingSource = parent / s"kyo-copyto-missing-${uuid.show}"
-            Abort.run[FileStructureException](
-                claimed.move(
+            Abort.run[FileSystemException](
+                Path.run(claimed.move(
                     exact,
                     Path.MoveOptions(
                         replace = Path.Replace.Never,
                         atomicity = Path.Atomicity.Required,
                         createFolders = false
                     )
-                )
+                ))
             ).map {
                 case Result.Success(_) =>
                     missingSource.exists.map { sourceExists =>
@@ -48,7 +48,7 @@ class HttpContainerBackendTest extends BasePodTest:
                 case Result.Panic(error) =>
                     claimed.removeAll.andThen(throw error)
             }
-        }
+        })
     end claimLegacyFixture
 
     "create payload" - {
@@ -93,9 +93,9 @@ class HttpContainerBackendTest extends BasePodTest:
 
     "copyTo" - {
         "scoped UUID temp directories do not overwrite or delete the exact legacy staging path" in {
-            claimLegacyFixture.map { (uuid, foreignPath, missingSource) =>
+            Path.run(claimLegacyFixture.map { (uuid, foreignPath, missingSource) =>
                 val sentinel = foreignPath / "sentinel"
-                Sync.ensure(Abort.run[FileStructureException](foreignPath.removeAll).unit) {
+                Sync.ensure(Abort.run[FileSystemException](Path.run(foreignPath.removeAll)).unit) {
                     sentinel.write("foreign fixture").andThen {
                         val generator = new FixedUUIDGenerator(uuid)
                         val backend   = new HttpContainerBackend("/unused.sock")
@@ -121,7 +121,7 @@ class HttpContainerBackendTest extends BasePodTest:
                         }
                     }
                 }
-            }
+            })
         }
     }
 end HttpContainerBackendTest

--- a/kyo-schema-ion/shared/src/test/scala/kyo/IonCorpusTest.scala
+++ b/kyo-schema-ion/shared/src/test/scala/kyo/IonCorpusTest.scala
@@ -218,15 +218,16 @@ class IonCorpusTest extends kyo.test.Test[Any]:
     // The JS test runner's working directory is the build root, while the JVM and Native runners use the
     // platform subproject directory. Resolve the repository root by walking up to the directory that holds
     // build.sbt, then read the shared corpus from there. This keeps the suite cross-platform with no classpath.
-    private def corpusRoot(using Frame): Path < (Sync & Abort[FileReadException]) =
+    private def corpusRoot(using Frame): Path < (Sync & Abort[FileSystemException]) =
+        Path.runReadOnly(
+            for
+                cwd   <- Path.cwd
+                chain <- cwd.ancestors.run
+                root  <- searchRepoRoot(cwd, chain.toList)
+            yield root
+        )
 
-        for
-            cwd   <- Path.cwd
-            chain <- cwd.ancestors.run
-            root  <- searchRepoRoot(cwd, chain.toList)
-        yield root
-
-    private def searchRepoRoot(cwd: Path, candidates: List[Path])(using Frame): Path < Sync =
+    private def searchRepoRoot(cwd: Path, candidates: List[Path])(using Frame): Path < PathRead =
         candidates match
             case Nil => Kyo.lift(cwd)
             case head :: tail =>
@@ -234,11 +235,12 @@ class IonCorpusTest extends kyo.test.Test[Any]:
                     if found then Kyo.lift(head) else searchRepoRoot(cwd, tail)
                 }
 
-    private def resource(name: String)(using Frame): String < (Sync & Abort[FileReadException]) =
+    private def resource(name: String)(using Frame): String < (Sync & Abort[FileSystemException]) =
         corpusRoot.flatMap { root =>
-            (root / "kyo-schema-ion" / "shared" / "src" / "test" / "resources" / name.stripPrefix("/"))
-                .read(StandardCharsets.UTF_8)
-
+            Path.runReadOnly(
+                (root / "kyo-schema-ion" / "shared" / "src" / "test" / "resources" / name.stripPrefix("/"))
+                    .read(StandardCharsets.UTF_8)
+            )
         }
 
 end IonCorpusTest

--- a/kyo-schema-json/CONTRIBUTING.md
+++ b/kyo-schema-json/CONTRIBUTING.md
@@ -264,23 +264,41 @@ Reading: the framer holds at most one partial record, capped by `maxLineSize`.
 Records complete within a chunk are emitted and dropped.
 
 Writing: `writeAll` folds the value stream chunk by chunk. Each chunk goes
-through `Json.Lines.encodeAllBytes`, which sizes its output array once and
-copies each encoded value and its newline into it exactly once, and is written
-straight out. What is held at any moment is one chunk of encoded bytes,
-regardless of how many values the stream has.
+through `Json.Lines.encodeAllBytes`, the same call `encode` streams, which sizes
+its output array once and copies each encoded value and its newline into it
+exactly once, and is written straight out. What is held at any moment is one
+chunk of encoded bytes, regardless of how many values the stream has.
 
-Four details of `writeAll` are contracts rather than incidental:
+`writeAll` is the one write implementation the module has, so `write` and
+`append` differ in `appending` alone and neither can grow behavior the other does
+not have. Five details of it are contracts rather than incidental:
 
 - **One handle across the whole fold**, so a stream of any length costs one open
-  and one close rather than one of each per chunk. `kyo-system` exposes no `Path`
-  stream sink, which is why this is hand-rolled over `Path.Unsafe.openWrite`
-  instead of composing an existing combinator.
-- **The fold runs under `Abort.run[Any]` INSIDE the bracket**, not outside it.
+  and one close rather than one of each per chunk. `Stream.writeTo` in
+  `kyo-system` opens truncating and hands the handle to the caller's `Scope`, so
+  it covers neither `append` nor a caller that must not be given a `Scope`, which
+  is why this is hand-rolled over `Path.Op.OpenWrite` and the installed service's
+  `writeChunk`.
+- **The open is a capability suspension and the chunk writes are not.** The open
+  suspends `Path.Op.OpenWrite`, which is what puts `PathWrite` in the row and
+  makes a runner authorize the write. Each chunk then calls `writeChunk` directly
+  on the service `FileSystem.useErased` hands back. Suspending
+  `Path.Op.WriteChunk` instead would put the failure out of reach: `Path.runWith`
+  maps the continuation over the dispatch result, so a failing dispatch drops the
+  continuation and every bracket the fold installed goes with it. The open fails
+  before there is a handle to release, so it needs no bracket of its own.
+
+  A backend still mediates every byte, because every `writeChunk` in the tree
+  dispatches on the handle alone.
+- **`Abort.run[Any]` runs INSIDE the bracket**, not outside it.
   `Sync.acquireReleaseWith` releases when its body completes or panics but not
-  when it aborts, and a stream's own values can abort for reasons unrelated to
-  the file. Reifying every outcome into a `Result` first leaves the bracket a
-  computation that always completes; the outcome is re-raised after the close.
-  Moving that `Abort.run` outward leaks the file handle on an aborting stream.
+  when it aborts, and the body can abort from the write above, from the stream's
+  own values, or from an interruption. Reifying every outcome into a `Result`
+  first leaves the bracket a computation that always completes; `reraise` puts
+  the outcome back afterwards, a `FileSystemException` onto the capability
+  through `Path.Op.Raise` and anything else into the caller's own row. Moving
+  that `Abort.run` outward leaks the file handle. This bracket, not a `Scope`, is
+  why the surface carries `Sync` rather than `Async`.
 - **The release finishes the handle before closing it**, on every exit including
   a failure part way, and closes it even when finishing throws. A write handle
   closed without `finish` is removed, which is exactly the rollback this surface
@@ -288,7 +306,14 @@ Four details of `writeAll` are contracts rather than incidental:
 - **The open happens before the fold and carries no bytes**, which is what makes
   the file's existence, and for `write` its emptiness, a fact about the call
   rather than about whether the stream produced anything. Writing an empty
-  stream empties the file; appending an empty stream still creates it.
+  stream empties the file; appending an empty stream still creates it. The open
+  also creates the parent directory when `createFolders` is set.
+
+One exit is not covered, and the omission is deliberate: a capability failure
+raised by the value stream's own effects, a stream reading another file through
+`PathRead`, say. That op is dispatched by the enclosing runner, outside this
+bracket, so its failure skips the release. Covering it would mean handling the
+caller's effects here, which is not `writeAll`'s to do.
 
 A failure part way through leaves the records already written on disk rather
 than removing the file. A prefix of a JSONL file is a valid JSONL file, so a

--- a/kyo-schema-json/README.md
+++ b/kyo-schema-json/README.md
@@ -283,24 +283,24 @@ Both pipes accept `maxDepth`, `maxCollectionSize`, and `maxLineSize`. Their outp
 Use `Jsonl.read` for a strict file stream and `Jsonl.readResults` for per-record outcomes. The file handle belongs to the enclosing `Scope`:
 
 ```scala
-def load(path: Path): Chunk[Event] < (Async & Abort[FileReadException | DecodeException]) =
+def load(path: Path): Chunk[Event] < (PathRead & Async & Abort[DecodeException]) =
     Scope.run(Jsonl.read[Event](path).run)
 
-def inspect(path: Path): Chunk[Result[DecodeException, Event]] < (Async & Abort[FileReadException]) =
+def inspect(path: Path): Chunk[Result[DecodeException, Event]] < (PathRead & Async) =
     Scope.run(Jsonl.readResults[Event](path).run)
 ```
 
-The exact inferred row for `load` is `Async & Abort[FileReadException | DecodeException]`: `Scope.run` closes the file, `Async` drives the scoped resource lifecycle, and the strict decoder adds its typed failure.
+The exact inferred row for `load` is `PathRead & Async & Abort[DecodeException]`: `PathRead` is the read authority the file needs, which a `Path.run` or `Path.runReadOnly` runner discharges into `Abort[FileSystemException]`; `Scope.run` closes the file, `Async` drives the scoped resource lifecycle, and the strict decoder adds its typed failure.
 
 ### Watching live files
 
 Use `Jsonl.watch` to replay a file and continue waiting for appended records. The default `Path.Origin.Start` replays existing data; `Path.Origin.End` waits for new records; `Path.Origin.Offset` resumes from a recorded byte position. `watchResults` keeps decode failures in the element type:
 
 ```scala
-def live(path: Path): Stream[Event, Scope & Async & Abort[FileReadException | DecodeException]] =
+def live(path: Path): Stream[Event, PathRead & Scope & Async & Abort[DecodeException]] =
     Jsonl.watch[Event](path, from = Path.Origin.End)
 
-def liveResults(path: Path): Stream[Result[DecodeException, Event], Scope & Async & Abort[FileReadException]] =
+def liveResults(path: Path): Stream[Result[DecodeException, Event], PathRead & Scope & Async] =
     Jsonl.watchResults[Event](path)
 ```
 
@@ -331,10 +331,10 @@ Each value determines one record regardless of upstream chunking. An empty strea
 Use `Jsonl.write` to empty or create a file before writing. Use `Jsonl.append` to preserve existing bytes and add records at its current end:
 
 ```scala
-def replace(path: Path, events: Stream[Event, Any]): Unit < (Sync & Abort[FileWriteException]) =
+def replace(path: Path, events: Stream[Event, Any]): Unit < (PathWrite & Sync) =
     Jsonl.write(path, events)
 
-def extend(path: Path, events: Stream[Event, Any]): Unit < (Sync & Abort[FileWriteException]) =
+def extend(path: Path, events: Stream[Event, Any]): Unit < (PathWrite & Sync) =
     Jsonl.append(path, events)
 ```
 
@@ -345,11 +345,11 @@ Both methods write incrementally and preserve the successfully written prefix if
 The same strict read can be named for a higher-level workflow without widening its inferred effects:
 
 ```scala
-def archive(path: Path): Chunk[Event] < (Async & Abort[FileReadException | DecodeException]) =
+def archive(path: Path): Chunk[Event] < (PathRead & Async & Abort[DecodeException]) =
     Scope.run(Jsonl.read[Event](path).run)
 ```
 
-The exact inferred row for `archive` remains `Async & Abort[FileReadException | DecodeException]`.
+The exact inferred row for `archive` remains `PathRead & Async & Abort[DecodeException]`: the read authority rides out to whichever runner the caller installs, and only the decoder's own failure is named here.
 
 ## Cross-platform behavior
 

--- a/kyo-schema-json/shared/src/main/scala/kyo/Jsonl.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/Jsonl.scala
@@ -1,5 +1,6 @@
 package kyo
 
+import kyo.kernel.ArrowEffect
 import scala.annotation.tailrec
 
 /** Streaming JSONL (also called NDJSON): one JSON value per line, over effectful sources.
@@ -154,7 +155,7 @@ object Jsonl:
         maxDepth: Int = Json.DefaultMaxDepth,
         maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
         maxLineSize: ByteSize = Json.Lines.DefaultMaxLineSize
-    )(using Json, Schema[A], Tag[Emit[Chunk[A]]], Frame): Stream[A, Scope & Sync & Abort[FileReadException | DecodeException]] =
+    )(using Json, Schema[A], Tag[Emit[Chunk[A]]], Frame): Stream[A, PathRead & Scope & Sync & Abort[DecodeException]] =
         path.readBytesStream.into(pipe[A](maxDepth, maxCollectionSize, maxLineSize))
 
     /** Reads a JSONL file as a stream of per-record `Result`s, surviving undecodable records.
@@ -182,7 +183,7 @@ object Jsonl:
         Schema[A],
         Tag[Emit[Chunk[Result[DecodeException, A]]]],
         Frame
-    ): Stream[Result[DecodeException, A], Scope & Sync & Abort[FileReadException]] =
+    ): Stream[Result[DecodeException, A], PathRead & Scope & Sync] =
         path.readBytesStream.into(pipeResults[A](maxDepth, maxCollectionSize, maxLineSize))
 
     /** Streams a JSONL file's records, continuing to emit as records are appended.
@@ -246,7 +247,7 @@ object Jsonl:
         Tag[Emit[Chunk[Result[DecodeException, A]]]],
         Tag[Emit[Chunk[A]]],
         Frame
-    ): Stream[A, Scope & Async & Abort[FileReadException | DecodeException]] =
+    ): Stream[A, PathRead & Scope & Async & Abort[DecodeException]] =
         watchResults[A](path, from, pollDelay, maxDepth, maxCollectionSize, maxLineSize).flatMapChunk { results =>
             val (values, failure) = splitAtFailure(results)
             failure match
@@ -300,7 +301,7 @@ object Jsonl:
         Schema[A],
         Tag[Emit[Chunk[Result[DecodeException, A]]]],
         Frame
-    ): Stream[Result[DecodeException, A], Scope & Async & Abort[FileReadException]] =
+    ): Stream[Result[DecodeException, A], PathRead & Scope & Async] =
         // The framer is the watch loop's carried state rather than a pipe downstream of it, which is what
         // ties its lifetime to the file's: a rewind restores this initial state, so bytes framed before a
         // truncation cannot reach a record replayed after one.
@@ -372,7 +373,7 @@ object Jsonl:
         Schema[A],
         Tag[Emit[Chunk[A]]],
         Frame
-    ): Unit < (S & Sync & Abort[FileWriteException]) =
+    ): Unit < (S & PathWrite & Sync) =
         writeAll(path, values, appending = false, createFolders)
 
     /** Appends a stream of values to a JSONL file, preserving whatever the file already held.
@@ -401,7 +402,7 @@ object Jsonl:
         Schema[A],
         Tag[Emit[Chunk[A]]],
         Frame
-    ): Unit < (S & Sync & Abort[FileWriteException]) =
+    ): Unit < (S & PathWrite & Sync) =
         writeAll(path, values, appending = true, createFolders)
 
     /** Writes `values` as JSONL to `path`, folding the stream chunk by chunk.
@@ -422,31 +423,56 @@ object Jsonl:
         Schema[A],
         Tag[Emit[Chunk[A]]],
         Frame
-    ): Unit < (S & Sync & Abort[FileWriteException]) =
-        Sync.acquireReleaseWith(
-            // Unsafe: `openWrite` is the only surface that hands back a channel a fold can keep writing to.
-            // The handle never leaves this method, and the bracket below owns its release.
-            Sync.Unsafe.defer(Abort.get(path.unsafe.openWrite(appending, Path.WriteOptions(createFolders = createFolders))))
-        ) { handle =>
-            // Unsafe: finishes and closes the write handle. `close` runs even when `finish` throws,
-            // so a failing fsync reports itself without also leaking the handle it was fsyncing.
-            Sync.Unsafe.defer {
-                try handle.finish()
-                finally handle.close()
-            }
-        } { handle =>
-            Abort.run[Any] {
-                values.foreachChunk { chunk =>
-                    // Unsafe: the same handle, bridged straight back into Sync and Abort on every chunk.
-                    // The Span `encodeAllBytes` just built is shared with nothing, so the Chunk takes its
-                    // backing array rather than copying bytes that are about to be written and dropped.
-                    Sync.Unsafe.defer {
-                        Abort.get(handle.writeBytes(Chunk.fromNoCopy(Json.Lines.encodeAllBytes(chunk).toArrayUnsafe)))
+    ): Unit < (S & PathWrite & Sync) =
+        FileSystem.useErased { service =>
+            Sync.acquireReleaseWith(
+                // `OpenWrite` is the only capability op that hands back a channel a fold can keep writing to.
+                // The handle never leaves this method, and the bracket below owns its release.
+                ArrowEffect.suspend(
+                    Tag[PathWrite],
+                    Path.Op.OpenWrite(path, appending, Path.WriteOptions(createFolders = createFolders))
+                )
+            ) { handle =>
+                // Unsafe: finishes and closes the vended write handle. `close` runs even when `finish` throws,
+                // so a failing fsync reports itself without also leaking the handle it was fsyncing.
+                Sync.Unsafe.defer {
+                    try handle.finish()
+                    finally handle.close()
+                }
+            } { handle =>
+                Abort.run[Any] {
+                    values.foreachChunk { chunk =>
+                        // The Span `encodeAllBytes` just built is shared with nothing, so the Chunk takes its
+                        // backing array rather than copying bytes that are about to be written and dropped.
+                        service.writeChunk(handle, Chunk.fromNoCopy(Json.Lines.encodeAllBytes(chunk).toArrayUnsafe))
                     }
                 }
-            }
-        }.map(outcome => Abort.get(outcome.asInstanceOf[Result[Nothing, Unit]]))
+            }.map(reraise)
+        }
     end writeAll
+
+    /** Re-raises the reified outcome of a [[writeAll]] fold, after its handle has been released.
+      *
+      * A filesystem failure goes back onto the capability through `Path.Op.Raise`, the way `Path.isolateWrite.restore` does, so the caller's
+      * row stays `PathWrite` and the enclosing runner reports the failure exactly as it would have reported a suspended op. Anything else is
+      * the stream's own outcome and is raised back into the caller's `S` unchanged.
+      */
+    private def reraise(outcome: Result[Any, Unit])(using Frame): Unit < (PathWrite & Sync) =
+        outcome match
+            case Result.Success(value) => value
+            case Result.Failure(error: FileSystemException) =>
+                ArrowEffect.suspend(Tag[PathWrite], Path.Op.Raise(Result.Failure(error)))
+            case other => raiseCaller(other)
+
+    /** Raises a reified non-filesystem outcome back into whatever `Abort` the caller's own row carries.
+      *
+      * The error's type was erased by the `Abort.run[Any]` that reified it, and the caller's row is a type parameter here, so there is no
+      * name to raise it under. Casting the error type back to `Nothing` re-raises the value into whichever `Abort` handler encloses the
+      * call, which is the one the stream's own effects came from. `Scope.run` re-raises its own reified outcome the same way. The residual
+      * is `Sync` because `Sync` is `Abort[Nothing]`, the row an untyped raise lands in.
+      */
+    private def raiseCaller(outcome: Result[Any, Unit])(using Frame): Unit < Sync =
+        Abort.get(outcome.asInstanceOf[Result[Nothing, Unit]])
 
     /** Read buffer size for the watch drivers.
       *

--- a/kyo-schema-json/shared/src/test/scala/kyo/JsonlTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/kyo/JsonlTest.scala
@@ -67,7 +67,7 @@ class JsonlTest extends kyo.test.Test[Any]:
       * folder would otherwise pass on a permission error or an I/O error against an unrelated path, which are the failures a wrong
       * `createFolders` path would substitute.
       */
-    private def assertMissingParent[A](result: Result[FileWriteException, A], path: Path)(using kyo.test.AssertScope): Unit =
+    private def assertMissingParent[A](result: Result[FileSystemException, A], path: Path)(using kyo.test.AssertScope): Unit =
         result.foldError(
             value => fail(s"expected a failure, got $value"),
             {
@@ -75,6 +75,49 @@ class JsonlTest extends kyo.test.Test[Any]:
                 case other                                    => fail(s"unexpected error $other")
             }
         )
+
+    /** A backend that fails the `failOnChunk`-th `writeChunk` and records the lifecycle of the handle it vended.
+      *
+      * The failure a backend raises does not reach the fold that caused it: `Path.runWith` dispatches an op and maps the continuation over
+      * the result, so a failing dispatch drops the continuation, and every bracket the fold had installed goes with it. That makes a
+      * backend write failure the one exit `writeAll` cannot observe locally unless it handles the capability itself, which is what
+      * `finished` and `closed` are here to pin.
+      */
+    final private class FailingWrites(base: FileSystem.Write[Sync], failOnChunk: Int) extends FileSystem.Write[Sync]:
+        export base.{openWrite as _, writeChunk as _, *}
+
+        private val chunks   = new java.util.concurrent.atomic.AtomicInteger(0)
+        private val finishes = new java.util.concurrent.atomic.AtomicBoolean(false)
+        private val closes   = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+        def finished: Boolean = finishes.get()
+        def closed: Boolean   = closes.get()
+
+        override def openWrite(path: Path, append: Boolean, options: Path.WriteOptions)(using
+            Frame
+        ): Path.WriteHandle < (Sync & Abort[FileReadException | FileWriteException]) =
+            base.openWrite(path, append, options).map { handle =>
+                new Path.WriteHandle:
+                    def writeBytes(chunk: Chunk[Byte])(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =
+                        handle.writeBytes(chunk)
+                    def writeString(s: String, charset: java.nio.charset.Charset)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Result[FileWriteException, Unit] =
+                        handle.writeString(s, charset)
+                    def finish()(using AllowUnsafe): Unit =
+                        finishes.set(true)
+                        handle.finish()
+                    def close()(using AllowUnsafe): Unit =
+                        closes.set(true)
+                        handle.close()
+            }
+
+        override def writeChunk(handle: Path.WriteHandle, chunk: Chunk[Byte])(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+            if chunks.incrementAndGet() >= failOnChunk then
+                Abort.fail(FileIOException(Path("injected"), FileSystemOperation.Write, new java.io.IOException("injected write failure")))
+            else base.writeChunk(handle, chunk)
+    end FailingWrites
 
     "pipe" - {
 
@@ -245,149 +288,167 @@ class JsonlTest extends kyo.test.Test[Any]:
     "read" - {
 
         "reads a jsonl file into values" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-read")
-                file = dir / "events.jsonl"
-                _      <- file.write("{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n")
-                values <- Scope.run(Jsonl.read[Event](file).run)
-                _      <- dir.removeAll
-            yield assert(values == Chunk(Event("a", 1), Event("b", 2)))
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read")
+                    file = dir / "events.jsonl"
+                    _      <- file.write("{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n")
+                    values <- Scope.run(Jsonl.read[Event](file).run)
+                    _      <- dir.removeAll
+                yield assert(values == Chunk(Event("a", 1), Event("b", 2)))
+            }
         }
 
         "reads an empty file as no values" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-read")
-                file = dir / "empty.jsonl"
-                _      <- file.write("")
-                values <- Scope.run(Jsonl.read[Event](file).run)
-                _      <- dir.removeAll
-            yield assert(values == Chunk.empty)
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read")
+                    file = dir / "empty.jsonl"
+                    _      <- file.write("")
+                    values <- Scope.run(Jsonl.read[Event](file).run)
+                    _      <- dir.removeAll
+                yield assert(values == Chunk.empty)
+            }
         }
 
         "reads a file whose final record has no trailing newline" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-read")
-                file = dir / "unterminated.jsonl"
-                _      <- file.write("{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}")
-                values <- Scope.run(Jsonl.read[Event](file).run)
-                _      <- dir.removeAll
-            yield assert(values == Chunk(Event("a", 1), Event("b", 2)))
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read")
+                    file = dir / "unterminated.jsonl"
+                    _      <- file.write("{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}")
+                    values <- Scope.run(Jsonl.read[Event](file).run)
+                    _      <- dir.removeAll
+                yield assert(values == Chunk(Event("a", 1), Event("b", 2)))
+            }
         }
 
         "emits the records before a bad one and then aborts" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-read")
-                file = dir / "mixed.jsonl"
-                _    <- file.write("{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n")
-                seen <- AtomicRef.init(Chunk.empty[Event])
-                r <- Abort.run[DecodeException](
-                    Scope.run(Jsonl.read[Event](file).foreach(e => seen.updateAndGet(_ :+ e)))
-                )
-                emitted <- seen.get
-                _       <- dir.removeAll
-            yield
-                assert(emitted == Chunk(Event("a", 1)))
-                assertRecordFailure(r, 1L)
-            end for
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read")
+                    file = dir / "mixed.jsonl"
+                    _    <- file.write("{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n")
+                    seen <- AtomicRef.init(Chunk.empty[Event])
+                    r <- Abort.run[DecodeException](
+                        Scope.run(Jsonl.read[Event](file).foreach(e => seen.updateAndGet(_ :+ e)))
+                    )
+                    emitted <- seen.get
+                    _       <- dir.removeAll
+                yield
+                    assert(emitted == Chunk(Event("a", 1)))
+                    assertRecordFailure(r, 1L)
+                end for
+            }
         }
 
         "readResults survives a bad record" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-read")
-                file = dir / "mixed.jsonl"
-                _  <- file.write("{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n")
-                rs <- Scope.run(Jsonl.readResults[Event](file).run)
-                _  <- dir.removeAll
-            yield
-                assert(rs.size == 3)
-                assert(rs(0).getOrThrow == Event("a", 1))
-                assertRecordFailure(rs(1), 1L)
-                assert(rs(2).getOrThrow == Event("c", 3))
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read")
+                    file = dir / "mixed.jsonl"
+                    _  <- file.write("{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n")
+                    rs <- Scope.run(Jsonl.readResults[Event](file).run)
+                    _  <- dir.removeAll
+                yield
+                    assert(rs.size == 3)
+                    assert(rs(0).getOrThrow == Event("a", 1))
+                    assertRecordFailure(rs(1), 1L)
+                    assert(rs(2).getOrThrow == Event("c", 3))
+            }
         }
 
         "aborts on a terminated oversized record rather than skipping it" in {
-            val in = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n{\"name\":\"c\",\"count\":3}\n"
-            for
-                dir <- Path.tempDir("kyo-jsonl-read-skip-strict")
-                file = dir / "oversized.jsonl"
-                _    <- file.write(in)
-                seen <- AtomicRef.init(Chunk.empty[Event])
-                r <- Abort.run[DecodeException](
-                    Scope.run(Jsonl.read[Event](file, maxLineSize = 30.bytes).foreach(e => seen.updateAndGet(_ :+ e)))
-                )
-                emitted <- seen.get
-                _       <- dir.removeAll
-            yield
-                assert(emitted == Chunk(Event("a", 1)))
-                r.foldError(
-                    _ => fail("expected a failure"),
-                    {
-                        case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
-                        case other                                     => fail(s"unexpected error $other")
-                    }
-                )
-            end for
+            Path.run {
+                val in = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n{\"name\":\"c\",\"count\":3}\n"
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read-skip-strict")
+                    file = dir / "oversized.jsonl"
+                    _    <- file.write(in)
+                    seen <- AtomicRef.init(Chunk.empty[Event])
+                    r <- Abort.run[DecodeException](
+                        Scope.run(Jsonl.read[Event](file, maxLineSize = 30.bytes).foreach(e => seen.updateAndGet(_ :+ e)))
+                    )
+                    emitted <- seen.get
+                    _       <- dir.removeAll
+                yield
+                    assert(emitted == Chunk(Event("a", 1)))
+                    r.foldError(
+                        _ => fail("expected a failure"),
+                        {
+                            case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
+                            case other                                     => fail(s"unexpected error $other")
+                        }
+                    )
+                end for
+            }
         }
 
         "readResults skips a terminated oversized record and keeps decoding the records after it" in {
-            // The file-backed lenient surface must agree with `pipeResults` and `watchResults`: one
-            // failure element for the over-long record, and the records behind it still delivered.
-            val in = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n{\"name\":\"c\",\"count\":3}\n"
-            for
-                dir <- Path.tempDir("kyo-jsonl-read-results-skip")
-                file = dir / "oversized.jsonl"
-                _  <- file.write(in)
-                rs <- Scope.run(Jsonl.readResults[Event](file, maxLineSize = 30.bytes).run)
-                _  <- dir.removeAll
-            yield
-                assert(rs.size == 3)
-                assert(rs(0).getOrThrow == Event("a", 1))
-                rs(1).foldError(
-                    _ => fail("expected a failure"),
-                    {
-                        case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
-                        case other                                     => fail(s"unexpected error $other")
-                    }
-                )
-                assert(rs(2).getOrThrow == Event("c", 3))
-            end for
+            Path.run {
+                // The file-backed lenient surface must agree with `pipeResults` and `watchResults`: one
+                // failure element for the over-long record, and the records behind it still delivered.
+                val in = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n{\"name\":\"c\",\"count\":3}\n"
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read-results-skip")
+                    file = dir / "oversized.jsonl"
+                    _  <- file.write(in)
+                    rs <- Scope.run(Jsonl.readResults[Event](file, maxLineSize = 30.bytes).run)
+                    _  <- dir.removeAll
+                yield
+                    assert(rs.size == 3)
+                    assert(rs(0).getOrThrow == Event("a", 1))
+                    rs(1).foldError(
+                        _ => fail("expected a failure"),
+                        {
+                            case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
+                            case other                                     => fail(s"unexpected error $other")
+                        }
+                    )
+                    assert(rs(2).getOrThrow == Event("c", 3))
+                end for
+            }
         }
 
         "read applies maxDepth and maxCollectionSize" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-read-limits")
-                file = dir / "bag.jsonl"
-                _     <- file.write(bagLine + "\n")
-                depth <- Abort.run[DecodeException](Scope.run(Jsonl.read[Bag](file, maxDepth = 1, maxCollectionSize = 50).run))
-                collection <- Abort.run[DecodeException](
-                    Scope.run(Jsonl.read[Bag](file, maxDepth = 8, maxCollectionSize = 4).run)
-                )
-                within <- Scope.run(Jsonl.read[Bag](file, maxDepth = 8, maxCollectionSize = 50).run)
-                _      <- dir.removeAll
-            yield
-                assertLimitBreach(depth, "Nesting depth", 1)
-                assertLimitBreach(collection, "Collection size", 4)
-                assert(within == Chunk(bag))
-            end for
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read-limits")
+                    file = dir / "bag.jsonl"
+                    _     <- file.write(bagLine + "\n")
+                    depth <- Abort.run[DecodeException](Scope.run(Jsonl.read[Bag](file, maxDepth = 1, maxCollectionSize = 50).run))
+                    collection <- Abort.run[DecodeException](
+                        Scope.run(Jsonl.read[Bag](file, maxDepth = 8, maxCollectionSize = 4).run)
+                    )
+                    within <- Scope.run(Jsonl.read[Bag](file, maxDepth = 8, maxCollectionSize = 50).run)
+                    _      <- dir.removeAll
+                yield
+                    assertLimitBreach(depth, "Nesting depth", 1)
+                    assertLimitBreach(collection, "Collection size", 4)
+                    assert(within == Chunk(bag))
+                end for
+            }
         }
 
         "readResults applies maxDepth and maxCollectionSize" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-read-results-limits")
-                file = dir / "bag.jsonl"
-                _          <- file.write(bagLine + "\n")
-                depth      <- Scope.run(Jsonl.readResults[Bag](file, maxDepth = 1, maxCollectionSize = 50).run)
-                collection <- Scope.run(Jsonl.readResults[Bag](file, maxDepth = 8, maxCollectionSize = 4).run)
-                within     <- Scope.run(Jsonl.readResults[Bag](file, maxDepth = 8, maxCollectionSize = 50).run)
-                _          <- dir.removeAll
-            yield
-                assert(depth.size == 1)
-                assertLimitBreach(depth(0), "Nesting depth", 1)
-                assert(collection.size == 1)
-                assertLimitBreach(collection(0), "Collection size", 4)
-                assert(within.size == 1)
-                assert(within(0).getOrThrow == bag)
-            end for
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-read-results-limits")
+                    file = dir / "bag.jsonl"
+                    _          <- file.write(bagLine + "\n")
+                    depth      <- Scope.run(Jsonl.readResults[Bag](file, maxDepth = 1, maxCollectionSize = 50).run)
+                    collection <- Scope.run(Jsonl.readResults[Bag](file, maxDepth = 8, maxCollectionSize = 4).run)
+                    within     <- Scope.run(Jsonl.readResults[Bag](file, maxDepth = 8, maxCollectionSize = 50).run)
+                    _          <- dir.removeAll
+                yield
+                    assert(depth.size == 1)
+                    assertLimitBreach(depth(0), "Nesting depth", 1)
+                    assert(collection.size == 1)
+                    assertLimitBreach(collection(0), "Collection size", 4)
+                    assert(within.size == 1)
+                    assert(within(0).getOrThrow == bag)
+                end for
+            }
         }
     }
 
@@ -511,8 +572,8 @@ class JsonlTest extends kyo.test.Test[Any]:
         def writeUntilDone[A, S](
             fiber: Fiber[A, S],
             control: Clock.TimeControl,
-            write: Unit < (Async & Abort[FileWriteException])
-        )(using Frame): Unit < (Async & Abort[FileWriteException]) =
+            write: Unit < (PathWrite & Async)
+        )(using Frame): Unit < (PathWrite & Async) =
             Loop.foreach {
                 fiber.done.map { done =>
                     if done then Loop.done
@@ -543,350 +604,342 @@ class JsonlTest extends kyo.test.Test[Any]:
             fiber.done.map(done => if done then true else condition)
 
         "replays existing records then emits appended ones" in {
-            Clock.withTimeControl { control =>
-                for
-                    dir <- Path.tempDir("kyo-jsonl-watch")
-                    file = dir / "t.jsonl"
-                    _ <- file.write("{\"name\":\"a\",\"count\":1}\n")
-                    fiber <- Fiber.initUnscoped(
-                        Scope.run(Jsonl.watch[Event](file, pollDelay = pollDelay).take(2).run)
-                    )
-                    // Each append writes one complete record, so any number of them leaves the first
-                    // two records of the file unchanged and the assertion holds whenever the watcher starts.
-                    _   <- writeUntilDone(fiber, control, file.append("{\"name\":\"b\",\"count\":2}\n"))
-                    got <- fiber.get
-                    _   <- dir.removeAll
-                yield assert(got == Chunk(Event("a", 1), Event("b", 2)))
-                end for
+            Path.run {
+                Clock.withTimeControl { control =>
+                    for
+                        dir <- Path.tempDir("kyo-jsonl-watch")
+                        file = dir / "t.jsonl"
+                        _ <- file.write("{\"name\":\"a\",\"count\":1}\n")
+                        fiber <- Fiber.initUnscoped(
+                            Path.runReadOnly(
+                                Scope.run(Jsonl.watch[Event](file, pollDelay = pollDelay).take(2).run)
+                            )
+                        )
+                        // Each append writes one complete record, so any number of them leaves the first
+                        // two records of the file unchanged and the assertion holds whenever the watcher starts.
+                        _   <- writeUntilDone(fiber, control, file.append("{\"name\":\"b\",\"count\":2}\n"))
+                        got <- fiber.get
+                        _   <- dir.removeAll
+                    yield assert(got == Chunk(Event("a", 1), Event("b", 2)))
+                    end for
+                }
             }
         }
 
         "Origin.End skips existing records" in {
-            Clock.withTimeControl { control =>
-                for
-                    dir <- Path.tempDir("kyo-jsonl-watch-end")
-                    file = dir / "t.jsonl"
-                    _ <- file.write("{\"name\":\"old\",\"count\":0}\n")
-                    fiber <- Fiber.initUnscoped(
-                        Scope.run(Jsonl.watch[Event](file, Path.Origin.End, pollDelay).take(1).run)
-                    )
-                    // The file at rest is always a whole number of records, so wherever Origin.End
-                    // lands it lands on a record boundary and the next record read is a "new" one.
-                    _   <- writeUntilDone(fiber, control, file.append("{\"name\":\"new\",\"count\":1}\n"))
-                    got <- fiber.get
-                    _   <- dir.removeAll
-                yield assert(got == Chunk(Event("new", 1)))
-                end for
+            Path.run {
+                Clock.withTimeControl { control =>
+                    for
+                        dir <- Path.tempDir("kyo-jsonl-watch-end")
+                        file = dir / "t.jsonl"
+                        _ <- file.write("{\"name\":\"old\",\"count\":0}\n")
+                        fiber <- Fiber.initUnscoped(
+                            Path.runReadOnly(
+                                Scope.run(Jsonl.watch[Event](file, Path.Origin.End, pollDelay).take(1).run)
+                            )
+                        )
+                        // The file at rest is always a whole number of records, so wherever Origin.End
+                        // lands it lands on a record boundary and the next record read is a "new" one.
+                        _   <- writeUntilDone(fiber, control, file.append("{\"name\":\"new\",\"count\":1}\n"))
+                        got <- fiber.get
+                        _   <- dir.removeAll
+                    yield assert(got == Chunk(Event("new", 1)))
+                    end for
+                }
             }
         }
 
         "Origin.Offset resumes at a recorded byte offset" in {
-            val first = "{\"name\":\"a\",\"count\":1}\n"
-            for
-                dir <- Path.tempDir("kyo-jsonl-watch-offset")
-                file = dir / "t.jsonl"
-                _ <- file.write(first + "{\"name\":\"b\",\"count\":2}\n")
-                got <- Scope.run(
-                    Jsonl.watch[Event](file, Path.Origin.Offset(first.length.toLong), pollDelay).take(1).run
-                )
-                _ <- dir.removeAll
-            yield assert(got == Chunk(Event("b", 2)))
-            end for
+            Path.run {
+                val first = "{\"name\":\"a\",\"count\":1}\n"
+                for
+                    dir <- Path.tempDir("kyo-jsonl-watch-offset")
+                    file = dir / "t.jsonl"
+                    _ <- file.write(first + "{\"name\":\"b\",\"count\":2}\n")
+                    got <- Scope.run(
+                        Jsonl.watch[Event](file, Path.Origin.Offset(first.length.toLong), pollDelay).take(1).run
+                    )
+                    _ <- dir.removeAll
+                yield assert(got == Chunk(Event("b", 2)))
+                end for
+            }
         }
 
         "emits the records before a bad one and then aborts" in {
-            // Every record is already on disk, so the first read carries all three and the watcher reaches
-            // the abort without ever polling: no wakeup is needed and none is offered.
-            val in = "{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n"
-            for
-                dir <- Path.tempDir("kyo-jsonl-watch-bad")
-                file = dir / "t.jsonl"
-                _    <- file.write(in)
-                seen <- AtomicRef.init(Chunk.empty[Event])
-                r <- Abort.run[DecodeException](
-                    Scope.run(
-                        Jsonl.watch[Event](file, pollDelay = pollDelay)
-                            .take(3)
-                            .foreach(e => seen.updateAndGet(_ :+ e))
-                    )
-                )
-                emitted <- seen.get
-                _       <- dir.removeAll
-            yield
-                // The prefix belongs to the consumer even though the read that produced it also produced the
-                // failure: decoding the whole read and aborting before emitting would deliver nothing here.
-                assert(emitted == Chunk(Event("a", 1)))
-                assertRecordFailure(r, 1L)
-            end for
-        }
-
-        "watchResults reports a bad record as one failure and carries on" in {
-            val in = "{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n"
-            for
-                dir <- Path.tempDir("kyo-jsonl-watch-results-bad")
-                file = dir / "t.jsonl"
-                _  <- file.write(in)
-                rs <- Scope.run(Jsonl.watchResults[Event](file, pollDelay = pollDelay).take(3).run)
-                _  <- dir.removeAll
-            yield
-                assert(rs.size == 3)
-                assert(rs(0).getOrThrow == Event("a", 1))
-                assertRecordFailure(rs(1), 1L)
-                assert(rs(2).getOrThrow == Event("c", 3))
-            end for
-        }
-
-        "emits a record written in two partial appends exactly once, whole" in {
-            Clock.withTimeControl { control =>
-                // One complete record plus the first half of a second, written before the watcher starts:
-                // reading from Origin.Start makes the watcher's start time irrelevant, and the single
-                // write means the read that frames the first record necessarily also buffers the partial.
-                //
-                // The assumption this test's discriminating power rests on: these 37 bytes sit far below
-                // the watcher's 8192-byte read buffer, so one read delivers the complete first record and
-                // the partial second one together. The partial is therefore state the framer has to carry
-                // between reads, not an artifact of how the bytes happened to be chunked.
-                val existing   = "{\"name\":\"a\",\"count\":1}\n{\"name\":\"split"
-                val completion = "\",\"count\":7}\n{\"name\":\"split"
+            Path.run {
+                // Every record is already on disk, so the first read carries all three and the watcher reaches
+                // the abort without ever polling: no wakeup is needed and none is offered.
+                val in = "{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n"
                 for
-                    dir <- Path.tempDir("kyo-jsonl-watch-split")
+                    dir <- Path.tempDir("kyo-jsonl-watch-bad")
                     file = dir / "t.jsonl"
-                    _    <- file.write(existing)
+                    _    <- file.write(in)
                     seen <- AtomicRef.init(Chunk.empty[Event])
-                    fiber <- Fiber.initUnscoped(
+                    r <- Abort.run[DecodeException](
                         Scope.run(
                             Jsonl.watch[Event](file, pollDelay = pollDelay)
-                                .take(2)
+                                .take(3)
                                 .foreach(e => seen.updateAndGet(_ :+ e))
                         )
                     )
-                    // Emitting the first record is the observable proof that the partial second record
-                    // has been read and buffered, so the completing append below cannot land too early.
-                    _ <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.nonEmpty)))
-                    // Each append closes the pending record and opens a new partial one, so repeating it
-                    // only ever adds more Event("split", 7) records and never a malformed one.
-                    _   <- writeUntilDone(fiber, control, file.append(completion))
-                    _   <- fiber.get
-                    got <- seen.get
-                    _   <- dir.removeAll
-                // A framer rebuilt between polls would have dropped the buffered `{"name":"split` and
-                // tried to decode `","count":7}` on its own.
-                yield assert(got == Chunk(Event("a", 1), Event("split", 7)))
+                    emitted <- seen.get
+                    _       <- dir.removeAll
+                yield
+                    // The prefix belongs to the consumer even though the read that produced it also produced the
+                    // failure: decoding the whole read and aborting before emitting would deliver nothing here.
+                    assert(emitted == Chunk(Event("a", 1)))
+                    assertRecordFailure(r, 1L)
                 end for
+            }
+        }
+
+        "watchResults reports a bad record as one failure and carries on" in {
+            Path.run {
+                val in = "{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n"
+                for
+                    dir <- Path.tempDir("kyo-jsonl-watch-results-bad")
+                    file = dir / "t.jsonl"
+                    _  <- file.write(in)
+                    rs <- Scope.run(Jsonl.watchResults[Event](file, pollDelay = pollDelay).take(3).run)
+                    _  <- dir.removeAll
+                yield
+                    assert(rs.size == 3)
+                    assert(rs(0).getOrThrow == Event("a", 1))
+                    assertRecordFailure(rs(1), 1L)
+                    assert(rs(2).getOrThrow == Event("c", 3))
+                end for
+            }
+        }
+
+        "emits a record written in two partial appends exactly once, whole" in {
+            Path.run {
+                Clock.withTimeControl { control =>
+                    // One complete record plus the first half of a second, written before the watcher starts:
+                    // reading from Origin.Start makes the watcher's start time irrelevant, and the single
+                    // write means the read that frames the first record necessarily also buffers the partial.
+                    //
+                    // The assumption this test's discriminating power rests on: these 37 bytes sit far below
+                    // the watcher's 8192-byte read buffer, so one read delivers the complete first record and
+                    // the partial second one together. The partial is therefore state the framer has to carry
+                    // between reads, not an artifact of how the bytes happened to be chunked.
+                    val existing   = "{\"name\":\"a\",\"count\":1}\n{\"name\":\"split"
+                    val completion = "\",\"count\":7}\n{\"name\":\"split"
+                    for
+                        dir <- Path.tempDir("kyo-jsonl-watch-split")
+                        file = dir / "t.jsonl"
+                        _    <- file.write(existing)
+                        seen <- AtomicRef.init(Chunk.empty[Event])
+                        fiber <- Fiber.initUnscoped(
+                            Path.runReadOnly(
+                                Scope.run(
+                                    Jsonl.watch[Event](file, pollDelay = pollDelay)
+                                        .take(2)
+                                        .foreach(e => seen.updateAndGet(_ :+ e))
+                                )
+                            )
+                        )
+                        // Emitting the first record is the observable proof that the partial second record
+                        // has been read and buffered, so the completing append below cannot land too early.
+                        _ <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.nonEmpty)))
+                        // Each append closes the pending record and opens a new partial one, so repeating it
+                        // only ever adds more Event("split", 7) records and never a malformed one.
+                        _   <- writeUntilDone(fiber, control, file.append(completion))
+                        _   <- fiber.get
+                        got <- seen.get
+                        _   <- dir.removeAll
+                    // A framer rebuilt between polls would have dropped the buffered `{"name":"split` and
+                    // tried to decode `","count":7}` on its own.
+                    yield assert(got == Chunk(Event("a", 1), Event("split", 7)))
+                    end for
+                }
             }
         }
 
         "watchResults replays a truncation that cut a record in half without splicing it" in {
-            Clock.withTimeControl { control =>
-                // 28 bytes: one complete record and the opening of a second one.
-                val existing = "{\"name\":\"a\",\"count\":1}\n{\"nam"
-                // 23 bytes, below the watcher's position, so the rewind fires on the next poll.
-                val replaced = "{\"name\":\"b\",\"count\":2}\n"
-                for
-                    dir <- Path.tempDir("kyo-jsonl-watch-truncate")
-                    file = dir / "t.jsonl"
-                    _    <- file.write(existing)
-                    seen <- AtomicRef.init(Chunk.empty[Result[DecodeException, Event]])
-                    fiber <- Fiber.initUnscoped(
-                        Scope.run(
-                            Jsonl.watchResults[Event](file, pollDelay = pollDelay)
-                                .take(2)
-                                .foreach(r => seen.updateAndGet(_ :+ r))
+            Path.run {
+                Clock.withTimeControl { control =>
+                    // 28 bytes: one complete record and the opening of a second one.
+                    val existing = "{\"name\":\"a\",\"count\":1}\n{\"nam"
+                    // 23 bytes, below the watcher's position, so the rewind fires on the next poll.
+                    val replaced = "{\"name\":\"b\",\"count\":2}\n"
+                    for
+                        dir <- Path.tempDir("kyo-jsonl-watch-truncate")
+                        file = dir / "t.jsonl"
+                        _    <- file.write(existing)
+                        seen <- AtomicRef.init(Chunk.empty[Result[DecodeException, Event]])
+                        fiber <- Fiber.initUnscoped(
+                            Path.runReadOnly(
+                                Scope.run(
+                                    Jsonl.watchResults[Event](file, pollDelay = pollDelay)
+                                        .take(2)
+                                        .foreach(r => seen.updateAndGet(_ :+ r))
+                                )
+                            )
                         )
-                    )
-                    // The first result proves the read that framed it also buffered `{"nam`.
-                    _ <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.nonEmpty)))
-                    // A single truncating write: the file never grows back past the watcher's position.
-                    _   <- file.write(replaced)
-                    _   <- advanceUntil(control)(fiber.done)
-                    _   <- fiber.get
-                    got <- seen.get
-                    _   <- dir.removeAll
-                yield
-                    // The rewind carries no marker in the byte stream, so nothing downstream of the watch
-                    // loop could tell that `{"nam` went stale. The framer is rebuilt at the rewind instead,
-                    // which makes the splice impossible rather than merely unlikely.
-                    assert(got.size == 2)
-                    assert(got(0).getOrThrow == Event("a", 1))
-                    assert(got(1).getOrThrow == Event("b", 2))
-                end for
+                        // The first result proves the read that framed it also buffered `{"nam`.
+                        _ <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.nonEmpty)))
+                        // A single truncating write: the file never grows back past the watcher's position.
+                        _   <- file.write(replaced)
+                        _   <- advanceUntil(control)(fiber.done)
+                        _   <- fiber.get
+                        got <- seen.get
+                        _   <- dir.removeAll
+                    yield
+                        // The rewind carries no marker in the byte stream, so nothing downstream of the watch
+                        // loop could tell that `{"nam` went stale. The framer is rebuilt at the rewind instead,
+                        // which makes the splice impossible rather than merely unlikely.
+                        assert(got.size == 2)
+                        assert(got(0).getOrThrow == Event("a", 1))
+                        assert(got(1).getOrThrow == Event("b", 2))
+                    end for
+                }
             }
         }
 
         "watch does not abort when a truncation cuts a record in half" in {
-            Clock.withTimeControl { control =>
-                // 28 bytes: one complete record and the opening of a second one.
-                val existing = "{\"name\":\"a\",\"count\":1}\n{\"nam"
-                // 23 bytes, below the watcher's position, so the rewind fires on the next poll.
-                val replaced = "{\"name\":\"b\",\"count\":2}\n"
-                for
-                    dir <- Path.tempDir("kyo-jsonl-watch-truncate-strict")
-                    file = dir / "t.jsonl"
-                    _    <- file.write(existing)
-                    seen <- AtomicRef.init(Chunk.empty[Event])
-                    fiber <- Fiber.initUnscoped(
-                        Abort.run[DecodeException](
-                            Scope.run(
-                                Jsonl.watch[Event](file, pollDelay = pollDelay)
-                                    .take(2)
-                                    .foreach(e => seen.updateAndGet(_ :+ e))
+            Path.run {
+                Clock.withTimeControl { control =>
+                    // 28 bytes: one complete record and the opening of a second one.
+                    val existing = "{\"name\":\"a\",\"count\":1}\n{\"nam"
+                    // 23 bytes, below the watcher's position, so the rewind fires on the next poll.
+                    val replaced = "{\"name\":\"b\",\"count\":2}\n"
+                    for
+                        dir <- Path.tempDir("kyo-jsonl-watch-truncate-strict")
+                        file = dir / "t.jsonl"
+                        _    <- file.write(existing)
+                        seen <- AtomicRef.init(Chunk.empty[Event])
+                        fiber <- Fiber.initUnscoped(
+                            Path.runReadOnly(
+                                Abort.run[DecodeException](
+                                    Scope.run(
+                                        Jsonl.watch[Event](file, pollDelay = pollDelay)
+                                            .take(2)
+                                            .foreach(e => seen.updateAndGet(_ :+ e))
+                                    )
+                                )
                             )
                         )
-                    )
-                    // The first value proves the read that framed it also buffered `{"nam`.
-                    _       <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.nonEmpty)))
-                    _       <- file.write(replaced)
-                    _       <- advanceUntil(control)(fiber.done)
-                    outcome <- fiber.get
-                    got     <- seen.get
-                    _       <- dir.removeAll
-                yield
-                    // The strict variant is where a splice used to be worst: a stale fragment that fails to
-                    // parse ends the stream outright, and one that happens to parse ends it with a wrong value.
-                    assert(outcome == Result.succeed(()))
-                    assert(got == Chunk(Event("a", 1), Event("b", 2)))
-                end for
+                        // The first value proves the read that framed it also buffered `{"nam`.
+                        _       <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.nonEmpty)))
+                        _       <- file.write(replaced)
+                        _       <- advanceUntil(control)(fiber.done)
+                        outcome <- fiber.get
+                        got     <- seen.get
+                        _       <- dir.removeAll
+                    yield
+                        // The strict variant is where a splice used to be worst: a stale fragment that fails to
+                        // parse ends the stream outright, and one that happens to parse ends it with a wrong value.
+                        assert(outcome == Result.succeed(()))
+                        assert(got == Chunk(Event("a", 1), Event("b", 2)))
+                    end for
+                }
             }
         }
 
         "watch replays a truncation that fell on a record boundary" in {
-            Clock.withTimeControl { control =>
-                // 46 bytes: two complete records, so the watcher's residual is empty when the file shrinks.
-                val existing = "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n"
-                // 23 bytes, below the watcher's position, so the rewind fires on the next poll.
-                val replaced = "{\"name\":\"c\",\"count\":3}\n"
-                for
-                    dir <- Path.tempDir("kyo-jsonl-watch-truncate-boundary")
-                    file = dir / "t.jsonl"
-                    _    <- file.write(existing)
-                    seen <- AtomicRef.init(Chunk.empty[Event])
-                    fiber <- Fiber.initUnscoped(
-                        Scope.run(
-                            Jsonl.watch[Event](file, pollDelay = pollDelay)
-                                .take(3)
-                                .foreach(e => seen.updateAndGet(_ :+ e))
+            Path.run {
+                Clock.withTimeControl { control =>
+                    // 46 bytes: two complete records, so the watcher's residual is empty when the file shrinks.
+                    val existing = "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n"
+                    // 23 bytes, below the watcher's position, so the rewind fires on the next poll.
+                    val replaced = "{\"name\":\"c\",\"count\":3}\n"
+                    for
+                        dir <- Path.tempDir("kyo-jsonl-watch-truncate-boundary")
+                        file = dir / "t.jsonl"
+                        _    <- file.write(existing)
+                        seen <- AtomicRef.init(Chunk.empty[Event])
+                        fiber <- Fiber.initUnscoped(
+                            Path.runReadOnly(
+                                Scope.run(
+                                    Jsonl.watch[Event](file, pollDelay = pollDelay)
+                                        .take(3)
+                                        .foreach(e => seen.updateAndGet(_ :+ e))
+                                )
+                            )
                         )
-                    )
-                    // Both existing records emitted, so the watcher's cursor sits at the end of the file.
-                    _   <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.size >= 2)))
-                    _   <- file.write(replaced)
-                    _   <- advanceUntil(control)(fiber.done)
-                    _   <- fiber.get
-                    got <- seen.get
-                    _   <- dir.removeAll
-                // Nothing was pending when the file shrank, so this is the case a rebuilt framer must leave
-                // exactly as it was: the replayed record decodes on its own and carries the fresh index.
-                yield assert(got == Chunk(Event("a", 1), Event("b", 2), Event("c", 3)))
-                end for
+                        // Both existing records emitted, so the watcher's cursor sits at the end of the file.
+                        _   <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.size >= 2)))
+                        _   <- file.write(replaced)
+                        _   <- advanceUntil(control)(fiber.done)
+                        _   <- fiber.get
+                        got <- seen.get
+                        _   <- dir.removeAll
+                    // Nothing was pending when the file shrank, so this is the case a rebuilt framer must leave
+                    // exactly as it was: the replayed record decodes on its own and carries the fresh index.
+                    yield assert(got == Chunk(Event("a", 1), Event("b", 2), Event("c", 3)))
+                    end for
+                }
             }
         }
 
         "watchResults skips a terminated oversized record and keeps watching" in {
-            Clock.withTimeControl { control =>
-                // The record and the oversized line are both on disk before the watcher starts, so the
-                // first read carries the skip. The third element can then only come from a later poll,
-                // which is the point: a watcher that ended at the breach never reaches it, and one
-                // bad line would end a live log's reader permanently.
-                val existing = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n"
-                for
-                    dir <- Path.tempDir("kyo-jsonl-watch-skip")
-                    file = dir / "t.jsonl"
-                    _    <- file.write(existing)
-                    seen <- AtomicRef.init(Chunk.empty[Result[DecodeException, Event]])
-                    fiber <- Fiber.initUnscoped(
-                        Scope.run(
-                            Jsonl.watchResults[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
-                                .take(3)
-                                .foreach(r => seen.updateAndGet(_ :+ r))
+            Path.run {
+                Clock.withTimeControl { control =>
+                    // The record and the oversized line are both on disk before the watcher starts, so the
+                    // first read carries the skip. The third element can then only come from a later poll,
+                    // which is the point: a watcher that ended at the breach never reaches it, and one
+                    // bad line would end a live log's reader permanently.
+                    val existing = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n"
+                    for
+                        dir <- Path.tempDir("kyo-jsonl-watch-skip")
+                        file = dir / "t.jsonl"
+                        _    <- file.write(existing)
+                        seen <- AtomicRef.init(Chunk.empty[Result[DecodeException, Event]])
+                        fiber <- Fiber.initUnscoped(
+                            Path.runReadOnly(
+                                Scope.run(
+                                    Jsonl.watchResults[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
+                                        .take(3)
+                                        .foreach(r => seen.updateAndGet(_ :+ r))
+                                )
+                            )
                         )
-                    )
-                    // Each append adds one complete record, so any number of them leaves the third
-                    // element Event("c", 3) and the assertion holds whenever the watcher gets there.
-                    _   <- writeUntilDone(fiber, control, file.append("{\"name\":\"c\",\"count\":3}\n"))
-                    _   <- fiber.get
-                    got <- seen.get
-                    _   <- dir.removeAll
-                yield
-                    assert(got.size == 3)
-                    assert(got(0).getOrThrow == Event("a", 1))
-                    got(1).foldError(
-                        _ => fail("expected a failure"),
-                        {
-                            case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
-                            case other                                     => fail(s"unexpected error $other")
-                        }
-                    )
-                    assert(got(2).getOrThrow == Event("c", 3))
-                end for
+                        // Each append adds one complete record, so any number of them leaves the third
+                        // element Event("c", 3) and the assertion holds whenever the watcher gets there.
+                        _   <- writeUntilDone(fiber, control, file.append("{\"name\":\"c\",\"count\":3}\n"))
+                        _   <- fiber.get
+                        got <- seen.get
+                        _   <- dir.removeAll
+                    yield
+                        assert(got.size == 3)
+                        assert(got(0).getOrThrow == Event("a", 1))
+                        got(1).foldError(
+                            _ => fail("expected a failure"),
+                            {
+                                case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
+                                case other                                     => fail(s"unexpected error $other")
+                            }
+                        )
+                        assert(got(2).getOrThrow == Event("c", 3))
+                    end for
+                }
             }
         }
 
         "watch aborts on a terminated oversized record after emitting the prefix" in {
-            // Everything is on disk before the watcher starts, so the first read frames the record,
-            // skips the oversized line, and reaches the abort without polling. The record after the
-            // breach is on disk too, and `take(2)` is what a watcher that skipped the breach would
-            // satisfy with it: the assertion then reports the wrong prefix rather than waiting forever.
-            val in = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n{\"name\":\"c\",\"count\":3}\n"
-            for
-                dir <- Path.tempDir("kyo-jsonl-watch-skip-strict")
-                file = dir / "t.jsonl"
-                _    <- file.write(in)
-                seen <- AtomicRef.init(Chunk.empty[Event])
-                r <- Abort.run[DecodeException](
-                    Scope.run(
-                        Jsonl.watch[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
-                            .take(2)
-                            .foreach(e => seen.updateAndGet(_ :+ e))
-                    )
-                )
-                emitted <- seen.get
-                _       <- dir.removeAll
-            yield
-                assert(emitted == Chunk(Event("a", 1)))
-                r.foldError(
-                    _ => fail("expected a failure"),
-                    {
-                        case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
-                        case other                                     => fail(s"unexpected error $other")
-                    }
-                )
-            end for
-        }
-
-        "watchResults keeps the records framed before a limit breach, then ends" in {
-            Clock.withTimeControl { control =>
-                // One record of 22 bytes, then 49 bytes with no terminator: no record boundary can be found
-                // for the pending bytes, which is the one framing failure that has nothing to skip to.
-                val existing = "{\"name\":\"a\",\"count\":1}\n" + "{\"name\":\"" + ("b" * 40)
-                // 23 bytes, below the watcher's position, so a rewind would fire on the next poll if the
-                // watcher were still reading. It is written precisely to prove that it is not.
-                val replaced = "{\"name\":\"c\",\"count\":3}\n"
+            Path.run {
+                // Everything is on disk before the watcher starts, so the first read frames the record,
+                // skips the oversized line, and reaches the abort without polling. The record after the
+                // breach is on disk too, and `take(2)` is what a watcher that skipped the breach would
+                // satisfy with it: the assertion then reports the wrong prefix rather than waiting forever.
+                val in = "{\"name\":\"a\",\"count\":1}\n" + oversizedLine + "\n{\"name\":\"c\",\"count\":3}\n"
                 for
-                    dir <- Path.tempDir("kyo-jsonl-watch-breach")
+                    dir <- Path.tempDir("kyo-jsonl-watch-skip-strict")
                     file = dir / "t.jsonl"
-                    _    <- file.write(existing)
-                    seen <- AtomicRef.init(Chunk.empty[Result[DecodeException, Event]])
-                    fiber <- Fiber.initUnscoped(
+                    _    <- file.write(in)
+                    seen <- AtomicRef.init(Chunk.empty[Event])
+                    r <- Abort.run[DecodeException](
                         Scope.run(
-                            Jsonl.watchResults[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
-                                .take(3)
-                                .foreach(r => seen.updateAndGet(_ :+ r))
+                            Jsonl.watch[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
+                                .take(2)
+                                .foreach(e => seen.updateAndGet(_ :+ e))
                         )
                     )
-                    // The record framed before the breach and the breach itself both arrive in the first read.
-                    _   <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.size >= 2)))
-                    _   <- file.write(replaced)
-                    _   <- advanceUntil(control)(fiber.done)
-                    _   <- fiber.get
-                    got <- seen.get
-                    _   <- dir.removeAll
+                    emitted <- seen.get
+                    _       <- dir.removeAll
                 yield
-                    // `take(3)` never reaches a third element: the breach ends the stream after the records
-                    // framed before it, so the truncation written afterwards yields nothing at all. A stream
-                    // that stayed open would have replayed Event("c", 3) here instead.
-                    assert(got.size == 2)
-                    assert(got(0).getOrThrow == Event("a", 1))
-                    got(1).foldError(
+                    assert(emitted == Chunk(Event("a", 1)))
+                    r.foldError(
                         _ => fail("expected a failure"),
                         {
                             case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
@@ -897,87 +950,141 @@ class JsonlTest extends kyo.test.Test[Any]:
             }
         }
 
+        "watchResults keeps the records framed before a limit breach, then ends" in {
+            Path.run {
+                Clock.withTimeControl { control =>
+                    // One record of 22 bytes, then 49 bytes with no terminator: no record boundary can be found
+                    // for the pending bytes, which is the one framing failure that has nothing to skip to.
+                    val existing = "{\"name\":\"a\",\"count\":1}\n" + "{\"name\":\"" + ("b" * 40)
+                    // 23 bytes, below the watcher's position, so a rewind would fire on the next poll if the
+                    // watcher were still reading. It is written precisely to prove that it is not.
+                    val replaced = "{\"name\":\"c\",\"count\":3}\n"
+                    for
+                        dir <- Path.tempDir("kyo-jsonl-watch-breach")
+                        file = dir / "t.jsonl"
+                        _    <- file.write(existing)
+                        seen <- AtomicRef.init(Chunk.empty[Result[DecodeException, Event]])
+                        fiber <- Fiber.initUnscoped(
+                            Path.runReadOnly(
+                                Scope.run(
+                                    Jsonl.watchResults[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
+                                        .take(3)
+                                        .foreach(r => seen.updateAndGet(_ :+ r))
+                                )
+                            )
+                        )
+                        // The record framed before the breach and the breach itself both arrive in the first read.
+                        _   <- advanceUntil(control)(doneOr(fiber)(seen.get.map(_.size >= 2)))
+                        _   <- file.write(replaced)
+                        _   <- advanceUntil(control)(fiber.done)
+                        _   <- fiber.get
+                        got <- seen.get
+                        _   <- dir.removeAll
+                    yield
+                        // `take(3)` never reaches a third element: the breach ends the stream after the records
+                        // framed before it, so the truncation written afterwards yields nothing at all. A stream
+                        // that stayed open would have replayed Event("c", 3) here instead.
+                        assert(got.size == 2)
+                        assert(got(0).getOrThrow == Event("a", 1))
+                        got(1).foldError(
+                            _ => fail("expected a failure"),
+                            {
+                                case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
+                                case other                                     => fail(s"unexpected error $other")
+                            }
+                        )
+                    end for
+                }
+            }
+        }
+
         "watch keeps the records framed before a limit breach, then aborts" in {
-            // One record of 22 bytes, then 49 bytes with no terminator, all on disk before the watcher
-            // starts: one read frames the record and hits the breach, so the abort is reached without
-            // polling and no wakeup is needed.
-            val in = "{\"name\":\"a\",\"count\":1}\n" + "{\"name\":\"" + ("b" * 40)
-            for
-                dir <- Path.tempDir("kyo-jsonl-watch-breach-strict")
-                file = dir / "t.jsonl"
-                _    <- file.write(in)
-                seen <- AtomicRef.init(Chunk.empty[Event])
-                r <- Abort.run[DecodeException](
-                    Scope.run(
-                        Jsonl.watch[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
-                            .take(2)
-                            .foreach(e => seen.updateAndGet(_ :+ e))
+            Path.run {
+                // One record of 22 bytes, then 49 bytes with no terminator, all on disk before the watcher
+                // starts: one read frames the record and hits the breach, so the abort is reached without
+                // polling and no wakeup is needed.
+                val in = "{\"name\":\"a\",\"count\":1}\n" + "{\"name\":\"" + ("b" * 40)
+                for
+                    dir <- Path.tempDir("kyo-jsonl-watch-breach-strict")
+                    file = dir / "t.jsonl"
+                    _    <- file.write(in)
+                    seen <- AtomicRef.init(Chunk.empty[Event])
+                    r <- Abort.run[DecodeException](
+                        Scope.run(
+                            Jsonl.watch[Event](file, pollDelay = pollDelay, maxLineSize = 30.bytes)
+                                .take(2)
+                                .foreach(e => seen.updateAndGet(_ :+ e))
+                        )
                     )
-                )
-                emitted <- seen.get
-                _       <- dir.removeAll
-            yield
-                // The framing route into the abort, which "watch emits the records before a bad one and then
-                // aborts" does not reach: that one covers the decode route. The breach arrives at the strict
-                // variant as a failure element, and the record framed before it is still delivered.
-                assert(emitted == Chunk(Event("a", 1)))
-                r.foldError(
-                    _ => fail("expected a failure"),
-                    {
-                        case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
-                        case other                                     => fail(s"unexpected error $other")
-                    }
-                )
-            end for
+                    emitted <- seen.get
+                    _       <- dir.removeAll
+                yield
+                    // The framing route into the abort, which "watch emits the records before a bad one and then
+                    // aborts" does not reach: that one covers the decode route. The breach arrives at the strict
+                    // variant as a failure element, and the record framed before it is still delivered.
+                    assert(emitted == Chunk(Event("a", 1)))
+                    r.foldError(
+                        _ => fail("expected a failure"),
+                        {
+                            case Result.Failure(e: LimitExceededException) => assert(e.maximum == 30)
+                            case other                                     => fail(s"unexpected error $other")
+                        }
+                    )
+                end for
+            }
         }
 
         "watch applies maxDepth and maxCollectionSize" in {
-            // The whole record is on disk before the watcher starts, so the first read reaches the decode
-            // without ever polling and no wakeup is needed.
-            for
-                dir <- Path.tempDir("kyo-jsonl-watch-limits")
-                file = dir / "bag.jsonl"
-                _ <- file.write(bagLine + "\n")
-                depth <- Abort.run[DecodeException](
-                    Scope.run(Jsonl.watch[Bag](file, pollDelay = pollDelay, maxDepth = 1, maxCollectionSize = 50).take(1).run)
-                )
-                collection <- Abort.run[DecodeException](
-                    Scope.run(Jsonl.watch[Bag](file, pollDelay = pollDelay, maxDepth = 8, maxCollectionSize = 4).take(1).run)
-                )
-                within <- Scope.run(
-                    Jsonl.watch[Bag](file, pollDelay = pollDelay, maxDepth = 8, maxCollectionSize = 50).take(1).run
-                )
-                _ <- dir.removeAll
-            yield
-                assertLimitBreach(depth, "Nesting depth", 1)
-                assertLimitBreach(collection, "Collection size", 4)
-                assert(within == Chunk(bag))
-            end for
+            Path.run {
+                // The whole record is on disk before the watcher starts, so the first read reaches the decode
+                // without ever polling and no wakeup is needed.
+                for
+                    dir <- Path.tempDir("kyo-jsonl-watch-limits")
+                    file = dir / "bag.jsonl"
+                    _ <- file.write(bagLine + "\n")
+                    depth <- Abort.run[DecodeException](
+                        Scope.run(Jsonl.watch[Bag](file, pollDelay = pollDelay, maxDepth = 1, maxCollectionSize = 50).take(1).run)
+                    )
+                    collection <- Abort.run[DecodeException](
+                        Scope.run(Jsonl.watch[Bag](file, pollDelay = pollDelay, maxDepth = 8, maxCollectionSize = 4).take(1).run)
+                    )
+                    within <- Scope.run(
+                        Jsonl.watch[Bag](file, pollDelay = pollDelay, maxDepth = 8, maxCollectionSize = 50).take(1).run
+                    )
+                    _ <- dir.removeAll
+                yield
+                    assertLimitBreach(depth, "Nesting depth", 1)
+                    assertLimitBreach(collection, "Collection size", 4)
+                    assert(within == Chunk(bag))
+                end for
+            }
         }
 
         "watchResults applies maxDepth and maxCollectionSize" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-watch-results-limits")
-                file = dir / "bag.jsonl"
-                _ <- file.write(bagLine + "\n")
-                depth <- Scope.run(
-                    Jsonl.watchResults[Bag](file, pollDelay = pollDelay, maxDepth = 1, maxCollectionSize = 50).take(1).run
-                )
-                collection <- Scope.run(
-                    Jsonl.watchResults[Bag](file, pollDelay = pollDelay, maxDepth = 8, maxCollectionSize = 4).take(1).run
-                )
-                within <- Scope.run(
-                    Jsonl.watchResults[Bag](file, pollDelay = pollDelay, maxDepth = 8, maxCollectionSize = 50).take(1).run
-                )
-                _ <- dir.removeAll
-            yield
-                assert(depth.size == 1)
-                assertLimitBreach(depth(0), "Nesting depth", 1)
-                assert(collection.size == 1)
-                assertLimitBreach(collection(0), "Collection size", 4)
-                assert(within.size == 1)
-                assert(within(0).getOrThrow == bag)
-            end for
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-watch-results-limits")
+                    file = dir / "bag.jsonl"
+                    _ <- file.write(bagLine + "\n")
+                    depth <- Scope.run(
+                        Jsonl.watchResults[Bag](file, pollDelay = pollDelay, maxDepth = 1, maxCollectionSize = 50).take(1).run
+                    )
+                    collection <- Scope.run(
+                        Jsonl.watchResults[Bag](file, pollDelay = pollDelay, maxDepth = 8, maxCollectionSize = 4).take(1).run
+                    )
+                    within <- Scope.run(
+                        Jsonl.watchResults[Bag](file, pollDelay = pollDelay, maxDepth = 8, maxCollectionSize = 50).take(1).run
+                    )
+                    _ <- dir.removeAll
+                yield
+                    assert(depth.size == 1)
+                    assertLimitBreach(depth(0), "Nesting depth", 1)
+                    assert(collection.size == 1)
+                    assertLimitBreach(collection(0), "Collection size", 4)
+                    assert(within.size == 1)
+                    assert(within(0).getOrThrow == bag)
+                end for
+            }
         }
     }
 
@@ -1042,260 +1149,320 @@ class JsonlTest extends kyo.test.Test[Any]:
     "write" - {
 
         "writes a stream of values as jsonl" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-write")
-                file = dir / "out.jsonl"
-                _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1), Event("b", 2))))
-                text <- file.read
-                _    <- dir.removeAll
-            yield assert(text == "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n")
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write")
+                    file = dir / "out.jsonl"
+                    _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1), Event("b", 2))))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield assert(text == "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n")
+            }
         }
 
         "replaces the existing content rather than adding to it" in {
-            // The existing content is longer than what replaces it, so a write that only overwrote from the
-            // start would leave the tail of the old content behind and the assertion would see it.
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-truncate")
-                file = dir / "out.jsonl"
-                _    <- Jsonl.write(file, Stream.init(Chunk(Event("old", 1), Event("older", 2), Event("oldest", 3))))
-                _    <- Jsonl.write(file, Stream.init(Chunk(Event("new", 9))))
-                text <- file.read
-                _    <- dir.removeAll
-            yield assert(text == "{\"name\":\"new\",\"count\":9}\n")
+            Path.run {
+                // The existing content is longer than what replaces it, so a write that only overwrote from the
+                // start would leave the tail of the old content behind and the assertion would see it.
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-truncate")
+                    file = dir / "out.jsonl"
+                    _    <- Jsonl.write(file, Stream.init(Chunk(Event("old", 1), Event("older", 2), Event("oldest", 3))))
+                    _    <- Jsonl.write(file, Stream.init(Chunk(Event("new", 9))))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield assert(text == "{\"name\":\"new\",\"count\":9}\n")
+            }
         }
 
         "writing an empty stream produces an empty file" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-empty")
-                file = dir / "empty.jsonl"
-                _    <- Jsonl.write(file, Stream.init(Chunk.empty[Event]))
-                text <- file.read
-                _    <- dir.removeAll
-            yield assert(text == "")
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-empty")
+                    file = dir / "empty.jsonl"
+                    _    <- Jsonl.write(file, Stream.init(Chunk.empty[Event]))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield assert(text == "")
+            }
         }
 
         "writing an empty stream over an existing file empties it" in {
-            // The emptying is part of the call rather than of the first chunk, so a stream that never
-            // produces one still leaves an empty file instead of the previous content.
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-empty-over")
-                file = dir / "out.jsonl"
-                _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1))))
-                _    <- Jsonl.write(file, Stream.init(Chunk.empty[Event]))
-                text <- file.read
-                _    <- dir.removeAll
-            yield assert(text == "")
+            Path.run {
+                // The emptying is part of the call rather than of the first chunk, so a stream that never
+                // produces one still leaves an empty file instead of the previous content.
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-empty-over")
+                    file = dir / "out.jsonl"
+                    _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1))))
+                    _    <- Jsonl.write(file, Stream.init(Chunk.empty[Event]))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield assert(text == "")
+            }
         }
 
         "creates missing parent directories by default" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-folders")
-                file = dir / "nested" / "deeper" / "out.jsonl"
-                _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1))))
-                text <- file.read
-                _    <- dir.removeAll
-            yield assert(text == "{\"name\":\"a\",\"count\":1}\n")
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-folders")
+                    file = dir / "nested" / "deeper" / "out.jsonl"
+                    _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1))))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield assert(text == "{\"name\":\"a\",\"count\":1}\n")
+            }
         }
 
         "fails when createFolders is false and a parent is missing" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-no-folders")
-                file = dir / "nested" / "out.jsonl"
-                r <- Abort.run[FileWriteException](Jsonl.write(
-                    file,
-                    Stream.init(Chunk(Event("a", 1))),
-                    createFolders = false
-                ))
-                exists <- file.exists
-                _      <- dir.removeAll
-            yield
-                assertMissingParent(r, file)
-                assert(!exists)
-            end for
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-no-folders")
+                    file = dir / "nested" / "out.jsonl"
+                    r <- Abort.run[FileSystemException](Path.run(Jsonl.write(
+                        file,
+                        Stream.init(Chunk(Event("a", 1))),
+                        createFolders = false
+                    )))
+                    exists <- file.exists
+                    _      <- dir.removeAll
+                yield
+                    assertMissingParent(r, file)
+                    assert(!exists)
+                end for
+            }
         }
 
         "round trips through read" in {
-            val values = Chunk(Event("café", 1), Event("🎉", 2))
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-round-trip")
-                file = dir / "rt.jsonl"
-                _   <- Jsonl.write(file, Stream.init(values))
-                got <- Scope.run(Jsonl.read[Event](file).run)
-                _   <- dir.removeAll
-            yield assert(got == values)
-            end for
+            Path.run {
+                val values = Chunk(Event("café", 1), Event("🎉", 2))
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-round-trip")
+                    file = dir / "rt.jsonl"
+                    _   <- Jsonl.write(file, Stream.init(values))
+                    got <- Scope.run(Jsonl.read[Event](file).run)
+                    _   <- dir.removeAll
+                yield assert(got == values)
+                end for
+            }
         }
 
         "keeps the records already written when the stream fails part way" in {
-            // A prefix of a JSONL file is still a valid JSONL file, so the records that completed belong to
-            // the consumer. Removing the partial file instead would lose all of them to the record that failed.
-            val failing = Stream[Event, Abort[String]](Emit.valueWith(Chunk(Event("a", 1)))(Abort.fail("boom")))
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-failure")
-                file = dir / "partial.jsonl"
-                r      <- Abort.run[String](Jsonl.write(file, failing))
-                exists <- file.exists
-                text   <- file.read
-                _      <- dir.removeAll
-            yield
-                // The stream's own failure reaches the caller unchanged: the write surface neither swallows it
-                // nor rewrites it into a file failure of its own once the handle has been closed.
-                r.foldError(
-                    value => fail(s"expected a failure, got $value"),
-                    {
-                        case Result.Failure(e) => assert(e == "boom")
-                        case other             => fail(s"unexpected error $other")
-                    }
-                )
-                assert(exists)
-                assert(text == "{\"name\":\"a\",\"count\":1}\n")
-            end for
+            Path.run {
+                // A prefix of a JSONL file is still a valid JSONL file, so the records that completed belong to
+                // the consumer. Removing the partial file instead would lose all of them to the record that failed.
+                val failing = Stream[Event, Abort[String]](Emit.valueWith(Chunk(Event("a", 1)))(Abort.fail("boom")))
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-failure")
+                    file = dir / "partial.jsonl"
+                    r      <- Abort.run[String](Jsonl.write(file, failing))
+                    exists <- file.exists
+                    text   <- file.read
+                    _      <- dir.removeAll
+                yield
+                    // The stream's own failure reaches the caller unchanged: the write surface neither swallows it
+                    // nor rewrites it into a file failure of its own once the handle has been closed.
+                    r.foldError(
+                        value => fail(s"expected a failure, got $value"),
+                        {
+                            case Result.Failure(e) => assert(e == "boom")
+                            case other             => fail(s"unexpected error $other")
+                        }
+                    )
+                    assert(exists)
+                    assert(text == "{\"name\":\"a\",\"count\":1}\n")
+                end for
+            }
+        }
+
+        "releases the write handle when the backend fails a write part way" in {
+            // The sibling of the test above, for the other way a fold can end. A stream's own abort is raised inside
+            // the fold, so a bracket around the fold sees it. A backend write failure is raised by the runner that
+            // dispatched the op, outside every bracket the fold installed, so nothing local sees it at all. The
+            // handle must still be finished and closed: an OS handle that outlives the call leaks, and a handle
+            // closed without finish takes the records already written down with it.
+            Path.run {
+                val values = Stream.init(Chunk(Event("a", 1), Event("b", 2)), chunkSize = 1)
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-backend-failure")
+                    file    = dir / "partial.jsonl"
+                    backend = FailingWrites(FileSystem.host, failOnChunk = 2)
+                    r    <- Abort.run[FileSystemException](Path.runWith(backend)(Jsonl.write(file, values)))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield
+                    assert(r.isFailure, "the backend's write failure must reach the caller")
+                    assert(backend.finished, "the write handle must be finished when a backend write fails")
+                    assert(backend.closed, "the write handle must be closed when a backend write fails")
+                    // finish() before close() is what keeps the prefix: the first chunk was written and the second
+                    // was refused, so the record that completed survives.
+                    assert(text == "{\"name\":\"a\",\"count\":1}\n")
+                end for
+            }
         }
 
         "writes each chunk before pulling the next one" in {
-            // The bounded-memory property as an observable fact rather than a claim about the heap: the file's
-            // size at the moment a chunk is pulled counts the bytes of every chunk written before it, so the
-            // write happens between pulls and nothing accumulates across the stream. A fold that buffered the
-            // whole stream and wrote once at the end would report 0 at every pull. Each record here encodes to
-            // 23 bytes and the source hands out two at a time, so the second pull must see 46.
-            val values   = Chunk(Event("a", 1), Event("b", 2), Event("c", 3), Event("d", 4))
-            val lineSize = "{\"name\":\"a\",\"count\":1}\n".getBytes(StandardCharsets.UTF_8).length.toLong
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-incremental")
-                file = dir / "out.jsonl"
-                sizes <- AtomicRef.init(Chunk.empty[Long])
-                source = Stream.init(values, 2).mapChunk(chunk =>
-                    file.size.map(size => sizes.updateAndGet(_ :+ size)).andThen(chunk)
-                )
-                _   <- Jsonl.write(file, source)
-                got <- sizes.get
-                _   <- dir.removeAll
-            yield assert(got == Chunk(0L, 2 * lineSize))
-            end for
+            Path.run {
+                // The bounded-memory property as an observable fact rather than a claim about the heap: the file's
+                // size at the moment a chunk is pulled counts the bytes of every chunk written before it, so the
+                // write happens between pulls and nothing accumulates across the stream. A fold that buffered the
+                // whole stream and wrote once at the end would report 0 at every pull. Each record here encodes to
+                // 23 bytes and the source hands out two at a time, so the second pull must see 46.
+                val values   = Chunk(Event("a", 1), Event("b", 2), Event("c", 3), Event("d", 4))
+                val lineSize = "{\"name\":\"a\",\"count\":1}\n".getBytes(StandardCharsets.UTF_8).length.toLong
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-incremental")
+                    file = dir / "out.jsonl"
+                    sizes <- AtomicRef.init(Chunk.empty[Long])
+                    source = Stream.init(values, 2).mapChunk(chunk =>
+                        file.size.map(size => sizes.updateAndGet(_ :+ size)).andThen(chunk)
+                    )
+                    _   <- Jsonl.write(file, source)
+                    got <- sizes.get
+                    _   <- dir.removeAll
+                yield assert(got == Chunk(0L, 2 * lineSize))
+                end for
+            }
         }
 
         "writes a large stream to exactly the expected byte length and record count" in {
-            // Nothing here observes memory; what it pins is the byte arithmetic over a stream long enough that
-            // the arithmetic errors buffering hides have somewhere to accumulate: a chunk written twice, a chunk
-            // dropped, or a newline emitted per chunk instead of per record. Reading the file back pins the
-            // record count independently of the length. The chunk-at-a-time write is pinned by the test above.
-            val n = 50000
-            val expectedSize =
-                (0 until n).foldLeft(0L)((acc, i) => acc + Json.encode(Event("e", i)).getBytes(StandardCharsets.UTF_8).length + 1L)
-            for
-                dir <- Path.tempDir("kyo-jsonl-write-large")
-                file = dir / "large.jsonl"
-                _     <- Jsonl.write(file, Stream.range(0, n).mapPure(i => Event("e", i)))
-                size  <- file.size
-                count <- Scope.run(Jsonl.read[Event](file).fold(0)((acc, _) => acc + 1))
-                _     <- dir.removeAll
-            yield
-                assert(size == expectedSize)
-                assert(count == n)
-            end for
+            Path.run {
+                // Nothing here observes memory; what it pins is the byte arithmetic over a stream long enough that
+                // the arithmetic errors buffering hides have somewhere to accumulate: a chunk written twice, a chunk
+                // dropped, or a newline emitted per chunk instead of per record. Reading the file back pins the
+                // record count independently of the length. The chunk-at-a-time write is pinned by the test above.
+                val n = 50000
+                val expectedSize =
+                    (0 until n).foldLeft(0L)((acc, i) => acc + Json.encode(Event("e", i)).getBytes(StandardCharsets.UTF_8).length + 1L)
+                for
+                    dir <- Path.tempDir("kyo-jsonl-write-large")
+                    file = dir / "large.jsonl"
+                    _     <- Jsonl.write(file, Stream.range(0, n).mapPure(i => Event("e", i)))
+                    size  <- file.size
+                    count <- Scope.run(Jsonl.read[Event](file).fold(0)((acc, _) => acc + 1))
+                    _     <- dir.removeAll
+                yield
+                    assert(size == expectedSize)
+                    assert(count == n)
+                end for
+            }
         }
     }
 
     "append" - {
 
         "adds to an existing file without truncating it" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-append")
-                file = dir / "out.jsonl"
-                _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1))))
-                _    <- Jsonl.append(file, Stream.init(Chunk(Event("b", 2))))
-                text <- file.read
-                _    <- dir.removeAll
-            yield assert(text == "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n")
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-append")
+                    file = dir / "out.jsonl"
+                    _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1))))
+                    _    <- Jsonl.append(file, Stream.init(Chunk(Event("b", 2))))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield assert(text == "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n")
+            }
         }
 
         "creates the file when it does not exist" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-append-create")
-                file = dir / "nested" / "out.jsonl"
-                _    <- Jsonl.append(file, Stream.init(Chunk(Event("a", 1))))
-                text <- file.read
-                _    <- dir.removeAll
-            yield assert(text == "{\"name\":\"a\",\"count\":1}\n")
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-append-create")
+                    file = dir / "nested" / "out.jsonl"
+                    _    <- Jsonl.append(file, Stream.init(Chunk(Event("a", 1))))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield assert(text == "{\"name\":\"a\",\"count\":1}\n")
+            }
         }
 
         "appending an empty stream creates a file that does not exist" in {
-            // The file's existence is a fact about the call, not about whether the stream produced anything,
-            // so an append of nothing leaves the same empty log an append of nothing to an empty file leaves.
-            for
-                dir <- Path.tempDir("kyo-jsonl-append-empty-create")
-                file = dir / "out.jsonl"
-                _      <- Jsonl.append(file, Stream.init(Chunk.empty[Event]))
-                exists <- file.exists
-                text   <- file.read
-                _      <- dir.removeAll
-            yield
-                assert(exists)
-                assert(text == "")
-            end for
+            Path.run {
+                // The file's existence is a fact about the call, not about whether the stream produced anything,
+                // so an append of nothing leaves the same empty log an append of nothing to an empty file leaves.
+                for
+                    dir <- Path.tempDir("kyo-jsonl-append-empty-create")
+                    file = dir / "out.jsonl"
+                    _      <- Jsonl.append(file, Stream.init(Chunk.empty[Event]))
+                    exists <- file.exists
+                    text   <- file.read
+                    _      <- dir.removeAll
+                yield
+                    assert(exists)
+                    assert(text == "")
+                end for
+            }
         }
 
         "appending an empty stream leaves the file unchanged" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-append-empty")
-                file = dir / "out.jsonl"
-                _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1))))
-                _    <- Jsonl.append(file, Stream.init(Chunk.empty[Event]))
-                text <- file.read
-                _    <- dir.removeAll
-            yield assert(text == "{\"name\":\"a\",\"count\":1}\n")
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-append-empty")
+                    file = dir / "out.jsonl"
+                    _    <- Jsonl.write(file, Stream.init(Chunk(Event("a", 1))))
+                    _    <- Jsonl.append(file, Stream.init(Chunk.empty[Event]))
+                    text <- file.read
+                    _    <- dir.removeAll
+                yield assert(text == "{\"name\":\"a\",\"count\":1}\n")
+            }
         }
 
         "splices onto a last record that carries no trailing newline" in {
-            // The documented hazard, pinned as bytes. Appending starts at the file's current end and writes no
-            // separator, so a file whose last line was never terminated gets the appended record stuck onto it.
-            // The state is reachable rather than hypothetical: `pipe` accepts an unterminated final record, so
-            // `read` reads such a file without complaint and nothing before the append reports anything wrong.
-            // A future change that "helpfully" inserted a newline first would fail here, which is the point:
-            // the separator is the caller's to write, and this is the behavior the scaladoc promises.
-            for
-                dir <- Path.tempDir("kyo-jsonl-append-splice")
-                file = dir / "unterminated.jsonl"
-                _    <- file.write("{\"name\":\"a\",\"count\":1}")
-                _    <- Jsonl.append(file, Stream.init(Chunk(Event("b", 2))))
-                text <- file.read
-                r    <- Abort.run[DecodeException](Scope.run(Jsonl.read[Event](file).run))
-                _    <- dir.removeAll
-            yield
-                assert(text == "{\"name\":\"a\",\"count\":1}{\"name\":\"b\",\"count\":2}\n")
-                // Two records became one line, and that line is not a record: the splice is a corruption
-                // rather than a cosmetic join, and it surfaces only on the read that follows it.
-                assertRecordFailure(r, 0L)
-            end for
+            Path.run {
+                // The documented hazard, pinned as bytes. Appending starts at the file's current end and writes no
+                // separator, so a file whose last line was never terminated gets the appended record stuck onto it.
+                // The state is reachable rather than hypothetical: `pipe` accepts an unterminated final record, so
+                // `read` reads such a file without complaint and nothing before the append reports anything wrong.
+                // A future change that "helpfully" inserted a newline first would fail here, which is the point:
+                // the separator is the caller's to write, and this is the behavior the scaladoc promises.
+                for
+                    dir <- Path.tempDir("kyo-jsonl-append-splice")
+                    file = dir / "unterminated.jsonl"
+                    _    <- file.write("{\"name\":\"a\",\"count\":1}")
+                    _    <- Jsonl.append(file, Stream.init(Chunk(Event("b", 2))))
+                    text <- file.read
+                    r    <- Abort.run[DecodeException](Scope.run(Jsonl.read[Event](file).run))
+                    _    <- dir.removeAll
+                yield
+                    assert(text == "{\"name\":\"a\",\"count\":1}{\"name\":\"b\",\"count\":2}\n")
+                    // Two records became one line, and that line is not a record: the splice is a corruption
+                    // rather than a cosmetic join, and it surfaces only on the read that follows it.
+                    assertRecordFailure(r, 0L)
+                end for
+            }
         }
 
         "fails when createFolders is false and a parent is missing" in {
-            for
-                dir <- Path.tempDir("kyo-jsonl-append-no-folders")
-                file = dir / "nested" / "out.jsonl"
-                r <- Abort.run[FileWriteException](Jsonl.append(
-                    file,
-                    Stream.init(Chunk(Event("a", 1))),
-                    createFolders = false
-                ))
-                exists <- file.exists
-                _      <- dir.removeAll
-            yield
-                assertMissingParent(r, file)
-                assert(!exists)
-            end for
+            Path.run {
+                for
+                    dir <- Path.tempDir("kyo-jsonl-append-no-folders")
+                    file = dir / "nested" / "out.jsonl"
+                    r <- Abort.run[FileSystemException](Path.run(Jsonl.append(
+                        file,
+                        Stream.init(Chunk(Event("a", 1))),
+                        createFolders = false
+                    )))
+                    exists <- file.exists
+                    _      <- dir.removeAll
+                yield
+                    assertMissingParent(r, file)
+                    assert(!exists)
+                end for
+            }
         }
 
         "repeated appends build a log readable in one pass" in {
-            val rounds = 200
-            for
-                dir <- Path.tempDir("kyo-jsonl-append-rounds")
-                file = dir / "log.jsonl"
-                _   <- Kyo.foreachDiscard(Chunk.from(0 until rounds))(i => Jsonl.append(file, Stream.init(Chunk(Event("e", i)))))
-                got <- Scope.run(Jsonl.read[Event](file).run)
-                _   <- dir.removeAll
-            yield assert(got == Chunk.from((0 until rounds).map(i => Event("e", i))))
-            end for
+            Path.run {
+                val rounds = 200
+                for
+                    dir <- Path.tempDir("kyo-jsonl-append-rounds")
+                    file = dir / "log.jsonl"
+                    _   <- Kyo.foreachDiscard(Chunk.from(0 until rounds))(i => Jsonl.append(file, Stream.init(Chunk(Event("e", i)))))
+                    got <- Scope.run(Jsonl.read[Event](file).run)
+                    _   <- dir.removeAll
+                yield assert(got == Chunk.from((0 until rounds).map(i => Event("e", i))))
+                end for
+            }
         }
     }
 end JsonlTest

--- a/kyo-sql-mysql/README.md
+++ b/kyo-sql-mysql/README.md
@@ -374,11 +374,11 @@ about which engine, and a mismatched URL contradicts it rather than silently ret
 ### The upload and what it promises
 
 `loadLocalInfile` takes the statement and a `Stream[Byte, S]`, and answers with the affected-row count the server
-reports. The stream's own effects stay in the result's effect row, so a file-backed load carries what reading a file
-carries:
+reports. The stream's own effects stay in the result's effect row, so a file-backed load carries the read capability
+the file needs, which a `Path.runReadOnly` runner discharges into `Abort[FileSystemException]`:
 
 ```scala
-val fromFile: Long < (Async & Abort[SqlException | FileReadException] & Scope & DB) =
+val fromFile: Long < (Async & Abort[SqlException] & PathRead & Scope & DB) =
     MysqlClient.use { client =>
         client.loadLocalInfile(
             "LOAD DATA LOCAL INFILE 'readings.csv' INTO TABLE reading FIELDS TERMINATED BY ','",

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/LocalInfileIntegrationTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/LocalInfileIntegrationTest.scala
@@ -112,13 +112,15 @@ class LocalInfileIntegrationTest extends SqlContainerTest:
                 withLoadTable(client) { tbl =>
                     // Create a temp file with CSV data, use Path.readBytesStream to upload it.
                     Path.tempUnscoped(prefix = "kyo-infile", suffix = ".csv").flatMap { tmpPath =>
-                        Scope.ensure(Abort.run[FileStructureException](tmpPath.remove).unit).andThen {
+                        Scope.ensure(Abort.run[FileSystemException](Path.run(tmpPath.remove)).unit).andThen {
                             val csv = "1,alice\n2,bob\n3,carol\n"
-                            tmpPath.writeBytes(Span.from(csv.getBytes(java.nio.charset.StandardCharsets.UTF_8))).flatMap { _ =>
+                            Path.run(tmpPath.writeBytes(Span.from(csv.getBytes(java.nio.charset.StandardCharsets.UTF_8)))).flatMap { _ =>
                                 val sql =
                                     s"LOAD DATA LOCAL INFILE '${tmpPath.toString}' INTO TABLE $tbl FIELDS TERMINATED BY ',' LINES TERMINATED BY '\\n' (id, name)"
                                 Scope.run {
-                                    client.loadLocalInfile(sql, tmpPath.readBytesStream)
+                                    // The upload stream carries PathRead, discharged here so the read runs against
+                                    // the same host filesystem the temp file was written to.
+                                    Path.run(client.loadLocalInfile(sql, tmpPath.readBytesStream))
                                 }.flatMap { affected =>
                                     assert(affected == 3L, s"Expected 3 affected rows, got $affected")
                                     client.query(s"SELECT COUNT(*) FROM $tbl").flatMap { result =>

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/SqlConfigTlsModeIntegrationTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/SqlConfigTlsModeIntegrationTest.scala
@@ -297,8 +297,8 @@ class SqlConfigTlsModeIntegrationTest extends SqlContainerTest:
         withTlsContainer { ctx =>
             // Write a malformed PEM file to a temp path using kyo.Path (cross-platform).
             Path.tempUnscoped(prefix = "kyo-sql-bad-cert-", suffix = ".pem").flatMap { tempPath =>
-                tempPath.writeBytes(Span.from("NOT A VALID PEM CERTIFICATE".getBytes(StandardCharsets.UTF_8))).flatMap { _ =>
-                    Scope.ensure(Abort.run[FileSystemException](tempPath.remove).unit).andThen {
+                Path.run(tempPath.writeBytes(Span.from("NOT A VALID PEM CERTIFICATE".getBytes(StandardCharsets.UTF_8)))).flatMap { _ =>
+                    Scope.ensure(Abort.run[FileSystemException](Path.run(tempPath.remove)).unit).andThen {
                         val badPath = tempPath.toString
                         val url =
                             s"postgres://${ctx.user}:${ctx.password}@${ctx.host}:${ctx.port}/${ctx.db}?sslmode=verify-ca&sslrootcert=$badPath"

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainers.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainers.scala
@@ -188,7 +188,7 @@ private[kyo] object SqlTestContainers:
       */
     private[kyo] def claimOwnership(root: Path, id: Container.Id)(using Frame): Boolean < Async =
         // `mkFile` creates missing parents, so the per-container directory needs no separate step.
-        Abort.run[FileStructureException](Path(ownerDir(root, id), TestProcessId.pid.toString).mkFile).map(_.isSuccess)
+        Abort.run[FileSystemException](Path.run(Path(ownerDir(root, id), TestProcessId.pid.toString).mkFile)).map(_.isSuccess)
 
     /** Drop this process's co-ownership of `id`.
       *
@@ -197,20 +197,22 @@ private[kyo] object SqlTestContainers:
       * than raised: declining to reap costs one cycle, and the alternative would fail a leaf over registry hygiene.
       */
     private[kyo] def releaseOwnership(root: Path, id: Container.Id)(using Frame): Unit < Async =
-        Abort.run[FileStructureException](Path(ownerDir(root, id), TestProcessId.pid.toString).remove).unit
+        Abort.run[FileSystemException](Path.run(Path(ownerDir(root, id), TestProcessId.pid.toString).remove)).unit
 
     /** Whether any process that adopted `id` is still running. An unreadable registry reports true, which spares the container: the same
       * direction every other uncertainty in this object takes.
       */
     private[kyo] def hasLiveCoOwner(root: Path, id: Container.Id)(using Frame): Boolean < Async =
         val dir = ownerDir(root, id)
-        Abort.run[FileReadException](dir.exists).map {
+        Abort.run[FileSystemException](Path.runReadOnly(dir.exists)).map {
             case Result.Success(false) => false
             case Result.Success(true) =>
-                Abort.run[FileStructureException] {
-                    dir.list.map { entries =>
-                        Kyo.foreach(entries)(entry => TestProcessId.isAlive(entry.name.getOrElse("")))
-                            .map(_.exists(identity))
+                Abort.run[FileSystemException] {
+                    Path.runReadOnly {
+                        dir.list.map { entries =>
+                            Kyo.foreach(entries)(entry => TestProcessId.isAlive(entry.name.getOrElse("")))
+                                .map(_.exists(identity))
+                        }
                     }
                 }.map {
                     case Result.Success(live) => live
@@ -227,7 +229,7 @@ private[kyo] object SqlTestContainers:
       * directory and cannot change a reap decision.
       */
     private[kyo] def forgetOwners(root: Path, id: Container.Id)(using Frame): Unit < Async =
-        Abort.run[FileStructureException](ownerDir(root, id).removeAll).unit
+        Abort.run[FileSystemException](Path.run(ownerDir(root, id).removeAll)).unit
 
     /** Claim `id` for this process, reporting whether a reaper can now see the claim.
       *

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainersTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainersTest.scala
@@ -193,7 +193,7 @@ class SqlTestContainersTest extends kyo.Test:
             TestTempRoot.get.map {
                 case Present(tmp) =>
                     val root = Path(tmp, s"kyo-sql-owner-test-${(token & Long.MaxValue).toHexString}")
-                    Sync.ensure(Abort.run[FileStructureException](root.removeAll).unit)(f(root))
+                    Sync.ensure(Abort.run[FileSystemException](Path.run(root.removeAll)).unit)(f(root))
                 case Absent => fail("no temp root on this platform; the registry cannot be exercised")
             }
         }
@@ -228,7 +228,7 @@ class SqlTestContainersTest extends kyo.Test:
                 // under it, so the claim cannot land.
                 val blocker = Path(root, someId.value.take(12))
                 for
-                    _       <- blocker.mkFile
+                    _       <- Path.run(blocker.mkFile)
                     claimed <- SqlTestContainers.claimOwnership(root, someId)
                 yield assert(!claimed, "an unwritable registry must not report a recorded claim")
                 end for
@@ -241,7 +241,7 @@ class SqlTestContainersTest extends kyo.Test:
                 // anything: claim false AND hasLiveCoOwner false is exactly the combination adoption
                 // must refuse to walk into.
                 for
-                    _       <- root.mkFile
+                    _       <- Path.run(root.mkFile)
                     claimed <- SqlTestContainers.claimOwnership(root, someId)
                     live    <- SqlTestContainers.hasLiveCoOwner(root, someId)
                 yield
@@ -276,7 +276,7 @@ class SqlTestContainersTest extends kyo.Test:
                 // liveness probe answers "no such process" rather than "cannot tell".
                 val dead = Path(root, someId.value.take(12), "999999999")
                 for
-                    _    <- dead.mkFile
+                    _    <- Path.run(dead.mkFile)
                     live <- SqlTestContainers.hasLiveCoOwner(root, someId)
                 yield assert(!live, "a dead co-owner must not keep the container alive")
                 end for
@@ -286,7 +286,7 @@ class SqlTestContainersTest extends kyo.Test:
         "a live claim outweighs a dead one" in {
             withRegistry { root =>
                 for
-                    _    <- Path(root, someId.value.take(12), "999999999").mkFile
+                    _    <- Path.run(Path(root, someId.value.take(12), "999999999").mkFile)
                     _    <- SqlTestContainers.claimOwnership(root, someId)
                     live <- SqlTestContainers.hasLiveCoOwner(root, someId)
                 yield assert(live)

--- a/kyo-stats-machine/jvm/src/test/scala/kyo/stats/machine/MachineSamplerJvmTest.scala
+++ b/kyo-stats-machine/jvm/src/test/scala/kyo/stats/machine/MachineSamplerJvmTest.scala
@@ -138,7 +138,7 @@ class MachineSamplerJvmTest extends kyo.test.Test[Any]:
         // probe trial), and each call writes this fixture's memTotal into the retained LongGaugeCell;
         // against the shared scope that would poison "machine.memory.total" for every other suite's later
         // poll of the same well-known path (a real-host acceptance leaf among them).
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stats-machine-allocprobe-linux")
                 handles  = MachineHandles.initForTest(Stat.initScope("mstest-alloc-linux"), 8L)
@@ -162,7 +162,7 @@ class MachineSamplerJvmTest extends kyo.test.Test[Any]:
                 _ <- dir.removeAll
             yield ()
             end for
-        }
+        })
     }
 
     "the steady-state disk read on an unchanged mount table allocates exactly 0 bytes per op".onlyJvm in {
@@ -231,7 +231,7 @@ class MachineSamplerJvmTest extends kyo.test.Test[Any]:
                 0
             end statvfs
             def sysconf(name: Int)(using AllowUnsafe): Long = 100L
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stats-machine-allocprobe-disk-linux")
                 mountsFile = dir / "mounts"
@@ -253,7 +253,7 @@ class MachineSamplerJvmTest extends kyo.test.Test[Any]:
                 _ <- dir.removeAll
             yield ()
             end for
-        }
+        })
     }
 
     "the probe op is the reader's REAL decode+observe, not a degenerate callback, and an unsupported counter fails loud".onlyJvm in {
@@ -270,7 +270,7 @@ class MachineSamplerJvmTest extends kyo.test.Test[Any]:
         }
         assert(failure.diagram.contains("per-thread allocation measurement is unsupported"))
 
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stats-machine-allocprobe-substance")
                 baselineFile = dir / "stat-baseline"
@@ -298,7 +298,7 @@ class MachineSamplerJvmTest extends kyo.test.Test[Any]:
                 assert(summary.count == (warmupIters + probeTrials * measuredIters).toLong)
                 assert(summary.sum == 333.0)
             end for
-        }
+        })
     }
 
 end MachineSamplerJvmTest

--- a/kyo-stats-machine/shared/src/test/scala/kyo/stats/machine/MachineLinuxTest.scala
+++ b/kyo-stats-machine/shared/src/test/scala/kyo/stats/machine/MachineLinuxTest.scala
@@ -116,7 +116,7 @@ class MachineLinuxTest extends kyo.test.Test[Any]:
             // reads the SAME machine.cgroup.cpu.quota/cpu.period paths off a genuine live cgroup v2 hierarchy
             // (present on a real Linux CI runner). A uniquely-scoped MachineHandles keeps this fixture's
             // write and poll contained to a path no real reader ever touches.
-            Scope.run {
+            Scope.run(Path.run {
                 for
                     dir <- Path.tempDir("kyo-stats-machine-linux-cpumax")
                     handles = MachineHandles.initForTest(Stat.initScope("mlinuxtest-cpumax-decode"), 8L)
@@ -144,7 +144,7 @@ class MachineLinuxTest extends kyo.test.Test[Any]:
                     assert(quota == 50000000.0)
                     assert(period == 100000000.0)
                 end for
-            }
+            })
         }
     }
 
@@ -162,7 +162,7 @@ class MachineLinuxTest extends kyo.test.Test[Any]:
             // this module). A uniquely-scoped MachineHandles keeps the fixture write contained; the
             // decode's own parsing is verified directly against the same scan primitive and scale
             // LinuxDecoders.meminfo uses, decoupled from the gauge either way.
-            Scope.run {
+            Scope.run(Path.run {
                 for
                     dir <- Path.tempDir("kyo-stats-machine-linux-meminfo")
                     handles = MachineHandles.initForTest(Stat.initScope("mlinuxtest-meminfo-decode"), 8L)
@@ -188,7 +188,7 @@ class MachineLinuxTest extends kyo.test.Test[Any]:
                     assert(histogramSummary("mlinuxtest-meminfo-decode", "memory", "free").sum - memFreeSumBefore == 4194304.0)
                     assert(histogramSummary("mlinuxtest-meminfo-decode", "swap", "free").sum - swapFreeSumBefore == 1048576.0)
                 end for
-            }
+            })
         }
 
         "a meminfo line missing MemAvailable and missing the swap lines routes those cells to Absent, never a fabricated 0" in {
@@ -197,7 +197,7 @@ class MachineLinuxTest extends kyo.test.Test[Any]:
             // See the meminfo-decode leaf above: a uniquely-scoped MachineHandles keeps this fixture's
             // gauge writes from poisoning the shared "machine" scope's memTotal/swapTotal for a sibling
             // suite's later poll.
-            Scope.run {
+            Scope.run(Path.run {
                 for
                     dir <- Path.tempDir("kyo-stats-machine-linux-meminfo-missing")
                     handles = MachineHandles.initForTest(Stat.initScope("mlinuxtest-meminfo-missing"), 8L)
@@ -233,7 +233,7 @@ class MachineLinuxTest extends kyo.test.Test[Any]:
                         "total"
                     ) == swapTotalRegisteredBefore) // no new registration
                 end for
-            }
+            })
         }
     }
 

--- a/kyo-stats-machine/shared/src/test/scala/kyo/stats/machine/MachineSamplerTest.scala
+++ b/kyo-stats-machine/shared/src/test/scala/kyo/stats/machine/MachineSamplerTest.scala
@@ -19,7 +19,7 @@ class MachineSamplerTest extends kyo.test.Test[Any]:
             val decode = new MachineSampler.Decode:
                 def apply(bytes: Span[Byte], len: Int)(using AllowUnsafe): Unit =
                     discard(identities += java.lang.System.identityHashCode(this))
-            Scope.run {
+            Scope.run(Path.run {
                 for
                     handles <- MachineHandles.init
                     dir     <- Path.tempDir("kyo-stats-machine-sampler-identity")
@@ -36,7 +36,7 @@ class MachineSamplerTest extends kyo.test.Test[Any]:
                     assert(identities.size == 2)
                     assert(identities(0) == identities(1))
                 end for
-            }
+            })
         }
 
         "binds fill length before taking the span so a file larger than the initial 8192 buffer decodes in full" in {
@@ -47,7 +47,7 @@ class MachineSamplerTest extends kyo.test.Test[Any]:
                     decodedLen = len
                     decodedText = new String(bytes.toArrayUnsafe, 0, len, java.nio.charset.StandardCharsets.US_ASCII)
             val content = "0123456789" * 2000 // 20000 bytes, larger than the sampler's 8192-byte initial slot
-            Scope.run {
+            Scope.run(Path.run {
                 for
                     handles <- MachineHandles.init
                     dir     <- Path.tempDir("kyo-stats-machine-sampler-large")
@@ -62,7 +62,7 @@ class MachineSamplerTest extends kyo.test.Test[Any]:
                     assert(decodedLen == 20000)
                     assert(decodedText == content)
                 end for
-            }
+            })
         }
     }
 

--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -8,18 +8,18 @@ filesystem, process, and environment conventions specific to `kyo-system`.
 `kyo-system` is a four-platform cross-project for JVM, JavaScript, Native, and Wasm. Public
 filesystem behavior belongs in `shared`; platform leaves contain only host integration.
 
-The module owns these boundaries:
+The module owns these capability boundaries:
 
-| Surface | Safe API | Effect row |
+| Surface | Safe API | Capability or residual |
 |---|---|---|
-| Filesystem reads | `Path`, `FileSystem.Read` | `Sync`, `Abort[FileReadException]` |
-| Filesystem writes | `Path`, `FileSystem.Write` | `Sync`, `Abort[FileWriteException]`, `Abort[FileStructureException]` |
+| Filesystem reads | `Path`, `FileSystem.Read` | `PathRead` |
+| Filesystem writes | `Path`, `FileSystem.Write` | `PathWrite` |
 | Commands and processes | `Command`, `Process` | `Sync`, `Async`, `Scope` |
 | Environment | `System` | `Sync` |
 
-`FileSystem.Write[S] <: FileSystem.Read[S]`: write authority includes read authority, and a
-read-only backend intentionally cannot be passed where a write backend is required. Keep this
-negative authority law visible in return types and compile-time tests.
+`PathWrite <: PathRead`: write authority includes read authority.
+`Path.runReadOnly` intentionally cannot discharge a `PathWrite` operation. Keep this negative
+capability law visible in return types and compile-time tests.
 
 ### Source layout
 
@@ -48,24 +48,21 @@ The built-in factories are:
 |---|---|---|
 | `FileSystem.host` | write | Local host filesystem |
 
-A caller holds a backend as an ordinary value and calls its methods directly. Nothing routes
-`Path` through a backend yet: `Path`'s own methods go straight to `Path.Unsafe`, and `FileSystem`
-exists so a caller who wants a swappable filesystem has one contract to implement against. The
-conformance suites are the only consumers of the service in this module.
+`FileSystem.let(backend)(program)` changes the backend used by the default Path runners for a
+dynamic scope. Selection uses `Local`, propagates to child fibers, and restores the previous backend
+on exit. `Path.runWith` and `Path.runReadOnlyWith` select a backend explicitly for one runner.
 
 Never widen a read-only factory to `FileSystem.Write`. Authority is part of the public contract.
 
 ## Path operation flow
 
-1. A safe `Path` extension bridges the matching `Path.Unsafe` operation through `Sync.Unsafe.defer`.
-2. The unsafe tier returns a `Result` carrying a precise filesystem failure marker.
-3. `Abort.get` lifts that `Result` into the method's declared `Abort` row.
+1. A safe extension suspends a `Path.Op` under `PathRead` or `PathWrite`.
+2. `Path.run`, `Path.runReadOnly`, or an explicit-service runner dispatches the operation.
+3. A backend returns its own effect `S` plus a precise filesystem failure marker.
+4. Platform host code bridges a `Path.Unsafe` operation through `Sync.Unsafe.defer`.
 
-`FileSystem.host` follows the same three steps for every service method, so a host backend answers
-exactly what the matching `Path` method answers.
-
-Safe methods carry `Sync` plus a precise `Abort` row. Do not expose platform exceptions or widen an
-`Abort` row past what the unsafe tier can return.
+Safe Path methods carry capability effects. Backend methods carry backend effects and precise
+`Abort` rows. Do not expose platform exceptions or hide backend effects with casts.
 
 Every unsafe bridge must have a nearby `// Unsafe:` comment explaining the boundary. Unsafe methods
 return `Result`; safe backend methods lift those results into `Abort`.
@@ -81,9 +78,9 @@ passes `Origin.End` explicitly because the two are siblings over one polling loo
 the loop choose their own default. `Jsonl.watch` in `kyo-schema-json` defaults to `Origin.Start` so it
 replays existing records before emitting new ones.
 
-- `path.tail` and `path.tailBytes` carry `Async & Scope & Abort[FileReadException]`: `Abort` because
-  opening and measuring the handle can fail, `Async` because they sleep between polls, and `Scope`
-  because the handle closes when the enclosing scope exits.
+- `path.tail` and `path.tailBytes` carry `PathRead & Async & Scope`: `PathRead` because they open
+  their handle through the installed read service, exactly as every other read does, `Async` because
+  they sleep between polls, and `Scope` because the handle closes when the enclosing scope exits.
 - Both drive one `private[kyo] watch` loop, which owns the open handle, polling, and truncation
   rewind. `tail` threads UTF-8 and line-buffer state through that loop.
 - A `watch` step returns `Path.Step`: `Continue(values, state)` reads again, while `Stop(values)`
@@ -122,7 +119,7 @@ throwables into expected filesystem failures.
 
 1. Decide whether the operation needs read or write authority.
 2. Add a focused shared test that proves behavior and its precise failure case.
-3. Add the safe `Path` surface bridging the unsafe tier, when the operation belongs on `Path`.
+3. Add the safe Path surface and reified operation when it is a Path capability operation.
 4. Add the narrowest `FileSystem` tier method and precise effect row.
 5. Implement both platform leaves for host behavior.
 6. Add the safe-to-unsafe bridge with its `// Unsafe:` explanation.
@@ -141,7 +138,7 @@ Use the reusable suites for backend laws:
 - `FileSystemReadTestSuite`
 - `FileSystemWriteTestSuite`
 
-Test effect rows and backend authority with `typeCheck` and `typeCheckErrors`. Never use sleeps or blocking primitives
+Test capability rows with `typeCheck` and `typeCheckErrors`. Never use sleeps or blocking primitives
 to make scheduling tests pass.
 
 Before submission, run the affected module tests on all four platforms and the module doctest. Read

--- a/kyo-system/README.md
+++ b/kyo-system/README.md
@@ -1,49 +1,43 @@
 # kyo-system
 
-`kyo-system` is the file I/O, process execution, and environment layer for Kyo. File operations are tracked in the type system: reads carry `Abort[FileReadException]`, writes carry `Abort[FileWriteException]`, and structure changes carry `Abort[FileStructureException]`. Process launches carry `Abort[CommandException]`, and handles are `Scope`-managed for automatic cleanup. The same API compiles across JVM, Scala Native, and JavaScript (Node.js).
+`kyo-system` is the file I/O, process execution, and environment layer for Kyo. File operations are tracked through the `PathRead` and `PathWrite` capabilities: reads and writes suspend under these effects and are discharged by a runner (`Path.run`, `Path.runReadOnly`, or their `runWith` variants), which folds the per-operation `Abort[File*Exception]` markers into the umbrella `Abort[FileSystemException]`. Process launches carry `Abort[CommandException]`, and handles are `Scope`-managed for automatic cleanup. The same API compiles across JVM, Scala Native, and JavaScript (Node.js).
 
-The following example reads a configuration file, fetches a git revision, runs a build step, and writes an artifact record:
+The following example reads a configuration file, fetches a git revision, runs a build step, and writes an artifact record. Every filesystem op runs inside `Path.run`, which installs the default host service and discharges both capabilities:
 
 ```scala
 import kyo.*
 
 val deploy =
-    for
-        config  <- (Path / "etc" / "deploy.toml").read
-        version <- Command("git", "rev-parse", "--short", "HEAD").text
-        _       <- Command("sbt", "assembly").cwd(Path("backend")).waitForSuccess
-        _       <- (Path("dist") / "version.txt").write(version)
-    yield ()
+    Path.run {
+        for
+            config  <- (Path / "etc" / "deploy.toml").read
+            version <- Command("git", "rev-parse", "--short", "HEAD").text
+            _       <- Command("sbt", "assembly").cwd(Path("backend")).waitForSuccess
+            _       <- (Path("dist") / "version.txt").write(version)
+        yield ()
+    }
 ```
 
-## Filesystem failures in the type system
+## Path capabilities
 
-Each `Path` method carries the failure category it can actually raise. There is no umbrella row to discharge and no runner to install:
+Filesystem I/O is capability-tracked, not method-tracked. A program that only reads carries `< PathRead` in its row; a program that writes carries `< PathWrite` (which also satisfies reads). `Sync`, `Scope`, and the `Abort[FileSystemException]` umbrella appear on the runner residual after discharge, not on individual extension methods.
 
-| Operation group | Methods | Effect row |
+| Runner | Discharges | Residual (host service) |
 |---|---|---|
-| Inspection and reads | `exists`, `isDirectory`, `read`, `readBytes`, `readLines`, `size`, `stat`, `realPath`, the read streams | `Sync & Abort[FileReadException]` |
-| Writes | `write`, `writeBytes`, `writeLines`, `append`, `truncate`, `setLastModified` | `Sync & Abort[FileWriteException]` |
-| Structure changes | `mkDir`, `mkFile`, `list`, `walk`, `move`, `copy`, `remove`, `removeAll`, `temp`, `tempDir` | `Sync & Abort[FileStructureException]` |
+| `Path.run(program)` | `PathWrite` (and `PathRead` via subtyping) | `Sync & Abort[FileSystemException] & S` |
+| `Path.runReadOnly(program)` | `PathRead` only | `Sync & Abort[FileSystemException] & S` |
+| `Path.runWith(service)(program)` | `PathWrite` against a custom service | `S & Abort[FileSystemException] & S2` |
+| `Path.runReadOnlyWith(service)(program)` | `PathRead` against a custom service | `S & Abort[FileSystemException] & S2` |
 
-`isDirectory`, `isRegularFile`, and `isSymbolicLink` answer `false` for an inaccessible path and carry only `Sync`.
+`PathWrite <: PathRead`: a write-capable context also satisfies read operations, and `Path.runReadOnly` rejects write programs at the call site (the negative capability law).
 
-### The `FileSystem` service
+`Path.run` and `Path.runReadOnly` use the backend selected by `FileSystem.let`. The default is the
+local host backend. Selection is dynamically scoped, inherited by child fibers, and restored when
+the block exits.
 
-`FileSystem.Read[S]` describes inspection and content reads; `FileSystem.Write[S]` extends it with mutation and structure changes. `FileSystem.host` implements the write tier over the platform backends this module already uses, so a host service answers exactly what the matching `Path` method answers.
-
-A caller holds a backend as a value and calls its methods directly:
-
-```scala
-import kyo.*
-
-val backend: FileSystem.Write[Sync] = FileSystem.host
-
-val listed: Chunk[Path] < (Sync & Abort[FileReadException | FileStructureException]) =
-    backend.list(Path("var", "uploads"))
-```
-
-`Path` does not route through a backend: its methods go straight to the platform implementation. The service exists so a caller who needs a swappable filesystem has one contract to implement against, and so its behavior is pinned by the conformance suites before anything depends on it.
+Backends advertise the authority they actually provide. `FileSystem.Read[S]` can be passed only to
+`Path.runReadOnlyWith`; `FileSystem.Write[S]` supports both runners. This distinction prevents a
+caller from accidentally gaining mutation authority through a read-only service.
 
 Portable matching uses a compiled `Glob`, never a platform-specific string matcher:
 
@@ -51,12 +45,14 @@ Portable matching uses a compiled `Glob`, never a platform-specific string match
 import kyo.*
 
 val scalaFiles =
-    Path("src").walk(glob"**/*.scala", Glob.CaseSensitivity.Sensitive).run
+    Path.runReadOnly {
+        Path("src").walk(glob"**/*.scala", Glob.CaseSensitivity.Sensitive).run
+    }
 ```
 
 ## File paths
 
-Before reading or writing, you need a path value that identifies the target without touching the disk. `Path` is an immutable value built with the `/` operator or the `apply` factory; pure accessors like `parts` and `parent` require no effects.
+Before reading or writing, you need a path value that identifies the target without touching the disk. `Path` is an immutable value built with the `/` operator or the `apply` factory; pure accessors like `parts` and `parent` require no capability.
 
 The segment type `Part` accepts either a `String` or another `Path`; splicing a `Path` value expands its components inline:
 
@@ -70,17 +66,17 @@ val data: Path   = Path("var", "data", "myapp")
 val base: Path   = Path("home") / "user"
 val nested: Path = base / Path("projects", "kyo")
 
-// Pure accessors require no effects
+// Pure accessors require no Path capability
 val parts: Chunk[String] = config.parts
 ```
 
-Reading a file yields its content with the read failure category on the row:
+Filesystem reads and writes require a runner. Wrap read-only programs in `Path.runReadOnly` and read-write programs in `Path.run`:
 
 ```scala
 import kyo.*
 
-val text: String < (Sync & Abort[FileReadException]) =
-    (Path / "etc" / "app.toml").read
+val text: String < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly((Path / "etc" / "app.toml").read)
 ```
 
 `Path.fileSeparator` is the segment separator (`"/"` or `"\\"`) and `Path.pathSeparator` is the classpath-style delimiter (`":"` or `";"`) for the current OS.
@@ -103,24 +99,28 @@ import kyo.*
 val src: Path = Path("home") / "user" / "project" / "src"
 
 // Walk toward the root; return the first ancestor that contains build.sbt
-val projectRoot: Maybe[Path] < (Sync & Abort[FileReadException]) =
-    src.ancestors.find(ancestor => (ancestor / "build.sbt").exists)
+val projectRoot: Maybe[Path] < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly {
+        src.ancestors.find(ancestor => (ancestor / "build.sbt").exists)
+    }
 ```
 
 ### Inspecting files
 
-Before opening a file for read or write, check whether the path exists and what kind of entry it is. `isDirectory`, `isRegularFile`, and `isSymbolicLink` answer `false` for an inaccessible path rather than failing, so they carry only `Sync`. `exists` answers `false` for an absent path and fails only when the filesystem refuses the question:
+Before opening a file for read or write, check whether the path exists and what kind of entry it is. `exists`, `isDirectory`, `isRegularFile`, and `isSymbolicLink` suspend under `PathRead`. An inaccessible path produces `false` rather than failing, so a missing config file and a permission-denied path both return `false` instead of aborting. Run them inside `Path.runReadOnly`:
 
 ```scala
 import kyo.*
 
 val path: Path = Path / "dist" / "release" / "artifact.jar"
 
-val checks: (Boolean, Boolean) < (Sync & Abort[FileReadException]) =
-    for
-        e <- path.exists
-        f <- path.isRegularFile
-    yield (e, f)
+val checks: (Boolean, Boolean) < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly {
+        for
+            e <- path.exists
+            f <- path.isRegularFile
+        yield (e, f)
+    }
 ```
 
 `exists(followLinks: Boolean)` controls symlink traversal. All four methods return `false` on any permission or access failure.
@@ -130,25 +130,27 @@ val checks: (Boolean, Boolean) < (Sync & Abort[FileReadException]) =
 ```scala
 import kyo.*
 
-val canonical: Path < (Sync & Abort[FileReadException]) =
-    (Path / "var" / "run" / "app.sock").realPath
+val canonical: Path < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly {
+        (Path / "var" / "run" / "app.sock").realPath
+    }
 ```
 
 ## Reading files
 
-Once you know where a file lives, bulk reads and streams pull its contents. Each carries `Sync & Abort[FileReadException]`:
+Once you know where a file lives, bulk reads and streams pull its contents under `PathRead`. After `Path.runReadOnly`, the residual is `Sync & Abort[FileSystemException]`:
 
 ```scala
 import kyo.*
 
 val path: Path = Path / "etc" / "app" / "config.toml"
 
-val text: String < (Sync & Abort[FileReadException]) =
-    path.read
-val bytes: Span[Byte] < (Sync & Abort[FileReadException]) =
-    path.readBytes
-val lines: Chunk[String] < (Sync & Abort[FileReadException]) =
-    path.readLines
+val text: String < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly(path.read)
+val bytes: Span[Byte] < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly(path.readBytes)
+val lines: Chunk[String] < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly(path.readLines)
 ```
 
 All three accept an optional `java.nio.charset.Charset`; the default is UTF-8.
@@ -158,11 +160,11 @@ All three accept an optional `java.nio.charset.Charset`; the default is UTF-8.
 ```scala
 import kyo.*
 
-val info: Path.PathStat < (Sync & Abort[FileReadException]) =
-    (Path / "var" / "data" / "records.db").stat
+val info: Path.PathStat < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly((Path / "var" / "data" / "records.db").stat)
 
-val sz: Long < (Sync & Abort[FileReadException]) =
-    (Path / "var" / "data" / "records.db").size
+val sz: Long < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly((Path / "var" / "data" / "records.db").size)
 ```
 
 Streaming reads keep only a buffer in memory at a time. The OS handle is opened when the stream starts and released when the enclosing `Scope` closes, whether by normal completion, error, or cancellation. All streaming read methods carry `Scope` in the stream's effect row:
@@ -170,10 +172,12 @@ Streaming reads keep only a buffer in memory at a time. The OS handle is opened 
 ```scala
 import kyo.*
 
-val processed: Unit < (Sync & Scope & Abort[FileReadException]) =
-    Path("var", "log", "events.ndjson")
-        .readLinesStream
-        .foreach(line => Sync.defer(println(line)))
+val processed: Unit < (Sync & Scope & Abort[FileSystemException]) =
+    Path.runReadOnly {
+        Path("var", "log", "events.ndjson")
+            .readLinesStream
+            .foreach(line => Sync.defer(println(line)))
+    }
 ```
 
 `readStream(charset, bufferSize)` and `readBytesStream(bufferSize)` expose the buffer-size parameter for tuning. `walk` is a Scope-managed stream of directory entries (covered under Directory operations).
@@ -183,11 +187,13 @@ val processed: Unit < (Sync & Scope & Abort[FileReadException]) =
 ```scala
 import kyo.*
 
-val errors: Unit < (Async & Scope & Sync & Abort[FileReadException]) =
-    Path("var", "app.log")
-        .tail(500.millis)
-        .filter(_.contains("ERROR"))
-        .foreach(line => Sync.defer(println(line)))
+val errors: Unit < (Async & Scope & Sync & Abort[FileSystemException]) =
+    Path.runReadOnly {
+        Path("var", "app.log")
+            .tail(500.millis)
+            .filter(_.contains("ERROR"))
+            .foreach(line => Sync.defer(println(line)))
+    }
 ```
 
 For typed JSONL/NDJSON decoding, including per-record error recovery and watch mode, use `Jsonl` from [kyo-schema-json](../kyo-schema-json/README.md).
@@ -199,13 +205,13 @@ import kyo.*
 
 val path = Path("var", "log", "events.ndjson")
 
-val fromStart: Stream[Byte, Async & Scope & Abort[FileReadException]] =
+val fromStart: Stream[Byte, PathRead & Async & Scope] =
     path.tailBytes(Path.Origin.Start)
 
-val fromEnd: Stream[Byte, Async & Scope & Abort[FileReadException]] =
+val fromEnd: Stream[Byte, PathRead & Async & Scope] =
     path.tailBytes()
 
-val fromOffset: Stream[Byte, Async & Scope & Abort[FileReadException]] =
+val fromOffset: Stream[Byte, PathRead & Async & Scope] =
     path.tailBytes(Path.Origin.Offset(4096))
 ```
 
@@ -219,50 +225,52 @@ Following tracks the open file, not the path name. Rename-based rotation keeps r
 
 ## Writing files
 
-Write methods carry `Sync & Abort[FileWriteException]` and create parent directories by default. Pass `Path.WriteOptions(createFolders = false)` to fail when the parent is absent:
+Persisting output or mutating the tree requires `PathWrite`. Run write methods inside `Path.run`. Write methods create parent directories by default (`createFolders = true`). Pass `createFolders = false` to fail when the parent is absent:
 
 ```scala
 import kyo.*
 
 val out: Path = Path("dist") / "build" / "version.txt"
 
-val w: Unit < (Sync & Abort[FileWriteException]) =
-    out.write("1.0.0")
-val a: Unit < (Sync & Abort[FileWriteException]) =
-    out.append("\nbuilt by CI\n")
+val w: Unit < (Sync & Abort[FileSystemException]) =
+    Path.run(out.write("1.0.0"))
+val a: Unit < (Sync & Abort[FileSystemException]) =
+    Path.run(out.append("\nbuilt by CI\n"))
 val data: Span[Byte] = Span.from(Array[Byte](0x50.toByte, 0x4b.toByte))
-val wb: Unit < (Sync & Abort[FileWriteException]) =
-    out.writeBytes(data)
+val wb: Unit < (Sync & Abort[FileSystemException]) =
+    Path.run(out.writeBytes(data))
 ```
 
 `writeLines` and `appendLines` follow each line with the platform line separator including the last line. Use `write(lines.mkString(sep))` to control the trailing newline yourself. `truncate(size)` shrinks or pads a file to exactly `size` bytes. `setLastModified(epochMs)` sets the last-modified timestamp.
 
-`Stream[Byte, S].writeTo(path)`, `Stream[String, S].writeTo(path, charset)`, and `Stream[String, S].writeLinesTo(path, charset)` are stream sinks that acquire a write handle in a `Scope`. If the stream fails, the partially written file is deleted before the error is re-raised:
+`Stream[Byte, S].writeTo(path)`, `Stream[String, S].writeTo(path, charset)`, and `Stream[String, S].writeLinesTo(path, charset)` are stream sinks that acquire a write handle in a `Scope`. The sinks carry `PathWrite` in their row. If the stream fails, the partially written file is deleted before the error is re-raised:
 
 ```scala
 import kyo.*
 
-val sink: Unit < (Async & Scope & Sync & Abort[FileReadException | FileWriteException]) =
-    Path("var", "app.log")
-        .tail
-        .filter(_.contains("ERROR"))
-        .writeLinesTo(Path("var", "errors.log"))
+val sink: Unit < (Async & Scope & Sync & Abort[FileSystemException]) =
+    Path.run {
+        Path("var", "app.log")
+            .tail
+            .filter(_.contains("ERROR"))
+            .writeLinesTo(Path("var", "errors.log"))
+    }
 ```
 
 ### Directory operations
 
-Creating directories, listing children, and moving or deleting entries carry `Sync & Abort[FileStructureException]`. `mkDir` creates a directory and all missing parents. `mkFile` creates an empty file with missing parents. `list` returns direct children; `list(glob)` filters by a glob pattern supporting `*`, `**`, `?`, `[...]`, and `{a,b}` alternation. `walk` returns a Scope-managed stream of all entries in the tree:
+Creating directories, listing children, and moving or deleting entries are write-side mutations that belong with the other `PathWrite` operations. `mkDir` creates a directory and all missing parents. `mkFile` creates an empty file with missing parents. `list` returns direct children; `list(glob)` filters by a glob pattern supporting `*`, `**`, `?`, `[...]`, and `{a,b}` alternation. `walk` returns a Scope-managed stream of all entries in the tree:
 
 ```scala
 import kyo.*
 
 val dir: Path = Path("var", "uploads")
 
-val mk: Unit < (Sync & Abort[FileStructureException]) =
-    dir.mkDir
-val all: Chunk[Path] < (Sync & Abort[FileStructureException]) =
-    dir.list
-val tree: Stream[Path, Sync & Scope & Abort[FileStructureException]] =
+val mk: Unit < (Sync & Abort[FileSystemException]) =
+    Path.run(dir.mkDir)
+val all: Chunk[Path] < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly(dir.list)
+val tree: Stream[Path, PathRead & Scope & Sync] =
     dir.walk
 ```
 
@@ -274,10 +282,10 @@ import kyo.*
 val src: Path = Path("tmp") / "build-output"
 val dst: Path = Path("dist") / "release"
 
-val moved: Unit < (Sync & Abort[FileStructureException]) =
-    src.move(dst)
-val deleted: Boolean < (Sync & Abort[FileStructureException]) =
-    src.remove
+val moved: Unit < (Sync & Abort[FileSystemException]) =
+    Path.run(src.move(dst))
+val deleted: Boolean < (Sync & Abort[FileSystemException]) =
+    Path.run(src.remove)
 ```
 
 ## Error handling
@@ -290,15 +298,17 @@ val deleted: Boolean < (Sync & Abort[FileStructureException]) =
 | `FileWriteException` | Content mutation and synchronization |
 | `FileStructureException` | Creation, removal, copying, and movement |
 
-Each concrete exception implements only the marker traits that apply to it, so a read recovers against `FileReadException` and never sees a structure failure:
+Each concrete exception implements only the marker traits that apply to it. After `Path.runReadOnly`, the runner folds the markers into `Abort[FileSystemException]`:
 
 ```scala
 import kyo.*
 
-val content: String < (Sync & Abort[FileReadException]) =
-    Abort.recover[FileNotFoundException] { _ =>
-        "# default config\n"
-    }(Path("etc", "app.toml").read)
+val content: String < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly {
+        Abort.recover[FileNotFoundException] { _ =>
+            "# default config\n"
+        }(Path("etc", "app.toml").read)
+    }
 ```
 
 To materialize the error as a `Result` and decide what to do at the call site:
@@ -308,7 +318,7 @@ import kyo.*
 
 val result: Result[FileSystemException, String] < Sync =
     Abort.run[FileSystemException] {
-        Path("etc", "app.toml").read
+        Path.runReadOnly(Path("etc", "app.toml").read)
     }
 ```
 
@@ -324,8 +334,8 @@ val result: Result[FileSystemException, String] < Sync =
 ```scala
 import kyo.*
 
-val cwd: Path < Sync =
-    Path.cwd
+val cwd: Path < (Sync & Abort[FileSystemException]) =
+    Path.runReadOnly(Path.cwd)
 ```
 
 `Path.basePaths` and `Path.userPaths` are lazy vals that provide OS-appropriate paths without requiring an application identity. On Linux they follow the XDG Base Directory Specification; on macOS they use the `Library` hierarchy; on Windows they use `APPDATA` and `LOCALAPPDATA`:
@@ -362,22 +372,33 @@ val appData: Path   = proj.data
 
 `ProjectPaths` fields: `path`, `cache`, `config`, `data`, `dataLocal`, `preference`, `runtime`.
 
-`Path.temp(prefix, suffix)` creates a file and `Path.tempDir(prefix)` creates a directory. Both register removal for
-when the enclosing `Scope` closes, so the effect row carries `Scope`:
+`Path.temp(prefix, suffix)` creates a temporary file and `Path.tempDir(prefix)` creates a temporary directory. Both are
+created on whichever filesystem the runner installed, so both carry `PathWrite`, and both register removal for when the
+enclosing `Scope` closes, so both carry `Scope`. The removal runs through the service that created the entry, which is
+what keeps a temp path made by one backend from being deleted by another:
 
 ```scala
 import kyo.*
 
-val tmpFile: Path < (Sync & Scope & Abort[FileStructureException]) =
-    Path.temp("kyo-build-", ".json")
+val tmpFile: Path < (Sync & Scope & Abort[FileSystemException]) =
+    Path.run {
+        Path.temp("kyo-build-", ".json")
+    }
 
-val tmpDir: Path < (Sync & Scope & Abort[FileStructureException]) =
-    Path.tempDir("kyo-build-")
+val tmpDir: Path < (Sync & Scope & Abort[FileSystemException]) =
+    Path.run {
+        Path.tempDir("kyo-build-")
+    }
 ```
 
+Where the entry lands is the service's choice. The host backend uses the OS temporary directory; a confined or
+in-memory backend puts it wherever that backend keeps its entries.
+
 When the file or directory must outlive the scope that creates it, `Path.tempUnscoped` and `Path.tempDirUnscoped`
-skip the registration and hand removal to the caller. Reach for them only when something else owns the lifetime, such
-as a directory passed to a container or a background process that outlives the request:
+skip the registration and hand removal to the caller. These two are host primitives rather than service calls, because
+an entry whose lifetime the caller owns has no scope for a service-vended handle to hang from. Reach for them only when
+something else owns the lifetime, such as a directory passed to a container or a background process that outlives the
+request:
 
 ```scala
 import kyo.*

--- a/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -838,19 +838,6 @@ abstract private[kyo] class PathPlatformSpecific extends PathDirectories:
             }
         }
 
-    /** Creates a temporary file and registers it for deletion when the enclosing Scope closes.
-      *
-      * @param prefix
-      *   prefix for the temp file name (default `"kyo"`)
-      * @param suffix
-      *   suffix for the temp file name (default `".tmp"`)
-      */
-    override def temp(
-        prefix: String = "kyo",
-        suffix: String = ".tmp"
-    )(using Frame): Path < (Sync & Scope & Abort[FileStructureException]) =
-        super.temp(prefix, suffix)
-
     /** Generates a random identifier using the Node.js crypto module (avoids java.security.SecureRandom). */
     private def randomId(): String =
         NodeCrypto.randomBytes(16).applyDynamic("toString")("hex").asInstanceOf[String]

--- a/kyo-system/js/src/test/scala/kyo/PathNodeTest.scala
+++ b/kyo-system/js/src/test/scala/kyo/PathNodeTest.scala
@@ -5,7 +5,7 @@ import kyo.internal.NodeFs
 class PathNodeTest extends kyo.test.Test[Any]:
 
     "Node copy honors followLinks for symbolic links" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-node-copy-links")
                 source   = dir / "source.txt"
@@ -23,7 +23,7 @@ class PathNodeTest extends kyo.test.Test[Any]:
                 assert(noFollowIsLink)
                 assert(!followIsLink)
                 assert(followedValue == "content")
-        }
+        })
     }
 
     "Node setLastModified round-trips a millisecond exactly" in {
@@ -32,7 +32,7 @@ class PathNodeTest extends kyo.test.Test[Any]:
         // filesystem is already wrong: 987654 ms becomes 987.6539999999999850 s, and reading it back
         // gives 987653. Every value below round-trips exactly in whole seconds, so the failure is the
         // conversion rather than the filesystem's resolution.
-        Scope.run {
+        Scope.run(Path.run {
             val values = Chunk(987654L, 1234567L, 1_000_000_000_123L)
             Path.tempDir("kyo-node-mtime").map { dir =>
                 Kyo.foreach(values.zipWithIndex) { (target, i) =>
@@ -44,11 +44,11 @@ class PathNodeTest extends kyo.test.Test[Any]:
                     }
                 }.unit
             }
-        }
+        })
     }
 
     "Node copyAttributes controls copied modification time" in {
-        Scope.run {
+        Scope.run(Path.run {
             val sourceMtime = 1234567L
             for
                 dir <- Path.tempDir("kyo-node-copy-stat")
@@ -67,20 +67,20 @@ class PathNodeTest extends kyo.test.Test[Any]:
                 assert(freshStat.lastModifiedMs != sourceMtime)
                 assert(preservedStat.lastModifiedMs == sourceMtime)
             end for
-        }
+        })
     }
 
     "Node directory copy enforces replacement policy for an existing target" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-node-copy-directory")
                 source = dir / "source"
                 target = dir / "target"
                 _     <- source.mkDir
                 _     <- target.mkDir
-                never <- Abort.run[FileSystemException](source.copy(target, Path.CopyOptions(replace = Path.Replace.Never)))
+                never <- Abort.run[FileSystemException](Path.run(source.copy(target, Path.CopyOptions(replace = Path.Replace.Never))))
                 _     <- source.copy(target, Path.CopyOptions(replace = Path.Replace.Existing))
             yield assert(never.failure.exists(_.isInstanceOf[FileAlreadyExistsException]))
-        }
+        })
     }
 end PathNodeTest

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -613,19 +613,6 @@ abstract private[kyo] class PathPlatformSpecific extends PathDirectories:
             )
         )
 
-    /** Creates a temporary file and registers it for deletion when the enclosing Scope closes.
-      *
-      * @param prefix
-      *   prefix for the temp file name (default `"kyo"`)
-      * @param suffix
-      *   suffix for the temp file name (default `".tmp"`)
-      */
-    override def temp(
-        prefix: String = "kyo",
-        suffix: String = ".tmp"
-    )(using Frame): Path < (Sync & Scope & Abort[FileStructureException]) =
-        super.temp(prefix, suffix)
-
     private[kyo] def make(parts: Chunk[String]): Path =
         val isAbsolute = parts.headOption.contains("")
         val nonEmpty   = parts.filter(_.nonEmpty)

--- a/kyo-system/jvm/src/test/scala/kyo/PathJvmTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/PathJvmTest.scala
@@ -48,11 +48,13 @@ class PathJvmTest extends kyo.test.Test[Any]:
         JFiles.createFile(target)
         JFiles.createSymbolicLink(link, target)
         val p = Path(link.toString)
-        for
-            result <- p.isSymbolicLink
-            _      <- (Path(tmp.toString)).removeAll
-        yield assert(result)
-        end for
+        Path.run {
+            for
+                result <- p.isSymbolicLink
+                _      <- (Path(tmp.toString)).removeAll
+            yield assert(result)
+            end for
+        }
     }
 
     "realPath follows a symbolic link to its underlying target" in {
@@ -62,11 +64,13 @@ class PathJvmTest extends kyo.test.Test[Any]:
         JFiles.createFile(target)
         JFiles.createSymbolicLink(link, target)
         val linkPath = Path(link.toString)
-        for
-            real <- linkPath.realPath
-            _    <- Path(tmp.toString).removeAll
-        yield assert(real.parts.lastOption.contains("target.txt"))
-        end for
+        Path.run {
+            for
+                real <- linkPath.realPath
+                _    <- Path(tmp.toString).removeAll
+            yield assert(real.parts.lastOption.contains("target.txt"))
+            end for
+        }
     }
 
     "confinedTo rejects a symlink inside root that escapes to outside root" in {
@@ -83,8 +87,8 @@ class PathJvmTest extends kyo.test.Test[Any]:
         val rootP   = Path(root.toString)
         val escapeP = Path(escape.toString)
         for
-            res <- Abort.run[FileReadException](escapeP.confinedTo(rootP))
-            _   <- Path(tmp.toString).removeAll
+            res <- Abort.run[FileSystemException](Path.runReadOnly(escapeP.confinedTo(rootP)))
+            _   <- Path.run(Path(tmp.toString).removeAll)
         yield
             assert(res.isFailure)
             assert(res.failure.exists(_.isInstanceOf[FileAccessDeniedException]))
@@ -97,12 +101,14 @@ class PathJvmTest extends kyo.test.Test[Any]:
         val link   = tmp.resolve("dangling-link.txt")
         JFiles.createSymbolicLink(link, target)
         val p = Path(link.toString)
-        for
-            existsNoFollow <- p.exists(followLinks = false)
-            existsFollow   <- p.exists(followLinks = true)
-            _              <- Path(tmp.toString).removeAll
-        yield assert(existsNoFollow && !existsFollow)
-        end for
+        Path.run {
+            for
+                existsNoFollow <- p.exists(followLinks = false)
+                existsFollow   <- p.exists(followLinks = true)
+                _              <- Path(tmp.toString).removeAll
+            yield assert(existsNoFollow && !existsFollow)
+            end for
+        }
     }
 
     "walk with followLinks=false does not follow symlinks" in {
@@ -114,9 +120,9 @@ class PathJvmTest extends kyo.test.Test[Any]:
         JFiles.createSymbolicLink(link, target)
         val dir = Path(tmp.toString)
         for
-            paths <- Scope.run(dir.walk(followLinks = false).run)
-            _     <- Path(tmp.toString).removeAll
-            _     <- Path(target.toString).removeAll
+            paths <- Scope.run(Path.runReadOnly(dir.walk(followLinks = false).run))
+            _     <- Path.run(Path(tmp.toString).removeAll)
+            _     <- Path.run(Path(target.toString).removeAll)
         yield
             val names = paths.toList.map(_.parts.last)
             assert(names.contains("link-to-target") && !names.contains("inner.txt"))
@@ -129,8 +135,8 @@ class PathJvmTest extends kyo.test.Test[Any]:
         val linkPath = tmp.resolve("cycle-link")
         JFiles.createSymbolicLink(linkPath, tmp)
         for
-            result <- Abort.run[FileSystemException](Scope.run(dir.walk(followLinks = false).run))
-            _      <- dir.removeAll
+            result <- Abort.run[FileSystemException](Scope.run(Path.runReadOnly(dir.walk(followLinks = false).run)))
+            _      <- Path.run(dir.removeAll)
         yield result match
             case Result.Success(paths) =>
                 val names = paths.toList.map(_.parts.last)
@@ -149,9 +155,9 @@ class PathJvmTest extends kyo.test.Test[Any]:
         JFiles.createSymbolicLink(link, dirA)
         val walkRoot = Path(dirB.toString)
         for
-            paths <- Scope.run(walkRoot.walk(maxDepth = Int.MaxValue, followLinks = true).run)
-            _     <- Path(dirA.toString).removeAll
-            _     <- Path(dirB.toString).removeAll
+            paths <- Scope.run(Path.runReadOnly(walkRoot.walk(maxDepth = Int.MaxValue, followLinks = true).run))
+            _     <- Path.run(Path(dirA.toString).removeAll)
+            _     <- Path.run(Path(dirB.toString).removeAll)
         yield
             val names = paths.toList.map(_.parts.last)
             assert(names.contains("inner.txt"))
@@ -166,12 +172,14 @@ class PathJvmTest extends kyo.test.Test[Any]:
         JFiles.createSymbolicLink(link, target)
         val src = Path(link.toString)
         val dst = Path(tmp.resolve("copy-of-link.txt").toString)
-        for
-            _              <- src.copy(dst, Path.CopyOptions(followLinks = false))
-            isSymbolicLink <- dst.isSymbolicLink
-            _              <- Path(tmp.toString).removeAll
-        yield assert(isSymbolicLink)
-        end for
+        Path.run {
+            for
+                _              <- src.copy(dst, Path.CopyOptions(followLinks = false))
+                isSymbolicLink <- dst.isSymbolicLink
+                _              <- Path(tmp.toString).removeAll
+            yield assert(isSymbolicLink)
+            end for
+        }
     }
 
     // =========================================================================
@@ -185,7 +193,7 @@ class PathJvmTest extends kyo.test.Test[Any]:
 
     "steady-state retained-handle read allocates zero bytes per op".onlyJvm in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-alloc-steady")
                 file    = dir / "steady.txt"
@@ -223,12 +231,12 @@ class PathJvmTest extends kyo.test.Test[Any]:
                 finally handle.close()
                 end try
             end for
-        }
+        })
     }
 
     "grow-to-fit read: a file larger than the initial buffer allocates only the one grow, then 0 per read".onlyJvm in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-alloc-grow")
                 file = dir / "grow.txt"
@@ -284,7 +292,7 @@ class PathJvmTest extends kyo.test.Test[Any]:
                 finally handle.close()
                 end try
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -296,7 +304,7 @@ class PathJvmTest extends kyo.test.Test[Any]:
 
     "readLong on a present numeric value allocates zero bytes per op".onlyJvm in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-readlong-alloc")
                 file = dir / "value"
@@ -312,12 +320,12 @@ class PathJvmTest extends kyo.test.Test[Any]:
                 finally handle.close()
                 end try
             end for
-        }
+        })
     }
 
     "readLong on the AbsentLong path allocates zero bytes per op".onlyJvm in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-readlong-absent-alloc")
                 file = dir / "empty"
@@ -334,7 +342,7 @@ class PathJvmTest extends kyo.test.Test[Any]:
                 finally handle.close()
                 end try
             end for
-        }
+        })
     }
 
 end PathJvmTest

--- a/kyo-system/native/src/test/scala/kyo/internal/NioAtomicMovePlatformTest.scala
+++ b/kyo-system/native/src/test/scala/kyo/internal/NioAtomicMovePlatformTest.scala
@@ -57,7 +57,7 @@ class NioAtomicMovePlatformTest extends kyo.test.Test[Any]:
                 _            <- Sync.defer(Files.setPosixFilePermissions(fixture.lockedDirectory, java.util.Set.of()))
                 inaccessible <- Sync.defer(!Files.exists(fixture.source, LinkOption.NOFOLLOW_LINKS))
                 result <- Abort.run[FileSystemException] {
-                    Path.of(fixture.source).move(Path.of(fixture.target), Path.MoveOptions(atomicity = Path.Atomicity.Required))
+                    Path.run(Path.of(fixture.source).move(Path.of(fixture.target), Path.MoveOptions(atomicity = Path.Atomicity.Required)))
                 }
             yield
                 assert(inaccessible)

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -2,12 +2,13 @@ package kyo
 
 import java.nio.charset.Charset
 
-/** Filesystem backend tiers, effect-polymorphic in the backend effect `S`. [[Read]] exposes
+/** Filesystem backend capabilities, effect-polymorphic in the backend effect `S`. [[Read]] exposes
   * inspection and content reads. [[Write]] extends it with mutation and structure operations.
   * Each public operation records the applicable typed failure category in its effect row and
   * accepts a call-site [[Frame]].
   *
-  * @see [[FileSystem.host]] for the backend over the platform implementations in this module
+  * @see [[Path.runReadOnlyWith]] for installing a read capability
+  * @see [[Path.runWith]] for installing a write capability
   */
 object FileSystem:
 
@@ -119,11 +120,46 @@ object FileSystem:
 
         // scoped temp: vends a service-correct removal handle so cleanup runs through the creating service
         def tempDir(prefix: String)(using Frame): Path.TempDirHandle < (S & Abort[FileStructureException])
+        def temp(prefix: String, suffix: String)(using Frame): Path.TempFileHandle < (S & Abort[FileStructureException])
 
     end Write
 
-    /** Default host backend: delegates every operation to [[Path.Unsafe]], so it answers exactly what
-      * the [[Path]] methods answer.
+    private val local = Local.init[FileSystem.Write[Any]](
+        FileSystem.host.asInstanceOf[FileSystem.Write[Any]]
+    )
+
+    private val readLocal = Local.init[FileSystem.Read[Any]](
+        FileSystem.host.asInstanceOf[FileSystem.Read[Any]]
+    )
+
+    /** Runs `value` with `fileSystem` selected as the backend used by [[Path.run]] and
+      * [[Path.runReadOnly]]. The selection is inherited by child fibers and restored when the
+      * dynamic scope exits.
+      *
+      * @tparam FS the backend's own effect, preserved in the result row
+      */
+    def let[A, S, FS](fileSystem: FileSystem.Write[FS])(value: A < S)(using Frame): A < (FS & S) =
+        local.let(fileSystem.asInstanceOf[FileSystem.Write[Any]])(
+            readLocal.let(fileSystem.asInstanceOf[FileSystem.Read[Any]])(value)
+        )
+
+    private[kyo] def useErased[A, S](f: FileSystem.Write[Any] => A < S)(using Frame): A < S =
+        local.use(f)
+
+    private[kyo] def useReadErased[A, S](f: FileSystem.Read[Any] => A < S)(using Frame): A < S =
+        readLocal.use(f)
+
+    private[kyo] def letErased[A, S, FS](fileSystem: FileSystem.Write[FS])(value: A < S)(using Frame): A < S =
+        local.let(fileSystem.asInstanceOf[FileSystem.Write[Any]])(
+            readLocal.let(fileSystem.asInstanceOf[FileSystem.Read[Any]])(value)
+        )
+
+    private[kyo] def letReadErased[A, S, FS](fileSystem: FileSystem.Read[FS])(value: A < S)(using Frame): A < S =
+        readLocal.let(fileSystem.asInstanceOf[FileSystem.Read[Any]])(value)
+
+    /** Default host backend: delegates every op to [[Path.Unsafe]], translating the concrete
+      * `Result[File*Exception, A]` into `Abort[FileSystemException]`, so it preserves current
+      * `Path` behavior exactly.
       */
     def host: FileSystem.Write[Sync] = HostFileSystem()
 

--- a/kyo-system/shared/src/main/scala/kyo/FileSystemException.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystemException.scala
@@ -4,7 +4,7 @@ package kyo
 enum FileSystemOperation derives CanEqual:
     case Exists, Inspect, RealPath, Read, Write, List, Walk, Create, Move, Copy, Remove
 
-/** Base type for failures reported by filesystem operations. */
+/** Base type for failures reported by filesystem capabilities. */
 sealed abstract class FileSystemException(message: String, cause: Throwable | String = "")(using Frame)
     extends KyoException(message, cause)
 

--- a/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
@@ -197,5 +197,12 @@ private[kyo] object HostFileSystem:
                     // Unsafe: recursive host delete of the created temp dir at Scope exit
                     def remove()(using AllowUnsafe): Unit = discard(dir.unsafe.removeAll())
             }
+        def temp(prefix: String, suffix: String)(using Frame): Path.TempFileHandle < (Sync & Abort[FileStructureException]) =
+            Path.tempUnscoped(prefix, suffix).map { file =>
+                new Path.TempFileHandle:
+                    def path: Path = file
+                    // Unsafe: host delete of the created temp file at Scope exit
+                    def remove()(using AllowUnsafe): Unit = discard(file.unsafe.remove())
+            }
     end HostFileSystem
 end HostFileSystem

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -7,8 +7,8 @@ import kyo.internal.PathPlatformSpecific
 /** A cross-platform, immutable file-system path with effect-tracked I/O.
   *
   * Path provides a unified API for file operations across JVM, Scala.js (Node.js), and Scala Native. Every I/O operation is tracked in the
-  * type system: reads carry `Abort[FileReadException]`, writes carry `Abort[FileWriteException]`, and directory mutations carry
-  * `Abort[FileStructureException]`. This means the compiler enforces that callers handle (or propagate) every possible failure mode.
+  * type system via capability effects: reads carry `PathRead` and writes carry `PathWrite`. A runner (`Path.run`, `Path.runReadOnly`,
+  * `Path.runWith`, or `Path.runReadOnlyWith`) discharges the capability and leaves `Sync & Abort[FileSystemException]` as the residual.
   *
   * Paths are constructed via the `/` operator or the `apply` factory:
   *
@@ -16,15 +16,18 @@ import kyo.internal.PathPlatformSpecific
   * val config = Path / "etc" / "app" / "config.toml"
   * val data   = Path("var", "data", "app")
   *
-  * // Read with typed error handling
-  * val content: String < (Sync & Abort[FileReadException]) = config.read
+  * // Read with capability effect
+  * val content: String < PathRead = config.read
+  *
+  * // Discharge with the host runner
+  * val result: String < (Sync & Abort[FileSystemException]) = Path.runReadOnly(content)
   *
   * // Streaming reads are Scope-managed (file handle auto-closed)
-  * val lines: Stream[String, Scope & Sync & Abort[FileReadException]] = config.readLinesStream
+  * val lines: Stream[String, PathRead & Scope & Sync] = config.readLinesStream
   * }}}
   *
-  * Inspection methods (`isDirectory`, `isRegularFile`, `isSymbolicLink`) return `false` for inaccessible paths rather than failing, so they
-  * require only `Sync` and not `Abort`. `exists` answers `false` for an absent path and fails only when the filesystem refuses the question.
+  * Inspection methods (`exists`, `isDirectory`, `isRegularFile`, `isSymbolicLink`) return `false` for inaccessible paths rather than
+  * failing, so they require only `PathRead` and not explicit `Abort`.
   *
   * **Streaming operations** (`readStream`, `readBytesStream`, `readLinesStream`, `walk`, `tail`, `tailBytes`) return `Stream` values
   * that carry `Scope` in their effect type. The underlying OS resource (file handle, directory handle) is acquired when the stream
@@ -34,8 +37,41 @@ import kyo.internal.PathPlatformSpecific
   *   [[FileSystemException]] for the typed error hierarchy
   * @see
   *   [[kyo.Path.Unsafe]] for the abstract platform-specific implementation class
+  * @see
+  *   [[PathRead]] for the read capability
+  * @see
+  *   [[PathWrite]] for the write capability (extends PathRead)
   */
 opaque type Path = Path.Unsafe
+
+import kyo.kernel.ArrowEffect
+
+/** Read capability for the file system: existence queries, reads, `list`, `walk`, `realPath`,
+  * `confinedTo`, `stat`, `size`. A computation that only reads carries `< PathRead` in its row;
+  * `Sync` and the `Abort[FileSystemException]` umbrella are folded into the capability and become visible
+  * only after a runner discharges it. Discharge with [[Path.runReadOnly]] (read-only) or
+  * [[Path.run]] (read and write). `PathWrite <: PathRead`: a write-capable context also satisfies
+  * reads, and a read-only runner rejects write programs at the call site.
+  *
+  * @see
+  *   [[Path.run]], [[Path.runReadOnly]], [[Path.runWith]], [[Path.runReadOnlyWith]] for the runners
+  * @see
+  *   [[FileSystem]] for the pluggable backend the runners install
+  */
+sealed trait PathRead extends ArrowEffect[[A] =>> Path.Op[A], Id]
+
+/** Write capability for the file system: writes, appends, `truncate`, `mkDir`, `mkFile`, `move`,
+  * `copy`, `remove`, and the scoped `tempDir`. Because `PathWrite <: PathRead`, a write-capable
+  * context also satisfies read operations, a mixed read plus write program's row collapses to
+  * `PathWrite`, and [[Path.runReadOnly]] rejects a program containing a write at the call site.
+  *
+  * Discharge with [[Path.run]] or [[Path.runWith]]; only these runners can satisfy `PathWrite`
+  * in a program's row.
+  *
+  * @see
+  *   [[PathRead]] for the read capability this extends
+  */
+sealed trait PathWrite extends PathRead
 
 object Path extends PathPlatformSpecific:
 
@@ -177,13 +213,278 @@ object Path extends PathPlatformSpecific:
     infix def /(part: Path.Part)(using Frame): Path =
         make(flattenParts(Seq(part)))
 
-    /** A handle to a service-created temporary directory. Vended by `FileSystem.Write.tempDir` so a
-      * caller removes the directory through the service that created it. Internal.
+    // --- Shared op family ---
+
+    /** Reified filesystem operations. Read-group cases suspend under `Tag[PathRead]`, write-group
+      * cases under `Tag[PathWrite]`; `Output = Id` (each case resumes with its raw `A`, no `Result`
+      * wrapper, so a failing op short-circuits the runner through the residual `Abort[FileSystemException]`).
+      * One shared op family serves both capabilities: a class cannot extend `ArrowEffect` twice with
+      * different inputs, and `PathWrite <: PathRead` inherits `PathRead`'s input constructor, so the read
+      * operations are the read-group cases and the mutations are the write-group cases of this one enum.
+      */
+    private[kyo] enum Op[A]:
+        // read-group (suspend under Tag[PathRead])
+        case Exists(path: Path)                                                             extends Op[Boolean]
+        case ExistsFollow(path: Path, followLinks: Boolean)                                 extends Op[Boolean]
+        case IsDirectory(path: Path)                                                        extends Op[Boolean]
+        case IsRegularFile(path: Path)                                                      extends Op[Boolean]
+        case IsSymbolicLink(path: Path)                                                     extends Op[Boolean]
+        case RealPath(path: Path)                                                           extends Op[Path]
+        case RealPathPrefix(path: Path)                                                     extends Op[Path]
+        case Read(path: Path)                                                               extends Op[String]
+        case ReadCharset(path: Path, charset: Charset)                                      extends Op[String]
+        case ReadBytes(path: Path)                                                          extends Op[Span[Byte]]
+        case ReadLines(path: Path)                                                          extends Op[Chunk[String]]
+        case ReadLinesCharset(path: Path, charset: Charset)                                 extends Op[Chunk[String]]
+        case Size(path: Path)                                                               extends Op[Long]
+        case Stat(path: Path)                                                               extends Op[Path.PathStat]
+        case ListDir(path: Path)                                                            extends Op[Chunk[Path]]
+        case ListGlob(path: Path, glob: Glob, caseSensitivity: Maybe[Glob.CaseSensitivity]) extends Op[Chunk[Path]]
+        case DefaultCaseSensitivity()                                                       extends Op[Glob.CaseSensitivity]
+        case OpenRead(path: Path)                                                           extends Op[Path.ReadHandle]
+        case OpenReadLines(path: Path, charset: Charset)                                    extends Op[Path.LineReadHandle]
+        case OpenWalk(path: Path, maxDepth: Int, followLinks: Boolean)                      extends Op[Path.WalkHandle]
+        case Raise(error: Result.Error[FileSystemException])                                extends Op[Nothing]
+        // write-group (suspend under Tag[PathWrite])
+        case Write(path: Path, value: String, options: WriteOptions)                extends Op[Unit]
+        case WriteBytes(path: Path, value: Span[Byte], options: WriteOptions)       extends Op[Unit]
+        case WriteLines(path: Path, value: Chunk[String], options: WriteOptions)    extends Op[Unit]
+        case Append(path: Path, value: String, options: WriteOptions)               extends Op[Unit]
+        case AppendBytes(path: Path, value: Span[Byte], options: WriteOptions)      extends Op[Unit]
+        case AppendLines(path: Path, value: Chunk[String], options: WriteOptions)   extends Op[Unit]
+        case Truncate(path: Path, size: Long)                                       extends Op[Unit]
+        case SetLastModified(path: Path, epochMs: Long)                             extends Op[Unit]
+        case MkDir(path: Path)                                                      extends Op[Unit]
+        case MkFile(path: Path)                                                     extends Op[Unit]
+        case Move(from: Path, to: Path, options: MoveOptions)                       extends Op[Unit]
+        case Copy(from: Path, to: Path, options: CopyOptions)                       extends Op[Unit]
+        case Remove(path: Path)                                                     extends Op[Boolean]
+        case RemoveExisting(path: Path)                                             extends Op[Unit]
+        case RemoveAll(path: Path)                                                  extends Op[Unit]
+        case OpenWrite(path: Path, append: Boolean, options: WriteOptions)          extends Op[Path.WriteHandle]
+        case TempDir(prefix: String)                                                extends Op[Path.TempDirHandle]
+        case Temp(prefix: String, suffix: String)                                   extends Op[Path.TempFileHandle]
+        case WriteChunk(handle: Path.WriteHandle, chunk: Chunk[Byte])               extends Op[Unit]
+        case WriteString(handle: Path.WriteHandle, value: String, charset: Charset) extends Op[Unit]
+    end Op
+
+    // --- Runners ---
+
+    /** Runs `program`, discharging both write and read capabilities against the Local-selected
+      * [[FileSystem]]. Every filesystem op inside `program` suspends under `PathWrite` or
+      * `PathRead` and is dispatched to that backend; the residual folds the per-op
+      * `Abort[File*Exception]` markers into the umbrella `Abort[FileSystemException]`.
+      *
+      * Residual: `Sync & Abort[FileSystemException] & S` (the caller's tail `S` rides through).
+      *
+      * @see
+      *   [[runWith]] to install a custom [[FileSystem]]
+      */
+    def run[A, S](program: A < (PathWrite & S))(using Frame): A < (Sync & Abort[FileSystemException] & S) =
+        FileSystem.useErased(service => runWith(service)(program))
+
+    /** Runs `program`, discharging the read capability only against the Local-selected service. A write
+      * op left in the program keeps `PathWrite` undischarged, so the ascribed read-only residual does
+      * not compile (the negative capability law).
+      *
+      * Use this at API boundaries that must not mutate the filesystem (read-only config loaders,
+      * projection rebuilds). The effect row is identical to [[run]] except that write ops are rejected
+      * at the call site rather than at runtime.
+      *
+      * @see
+      *   [[runReadOnlyWith]] to install a custom read-only [[FileSystem]]
+      */
+    def runReadOnly[A, S](program: A < (PathRead & S))(using Frame): A < (Sync & Abort[FileSystemException] & S) =
+        FileSystem.useReadErased(service => runReadOnlyWith(service)(program))
+
+    /** Runs `program` against an explicit `fileSystem`, discharging write and read; the backend's own
+      * effect `FS` rides the residual (the Journal `Backend[S]` mapping).
+      *
+      * The selected service determines when writes become durable relative to the enclosing run.
+      */
+    def runWith[A, S, FS](fileSystem: FileSystem.Write[FS])(program: A < (PathWrite & S))(using
+        Frame
+    ): A < (FS & Abort[FileSystemException] & S) =
+        FileSystem.letErased(fileSystem) {
+            ArrowEffect.handle[[A] =>> Op[A], Id, PathWrite, A, S, FS & Abort[FileSystemException]](Tag[PathWrite], program)(
+                [C] => (op, cont) => dispatch(fileSystem, op).map(cont)
+            )
+        }
+
+    /** Runs `program` against an explicit `service`, discharging the read capability only.
+      *
+      * Same negative-capability law as [[runReadOnly]]: a write op in `program` keeps `PathWrite`
+      * undischarged and fails to compile. The service's effect `FS` and the caller's tail `S` both
+      * ride the residual unchanged.
+      */
+    def runReadOnlyWith[A, S, FS](fileSystem: FileSystem.Read[FS])(program: A < (PathRead & S))(using
+        Frame
+    ): A < (FS & Abort[FileSystemException] & S) =
+        FileSystem.letReadErased(fileSystem) {
+            ArrowEffect.handle[[A] =>> Op[A], Id, PathRead, A, S, FS & Abort[FileSystemException]](Tag[PathRead], program)(
+                [C] => (op, cont) => dispatchRead(fileSystem, op).map(cont)
+            )
+        }
+
+    /** Stateless isolation for read operations. Each child captures the Local-selected backend and
+      * installs an independent Path handler around its computation.
+      */
+    given isolateRead: Isolate[PathRead, Async, PathRead] with
+        type State        = FileSystem.Read[Any]
+        type Transform[A] = Result[FileSystemException, A]
+
+        def capture[A, S](f: State => A < S)(using Frame): A < (PathRead & Async & S) =
+            FileSystem.useReadErased(f)
+
+        def isolate[A, S](state: State, value: A < (S & PathRead))(using Frame): Result[FileSystemException, A] < (Async & S) =
+            Abort.run[FileSystemException](runReadOnlyWith(state)(value))
+
+        def restore[A, S](value: Result[FileSystemException, A] < S)(using Frame): A < (PathRead & S) =
+            value.map {
+                case Result.Success(result) => result
+                case Result.Failure(error) =>
+                    ArrowEffect.suspend(Tag[PathRead], Op.Raise(Result.Failure(error)))
+                case panic: Result.Panic =>
+                    ArrowEffect.suspend(Tag[PathRead], Op.Raise(panic))
+            }
+    end isolateRead
+
+    /** Stateless isolation for write operations. See [[isolateRead]]. */
+    given isolateWrite: Isolate[PathWrite, Sync, PathWrite] with
+        type State        = FileSystem.Write[Any]
+        type Transform[A] = Result[FileSystemException, A]
+
+        def capture[A, S](f: State => A < S)(using Frame): A < (PathWrite & Sync & S) =
+            FileSystem.useErased(f)
+
+        def isolate[A, S](state: State, value: A < (S & PathWrite))(using Frame): Result[FileSystemException, A] < (Sync & S) =
+            Abort.run[FileSystemException](runWith(state)(value))
+
+        def restore[A, S](value: Result[FileSystemException, A] < S)(using Frame): A < (PathWrite & S) =
+            value.map {
+                case Result.Success(result) => result
+                case Result.Failure(error) =>
+                    ArrowEffect.suspend(Tag[PathWrite], Op.Raise(Result.Failure(error)))
+                case panic: Result.Panic =>
+                    ArrowEffect.suspend(Tag[PathWrite], Op.Raise(panic))
+            }
+    end isolateWrite
+
+    private def dispatch[S, C](service: FileSystem.Write[S], op: Op[C])(using Frame): C < (S & Abort[FileSystemException]) =
+        op match
+            case Op.Exists(p)                 => service.exists(p)
+            case Op.ExistsFollow(p, f)        => service.exists(p, f)
+            case Op.IsDirectory(p)            => service.isDirectory(p)
+            case Op.IsRegularFile(p)          => service.isRegularFile(p)
+            case Op.IsSymbolicLink(p)         => service.isSymbolicLink(p)
+            case Op.RealPath(p)               => service.realPath(p)
+            case Op.RealPathPrefix(p)         => service.realPathPrefix(p)
+            case Op.Read(p)                   => service.read(p)
+            case Op.ReadCharset(p, c)         => service.read(p, c)
+            case Op.ReadBytes(p)              => service.readBytes(p)
+            case Op.ReadLines(p)              => service.readLines(p)
+            case Op.ReadLinesCharset(p, c)    => service.readLines(p, c)
+            case Op.Size(p)                   => service.size(p)
+            case Op.Stat(p)                   => service.stat(p)
+            case Op.ListDir(p)                => service.list(p)
+            case Op.ListGlob(p, g, c)         => c.fold(service.list(p, g))(service.list(p, g, _))
+            case Op.DefaultCaseSensitivity()  => service.defaultCaseSensitivity
+            case Op.OpenRead(p)               => service.openRead(p)
+            case Op.OpenReadLines(p, c)       => service.openReadLines(p, c)
+            case Op.OpenWalk(p, d, f)         => service.openWalk(p, d, f)
+            case Op.Raise(error)              => Abort.error(error)
+            case Op.Write(p, v, cf)           => service.write(p, v, cf)
+            case Op.WriteBytes(p, v, options) => service.writeBytes(p, v, options)
+            case Op.WriteLines(p, v, cf)      => service.writeLines(p, v, cf)
+            case Op.Append(p, v, cf)          => service.append(p, v, cf)
+            case Op.AppendBytes(p, v, cf)     => service.appendBytes(p, v, cf)
+            case Op.AppendLines(p, v, cf)     => service.appendLines(p, v, cf)
+            case Op.Truncate(p, s)            => service.truncate(p, s)
+            case Op.SetLastModified(p, e)     => service.setLastModified(p, e)
+            case Op.MkDir(p)                  => service.mkDir(p)
+            case Op.MkFile(p)                 => service.mkFile(p)
+            case Op.Move(f, t, options)       => service.move(f, t, options)
+            case Op.Copy(f, t, options)       => service.copy(f, t, options)
+            case Op.Remove(p)                 => service.remove(p)
+            case Op.RemoveExisting(p)         => service.removeExisting(p)
+            case Op.RemoveAll(p)              => service.removeAll(p)
+            case Op.OpenWrite(p, a, cf)       => service.openWrite(p, a, cf)
+            case Op.TempDir(prefix)           => service.tempDir(prefix)
+            case Op.Temp(prefix, suffix)      => service.temp(prefix, suffix)
+            case Op.WriteChunk(h, ch)         => service.writeChunk(h, ch)
+            case Op.WriteString(h, s, c)      => service.writeString(h, s, c)
+    end dispatch
+
+    private def dispatchRead[S, C](service: FileSystem.Read[S], op: Op[C])(using Frame): C < (S & Abort[FileSystemException]) =
+        op match
+            case Op.Exists(p)                => service.exists(p)
+            case Op.ExistsFollow(p, f)       => service.exists(p, f)
+            case Op.IsDirectory(p)           => service.isDirectory(p)
+            case Op.IsRegularFile(p)         => service.isRegularFile(p)
+            case Op.IsSymbolicLink(p)        => service.isSymbolicLink(p)
+            case Op.RealPath(p)              => service.realPath(p)
+            case Op.RealPathPrefix(p)        => service.realPathPrefix(p)
+            case Op.Read(p)                  => service.read(p)
+            case Op.ReadCharset(p, c)        => service.read(p, c)
+            case Op.ReadBytes(p)             => service.readBytes(p)
+            case Op.ReadLines(p)             => service.readLines(p)
+            case Op.ReadLinesCharset(p, c)   => service.readLines(p, c)
+            case Op.Size(p)                  => service.size(p)
+            case Op.Stat(p)                  => service.stat(p)
+            case Op.ListDir(p)               => service.list(p)
+            case Op.ListGlob(p, g, c)        => c.fold(service.list(p, g))(service.list(p, g, _))
+            case Op.DefaultCaseSensitivity() => service.defaultCaseSensitivity
+            case Op.OpenRead(p)              => service.openRead(p)
+            case Op.OpenReadLines(p, c)      => service.openReadLines(p, c)
+            case Op.OpenWalk(p, d, f)        => service.openWalk(p, d, f)
+            case Op.Raise(error)             => Abort.error(error)
+            case _ => Abort.panic[FileSystemException](new IllegalStateException("PathWrite operation reached the PathRead handler"))
+    end dispatchRead
+
+    // --- Scoped temp file and temp directory ---
+
+    /** Creates a temporary file in the active service and registers its removal with the enclosing
+      * `Scope`. The removal runs through the service that created the file, so a temp file made by one
+      * service is never deleted by another service's `remove`. The location of the created file is
+      * service-defined; the host service uses the OS temporary directory.
+      *
+      * Use [[tempUnscoped]] when the file must outlive the scope that creates it. That variant is a host
+      * primitive rather than a service call, because a file whose lifetime the caller owns has no scope
+      * for a service-vended handle to hang from.
+      */
+    def temp(prefix: String = "kyo", suffix: String = ".tmp")(using Frame): Path < (PathWrite & Sync & Scope) =
+        Scope.acquireRelease(
+            ArrowEffect.suspend(Tag[PathWrite], Op.Temp(prefix, suffix))
+        )(handle => Sync.Unsafe.defer(handle.remove())) // Unsafe: service-vended cleanup at Scope exit
+            .map(_.path)
+
+    /** Creates a temporary directory in the active service and registers its recursive removal with
+      * the enclosing `Scope`. The removal runs through the service that created the directory, so a
+      * temp dir made by one service is never deleted by another service's `removeAll`. There is no
+      * unscoped public temp-directory primitive. The location of the created directory is
+      * service-defined; the host service uses the OS temporary directory.
+      */
+    def tempDir(prefix: String = "kyo")(using Frame): Path < (PathWrite & Sync & Scope) =
+        Scope.acquireRelease(
+            ArrowEffect.suspend(Tag[PathWrite], Op.TempDir(prefix))
+        )(handle => Sync.Unsafe.defer(handle.remove())) // Unsafe: service-vended recursive cleanup at Scope exit
+            .map(_.path)
+
+    /** A handle to a service-created temporary directory. Vended by [[FileSystem.tempDir]] so the scoped
+      * [[Path.tempDir]] finalizer removes through the creating service. Internal.
       */
     abstract private[kyo] class TempDirHandle:
         def path: Path
         def remove()(using AllowUnsafe): Unit
     end TempDirHandle
+
+    /** A handle to a service-created temporary file. Vended by [[FileSystem.temp]] so the scoped
+      * [[Path.temp]] finalizer removes through the creating service. Internal.
+      */
+    abstract private[kyo] class TempFileHandle:
+        def path: Path
+        def remove()(using AllowUnsafe): Unit
+    end TempFileHandle
 
     // --- Safe extension methods ---
 
@@ -248,24 +549,24 @@ object Path extends PathPlatformSpecific:
         // --- Inspection ---
 
         /** Returns `true` if this path exists in the file system (following symbolic links). */
-        def exists(using Frame): Boolean < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.exists()))
+        inline def exists(using inline frame: Frame): Boolean < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.Exists(self))
 
         /** Returns `true` if this path exists, optionally following symbolic links. */
-        def exists(followLinks: Boolean)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.exists(followLinks)))
+        inline def exists(followLinks: Boolean)(using inline frame: Frame): Boolean < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.ExistsFollow(self, followLinks))
 
         /** Returns `true` if this path is a directory. */
-        def isDirectory(using Frame): Boolean < Sync =
-            Sync.Unsafe.defer(self.unsafe.isDirectory())
+        inline def isDirectory(using inline frame: Frame): Boolean < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.IsDirectory(self))
 
         /** Returns `true` if this path is a regular file. */
-        def isRegularFile(using Frame): Boolean < Sync =
-            Sync.Unsafe.defer(self.unsafe.isRegularFile())
+        inline def isRegularFile(using inline frame: Frame): Boolean < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.IsRegularFile(self))
 
         /** Returns `true` if this path is a symbolic link. */
-        def isSymbolicLink(using Frame): Boolean < Sync =
-            Sync.Unsafe.defer(self.unsafe.isSymbolicLink())
+        inline def isSymbolicLink(using inline frame: Frame): Boolean < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.IsSymbolicLink(self))
 
         /** Returns the canonical absolute path with every symbolic link in the chain resolved.
           *
@@ -274,8 +575,8 @@ object Path extends PathPlatformSpecific:
           * path-under-root validation: compare `path.realPath` against `root.realPath` instead
           * of relying on syntactic checks (which miss symlinks that point outside the root).
           */
-        def realPath(using Frame): Path < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.realPath()))
+        inline def realPath(using inline frame: Frame): Path < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.RealPath(self))
 
         /** Returns this path resolved to its canonical real path, but only if that real path is contained
           * within `root` (after resolving `root`'s own symlinks).
@@ -284,44 +585,46 @@ object Path extends PathPlatformSpecific:
           * pointing outside is rejected. The pure path-prefix comparison runs against the canonical parts
           * of both paths; a path equal to `root` is considered contained.
           *
-          * Both `self` and `root` must exist; if either does not, fails with `FileNotFoundException`.
           * If `self`'s real path is outside `root`'s real path, fails with `FileAccessDeniedException`
           * carrying the offending real path.
           *
           * Useful for any tool that exposes a configured root and accepts user-supplied relative paths:
           * call `(root / userInput).confinedTo(root)` to obtain a path that is statically known to live
-          * under the root, defending against symlink escapes.
+          * under the root, defending against symlink escapes. Run the check before using the path,
+          * which is also the ordering under which every backend resolves links.
+          *
+          * The check is only as strong as the active backend's `realPath`. Host backends resolve
+          * every link, and require both `self` and `root` to exist: either one missing fails with
+          * `FileNotFoundException`.
           */
-        def confinedTo(root: Path)(using Frame): Path < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer {
-                Abort.get(root.unsafe.realPath()).map { rootReal =>
-                    Abort.get(self.unsafe.realPath()).map { selfReal =>
-                        if selfReal.parts.take(rootReal.parts.size) == rootReal.parts then (selfReal: Path < Abort[FileReadException])
-                        else Abort.fail[FileReadException](FileAccessDeniedException(selfReal))
-                    }
+        def confinedTo(root: Path)(using Frame): Path < (PathRead & Abort[FileSystemException]) =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.RealPath(root)).map { rootReal =>
+                ArrowEffect.suspend(Tag[PathRead], Path.Op.RealPath(self)).map { selfReal =>
+                    if selfReal.parts.take(rootReal.parts.size) == rootReal.parts then selfReal
+                    else Abort.fail(FileAccessDeniedException(selfReal))
                 }
             }
 
         // --- Read ---
 
         /** Reads the entire file contents as a UTF-8 string. */
-        def read(using Frame): String < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.read()))
+        inline def read(using inline frame: Frame): String < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.Read(self))
 
         /** Reads the entire file contents using the given charset. */
-        def read(charset: Charset)(using Frame): String < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.read(charset)))
+        inline def read(charset: Charset)(using inline frame: Frame): String < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.ReadCharset(self, charset))
 
         /** Reads the entire file contents as a `Span[Byte]`. */
-        def readBytes(using Frame): Span[Byte] < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.readBytes()))
+        inline def readBytes(using inline frame: Frame): Span[Byte] < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.ReadBytes(self))
 
         /** Returns the size in bytes of the regular file at this path.
           *
           * Fails with `FileReadException` if the path does not exist, is not a regular file, or the underlying read fails.
           */
-        def size(using Frame): Long < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.size()))
+        inline def size(using inline frame: Frame): Long < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.Size(self))
 
         /** Returns mtime and size atomically from a single underlying syscall.
           *
@@ -330,23 +633,23 @@ object Path extends PathPlatformSpecific:
           * Prefer this over separate `lastModified` + `size` reads when both are needed:
           * a single syscall guarantees the two values reflect the same instant.
           */
-        def stat(using Frame): PathStat < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.stat()))
+        inline def stat(using inline frame: Frame): PathStat < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.Stat(self))
 
         /** Reads all lines from the file as a `Chunk[String]` (UTF-8). */
-        def readLines(using Frame): Chunk[String] < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.readLines()))
+        inline def readLines(using inline frame: Frame): Chunk[String] < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.ReadLines(self))
 
         /** Reads all lines from the file as a `Chunk[String]` using the given charset. */
-        def readLines(charset: Charset)(using Frame): Chunk[String] < (Sync & Abort[FileReadException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.readLines(charset)))
+        inline def readLines(charset: Charset)(using inline frame: Frame): Chunk[String] < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.ReadLinesCharset(self, charset))
 
         /** Streams the file contents as UTF-8 decoded strings (chunked by the platform buffer size). */
-        def readStream(using Frame): Stream[String, Scope & Sync & Abort[FileReadException]] =
+        def readStream(using Frame): Stream[String, PathRead & Scope & Sync] =
             readStream(StandardCharsets.UTF_8)
 
         /** Streams the file contents as decoded strings using the given charset. */
-        def readStream(charset: Charset)(using Frame): Stream[String, Scope & Sync & Abort[FileReadException]] =
+        def readStream(charset: Charset)(using Frame): Stream[String, PathRead & Scope & Sync] =
             readStream(charset, 8.kib)
 
         /** Streams the file contents as decoded strings using the given charset and read buffer size.
@@ -354,12 +657,12 @@ object Path extends PathPlatformSpecific:
           * `bufferSize` is clamped to the range an array can address: `ByteSize.Zero` reads one byte at a time rather than spinning on a
           * buffer that holds nothing, and anything above `Int.MaxValue` bytes reads through the largest buffer there is.
           */
-        def readStream(charset: Charset, bufferSize: ByteSize)(using Frame): Stream[String, Scope & Sync & Abort[FileReadException]] =
+        def readStream(charset: Charset, bufferSize: ByteSize)(using Frame): Stream[String, PathRead & Scope & Sync] =
             val capacity = readBufferCapacity(bufferSize)
             Stream {
                 Scope.acquireRelease(
-                    Sync.Unsafe.defer(Abort.get(self.unsafe.openRead()))
-                )(handle => Sync.Unsafe.defer(handle.close())).map { handle => // Unsafe: closes the read handle at Scope exit
+                    ArrowEffect.suspend(Tag[PathRead], Path.Op.OpenRead(self))
+                )(handle => Sync.Unsafe.defer(handle.close())).map { handle => // Unsafe: closes the vended read handle at Scope exit
                     val rawBuf      = new Array[Byte](capacity)
                     val decoder     = charset.newDecoder()
                     val maxTrailing = math.ceil(charset.newEncoder().maxBytesPerChar()).toInt
@@ -367,7 +670,7 @@ object Path extends PathPlatformSpecific:
                         java.nio.ByteBuffer.allocate(capacity + maxTrailing) // extra space for incomplete trailing multi-byte sequence
                     val outBuf = java.nio.CharBuffer.allocate(math.ceil(capacity * decoder.maxCharsPerByte()).toInt)
                     Loop.foreach {
-                        // Unsafe: bridges read-handle chunk reads into the Sync tier.
+                        // Unsafe: bridges vended read-handle chunk reads into the Sync tier.
                         Sync.Unsafe.defer {
                             val result = handle.readChunk(rawBuf)
                             if result.isEof then
@@ -400,7 +703,7 @@ object Path extends PathPlatformSpecific:
         end readStream
 
         /** Streams the raw bytes of the file. */
-        def readBytesStream(using Frame): Stream[Byte, Scope & Sync & Abort[FileReadException]] =
+        def readBytesStream(using Frame): Stream[Byte, PathRead & Scope & Sync] =
             readBytesStream(8.kib)
 
         /** Streams the raw bytes of the file using the given read buffer size.
@@ -408,14 +711,14 @@ object Path extends PathPlatformSpecific:
           * `bufferSize` is clamped to the range an array can address: `ByteSize.Zero` reads one byte at a time rather than spinning on a
           * buffer that holds nothing, and anything above `Int.MaxValue` bytes reads through the largest buffer there is.
           */
-        def readBytesStream(bufferSize: ByteSize)(using Frame): Stream[Byte, Scope & Sync & Abort[FileReadException]] =
+        def readBytesStream(bufferSize: ByteSize)(using Frame): Stream[Byte, PathRead & Scope & Sync] =
             val capacity = readBufferCapacity(bufferSize)
             Stream {
                 Scope.acquireRelease(
-                    Sync.Unsafe.defer(Abort.get(self.unsafe.openRead()))
-                )(handle => Sync.Unsafe.defer(handle.close())).map { handle => // Unsafe: closes the read handle at Scope exit
+                    ArrowEffect.suspend(Tag[PathRead], Path.Op.OpenRead(self))
+                )(handle => Sync.Unsafe.defer(handle.close())).map { handle => // Unsafe: closes the vended read handle at Scope exit
                     Loop.foreach {
-                        // Unsafe: bridges read-handle chunk reads into the Sync tier.
+                        // Unsafe: bridges vended read-handle chunk reads into the Sync tier.
                         Sync.Unsafe.defer {
                             val buf    = new Array[Byte](capacity)
                             val result = handle.readChunk(buf)
@@ -432,17 +735,17 @@ object Path extends PathPlatformSpecific:
         end readBytesStream
 
         /** Streams the file line-by-line as UTF-8 strings. */
-        def readLinesStream(using Frame): Stream[String, Scope & Sync & Abort[FileReadException]] =
+        def readLinesStream(using Frame): Stream[String, PathRead & Scope & Sync] =
             readLinesStream(StandardCharsets.UTF_8)
 
         /** Streams the file line-by-line using the given charset. */
-        def readLinesStream(charset: Charset)(using Frame): Stream[String, Scope & Sync & Abort[FileReadException]] =
+        def readLinesStream(charset: Charset)(using Frame): Stream[String, PathRead & Scope & Sync] =
             Stream {
                 Scope.acquireRelease(
-                    Sync.Unsafe.defer(Abort.get(self.unsafe.openReadLines(charset)))
-                )(handle => Sync.Unsafe.defer(handle.close())).map { handle => // Unsafe: closes the read handle at Scope exit
+                    ArrowEffect.suspend(Tag[PathRead], Path.Op.OpenReadLines(self, charset))
+                )(handle => Sync.Unsafe.defer(handle.close())).map { handle => // Unsafe: closes the vended read handle at Scope exit
                     Loop.foreach {
-                        // Unsafe: bridges the line-read handle into the Sync tier.
+                        // Unsafe: bridges vended line-read handle into the Sync tier.
                         Sync.Unsafe.defer {
                             handle.readLine() match
                                 case Absent        => Loop.done
@@ -453,11 +756,11 @@ object Path extends PathPlatformSpecific:
             }
 
         /** Tails the file, emitting new lines as they are appended. Uses a 100ms default poll delay. */
-        def tail(using Frame): Stream[String, Async & Scope & Abort[FileReadException]] =
+        def tail(using Frame): Stream[String, PathRead & Async & Scope] =
             tail(100.millis)
 
         /** Tails the file, emitting new lines as they are appended, sleeping `pollDelay` between polls. */
-        def tail(pollDelay: Duration)(using Frame): Stream[String, Async & Scope & Abort[FileReadException]] =
+        def tail(pollDelay: Duration)(using Frame): Stream[String, PathRead & Async & Scope] =
             tail(pollDelay, 8.kib)
 
         /** Tails the file, emitting new lines as they are appended, sleeping `pollDelay` between polls, using the given read buffer size.
@@ -469,7 +772,7 @@ object Path extends PathPlatformSpecific:
           * `bufferSize` is clamped to the range an array can address: `ByteSize.Zero` reads one byte at a time rather than spinning on a
           * buffer that holds nothing, and anything above `Int.MaxValue` bytes reads through the largest buffer there is.
           */
-        def tail(pollDelay: Duration, bufferSize: ByteSize)(using Frame): Stream[String, Async & Scope & Abort[FileReadException]] =
+        def tail(pollDelay: Duration, bufferSize: ByteSize)(using Frame): Stream[String, PathRead & Async & Scope] =
             // State carried between reads: leftover bytes from an incomplete UTF-8 sequence, plus the pending incomplete line text.
             // `watch` restores this initial state when the file is truncated, so neither survives a rewind.
             val emptyBytes = new Array[Byte](0)
@@ -538,7 +841,7 @@ object Path extends PathPlatformSpecific:
             from: Origin = Origin.End,
             pollDelay: Duration = 100.millis,
             bufferSize: ByteSize = 8.kib
-        )(using Frame): Stream[Byte, Async & Scope & Abort[FileReadException]] =
+        )(using Frame): Stream[Byte, PathRead & Async & Scope] =
             watch[Byte, Unit](self, from, pollDelay, bufferSize, ()) { (_, buf, n) =>
                 // The loop reuses `buf`, so each emitted chunk gets its own copy
                 Step.Continue(Chunk.fromNoCopy(java.util.Arrays.copyOf(buf, n)), ())
@@ -547,93 +850,88 @@ object Path extends PathPlatformSpecific:
         // --- Write ---
 
         /** Writes `value` to the file according to `options`. */
-        def write(value: String, options: WriteOptions = WriteOptions())(using Frame): Unit < (Sync & Abort[FileWriteException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.write(value, options)))
+        inline def write(value: String, options: WriteOptions = WriteOptions())(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.Write(self, value, options))
 
         /** Writes raw bytes to the file. */
-        def writeBytes(value: Span[Byte], options: WriteOptions = WriteOptions())(using Frame): Unit < (Sync & Abort[FileWriteException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.writeBytes(value, options)))
+        inline def writeBytes(value: Span[Byte], options: WriteOptions = WriteOptions())(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.WriteBytes(self, value, options))
 
         /** Writes a collection of lines to the file.
           *
           * Each line is written followed by the platform line separator (including the last line), so `writeLines(Chunk("a", "b"))`
           * produces `"a\nb\n"` on Unix. Use `write(lines.mkString(lineSep))` if you need to control trailing newline behavior.
           */
-        def writeLines(value: Chunk[String], options: WriteOptions = WriteOptions())(using
-            Frame
-        ): Unit < (Sync & Abort[FileWriteException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.writeLines(value, options)))
+        inline def writeLines(value: Chunk[String], options: WriteOptions = WriteOptions())(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.WriteLines(self, value, options))
 
         /** Appends `value` to the file according to `options`. */
-        def append(value: String, options: WriteOptions = WriteOptions())(using Frame): Unit < (Sync & Abort[FileWriteException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.append(value, options)))
+        inline def append(value: String, options: WriteOptions = WriteOptions())(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.Append(self, value, options))
 
         /** Appends raw bytes to the file. */
-        def appendBytes(value: Span[Byte], options: WriteOptions = WriteOptions())(using Frame): Unit < (Sync & Abort[FileWriteException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.appendBytes(value, options)))
+        inline def appendBytes(value: Span[Byte], options: WriteOptions = WriteOptions())(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.AppendBytes(self, value, options))
 
         /** Appends a collection of lines to the file.
           *
           * Each line is written followed by the platform line separator (including the last line), so `appendLines(Chunk("a", "b"))`
           * produces `"a\nb\n"` on Unix. Use `write(lines.mkString(lineSep))` if you need to control trailing newline behavior.
           */
-        def appendLines(value: Chunk[String], options: WriteOptions = WriteOptions())(using
-            Frame
-        ): Unit < (Sync & Abort[FileWriteException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.appendLines(value, options)))
+        inline def appendLines(value: Chunk[String], options: WriteOptions = WriteOptions())(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.AppendLines(self, value, options))
 
         /** Truncates the file to at most `size` bytes. */
-        def truncate(size: Long)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.truncate(size)))
+        inline def truncate(size: Long)(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.Truncate(self, size))
 
         /** Sets the last-modified time of the file to `epochMs` milliseconds since the Unix epoch.
           *
           * Fails with `FileWriteException` if the path does not exist or the operation is not permitted.
           */
-        def setLastModified(epochMs: Long)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.setLastModified(epochMs)))
+        inline def setLastModified(epochMs: Long)(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.SetLastModified(self, epochMs))
 
         // --- Directory / structure ---
 
         /** Creates this path as a directory (including all missing parent directories). */
-        def mkDir(using Frame): Unit < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.mkDir()))
+        inline def mkDir(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.MkDir(self))
 
         /** Creates this path as an empty file (parent directories created if missing). */
-        def mkFile(using Frame): Unit < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.mkFile()))
+        inline def mkFile(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.MkFile(self))
 
         /** Lists all direct children of this directory. */
-        def list(using Frame): Chunk[Path] < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.list()))
+        inline def list(using inline frame: Frame): Chunk[Path] < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.ListDir(self))
 
-        /** Lists direct children of this directory whose names match `glob`, comparing case-sensitively. */
-        def list(glob: Glob)(using Frame): Chunk[Path] < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.list(glob, Glob.CaseSensitivity.Sensitive)))
+        /** Lists direct children of this directory whose names match `glob`. */
+        inline def list(glob: Glob)(using inline frame: Frame): Chunk[Path] < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.ListGlob(self, glob, Absent))
 
-        /** Lists direct children of this directory whose names match `glob` under `caseSensitivity`. */
-        def list(glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using Frame): Chunk[Path] < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.list(glob, caseSensitivity)))
+        inline def list(glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using inline frame: Frame): Chunk[Path] < PathRead =
+            ArrowEffect.suspend(Tag[PathRead], Path.Op.ListGlob(self, glob, Maybe(caseSensitivity)))
 
         /** Streams all entries under this directory tree (unlimited depth, not following links). */
-        def walk(using Frame): Stream[Path, Sync & Scope & Abort[FileStructureException]] =
+        def walk(using Frame): Stream[Path, PathRead & Scope & Sync] =
             walk(Int.MaxValue, followLinks = false)
 
         /** Streams all entries under this directory tree up to `maxDepth`, optionally following symbolic links. */
         def walk(maxDepth: Int = Int.MaxValue, followLinks: Boolean = false)(using
             Frame
-        ): Stream[Path, Sync & Scope & Abort[FileStructureException]] =
+        ): Stream[Path, PathRead & Scope & Sync] =
             walkWhere(maxDepth, followLinks)(_ => true)
 
         private def walkWhere(maxDepth: Int, followLinks: Boolean)(matches: Path => Boolean)(using
             Frame
-        ): Stream[Path, Sync & Scope & Abort[FileStructureException]] =
+        ): Stream[Path, PathRead & Scope & Sync] =
             Stream {
                 Scope.acquireRelease(
-                    Sync.Unsafe.defer(Abort.get(self.unsafe.openWalk(maxDepth, followLinks)))
-                )(handle => Sync.Unsafe.defer(handle.close())).map { handle => // Unsafe: closes the walk handle at Scope exit
+                    ArrowEffect.suspend(Tag[PathRead], Path.Op.OpenWalk(self, maxDepth, followLinks))
+                )(handle => Sync.Unsafe.defer(handle.close())).map { handle => // Unsafe: closes the vended walk handle at Scope exit
                     Loop.foreach {
-                        // Unsafe: bridges walk-handle iteration into the Sync tier.
+                        // Unsafe: bridges vended walk-handle iteration into the Sync tier.
                         Sync.Unsafe.defer {
                             handle.next() match
                                 case Absent => Loop.done
@@ -645,35 +943,33 @@ object Path extends PathPlatformSpecific:
                 }
             }
 
-        /** Streams entries under this directory tree whose relative paths match `glob`, comparing case-sensitively. */
-        def walk(glob: Glob)(using Frame): Stream[Path, Sync & Scope & Abort[FileStructureException]] =
-            walk(glob, Glob.CaseSensitivity.Sensitive)
+        def walk(glob: Glob)(using Frame): Stream[Path, PathRead & Scope & Sync] =
+            Stream.unwrap(
+                ArrowEffect.suspend(Tag[PathRead], Path.Op.DefaultCaseSensitivity()).map(cs => walk(glob, cs))
+            )
 
-        /** Streams entries under this directory tree whose relative paths match `glob` under `caseSensitivity`. */
-        def walk(glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using
-            Frame
-        ): Stream[Path, Sync & Scope & Abort[FileStructureException]] =
+        def walk(glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using Frame): Stream[Path, PathRead & Scope & Sync] =
             walkWhere(Int.MaxValue, followLinks = false)(path => glob.matches(path.parts.drop(self.parts.size), caseSensitivity))
 
         /** Moves this path to `to`. */
-        def move(to: Path, options: MoveOptions = MoveOptions())(using Frame): Unit < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.move(to, options)))
+        inline def move(to: Path, options: MoveOptions = MoveOptions())(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.Move(self, to, options))
 
         /** Copies this path to `to`. */
-        def copy(to: Path, options: CopyOptions = CopyOptions())(using Frame): Unit < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.copy(to, options)))
+        inline def copy(to: Path, options: CopyOptions = CopyOptions())(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.Copy(self, to, options))
 
         /** Deletes this path if it exists. Returns `true` if it was deleted, `false` if it did not exist. */
-        def remove(using Frame): Boolean < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.remove()))
+        inline def remove(using inline frame: Frame): Boolean < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.Remove(self))
 
         /** Deletes this path, raising `FileNotFoundException` if it does not exist. */
-        def removeExisting(using Frame): Unit < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.removeExisting()))
+        inline def removeExisting(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.RemoveExisting(self))
 
         /** Recursively deletes this path and all of its contents. */
-        def removeAll(using Frame): Unit < (Sync & Abort[FileStructureException]) =
-            Sync.Unsafe.defer(Abort.get(self.unsafe.removeAll()))
+        inline def removeAll(using inline frame: Frame): Unit < PathWrite =
+            ArrowEffect.suspend(Tag[PathWrite], Path.Op.RemoveAll(self))
 
         /** Returns the underlying `Unsafe` implementation for direct use in unsafe code. */
         def unsafe: Path.Unsafe = self
@@ -791,6 +1087,15 @@ object Path extends PathPlatformSpecific:
         end if
     end poll
 
+    /** Fails the enclosing read capability with `error`.
+      *
+      * A failure the loop detects itself, rather than one a backend call returned, still belongs on the runner's
+      * `Abort[FileSystemException]`. Suspending [[Path.Op.Raise]] puts it there without giving every follower an
+      * `Abort` row of its own.
+      */
+    private def raiseRead(error: Result.Error[FileSystemException])(using Frame): Nothing < PathRead =
+        ArrowEffect.suspend(Tag[PathRead], Op.Raise(error))
+
     /** Polling loop shared by [[Path.tailBytes]] and [[Path.tail]].
       *
       * Opens a `Scope`-managed read handle, seeks to the position `from` selects, then reads until the end of the file, sleeping
@@ -808,6 +1113,9 @@ object Path extends PathPlatformSpecific:
       * re-arm an unbroken replay.
       *
       * `step` receives the read buffer itself, which the loop reuses across iterations: it must copy any bytes it retains.
+      *
+      * The handle comes from the installed read service, exactly as [[Path.openRead]] gets its own, so a follower reads whatever
+      * filesystem the enclosing runner selected rather than always the host.
       */
     private[kyo] def watch[V, St](
         self: Path,
@@ -817,12 +1125,12 @@ object Path extends PathPlatformSpecific:
         initialState: St
     )(
         step: (St, Array[Byte], Int) => Step[V, St]
-    )(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Stream[V, Async & Scope & Abort[FileReadException]] =
+    )(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Stream[V, PathRead & Async & Scope] =
         val capacity = readBufferCapacity(bufferSize)
         Stream {
             Scope.acquireRelease(
-                // Unsafe: closes the read handle at Scope exit
-                Sync.Unsafe.defer(Abort.get(self.unsafe.openRead()))
+                ArrowEffect.suspend(Tag[PathRead], Path.Op.OpenRead(self))
+                // Unsafe: closes the vended read handle at Scope exit
             )(handle => Sync.Unsafe.defer(handle.close())).map { handle =>
                 // Unsafe: the read handle is a single-consumer cursor owned by this stream, so its
                 // position, size, and buffer reads are bridged into Sync one call at a time.
@@ -836,35 +1144,40 @@ object Path extends PathPlatformSpecific:
                             // Clamped so a negative offset means the same thing everywhere: JVM and Native raise a raw
                             // IllegalArgumentException from the channel, while Node reads from the current position instead.
                             case Origin.Offset(bytes) => Result.succeed(math.max(0L, bytes))
-                    Abort.get(startPos).map { start =>
-                        Sync.Unsafe.defer {
-                            handle.position(start)
-                            val buf = new Array[Byte](capacity)
-                            Loop(start, initialState) { (pos, state) =>
-                                Sync.Unsafe.defer {
-                                    poll(handle, buf, pos) match
-                                        case Observed.Data(n) =>
-                                            step(state, buf, n) match
-                                                case Step.Continue(values, next) =>
-                                                    if values.isEmpty then Loop.continue(pos + n, next)
-                                                    else Emit.valueWith(values)(Loop.continue(pos + n, next))
-                                                case Step.Stop(values) =>
-                                                    if values.isEmpty then Loop.done(())
-                                                    else Emit.valueWith(values)(Loop.done(()))
-                                        case Observed.Rewound =>
-                                            Sync.Unsafe.defer(handle.position(0L))
-                                                .andThen(Async.sleep(pollDelay))
-                                                .andThen(Loop.continue(0L, initialState))
-                                        case Observed.Idle =>
-                                            Async.sleep(pollDelay)
-                                                .andThen(Loop.continue(pos, state))
-                                        case Observed.Unreadable(error) =>
-                                            // The handle can no longer be measured, so the stream fails instead of idling.
-                                            Abort.error(error)
+                    startPos.foldError(
+                        start =>
+                            Sync.Unsafe.defer {
+                                handle.position(start)
+                                val buf = new Array[Byte](capacity)
+                                Loop(start, initialState) { (pos, state) =>
+                                    Sync.Unsafe.defer {
+                                        poll(handle, buf, pos) match
+                                            case Observed.Data(n) =>
+                                                step(state, buf, n) match
+                                                    case Step.Continue(values, next) =>
+                                                        if values.isEmpty then Loop.continue(pos + n, next)
+                                                        else Emit.valueWith(values)(Loop.continue(pos + n, next))
+                                                    case Step.Stop(values) =>
+                                                        if values.isEmpty then Loop.done(())
+                                                        else Emit.valueWith(values)(Loop.done(()))
+                                            case Observed.Rewound =>
+                                                Sync.Unsafe.defer(handle.position(0L))
+                                                    .andThen(Async.sleep(pollDelay))
+                                                    .andThen(Loop.continue(0L, initialState))
+                                            case Observed.Idle =>
+                                                Async.sleep(pollDelay)
+                                                    .andThen(Loop.continue(pos, state))
+                                            case Observed.Unreadable(error) =>
+                                                // The handle can no longer be measured. Raising through the capability keeps the
+                                                // failure on the runner's Abort[FileSystemException] instead of adding an Abort
+                                                // row of its own to every follower's type.
+                                                raiseRead(error)
+                                    }
                                 }
-                            }
-                        }
-                    }
+                            },
+                        // The file could not be measured at all, so the stream never starts.
+                        error => raiseRead(error)
+                    )
                 }
             }
         }

--- a/kyo-system/shared/src/main/scala/kyo/StreamSystemExtensions.scala
+++ b/kyo-system/shared/src/main/scala/kyo/StreamSystemExtensions.scala
@@ -1,45 +1,53 @@
 package kyo
 
+import kyo.kernel.ArrowEffect
+
 /** Stream sinks that write byte and text streams to the file system.
   *
-  * These live in kyo-system rather than kyo-core because they are typed in terms of [[kyo.Path]] and [[kyo.FileWriteException]]. Keeping
-  * them in kyo-core would make kyo-core depend on kyo-system, which already depends on kyo-core.
+  * These live in kyo-system rather than kyo-core because they are typed in terms of [[kyo.Path]] and the write capability. Keeping them in
+  * kyo-core would make kyo-core depend on kyo-system, which already depends on kyo-core.
+  *
+  * Every sink carries `PathWrite`, so it writes to whichever filesystem the enclosing runner installed and the write failure lands on that
+  * runner's `Abort[FileSystemException]`.
   *
   * @see
   *   [[kyo.Path]] for the path type these sinks target
   */
 object StreamSystemExtensions:
 
-    /** Shared write logic: opens a write handle via Scope, runs the body, and marks the handle finished.
+    /** Shared write logic: opens a write handle through the write capability, runs the body, and marks the handle finished.
       *
       * A body that fails never reaches `finish()`, so the handle's close removes what was half written. An appending sink is the exception
       * and finishes anyway: the entry already held content the sink never wrote, and close would take that content along with the partial
       * append.
+      *
+      * The failure is raised by the enclosing runner rather than by this frame, so there is no local `Abort` for an `Abort.run` to catch.
+      * The append case is decided in the `Scope` finalizer instead, which is the one place that sees whether the computation finished or
+      * failed. Finishing and closing in a single finalizer keeps that decision independent of the finalizer parallelism `Scope.run` was
+      * given.
       */
     private def writeWith[S](path: Path, append: Boolean, options: Path.WriteOptions)(
-        body: Path.WriteHandle => Unit < (Sync & Abort[FileWriteException] & S)
-    )(using Frame): Unit < (Scope & Sync & Abort[FileWriteException] & S) =
-        Scope
-            .acquireRelease(
-                Sync.Unsafe.defer(Abort.get(path.unsafe.openWrite(append, options)))
-            )(handle => Sync.Unsafe.defer(handle.close())) // Unsafe: closes the write handle at Scope exit
-            .map { handle =>
-                Abort.run[FileWriteException](body(handle)).map {
-                    case Result.Failure(e) =>
-                        if append then Sync.Unsafe.defer(handle.finish()).andThen(Abort.fail(e)) // Unsafe: keeps the pre-existing content
-                        else Abort.fail(e)
-                    case ok =>
-                        Sync.Unsafe.defer(handle.finish()).andThen(Abort.get(ok)) // Unsafe: marks the write handle complete
+        body: Path.WriteHandle => Unit < (PathWrite & Sync & S)
+    )(using Frame): Unit < (Scope & PathWrite & Sync & S) =
+        ArrowEffect.suspend(Tag[PathWrite], Path.Op.OpenWrite(path, append, options)).map { handle =>
+            Scope.ensure { outcome =>
+                // Unsafe: finishes and closes the vended write handle at Scope exit.
+                Sync.Unsafe.defer {
+                    if outcome.nonEmpty && append then handle.finish() // keeps the content the entry already held
+                    handle.close()
                 }
             }
+                .andThen(body(handle))
+                .andThen(Sync.Unsafe.defer(handle.finish())) // Unsafe: marks the vended write handle complete
+        }
 
     extension [S](stream: Stream[Byte, S])
         /** Writes each byte of the stream to `path`, truncating an existing file and creating parent directories as needed. */
-        def writeTo(path: Path)(using Frame): Unit < (Scope & Sync & Abort[FileWriteException] & S) =
+        def writeTo(path: Path)(using Frame): Unit < (Scope & PathWrite & Sync & S) =
             writeTo(path, append = false, Path.WriteOptions())
 
         /** Writes each byte of the stream to `path`, creating parent directories as needed. */
-        def writeTo(path: Path, append: Boolean)(using Frame): Unit < (Scope & Sync & Abort[FileWriteException] & S) =
+        def writeTo(path: Path, append: Boolean)(using Frame): Unit < (Scope & PathWrite & Sync & S) =
             writeTo(path, append, Path.WriteOptions())
 
         /** Writes each byte of the stream to `path`.
@@ -59,10 +67,10 @@ object StreamSystemExtensions:
           */
         def writeTo(path: Path, append: Boolean, options: Path.WriteOptions)(using
             Frame
-        ): Unit < (Scope & Sync & Abort[FileWriteException] & S) =
+        ): Unit < (Scope & PathWrite & Sync & S) =
             writeWith(path, append, options) { handle =>
                 stream.foreachChunk { chunk =>
-                    Sync.Unsafe.defer(Abort.get(handle.writeBytes(chunk))) // Unsafe: bridges a write-handle chunk write into the Sync tier
+                    ArrowEffect.suspend(Tag[PathWrite], Path.Op.WriteChunk(handle, chunk))
                 }
             }
     end extension
@@ -87,10 +95,10 @@ object StreamSystemExtensions:
             charset: java.nio.charset.Charset = java.nio.charset.StandardCharsets.UTF_8,
             append: Boolean = false,
             options: Path.WriteOptions = Path.WriteOptions()
-        )(using Frame): Unit < (Scope & Sync & Abort[FileWriteException] & S) =
+        )(using Frame): Unit < (Scope & PathWrite & Sync & S) =
             writeWith(path, append, options) { handle =>
                 stream.foreach { s =>
-                    Sync.Unsafe.defer(Abort.get(handle.writeString(s, charset))) // Unsafe: bridges a write-handle string write into Sync
+                    ArrowEffect.suspend(Tag[PathWrite], Path.Op.WriteString(handle, s, charset))
                 }
             }
 
@@ -114,11 +122,11 @@ object StreamSystemExtensions:
             charset: java.nio.charset.Charset = java.nio.charset.StandardCharsets.UTF_8,
             append: Boolean = false,
             options: Path.WriteOptions = Path.WriteOptions()
-        )(using Frame): Unit < (Scope & Sync & Abort[FileWriteException] & S) =
+        )(using Frame): Unit < (Scope & PathWrite & Sync & S) =
             System.lineSeparator.map { sep =>
                 writeWith(path, append, options) { handle =>
                     stream.foreach { s =>
-                        Sync.Unsafe.defer(Abort.get(handle.writeString(s + sep, charset))) // Unsafe: bridges the write into the Sync tier
+                        ArrowEffect.suspend(Tag[PathWrite], Path.Op.WriteString(handle, s + sep, charset))
                     }
                 }
             }

--- a/kyo-system/shared/src/main/scala/kyo/internal/PathDirectories.scala
+++ b/kyo-system/shared/src/main/scala/kyo/internal/PathDirectories.scala
@@ -69,28 +69,6 @@ private[kyo] trait PathDirectories:
         )
     end platformProjectPaths
 
-    /** Creates a temporary directory in the platform temporary location and registers its recursive
-      * removal with the enclosing `Scope`. Use `tempDirUnscoped` when the directory must outlive the
-      * scope that creates it.
-      */
-    def tempDir(prefix: String = "kyo")(using Frame): Path < (Sync & Scope & Abort[FileStructureException]) =
-        tempDirUnscoped(prefix).map { dir =>
-            Scope.acquireRelease(dir)(created => Abort.run[FileStructureException](created.removeAll).unit)
-        }
-
-    /** Creates a temporary file in the platform temporary location and registers its removal with the
-      * enclosing `Scope`. Use `tempUnscoped` when the file must outlive the scope that creates it.
-      */
-    private[kyo] def temp(
-        prefix: String = "kyo",
-        suffix: String = ".tmp"
-    )(using Frame): Path < (Sync & Scope & Abort[FileStructureException]) =
-        tempUnscoped(prefix, suffix).map { p =>
-            Scope.acquireRelease(p) { q =>
-                Abort.run[FileStructureException](q.removeAll).unit
-            }
-        }
-
     // --- Private env helpers ---
 
     private def envOrElse(name: String, fallback: => String): String =

--- a/kyo-system/shared/src/test/resources/kyo/path/glob-matrix.snap
+++ b/kyo-system/shared/src/test/resources/kyo/path/glob-matrix.snap
@@ -1,0 +1,3 @@
+*.txt|alpha.txt=true|nested/alpha.txt=false
+**/*.txt|alpha.txt=true|nested/alpha.txt=true
+*.TXT|alpha.txt=false|ALPHA.TXT=true

--- a/kyo-system/shared/src/test/resources/kyo/path/normalized-errors.snap
+++ b/kyo-system/shared/src/test/resources/kyo/path/normalized-errors.snap
@@ -1,0 +1,3 @@
+Read|root/missing.txt|FileNotFoundException
+Write|root/missing/value.txt|FileNotFoundException
+Create|root/a.txt|FileAlreadyExistsException

--- a/kyo-system/shared/src/test/resources/kyo/path/normalized-tree.snap
+++ b/kyo-system/shared/src/test/resources/kyo/path/normalized-tree.snap
@@ -1,0 +1,4 @@
+root/
+root/a.txt=a
+root/nested/
+root/nested/b.txt=b

--- a/kyo-system/shared/src/test/scala/kyo/CommandTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/CommandTest.scala
@@ -90,15 +90,17 @@ class CommandTest extends kyo.test.Test[Any]:
     }
 
     "cwd sets working directory for the process" in {
-        for
-            tmpDir <- Path.tempDir("kyo-cmd-cwd-test")
-            result <- pwd.cwd(tmpDir).text
-            _      <- tmpDir.removeAll
-        yield
-            val pwdPath = normalize(result).trim
-            val dirName = tmpDir.name.getOrElse("")
-            assert(pwdPath.contains(dirName))
-        end for
+        Path.run {
+            for
+                tmpDir <- Path.tempDir("kyo-cmd-cwd-test")
+                result <- pwd.cwd(tmpDir).text
+                _      <- tmpDir.removeAll
+            yield
+                val pwdPath = normalize(result).trim
+                val dirName = tmpDir.name.getOrElse("")
+                assert(pwdPath.contains(dirName))
+            end for
+        }
     }
 
     "non-existent program raises ProgramNotFoundException" in {
@@ -183,58 +185,66 @@ class CommandTest extends kyo.test.Test[Any]:
     // ---------------------------------------------------------------------------
 
     "stdoutToFile writes stdout to file" in {
-        for
-            path    <- Path.tempUnscoped("kyo-stdout-file-test", ".txt")
-            _       <- echo("stdout line").stdoutToFile(path).waitFor
-            content <- path.read
-            _       <- path.remove
-        yield assert(normalize(content).trim == "stdout line")
-        end for
+        Path.run {
+            for
+                path    <- Path.tempUnscoped("kyo-stdout-file-test", ".txt")
+                _       <- echo("stdout line").stdoutToFile(path).waitFor
+                content <- path.read
+                _       <- path.remove
+            yield assert(normalize(content).trim == "stdout line")
+            end for
+        }
     }
 
     // ProcessBuilder.Redirect.appendTo is broken on Scala Native Windows ARM64
     "stdoutToFile with append=true appends" in {
         assume(!(isWindows && kyo.internal.Platform.isNative), "ProcessBuilder append broken on Native Windows")
         {
-            for
-                path    <- Path.tempUnscoped("kyo-stdout-append-test", ".txt")
-                _       <- path.write("line1\n")
-                _       <- echo("line2").stdoutToFile(path, append = true).waitFor
-                content <- path.read
-                _       <- path.remove
-            yield
-                assert(content.contains("line1"))
-                assert(content.contains("line2"))
-            end for
+            Path.run {
+                for
+                    path    <- Path.tempUnscoped("kyo-stdout-append-test", ".txt")
+                    _       <- path.write("line1\n")
+                    _       <- echo("line2").stdoutToFile(path, append = true).waitFor
+                    content <- path.read
+                    _       <- path.remove
+                yield
+                    assert(content.contains("line1"))
+                    assert(content.contains("line2"))
+                end for
+            }
         }
     }
 
     "stderrToFile writes stderr to file" in {
         assumeUnix("stderr redirect");
         {
-            for
-                path    <- Path.tempUnscoped("kyo-stderr-file-test", ".txt")
-                _       <- Command("sh", "-c", "echo err >&2").stderrToFile(path).waitFor
-                content <- path.read
-                _       <- path.remove
-            yield assert(normalize(content).trim == "err")
-            end for
+            Path.run {
+                for
+                    path    <- Path.tempUnscoped("kyo-stderr-file-test", ".txt")
+                    _       <- Command("sh", "-c", "echo err >&2").stderrToFile(path).waitFor
+                    content <- path.read
+                    _       <- path.remove
+                yield assert(normalize(content).trim == "err")
+                end for
+            }
         }
     }
 
     "stderrToFile with append=true appends" in {
         assumeUnix("stderr redirect");
         {
-            for
-                path    <- Path.tempUnscoped("kyo-stderr-append-test", ".txt")
-                _       <- path.write("first\n")
-                _       <- Command("sh", "-c", "echo second >&2").stderrToFile(path, append = true).waitFor
-                content <- path.read
-                _       <- path.remove
-            yield
-                assert(content.contains("first"))
-                assert(content.contains("second"))
-            end for
+            Path.run {
+                for
+                    path    <- Path.tempUnscoped("kyo-stderr-append-test", ".txt")
+                    _       <- path.write("first\n")
+                    _       <- Command("sh", "-c", "echo second >&2").stderrToFile(path, append = true).waitFor
+                    content <- path.read
+                    _       <- path.remove
+                yield
+                    assert(content.contains("first"))
+                    assert(content.contains("second"))
+                end for
+            }
         }
     }
 
@@ -397,18 +407,20 @@ class CommandTest extends kyo.test.Test[Any]:
 
     "Path.unsafe.read returns Success for readable file" in {
         val text = "unsafe read content"
-        for
-            dir <- Path.tempDir("kyo-unsafe-test")
-            file = dir / "unsafe-read.txt"
-            _ <- file.write(text)
-            result =
-                import AllowUnsafe.embrace.danger
-                file.unsafe.read()
-            _ <- dir.removeAll
-        yield result match
-            case Result.Success(content) => assert(content == text)
-            case other                   => fail(s"Expected Success, got: $other")
-        end for
+        Path.run {
+            for
+                dir <- Path.tempDir("kyo-unsafe-test")
+                file = dir / "unsafe-read.txt"
+                _ <- file.write(text)
+                result =
+                    import AllowUnsafe.embrace.danger
+                    file.unsafe.read()
+                _ <- dir.removeAll
+            yield result match
+                case Result.Success(content) => assert(content == text)
+                case other                   => fail(s"Expected Success, got: $other")
+            end for
+        }
     }
 
     "Path.unsafe.read returns Failure(FileNotFoundException) for absent file" in {
@@ -547,16 +559,18 @@ class CommandTest extends kyo.test.Test[Any]:
     "stdoutToFile with append=true preserves existing content" in {
         assume(!(isWindows && kyo.internal.Platform.isNative), "ProcessBuilder append broken on Native Windows")
         {
-            for
-                path    <- Path.tempUnscoped("kyo-stdout-append-preserve-test", ".txt")
-                _       <- path.write("line1\n")
-                _       <- echo("line2").stdoutToFile(path, append = true).waitFor
-                content <- path.read
-                _       <- path.remove
-            yield
-                assert(content.contains("line1"))
-                assert(content.contains("line2"))
-            end for
+            Path.run {
+                for
+                    path    <- Path.tempUnscoped("kyo-stdout-append-preserve-test", ".txt")
+                    _       <- path.write("line1\n")
+                    _       <- echo("line2").stdoutToFile(path, append = true).waitFor
+                    content <- path.read
+                    _       <- path.remove
+                yield
+                    assert(content.contains("line1"))
+                    assert(content.contains("line2"))
+                end for
+            }
         }
     }
 

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemSnapshotTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemSnapshotTest.scala
@@ -1,9 +1,12 @@
 package kyo
 
-/** Cross-platform behavioral assertions represented by the stable Path snapshots. */
-class PathSnapshotTest extends kyo.test.Test[Any]:
+/** Cross-platform behavioral assertions represented by the stable filesystem snapshots. */
+class FileSystemSnapshotTest extends kyo.test.Test[Any]:
 
     private given Frame = Frame.internal
+
+    private def hostTempDir(prefix: String): Path < (Sync & Scope & Abort[FileSystemException]) =
+        Scope.acquireRelease(FileSystem.host.tempDir(prefix))(h => Sync.Unsafe.defer(h.remove())).map(_.path)
 
     private def glob(value: String): Glob =
         Glob.parse(value) match
@@ -16,23 +19,24 @@ class PathSnapshotTest extends kyo.test.Test[Any]:
             s"**/*.txt|alpha.txt=${glob("**/*.txt").matches("alpha.txt", Glob.CaseSensitivity.Sensitive)}|nested/alpha.txt=${glob("**/*.txt").matches("nested/alpha.txt", Glob.CaseSensitivity.Sensitive)}",
             s"*.TXT|alpha.txt=${glob("*.TXT").matches("alpha.txt", Glob.CaseSensitivity.Sensitive)}|ALPHA.TXT=${glob("*.TXT").matches("ALPHA.TXT", Glob.CaseSensitivity.Sensitive)}"
         )
-        assert(rows.mkString("\n") == PathSnapshotValues.globMatrix)
+        assert(rows.mkString("\n") == FileSystemSnapshotValues.globMatrix)
     }
 
     "normalized tree snapshot represents backend contents" in {
-        Path.tempDir("kyo-snapshot-tree").map { dir =>
-            val root = dir / "root"
-            root.mkDir.andThen {
-                (root / "a.txt").write("a").andThen {
-                    (root / "nested" / "b.txt").write("b").andThen {
-                        root.list.map { top =>
-                            (root / "nested").list.map { nested =>
+        hostTempDir("kyo-snapshot-tree").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "root"
+            fileSystem.mkDir(root).andThen {
+                fileSystem.write(root / "a.txt", "a", Path.WriteOptions()).andThen {
+                    fileSystem.write(root / "nested" / "b.txt", "b", Path.WriteOptions()).andThen {
+                        fileSystem.list(root).map { top =>
+                            fileSystem.list(root / "nested").map { nested =>
                                 // list order is unspecified: Files.list and readdirSync both report entries
                                 // in filesystem order, which differs between platforms and architectures.
                                 assert(top.toList.sortBy(_.parts.last) == List(root / "a.txt", root / "nested"))
                                 assert(nested == Chunk(root / "nested" / "b.txt"))
                                 val normalized = Chunk("root/", "root/a.txt=a", "root/nested/", "root/nested/b.txt=b")
-                                assert(normalized.mkString("\n") == PathSnapshotValues.normalizedTree)
+                                assert(normalized.mkString("\n") == FileSystemSnapshotValues.normalizedTree)
                             }
                         }
                     }
@@ -49,15 +53,15 @@ class PathSnapshotTest extends kyo.test.Test[Any]:
         )
         assert(FileNotFoundException(Path("root", "missing.txt")).path == Path("root", "missing.txt"))
         assert(FileAlreadyExistsException(Path("root", "a.txt")).path == Path("root", "a.txt"))
-        assert(rows.mkString("\n") == PathSnapshotValues.normalizedErrors)
+        assert(rows.mkString("\n") == FileSystemSnapshotValues.normalizedErrors)
     }
 
-end PathSnapshotTest
+end FileSystemSnapshotTest
 
-private[kyo] object PathSnapshotValues:
+private[kyo] object FileSystemSnapshotValues:
     val globMatrix: String =
         "*.txt|alpha.txt=true|nested/alpha.txt=false\n**/*.txt|alpha.txt=true|nested/alpha.txt=true\n*.TXT|alpha.txt=false|ALPHA.TXT=true"
     val normalizedTree: String = "root/\nroot/a.txt=a\nroot/nested/\nroot/nested/b.txt=b"
     val normalizedErrors: String =
         "Read|root/missing.txt|FileNotFoundException\nWrite|root/missing/value.txt|FileNotFoundException\nCreate|root/a.txt|FileAlreadyExistsException"
-end PathSnapshotValues
+end FileSystemSnapshotValues

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemTest.scala
@@ -1,16 +1,19 @@
 package kyo
 
 import java.nio.charset.Charset
+import scala.compiletime.testing.typeCheckErrors
 
-/** Tests for the top-level [[FileSystem]] surface: the read and write tiers as types, and a
-  * user-defined backend answering through the same service methods the host backend implements.
+/** Tests for the top-level [[FileSystem]] surface: installation through [[Path.runWith]] and the
+  * negative-capability rejection of a write program at a read-only runner.
   */
 class FileSystemTest extends kyo.test.Test[Any]:
 
-    /** Rebases `write` and `read`, the only two ops this suite exercises, under `root`. Two instances
-      * backed by the real host filesystem then behave as independent stores addressable through the
-      * same literal `Path` value, which is what a backend test needs: the store a read reaches must
-      * depend only on which service it is asked of.
+    private val selectedPath = Path("selected.txt")
+
+    /** Rebases `write` and `read`, the only two ops this suite exercises, under `root`. Two
+      * instances backed by the real host filesystem then behave as independent stores addressable
+      * through the same literal `Path` value, which is what these `FileSystem.let` selection tests
+      * need: the store a read reaches must depend only on which service is ambient.
       */
     final private class IsolatedFileSystem(root: Path) extends FileSystem.Write[Sync]:
         private val delegate = FileSystem.host
@@ -45,6 +48,7 @@ class FileSystemTest extends kyo.test.Test[Any]:
         export delegate.setLastModified
         export delegate.size
         export delegate.stat
+        export delegate.temp
         export delegate.tempDir
         export delegate.truncate
         export delegate.writeBytes
@@ -91,25 +95,92 @@ class FileSystemTest extends kyo.test.Test[Any]:
         )
     }
 
-    "a user-defined backend serves reads and writes through the service methods" in {
+    "runReadOnlyWith accepts Read" in {
+        typeCheck(
+            "def check(fs: kyo.FileSystem.Read[kyo.Sync]) = kyo.Path.runReadOnlyWith(fs)(kyo.Path(\"a\").read)"
+        )
+    }
+
+    private def services: (FileSystem.Write[Sync], FileSystem.Write[Sync]) < (Sync & Scope & Abort[FileSystemException]) =
+        for
+            outer <- isolatedFileSystem("kyo-fs-let-outer")
+            inner <- isolatedFileSystem("kyo-fs-let-inner")
+            _     <- Path.runWith(outer)(selectedPath.write("outer"))
+            _     <- Path.runWith(inner)(selectedPath.write("inner"))
+        yield (outer, inner)
+
+    "top-level FileSystem installs through runWith" in {
         isolatedFileSystem("kyo-fs-top-level").map { service =>
             val p = Path("a")
-            service.write(p, "x", Path.WriteOptions()).andThen {
-                service.read(p).map(v => assert(v == "x"))
+            val program: Unit < (Sync & Abort[FileSystemException]) =
+                Path.runWith(service)(p.write("x"))
+            program.andThen {
+                Path.runWith(service)(p.read).map(v => assert(v == "x"))
             }
         }
     }
 
-    "two backends addressed by the same path reach independent stores" in {
-        for
-            outer <- isolatedFileSystem("kyo-fs-outer")
-            inner <- isolatedFileSystem("kyo-fs-inner")
-            selected = Path("selected.txt")
-            _         <- outer.write(selected, "outer", Path.WriteOptions())
-            _         <- inner.write(selected, "inner", Path.WriteOptions())
-            fromOuter <- outer.read(selected)
-            fromInner <- inner.read(selected)
-        yield assert((fromOuter, fromInner) == ("outer", "inner"))
+    "runReadOnly rejects PathWrite at the call site (compile-negative)" in {
+        val errors = typeCheckErrors("""
+            given kyo.Frame = kyo.Frame.internal
+            val prog: Unit < kyo.PathWrite = kyo.Path("a").write("x")
+            val _: Unit < (kyo.Sync & kyo.Abort[kyo.FileSystemException]) = kyo.Path.runReadOnly(prog)
+            """)
+        assert(errors.nonEmpty, "runReadOnly ascription should fail to compile for a PathWrite program")
+        assert(errors.exists(_.message.contains("PathWrite")))
+    }
+
+    "runWith retains a custom backend effect in its residual" in {
+        val errors = typeCheckErrors("""
+            given kyo.Frame = kyo.Frame.internal
+            sealed trait BackendEffect
+            def check(backend: kyo.FileSystem.Write[BackendEffect]) =
+                val write = kyo.Path.runWith(backend)(kyo.Path("a").write("x"))
+                val _: Unit < kyo.Abort[kyo.FileSystemException] = write
+            """)
+        assert(errors.nonEmpty)
+        assert(errors.exists(_.message.contains("BackendEffect")))
+    }
+
+    "FileSystem.let nests and restores the selected service" in {
+        services.map { (outer, inner) =>
+            FileSystem.let(outer) {
+                for
+                    before <- Path.runReadOnly(selectedPath.read)
+                    during <- FileSystem.let(inner)(Path.runReadOnly(selectedPath.read))
+                    after  <- Path.runReadOnly(selectedPath.read)
+                yield assert((before, during, after) == ("outer", "inner", "outer"))
+            }
+        }
+    }
+
+    "FileSystem.let restores the selected service after failure" in {
+        services.map { (outer, inner) =>
+            FileSystem.let(outer) {
+                Abort.run[String] {
+                    FileSystem.let(inner)(Path.runReadOnly(selectedPath.read).andThen(Abort.fail("stop")))
+                }.map { failed =>
+                    Path.runReadOnly(selectedPath.read).map(after => assert((failed, after) == (Result.fail("stop"), "outer")))
+                }
+            }
+        }
+    }
+
+    "child fibers inherit the selected service" in {
+        services.map { (_, inner) =>
+            FileSystem.let(inner) {
+                Path.runReadOnly(Async.zip(selectedPath.read, selectedPath.read)).map(values => assert(values == ("inner", "inner")))
+            }
+        }
+    }
+
+    "sibling fibers keep independently selected services" in {
+        services.map { (outer, inner) =>
+            Async.zip(
+                FileSystem.let(outer)(Path.runReadOnly(selectedPath.read)),
+                FileSystem.let(inner)(Path.runReadOnly(selectedPath.read))
+            ).map(values => assert(values == ("outer", "inner")))
+        }
     }
 
 end FileSystemTest

--- a/kyo-system/shared/src/test/scala/kyo/PathCapabilityTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathCapabilityTest.scala
@@ -1,0 +1,320 @@
+package kyo
+
+import java.nio.charset.StandardCharsets
+import scala.compiletime.testing.typeCheckErrors
+
+class PathCapabilityTest extends kyo.test.Test[Any]:
+
+    val somePath  = Path("tmp", "cap-a.txt")
+    val otherPath = Path("tmp", "cap-b.txt")
+
+    private def hostTempDir(prefix: String)(using Frame): Path < (Sync & Scope & Abort[FileSystemException]) =
+        Scope.acquireRelease(FileSystem.host.tempDir(prefix))(h => Sync.Unsafe.defer(h.remove())).map(_.path)
+
+    // --- Compile-time capability laws: a green compile proves each row ascription below. ---
+
+    val readOnly: String < PathRead                            = somePath.read
+    val writableRead: String < PathWrite                       = somePath.read
+    val write: Unit < PathWrite                                = somePath.write("x")
+    val mixed: String < PathWrite                              = somePath.read.map(s => otherPath.write(s).andThen(s))
+    val readRuns: String < (Sync & Abort[FileSystemException]) = Path.runReadOnly(readOnly)
+    val writeRuns: Unit < (Sync & Abort[FileSystemException])  = Path.run(write)
+
+    "the read-only runner leaves a write undischarged so its residual does not type-check" in {
+        val errors = typeCheckErrors(
+            """
+            given kyo.Frame = kyo.Frame.internal
+            val w: Unit < kyo.PathWrite = kyo.Path("x").write("y")
+            val bad: Unit < (kyo.Sync & kyo.Abort[kyo.FileSystemException]) = kyo.Path.runReadOnly(w)
+            """
+        )
+        assert(errors.nonEmpty)
+        assert(errors.exists(_.message.contains("PathWrite")))
+    }
+
+    "an explicit backend effect remains in the runner residual" in {
+        val positive = typeCheckErrors(
+            """
+            given kyo.Frame = kyo.Frame.internal
+            sealed trait BackendEffect
+            val backend = null.asInstanceOf[kyo.FileSystem.Write[BackendEffect]]
+            val read: String < (BackendEffect & kyo.Abort[kyo.FileSystemException]) =
+                kyo.Path.runReadOnlyWith(backend)(kyo.Path("x").read)
+            val write: Unit < (BackendEffect & kyo.Abort[kyo.FileSystemException]) =
+                kyo.Path.runWith(backend)(kyo.Path("x").write("value"))
+            """
+        )
+        val errors = typeCheckErrors(
+            """
+            given kyo.Frame = kyo.Frame.internal
+            sealed trait BackendEffect
+            val backend = null.asInstanceOf[kyo.FileSystem.Write[BackendEffect]]
+            val read = kyo.Path.runReadOnlyWith(backend)(kyo.Path("x").read)
+            val bad: String < kyo.Abort[kyo.FileSystemException] = read
+            """
+        )
+        assert(positive.isEmpty)
+        assert(errors.nonEmpty)
+        assert(errors.exists(_.message.contains("BackendEffect")))
+    }
+
+    "concurrent child operations have isolated Path handlers" in {
+        hostTempDir("kyo-cap-concurrent").map { root =>
+            val service = FileSystem.host
+            val first   = root / "isolate-first.txt"
+            val second  = root / "isolate-second.txt"
+            FileSystem.let(service) {
+                Path.run {
+                    Async.zip(
+                        first.write("first").andThen(first.read),
+                        second.write("second").andThen(second.read)
+                    )
+                }
+            }.map(values => assert(values == ("first", "second")))
+        }
+    }
+
+    "a child Path failure is restored through the parent handler" in {
+        hostTempDir("kyo-cap-child-failure").map { root =>
+            val service  = FileSystem.host
+            val existing = root / "isolate-existing.txt"
+            val missing  = root / "isolate-missing.txt"
+            Path.runWith(service)(existing.write("value")).andThen {
+                Abort.run[FileSystemException] {
+                    FileSystem.let(service) {
+                        Path.runReadOnly(Async.zip(missing.read, existing.read))
+                    }
+                }.map { result =>
+                    assert(result.isFailure)
+                    assert(result.failure.exists(_.isInstanceOf[FileNotFoundException]))
+                }
+            }
+        }
+    }
+
+    "a child PathRead panic is restored with the same throwable" in {
+        hostTempDir("kyo-cap-read-panic").map { root =>
+            val service  = FileSystem.host
+            val sentinel = new RuntimeException("path-read-child-panic")
+            val existing = root / "isolate-read-panic.txt"
+            Path.runWith(service)(existing.write("value")).andThen {
+                Abort.run[FileSystemException] {
+                    FileSystem.let(service) {
+                        Path.runReadOnly {
+                            Async.zip(
+                                existing.read.andThen(Abort.panic[FileSystemException](sentinel)),
+                                existing.read
+                            )
+                        }
+                    }
+                }.map {
+                    case Result.Panic(actual) => assert(actual eq sentinel)
+                    case other                => fail(s"expected child PathRead panic, got: $other")
+                }
+            }
+        }
+    }
+
+    "a child PathWrite panic is restored with the same throwable" in {
+        hostTempDir("kyo-cap-write-panic").map { root =>
+            val service  = FileSystem.host
+            val sentinel = new RuntimeException("path-write-child-panic")
+            val first    = root / "isolate-write-panic-first.txt"
+            val second   = root / "isolate-write-panic-second.txt"
+            Abort.run[FileSystemException] {
+                FileSystem.let(service) {
+                    Path.run {
+                        Async.zip(
+                            first.write("first").andThen(Abort.panic[FileSystemException](sentinel)),
+                            second.write("second")
+                        )
+                    }
+                }
+            }.map {
+                case Result.Panic(actual) => assert(actual eq sentinel)
+                case other                => fail(s"expected child PathWrite panic, got: $other")
+            }
+        }
+    }
+
+    "a failing child PathWrite restores its concrete typed error" in {
+        hostTempDir("kyo-cap-typed-error").map { root =>
+            val service       = FileSystem.host
+            val missingParent = root / "isolate-missing-parent" / "child.txt"
+            val successful    = root / "isolate-write-success.txt"
+            Abort.run[FileSystemException] {
+                FileSystem.let(service) {
+                    Path.run {
+                        Async.zip(
+                            missingParent.write("value", Path.WriteOptions(createFolders = false)),
+                            successful.write("value")
+                        )
+                    }
+                }
+            }.map {
+                case Result.Failure(error: FileNotFoundException) => assert(error.path == missingParent)
+                case other                                        => fail(s"expected typed FileNotFoundException, got: $other")
+            }
+        }
+    }
+
+    // --- Row-guard block: the streaming, walk, tempDir, tail, and sink methods compile at exactly these rows. ---
+
+    val g1: Stream[String, PathRead & Scope & Sync] = somePath.readStream
+    val g2: Stream[String, PathRead & Scope & Sync] = somePath.readStream(StandardCharsets.UTF_8)
+    val g3: Stream[String, PathRead & Scope & Sync] = somePath.readStream(StandardCharsets.UTF_8, 8.kib)
+    val g4: Stream[Byte, PathRead & Scope & Sync]   = somePath.readBytesStream
+    val g5: Stream[Byte, PathRead & Scope & Sync]   = somePath.readBytesStream(8.kib)
+    val g6: Stream[String, PathRead & Scope & Sync] = somePath.readLinesStream
+    val g7: Stream[String, PathRead & Scope & Sync] = somePath.readLinesStream(StandardCharsets.UTF_8)
+    val g8: Stream[Path, PathRead & Scope & Sync]   = somePath.walk
+    val g9: Stream[Path, PathRead & Scope & Sync]   = somePath.walk(Int.MaxValue, followLinks = false)
+    val gList: Chunk[Path] < PathRead               = somePath.list(glob"*.txt")
+    val gListCase: Chunk[Path] < PathRead =
+        somePath.list(glob"*.txt", Glob.CaseSensitivity.Insensitive)
+    val gWalkGlob: Stream[Path, PathRead & Scope & Sync] = somePath.walk(glob"**/*.txt")
+    val gWalkGlobCase: Stream[Path, PathRead & Scope & Sync] =
+        somePath.walk(glob"**/*.txt", Glob.CaseSensitivity.Sensitive)
+    val gWriteOptions: Unit < PathWrite =
+        somePath.write("x", Path.WriteOptions(createFolders = false))
+    val gMoveOptions: Unit < PathWrite =
+        somePath.move(
+            otherPath,
+            Path.MoveOptions(
+                replace = Path.Replace.Existing,
+                atomicity = Path.Atomicity.Required,
+                createFolders = false
+            )
+        )
+    val gCopyOptions: Unit < PathWrite =
+        somePath.copy(
+            otherPath,
+            Path.CopyOptions(
+                followLinks = false,
+                replace = Path.Replace.Existing,
+                copyAttributes = true,
+                createFolders = false
+            )
+        )
+    val gTempDir: Path < (PathWrite & Sync & Scope)     = Path.tempDir()
+    val gTail: Stream[String, PathRead & Async & Scope] = somePath.tail
+    // sink rows guarded via a byte and a string stream
+    val gSinkB: Unit < (Scope & PathWrite & Sync) = Stream.init(Chunk[Byte](1)).writeTo(somePath)
+    val gSinkS: Unit < (Scope & PathWrite & Sync) = Stream.init(Chunk("a")).writeTo(somePath)
+    val gSinkL: Unit < (Scope & PathWrite & Sync) = Stream.init(Chunk("a")).writeLinesTo(somePath)
+
+    // --- Runtime checks against the host service: returned values, concrete exceptions, streaming, scoped tempDir. ---
+
+    "a read returns its value and a write completes under Path.run" in {
+        Scope.run {
+            Path.run {
+                Path.tempDir().map { dir =>
+                    val f = dir / "hello.txt"
+                    Abort.run[FileSystemException](Path.run(f.write("hello").andThen(f.read))).map(r =>
+                        assert(r == Result.succeed("hello"))
+                    )
+                }
+            }
+        }
+    }
+
+    "a concrete FileSystemException subtype survives the umbrella row" in {
+        val missing = Path("does", "not", "exist-cap.txt")
+        Abort.run[FileSystemException](Path.run(missing.read)).map { r =>
+            assert(r.isFailure)
+            assert(r.failure.exists(_.isInstanceOf[FileNotFoundException]))
+        }
+    }
+
+    "streaming read yields exact content and releases the handle at Scope exit" in {
+        Scope.run {
+            Path.run {
+                Path.tempDir().map { dir =>
+                    val f = dir / "lines.txt"
+                    f.writeLines(Chunk("a", "b", "c")).andThen {
+                        Scope.run(Path.run(f.readLinesStream.run)).map { lines =>
+                            assert(lines == Chunk("a", "b", "c"))
+                            // second open succeeds -> the first handle was released
+                            Scope.run(Path.run(f.readLinesStream.run)).map(l2 => assert(l2 == Chunk("a", "b", "c")))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "writeTo removes the partial file on failure and keeps it on success" in {
+        Scope.run {
+            Path.run {
+                Path.tempDir().map { dir =>
+                    val ok                             = dir / "ok.bin"
+                    val bad                            = dir / "bad.bin"
+                    val cleanStream: Stream[Byte, Any] = Stream.init(Chunk[Byte](1, 2, 3))
+                    val failStream: Stream[Byte, Abort[Throwable]] =
+                        Stream.init(Chunk[Byte](1)).concat(Stream.init(Abort.fail(new RuntimeException("boom")).map(_ =>
+                            Chunk.empty[Byte]
+                        )))
+                    Scope.run(Path.run(cleanStream.writeTo(ok))).andThen {
+                        Abort.run[Throwable](Scope.run(Path.run(failStream.writeTo(bad)))).andThen {
+                            Path.runReadOnly(ok.readBytes).map(bytes =>
+                                assert(bytes.toArray sameElements Array(1.toByte, 2.toByte, 3.toByte))
+                            ).andThen(
+                                Path.runReadOnly(bad.exists).map(e => assert(!e))
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "tempDir creates a directory and removes it recursively at Scope exit" in {
+        var created: Option[Path] = None
+        Scope.run {
+            Path.run {
+                Path.tempDir().map { dir =>
+                    created = Some(dir)
+                    (dir / "child.txt").write("x").andThen(dir.exists.map(e => assert(e)))
+                }
+            }
+        }.andThen(Path.run(Path(created.get.parts*).exists).map(e => assert(!e)))
+    }
+
+    /** Vends both temp factories under `root` without touching the disk, so a test can tell whether a
+      * temp path was created through the installed service or straight on the host.
+      */
+    final private class RootedTempFileSystem(root: Path) extends FileSystem.Write[Sync]:
+        private val delegate = FileSystem.host
+        export delegate.{temp as _, tempDir as _, *}
+
+        def tempDir(prefix: String)(using Frame): Path.TempDirHandle < (Sync & Abort[FileStructureException]) =
+            new Path.TempDirHandle:
+                def path: Path                        = root / s"$prefix-dir"
+                def remove()(using AllowUnsafe): Unit = ()
+
+        def temp(prefix: String, suffix: String)(using Frame): Path.TempFileHandle < (Sync & Abort[FileStructureException]) =
+            new Path.TempFileHandle:
+                def path: Path                        = root / s"$prefix$suffix"
+                def remove()(using AllowUnsafe): Unit = ()
+    end RootedTempFileSystem
+
+    "temp creates the file through the installed service" in {
+        val root    = Path("kyo-cap-temp-root")
+        val service = RootedTempFileSystem(root)
+        Scope.run(Path.runWith(service)(Path.temp("kyo-cap-temp-", ".txt"))).map { created =>
+            assert(
+                created.parts.take(root.parts.size) == root.parts,
+                s"Path.temp bypassed the installed service and created $created"
+            )
+        }
+    }
+
+    "tempDir creates the directory through the installed service" in {
+        val root    = Path("kyo-cap-temp-root")
+        val service = RootedTempFileSystem(root)
+        Scope.run(Path.runWith(service)(Path.tempDir("kyo-cap-temp-"))).map { created =>
+            assert(created == root / "kyo-cap-temp--dir")
+        }
+    }
+
+end PathCapabilityTest

--- a/kyo-system/shared/src/test/scala/kyo/PathSizeTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathSizeTest.scala
@@ -3,7 +3,7 @@ package kyo
 class PathSizeTest extends kyo.test.Test[Any]:
 
     "size of a freshly-written file equals the written byte count" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-size-test")
                 file = dir / "sz.bin"
@@ -12,12 +12,12 @@ class PathSizeTest extends kyo.test.Test[Any]:
                 _ <- dir.removeAll
             yield assert(n == 2048L)
             end for
-        }
+        })
     }
 
     "size of a missing path fails with FileReadException via Abort" in {
         val file = Path("/nonexistent-kyo-path-size-test-xyz")
-        Abort.run[FileSystemException](file.size).map {
+        Abort.run[FileSystemException](Path.runReadOnly(file.size)).map {
             case Result.Failure(_: FileReadException) => succeed
             case other                                => fail(s"Expected FileReadException, got $other")
         }

--- a/kyo-system/shared/src/test/scala/kyo/PathStatTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathStatTest.scala
@@ -3,7 +3,7 @@ package kyo
 class PathStatTest extends kyo.test.Test[Any]:
 
     "stat returns size matching written bytes" in {
-        Scope.run {
+        Scope.run(Path.run {
             Path.tempDir("kyo-path-stat").map { dir =>
                 val file  = dir / "data.bin"
                 val bytes = Span.from(Array[Byte](0x01, 0x02, 0x03, 0x04, 0x05))
@@ -13,11 +13,11 @@ class PathStatTest extends kyo.test.Test[Any]:
                     }
                 }
             }
-        }
+        })
     }
 
     "stat reports a lastModifiedMs bracketed by the write" in {
-        Scope.run {
+        Scope.run(Path.run {
             Path.tempDir("kyo-path-stat").map { dir =>
                 val file  = dir / "data.bin"
                 val bytes = Span.from(Array[Byte](0x42))
@@ -42,23 +42,23 @@ class PathStatTest extends kyo.test.Test[Any]:
                     }
                 }
             }
-        }
+        })
     }
 
     "stat on missing path aborts with FileReadException" in {
-        Scope.run {
+        Scope.run(Path.run {
             Path.tempDir("kyo-path-stat").map { dir =>
                 val missing = dir / "no-such-file.bin"
-                Abort.run[FileSystemException](missing.stat).map {
+                Abort.run[FileSystemException](Path.runReadOnly(missing.stat)).map {
                     case Result.Failure(_: FileReadException) => succeed
                     case other                                => fail(s"expected FileReadException, got $other")
                 }
             }
-        }
+        })
     }
 
     "setLastModified round-trips through stat" in {
-        Scope.run {
+        Scope.run(Path.run {
             Path.tempDir("kyo-path-stat").map { dir =>
                 val file     = dir / "mtime.bin"
                 val targetMs = 1_000_000_000_000L // 2001-09-08 UTC, well in the past
@@ -74,19 +74,19 @@ class PathStatTest extends kyo.test.Test[Any]:
                     }
                 }
             }
-        }
+        })
     }
 
     "setLastModified on missing path aborts with FileWriteException" in {
-        Scope.run {
+        Scope.run(Path.run {
             Path.tempDir("kyo-path-stat").map { dir =>
                 val missing = dir / "no-such-file.bin"
-                Abort.run[FileSystemException](missing.setLastModified(1_000_000_000_000L)).map {
+                Abort.run[FileSystemException](Path.run(missing.setLastModified(1_000_000_000_000L))).map {
                     case Result.Failure(_: FileWriteException) => succeed
                     case other                                 => fail(s"expected FileWriteException, got $other")
                 }
             }
-        }
+        })
     }
 
 end PathStatTest

--- a/kyo-system/shared/src/test/scala/kyo/PathTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathTest.scala
@@ -96,7 +96,7 @@ class PathTest extends kyo.test.Test[Any]:
     }
 
     "a /-derived child path stays under its root (drive preserved)" in {
-        Scope.run {
+        Scope.run(Path.run {
             // Cross-platform regression: on Windows with the CWD on a different drive
             // than the temp dir, the drive letter was previously dropped so the child
             // re-anchored to the CWD drive and landed outside the root.
@@ -113,7 +113,7 @@ class PathTest extends kyo.test.Test[Any]:
                 )
                 assert(exists, "file written via a /-derived path should exist under the root")
             end for
-        }
+        })
     }
 
     "Path.basePaths fields are populated" in {
@@ -178,11 +178,11 @@ class PathTest extends kyo.test.Test[Any]:
 
     "exists returns false for nonexistent path" in {
         val p = Path / "kyo-test-nonexistent-path-should-never-exist-xyzzy-42"
-        p.exists.map(e => assert(!e))
+        Path.runReadOnly(p.exists.map(e => assert(!e)))
     }
 
     "exists returns true after file is created" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 p = dir / "test-exists.txt"
@@ -192,11 +192,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(!before && after)
             end for
-        }
+        })
     }
 
     "isDirectory returns true for directory and false for file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 file = dir / "test-isdir.txt"
@@ -206,11 +206,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _          <- dir.removeAll
             yield assert(dirResult && !fileResult)
             end for
-        }
+        })
     }
 
     "isRegularFile returns false for directory and true for file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 file = dir / "test-isfile.txt"
@@ -220,17 +220,17 @@ class PathTest extends kyo.test.Test[Any]:
                 _          <- dir.removeAll
             yield assert(!dirResult && fileResult)
             end for
-        }
+        })
     }
 
     "Path.cwd returns a non-empty path" in {
-        Path.cwd.map { cwd =>
+        Path.runReadOnly(Path.cwd.map { cwd =>
             assert(cwd.parts.nonEmpty, s"expected non-empty cwd, got parts=${cwd.parts.mkString(",")}")
-        }
+        })
     }
 
     "Path.parent terminates after finite steps" in {
-        Path.cwd.map { cwd =>
+        Path.runReadOnly(Path.cwd.map { cwd =>
             @scala.annotation.tailrec
             def loop(cur: Path, depth: Int): Int =
                 if depth > 64 then depth
@@ -240,32 +240,36 @@ class PathTest extends kyo.test.Test[Any]:
                         case Maybe.Absent     => depth
             val depth = loop(cwd, 0)
             assert(depth < 64, s"parent walk should terminate quickly, but reached depth $depth (cwd=${cwd.toString})")
-        }
+        })
     }
 
     "ancestors yields self -> parent -> ... -> root and terminates" in {
-        for
-            cwd <- Path.cwd
-            all <- cwd.ancestors.run
-        yield
-            assert(all.size >= 1)
-            assert(all.headOption.exists(_.parts == cwd.parts))
-            assert(all.size <= 50, s"ancestors should be small + finite, got ${all.size}")
-            assert(all.lastOption.exists(_.parts.size <= 1))
-        end for
+        Path.runReadOnly {
+            for
+                cwd <- Path.cwd
+                all <- cwd.ancestors.run
+            yield
+                assert(all.size >= 1)
+                assert(all.headOption.exists(_.parts == cwd.parts))
+                assert(all.size <= 50, s"ancestors should be small + finite, got ${all.size}")
+                assert(all.lastOption.exists(_.parts.size <= 1))
+            end for
+        }
     }
 
     "Stream.find on ancestors finds a matching ancestor and short-circuits" in {
-        for
-            cwd <- Path.cwd
-            // Find the cwd itself (trivial predicate, must match first).
-            hit <- cwd.ancestors.find(p => (p.parts == cwd.parts))
-        yield assert(hit.isDefined)
-        end for
+        Path.runReadOnly {
+            for
+                cwd <- Path.cwd
+                // Find the cwd itself (trivial predicate, must match first).
+                hit <- cwd.ancestors.find(p => (p.parts == cwd.parts))
+            yield assert(hit.isDefined)
+            end for
+        }
     }
 
     "realPath canonicalizes an existing file path" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 file = dir / "file.txt"
@@ -276,19 +280,19 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(real.isAbsolute)
                 assert(real.parts.lastOption.contains("file.txt"))
             end for
-        }
+        })
     }
 
     "realPath fails with FileNotFoundException for non-existent path" in {
         val ghost = Path / "kyo-test-realpath-does-not-exist-xyzzy-99"
-        Abort.run[FileSystemException](ghost.realPath).map { r =>
+        Abort.run[FileSystemException](Path.runReadOnly(ghost.realPath)).map { r =>
             assert(r.isFailure)
             assert(r.failure.exists(_.isInstanceOf[FileNotFoundException]))
         }
     }
 
     "confinedTo accepts a path inside root" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 file = dir / "inside.txt"
@@ -297,22 +301,22 @@ class PathTest extends kyo.test.Test[Any]:
                 _        <- dir.removeAll
             yield assert(confined.parts.takeRight(1).headOption.contains("inside.txt"))
             end for
-        }
+        })
     }
 
     "confinedTo rejects a path equal to root with success (root is contained in itself)" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir      <- Path.tempDir("kyo-test")
                 confined <- dir.confinedTo(dir)
                 _        <- dir.removeAll
             yield assert(confined.parts.lastOption == dir.parts.lastOption)
             end for
-        }
+        })
     }
 
     "confinedTo rejects a sibling-of-root path with FileAccessDeniedException" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 base <- Path.tempDir("kyo-test")
                 // Two siblings: `base/inside` is root; `base/outside.txt` is outside it.
@@ -320,13 +324,13 @@ class PathTest extends kyo.test.Test[Any]:
                 _ <- root.mkDir
                 outside = base / "outside.txt"
                 _   <- outside.write("escape")
-                res <- Abort.run[FileReadException](outside.confinedTo(root))
+                res <- Abort.run[FileSystemException](Path.runReadOnly(outside.confinedTo(root)))
                 _   <- base.removeAll
             yield
                 assert(res.isFailure)
                 assert(res.failure.exists(_.isInstanceOf[FileAccessDeniedException]))
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -334,7 +338,7 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "read round-trips string content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-read-test")
                 file = dir / "read-roundtrip.txt"
@@ -344,11 +348,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == text)
             end for
-        }
+        })
     }
 
     "read with explicit charset round-trips non-ASCII content" in {
-        Scope.run {
+        Scope.run(Path.run {
             val charset = StandardCharsets.ISO_8859_1
             val text    = "caf\u00e9 na\u00efve r\u00e9sum\u00e9"
             for
@@ -360,11 +364,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == text)
             end for
-        }
+        })
     }
 
     "readBytes returns raw file bytes" in {
-        Scope.run {
+        Scope.run(Path.run {
             val bytes = Span.from(Array[Byte](0, 1, 2, 3, 127, -1))
             for
                 dir <- Path.tempDir("kyo-path-read-test")
@@ -374,11 +378,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toArray.toList == bytes.toArray.toList)
             end for
-        }
+        })
     }
 
     "readLines returns one element per line without trailing newlines" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-read-test")
                 file = dir / "read-lines.txt"
@@ -387,11 +391,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == Chunk("line1", "line2", "line3"))
             end for
-        }
+        })
     }
 
     "readLines with explicit charset decodes lines correctly" in {
-        Scope.run {
+        Scope.run(Path.run {
             val charset = StandardCharsets.ISO_8859_1
             val content = "premi\u00e8re\ndeuxi\u00e8me"
             for
@@ -403,11 +407,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == Chunk("premi\u00e8re", "deuxi\u00e8me"))
             end for
-        }
+        })
     }
 
     "readStream emits all content and closes handle" in {
-        Scope.run {
+        Scope.run(Path.run {
             val text = "streaming content"
             for
                 dir <- Path.tempDir("kyo-path-read-test")
@@ -417,11 +421,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toList.mkString == text)
             end for
-        }
+        })
     }
 
     "readLinesStream matches readLines" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-read-test")
                 file = dir / "read-lines-stream.txt"
@@ -431,11 +435,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _           <- dir.removeAll
             yield assert(linesStream.toList == linesDirect)
             end for
-        }
+        })
     }
 
     "readBytesStream matches readBytes" in {
-        Scope.run {
+        Scope.run(Path.run {
             val data = Span.from(Array[Byte](10, 20, 30, 40, 50))
             for
                 dir <- Path.tempDir("kyo-path-read-test")
@@ -446,7 +450,7 @@ class PathTest extends kyo.test.Test[Any]:
                 _            <- dir.removeAll
             yield assert(streamResult.toArray.toList == directResult.toArray.toList)
             end for
-        }
+        })
     }
 
     // A zero-size buffer would read nothing on every pass, so the read loop would spin without ever
@@ -454,25 +458,29 @@ class PathTest extends kyo.test.Test[Any]:
     // byte in order, which is what this pins.
     "readBytesStream with a zero buffer size reads one byte at a time" in {
         val data = Span.from(Array[Byte](10, 20, 30, 40, 50))
-        for
-            dir <- Path.tempDir("kyo-path-read-test")
-            file = dir / "read-bytes-stream-zero-buffer.bin"
-            _      <- file.writeBytes(data)
-            result <- Scope.run(file.readBytesStream(ByteSize.Zero).run)
-            _      <- dir.removeAll
-        yield assert(result.toArray.toList == data.toArray.toList)
-        end for
+        Path.run {
+            for
+                dir <- Path.tempDir("kyo-path-read-test")
+                file = dir / "read-bytes-stream-zero-buffer.bin"
+                _      <- file.writeBytes(data)
+                result <- Scope.run(file.readBytesStream(ByteSize.Zero).run)
+                _      <- dir.removeAll
+            yield assert(result.toArray.toList == data.toArray.toList)
+            end for
+        }
     }
 
     "readStream with a zero buffer size decodes the whole file" in {
-        for
-            dir <- Path.tempDir("kyo-path-read-test")
-            file = dir / "read-stream-zero-buffer.txt"
-            _      <- file.write("hello")
-            result <- Scope.run(file.readStream(java.nio.charset.StandardCharsets.UTF_8, ByteSize.Zero).run)
-            _      <- dir.removeAll
-        yield assert(result.mkString == "hello")
-        end for
+        Path.run {
+            for
+                dir <- Path.tempDir("kyo-path-read-test")
+                file = dir / "read-stream-zero-buffer.txt"
+                _      <- file.write("hello")
+                result <- Scope.run(file.readStream(java.nio.charset.StandardCharsets.UTF_8, ByteSize.Zero).run)
+                _      <- dir.removeAll
+            yield assert(result.mkString == "hello")
+            end for
+        }
     }
 
     // The clamp is pinned on the function rather than through a read, because the upper end names a
@@ -487,28 +495,28 @@ class PathTest extends kyo.test.Test[Any]:
     }
 
     "read on a directory raises FileIsADirectoryException" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-path-read-test")
-                result <- Abort.run[FileSystemException](dir.read)
+                result <- Abort.run[FileSystemException](Path.runReadOnly(dir.read))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileIsADirectoryException) => succeed("expected exception type")
                 case other                                        => fail(s"Expected FileIsADirectoryException, got $other")
             end for
-        }
+        })
     }
 
     "read on non-existent path raises FileNotFoundException" in {
         val file = Path / "kyo-nonexistent-dir-xyzzy" / "nonexistent-read.txt"
-        Abort.run[FileSystemException](file.read).map {
+        Abort.run[FileSystemException](Path.runReadOnly(file.read)).map {
             case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
             case other                                    => fail(s"Expected FileNotFoundException, got $other")
         }
     }
 
     "readStream with ISO-8859-1 charset decodes content correctly" in {
-        Scope.run {
+        Scope.run(Path.run {
             val charset = StandardCharsets.ISO_8859_1
             val text    = "caf\u00e9 na\u00efve"
             for
@@ -520,11 +528,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toList.mkString == text)
             end for
-        }
+        })
     }
 
     "readLinesStream with ISO-8859-1 charset matches readLines" in {
-        Scope.run {
+        Scope.run(Path.run {
             val charset = StandardCharsets.ISO_8859_1
             val content = "premi\u00e8re\ndeuxi\u00e8me\ntrois\u00eem"
             for
@@ -537,12 +545,12 @@ class PathTest extends kyo.test.Test[Any]:
                 _           <- dir.removeAll
             yield assert(linesStream.toList == linesDirect)
             end for
-        }
+        })
     }
 
     "readBytes on non-existent path raises FileNotFoundException" in {
         val file = Path / "kyo-nonexistent-dir-xyzzy" / "nonexistent-readbytes.bin"
-        Abort.run[FileSystemException](file.readBytes).map {
+        Abort.run[FileSystemException](Path.runReadOnly(file.readBytes)).map {
             case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
             case other                                    => fail(s"Expected FileNotFoundException, got $other")
         }
@@ -550,14 +558,14 @@ class PathTest extends kyo.test.Test[Any]:
 
     "readLines on non-existent path raises FileNotFoundException" in {
         val file = Path / "kyo-nonexistent-dir-xyzzy" / "nonexistent-readlines.txt"
-        Abort.run[FileSystemException](file.readLines).map {
+        Abort.run[FileSystemException](Path.runReadOnly(file.readLines)).map {
             case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
             case other                                    => fail(s"Expected FileNotFoundException, got $other")
         }
     }
 
     "unsafe size returns correct byte count for a file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-size-test")
                 file = dir / "size-test.txt"
@@ -570,11 +578,11 @@ class PathTest extends kyo.test.Test[Any]:
                 case Result.Success(s) => assert(s == 5L)
                 case other             => fail(s"Expected Success(5), got $other")
             end for
-        }
+        })
     }
 
     "unsafe size returns 0 for empty file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-size-test")
                 file = dir / "empty-size.txt"
@@ -587,7 +595,7 @@ class PathTest extends kyo.test.Test[Any]:
                 case Result.Success(s) => assert(s == 0L)
                 case other             => fail(s"Expected Success(0), got $other")
             end for
-        }
+        })
     }
 
     "unsafe size on non-existent path returns FileReadException" in {
@@ -601,7 +609,7 @@ class PathTest extends kyo.test.Test[Any]:
     }
 
     "readBytesStream collects same bytes as readBytes for large file" in {
-        Scope.run {
+        Scope.run(Path.run {
             val data = Span.from(Array.tabulate[Byte](100000)(i => (i % 251).toByte))
             for
                 dir <- Path.tempDir("kyo-path-read-test")
@@ -612,7 +620,7 @@ class PathTest extends kyo.test.Test[Any]:
                 _        <- dir.removeAll
             yield assert(direct.toArray.toSeq == streamed.toArray.toSeq)
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -632,7 +640,7 @@ class PathTest extends kyo.test.Test[Any]:
         // A leading decimal token so readLong parses a real value, then known bytes so the interleaved
         // readChunk cursor can be checked byte-for-byte.
         val content = "12345 abcdefghij"
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-readlong-cursor")
                 file = dir / "readlong-cursor.txt"
@@ -657,12 +665,12 @@ class PathTest extends kyo.test.Test[Any]:
                 finally handle.close()
                 end try
             end for
-        }
+        })
     }
 
     "the borrowed byte view does not escape the read callback (aliasing safety)" in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-readhandle-alias")
                 fileA = dir / "a.txt"
@@ -695,12 +703,12 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(firstChecksum != secondChecksum)
                 assert(firstChecksum == ("aaaa".getBytes(StandardCharsets.UTF_8).foldLeft(0L)((s, b) => s * 31 + b)))
             end for
-        }
+        })
     }
 
     "position(0) re-reads the file from offset 0 through one retained handle" in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-readhandle-reread")
                 file    = dir / "content.txt"
@@ -731,12 +739,12 @@ class PathTest extends kyo.test.Test[Any]:
                 finally handle.close()
                 end try
             end for
-        }
+        })
     }
 
     "readLong parses the first ASCII-decimal Long out of a numeric file" in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-readlong-happy")
                 file = dir / "value"
@@ -747,12 +755,12 @@ class PathTest extends kyo.test.Test[Any]:
                 finally handle.close()
                 end try
             end for
-        }
+        })
     }
 
     "readLong returns AbsentLong for empty, non-numeric and leading-sign content" in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-readlong-total")
                 empty      = dir / "empty"
@@ -776,12 +784,12 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(readLongOf(negative) == Path.ReadHandle.AbsentLong)
                 assert(Path.ReadHandle.AbsentLong == Long.MinValue)
             end for
-        }
+        })
     }
 
     "readLong returns AbsentLong on overflow rather than a wrapped negative Long" in {
         import AllowUnsafe.embrace.danger
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-readlong-overflow")
                 file = dir / "overflow"
@@ -794,7 +802,7 @@ class PathTest extends kyo.test.Test[Any]:
                 finally handle.close()
                 end try
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -802,7 +810,7 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "write creates file if absent and sets content" in {
-        Scope.run {
+        Scope.run(Path.run {
             val text = "created fresh"
             for
                 dir <- Path.tempDir("kyo-path-write-test")
@@ -814,11 +822,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _       <- dir.removeAll
             yield assert(!exists1 && exists2 && content == text)
             end for
-        }
+        })
     }
 
     "write overwrites existing content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "write-overwrite.txt"
@@ -828,11 +836,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _       <- dir.removeAll
             yield assert(content == "new")
             end for
-        }
+        })
     }
 
     "writeBytes creates file and content matches readBytes" in {
-        Scope.run {
+        Scope.run(Path.run {
             val bytes = Span.from(Array[Byte](1, 2, 3, 4, 5))
             for
                 dir <- Path.tempDir("kyo-path-write-test")
@@ -842,11 +850,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toArray.toList == bytes.toArray.toList)
             end for
-        }
+        })
     }
 
     "writeLines readLines round-trip preserves lines" in {
-        Scope.run {
+        Scope.run(Path.run {
             val lines = Chunk("first", "second", "third")
             for
                 dir <- Path.tempDir("kyo-path-write-test")
@@ -856,11 +864,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == lines)
             end for
-        }
+        })
     }
 
     "append creates file if absent and accumulates content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "append.txt"
@@ -871,25 +879,25 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(!exists && result == "hello world")
             end for
-        }
+        })
     }
 
     "append with createFolders=false raises FileNotFoundException when parent missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "missing-parent" / "append-no-create.txt"
-                result <- Abort.run[FileSystemException](file.append("data", Path.WriteOptions(createFolders = false)))
+                result <- Abort.run[FileSystemException](Path.run(file.append("data", Path.WriteOptions(createFolders = false))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
                 case other                                    => fail(s"Expected FileNotFoundException, got $other")
             end for
-        }
+        })
     }
 
     "truncate to 0 clears file content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "truncate-zero.txt"
@@ -899,11 +907,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == "")
             end for
-        }
+        })
     }
 
     "write with createFolders=true creates intermediate parent directories" in {
-        Scope.run {
+        Scope.run(Path.run {
             val text = "deep file"
             for
                 dir <- Path.tempDir("kyo-path-write-test")
@@ -913,55 +921,55 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == text)
             end for
-        }
+        })
     }
 
     "write with createFolders=false raises FileNotFoundException when parent missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "missing" / "write-no-create.txt"
-                result <- Abort.run[FileSystemException](file.write("data", Path.WriteOptions(createFolders = false)))
+                result <- Abort.run[FileSystemException](Path.run(file.write("data", Path.WriteOptions(createFolders = false))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
                 case other                                    => fail(s"Expected FileNotFoundException, got $other")
             end for
-        }
+        })
     }
 
     "writeBytes with createFolders=false raises FileNotFoundException when parent missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             val bytes = Span.from(Array[Byte](1, 2, 3))
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "missing-bytes" / "write-bytes-no-create.bin"
-                result <- Abort.run[FileSystemException](file.writeBytes(bytes, Path.WriteOptions(createFolders = false)))
+                result <- Abort.run[FileSystemException](Path.run(file.writeBytes(bytes, Path.WriteOptions(createFolders = false))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
                 case other                                    => fail(s"Expected FileNotFoundException, got $other")
             end for
-        }
+        })
     }
 
     "writeLines with createFolders=false raises FileNotFoundException when parent missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "missing-lines" / "write-lines-no-create.txt"
                 result <-
-                    Abort.run[FileSystemException](file.writeLines(Chunk("a", "b"), Path.WriteOptions(createFolders = false)))
+                    Abort.run[FileSystemException](Path.run(file.writeLines(Chunk("a", "b"), Path.WriteOptions(createFolders = false))))
                 _ <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
                 case other                                    => fail(s"Expected FileNotFoundException, got $other")
             end for
-        }
+        })
     }
 
     "appendBytes accumulates bytes across two calls" in {
-        Scope.run {
+        Scope.run(Path.run {
             val bytes1 = Span.from(Array[Byte](1, 2, 3))
             val bytes2 = Span.from(Array[Byte](4, 5, 6))
             for
@@ -973,28 +981,28 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toArray.toList == List[Byte](1, 2, 3, 4, 5, 6))
             end for
-        }
+        })
     }
 
     "appendBytes with createFolders=false raises FileNotFoundException when parent missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "missing-appendbytes" / "append-bytes-no-create.bin"
-                result <- Abort.run[FileSystemException](file.appendBytes(
+                result <- Abort.run[FileSystemException](Path.run(file.appendBytes(
                     Span.from(Array[Byte](1)),
                     Path.WriteOptions(createFolders = false)
-                ))
+                )))
                 _ <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
                 case other                                    => fail(s"Expected FileNotFoundException, got $other")
             end for
-        }
+        })
     }
 
     "appendLines accumulates lines across two calls" in {
-        Scope.run {
+        Scope.run(Path.run {
             val lines1 = Chunk("first", "second")
             val lines2 = Chunk("third", "fourth")
             for
@@ -1006,25 +1014,25 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == Chunk("first", "second", "third", "fourth"))
             end for
-        }
+        })
     }
 
     "appendLines with createFolders=false raises FileNotFoundException when parent missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "missing-appendlines" / "append-lines-no-create.txt"
-                result <- Abort.run[FileSystemException](file.appendLines(Chunk("a"), Path.WriteOptions(createFolders = false)))
+                result <- Abort.run[FileSystemException](Path.run(file.appendLines(Chunk("a"), Path.WriteOptions(createFolders = false))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
                 case other                                    => fail(s"Expected FileNotFoundException, got $other")
             end for
-        }
+        })
     }
 
     "truncate to non-zero size trims file to that many bytes" in {
-        Scope.run {
+        Scope.run(Path.run {
             val bytes = Span.from(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
             for
                 dir <- Path.tempDir("kyo-path-write-test")
@@ -1035,32 +1043,32 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toArray.length == 5)
             end for
-        }
+        })
     }
 
     "truncate on non-existent file raises FileWriteException" in {
         val file = Path / "kyo-nonexistent-dir-xyzzy" / "nonexistent-truncate.txt"
-        Abort.run[FileSystemException](file.truncate(0L)).map {
+        Abort.run[FileSystemException](Path.run(file.truncate(0L))).map {
             case Result.Failure(_: FileWriteException) => succeed("expected exception type")
             case other                                 => fail(s"Expected FileWriteException, got $other")
         }
     }
 
     "write on a directory raises FileIsADirectoryException" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-path-write-test")
-                result <- Abort.run[FileSystemException](dir.write("data"))
+                result <- Abort.run[FileSystemException](Path.run(dir.write("data")))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileIsADirectoryException) => succeed("expected exception type")
                 case other                                        => fail(s"Expected FileIsADirectoryException, got $other")
             end for
-        }
+        })
     }
 
     "truncate with size exceeding Int.MaxValue is a no-op on smaller file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "truncate-large.txt"
@@ -1070,11 +1078,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _       <- dir.removeAll
             yield assert(content == "hello")
             end for
-        }
+        })
     }
 
     "writeLines then readLines with different charset shows encoding mismatch" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "charset-mismatch.txt"
@@ -1085,11 +1093,11 @@ class PathTest extends kyo.test.Test[Any]:
                 // writeLines always encodes UTF-8; reading as ISO-8859-1 garbles multi-byte chars
                 assert(back != Chunk("café"), "Expected mismatch when reading UTF-8 file as ISO-8859-1")
             end for
-        }
+        })
     }
 
     "appendLines always encodes UTF-8 regardless of existing file encoding" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "mixed-encoding.bin"
@@ -1104,11 +1112,11 @@ class PathTest extends kyo.test.Test[Any]:
                 // This documents that appendLines has no charset parameter
                 assert(bytes.size > 0)
             end for
-        }
+        })
     }
 
     "writeLines with empty chunk creates file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-write-test")
                 file = dir / "empty-writelines.txt"
@@ -1117,7 +1125,7 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(exists)
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -1125,7 +1133,7 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "mkDir creates a directory and isDirectory returns true" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 subdir = dir / "mkdir-subdir"
@@ -1134,24 +1142,24 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result)
             end for
-        }
+        })
     }
 
     "mkDir is idempotent when called twice" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 subdir = dir / "mkdir-idem"
                 _      <- subdir.mkDir
-                result <- Abort.run[FileSystemException](subdir.mkDir)
+                result <- Abort.run[FileSystemException](Path.run(subdir.mkDir))
                 _      <- dir.removeAll
             yield assert(result.isSuccess)
             end for
-        }
+        })
     }
 
     "mkFile creates a regular file and isRegularFile returns true" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 file = dir / "mkfile.txt"
@@ -1160,24 +1168,24 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result)
             end for
-        }
+        })
     }
 
     "mkFile is idempotent when called twice" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 file = dir / "mkfile-idem.txt"
                 _      <- file.mkFile
-                result <- Abort.run[FileSystemException](file.mkFile)
+                result <- Abort.run[FileSystemException](Path.run(file.mkFile))
                 _      <- dir.removeAll
             yield assert(result.isSuccess)
             end for
-        }
+        })
     }
 
     "list returns direct children of a directory" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 child1 = dir / "child-a.txt"
@@ -1190,11 +1198,11 @@ class PathTest extends kyo.test.Test[Any]:
                 val names = children.toList.map(_.parts.last).sorted
                 assert(names.contains("child-a.txt") && names.contains("child-b.txt"))
             end for
-        }
+        })
     }
 
     "list with glob returns only matching files" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 txt  = dir / "file-glob.txt"
@@ -1207,11 +1215,11 @@ class PathTest extends kyo.test.Test[Any]:
                 val names = children.toList.map(_.parts.last)
                 assert(names == List("file-glob.txt"))
             end for
-        }
+        })
     }
 
     "list with Glob matches immediate children including dot-prefixed names" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir   <- Path.tempDir("kyo-path-dir-test")
                 _     <- (dir / "a.json").mkFile
@@ -1221,11 +1229,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _     <- dir.removeAll
             yield assert(paths.toList.map(_.parts.last).sorted == List(".hidden.json", "a.json"))
             end for
-        }
+        })
     }
 
     "walk with Glob matches descendants relative to the walked root" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir   <- Path.tempDir("kyo-path-dir-test")
                 _     <- (dir / "top.json").mkFile
@@ -1235,11 +1243,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _     <- dir.removeAll
             yield assert(paths.toList.map(_.parts.last).sorted == List("deep.json", "top.json"))
             end for
-        }
+        })
     }
 
     "explicit Glob case sensitivity overrides the backend default" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir         <- Path.tempDir("kyo-path-dir-test")
                 _           <- (dir / "UPPER.JSON").mkFile
@@ -1248,11 +1256,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _           <- dir.removeAll
             yield assert(sensitive.isEmpty && insensitive.map(_.parts.last) == Chunk("UPPER.JSON"))
             end for
-        }
+        })
     }
 
     "list with glob * matches all files" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "a.txt").mkFile
@@ -1261,11 +1269,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"*")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("a.txt", "b.json", "c.log"))
-        }
+        })
     }
 
     "list with glob file.* matches all extensions" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "file.txt").mkFile
@@ -1274,11 +1282,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"file.*")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("file.json", "file.txt"))
-        }
+        })
     }
 
     "list with glob *data* matches files containing data" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "data.csv").mkFile
@@ -1287,11 +1295,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"*data*")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("data.csv", "mydata.txt"))
-        }
+        })
     }
 
     "list with glob ? matches exactly one character" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "file1.txt").mkFile
@@ -1301,11 +1309,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"file?.txt")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("file1.txt", "fileA.txt"))
-        }
+        })
     }
 
     "list with glob character class matches specified characters" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "file1.txt").mkFile
@@ -1315,11 +1323,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"file[123].txt")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("file1.txt", "file2.txt", "file3.txt"))
-        }
+        })
     }
 
     "list with glob character range matches range" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "filea.txt").mkFile
@@ -1329,11 +1337,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"file[a-c].txt")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("filea.txt", "fileb.txt", "filec.txt"))
-        }
+        })
     }
 
     "list with glob negated character class excludes matches" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "abc").mkFile
@@ -1342,11 +1350,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"[!a]*")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("bcd", "cde"))
-        }
+        })
     }
 
     "list with glob brace expansion matches alternatives" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "a.txt").mkFile
@@ -1355,11 +1363,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"*.{txt,json}")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("a.txt", "b.json"))
-        }
+        })
     }
 
     "list with glob brace expansion with specific names" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "foo.txt").mkFile
@@ -1368,11 +1376,11 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"{foo,bar}.txt")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last).sorted == List("bar.txt", "foo.txt"))
-        }
+        })
     }
 
     "list with glob *.* matches files with extensions" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-glob-test")
                 _      <- (dir / "file.txt").mkFile
@@ -1380,26 +1388,26 @@ class PathTest extends kyo.test.Test[Any]:
                 result <- dir.list(glob"*.*")
                 _      <- dir.removeAll
             yield assert(result.toList.map(_.parts.last) == List("file.txt"))
-        }
+        })
     }
 
     "list on a file raises FileNotADirectoryException" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 file = dir / "list-on-file.txt"
                 _      <- file.mkFile
-                result <- Abort.run[FileSystemException](file.list)
+                result <- Abort.run[FileSystemException](Path.runReadOnly(file.list))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileNotADirectoryException) => succeed("expected exception type")
                 case other                                         => fail(s"Expected FileNotADirectoryException, got $other")
             end for
-        }
+        })
     }
 
     "walk visits the full directory tree including nested files" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 sub   = dir / "walk-sub"
@@ -1414,11 +1422,11 @@ class PathTest extends kyo.test.Test[Any]:
                 val names = paths.toList.map(_.parts.last)
                 assert(names.contains("walk-a.txt") && names.contains("walk-b.txt"))
             end for
-        }
+        })
     }
 
     "walk with maxDepth=0 returns only the root" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 sub  = dir / "walk-depth-sub"
@@ -1429,11 +1437,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _     <- dir.removeAll
             yield assert(paths.size == 1 && paths.head == dir)
             end for
-        }
+        })
     }
 
     "move renames a file" in {
-        Scope.run {
+        Scope.run(Path.run {
             val text = "move me"
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
@@ -1447,28 +1455,28 @@ class PathTest extends kyo.test.Test[Any]:
                 _          <- dir.removeAll
             yield assert(!srcExists && dstExists && dstContent == text)
             end for
-        }
+        })
     }
 
     "move with Replace.Never raises FileAlreadyExistsException when destination exists" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "move-nooverwrite-src.txt"
                 dst = dir / "move-nooverwrite-dst.txt"
                 _      <- src.write("source")
                 _      <- dst.write("destination")
-                result <- Abort.run[FileSystemException](src.move(dst, Path.MoveOptions(replace = Path.Replace.Never)))
+                result <- Abort.run[FileSystemException](Path.run(src.move(dst, Path.MoveOptions(replace = Path.Replace.Never))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileAlreadyExistsException) => succeed("expected exception type")
                 case other                                         => fail(s"Expected FileAlreadyExistsException, got $other")
             end for
-        }
+        })
     }
 
     "copy creates a duplicate with equal content" in {
-        Scope.run {
+        Scope.run(Path.run {
             val text = "copy me"
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
@@ -1483,11 +1491,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _          <- dir.removeAll
             yield assert(srcExists && dstExists && srcContent == dstContent)
             end for
-        }
+        })
     }
 
     "remove on existing file returns true and file is gone" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 file = dir / "remove-exists.txt"
@@ -1497,12 +1505,12 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result && !exists)
             end for
-        }
+        })
     }
 
     "remove on non-existent path returns false without failure" in {
         val file = Path / "kyo-nonexistent-dir-xyzzy-remove" / "nosuchfile-remove.txt"
-        Abort.run[FileSystemException](file.remove).map {
+        Abort.run[FileSystemException](Path.run(file.remove)).map {
             case Result.Success(false) => succeed("expected: non-existent file returns false")
             case other                 => fail(s"Expected Success(false), got $other")
         }
@@ -1510,14 +1518,14 @@ class PathTest extends kyo.test.Test[Any]:
 
     "removeExisting on non-existent path raises FileNotFoundException" in {
         val file = Path / "kyo-nonexistent-dir-xyzzy-rmex" / "nosuchfile-rmex.txt"
-        Abort.run[FileSystemException](file.removeExisting).map {
+        Abort.run[FileSystemException](Path.run(file.removeExisting)).map {
             case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
             case other                                    => fail(s"Expected FileNotFoundException, got $other")
         }
     }
 
     "removeAll deletes a non-empty directory tree" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 sub   = dir / "rmall-sub"
@@ -1530,11 +1538,11 @@ class PathTest extends kyo.test.Test[Any]:
                 exists <- dir.exists
             yield assert(!exists)
             end for
-        }
+        })
     }
 
     "removeExisting on existing file succeeds" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 file = dir / "rmexisting.txt"
@@ -1544,12 +1552,12 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(!exists)
             end for
-        }
+        })
     }
 
     "removeAll on non-existent path succeeds without error" in {
         val missing = Path / "kyo-nonexistent-dir-xyzzy-rmall" / "does-not-exist-rmall"
-        Abort.run[FileSystemException](missing.removeAll).map {
+        Abort.run[FileSystemException](Path.run(missing.removeAll)).map {
             case Result.Success(_) => succeed("expected: removeAll on non-existent path succeeds")
             case other             => fail(s"Expected success, got $other")
         }
@@ -1557,14 +1565,14 @@ class PathTest extends kyo.test.Test[Any]:
 
     "list on non-existent path raises FileNotFoundException" in {
         val missing = Path / "kyo-nonexistent-dir-xyzzy-list" / "missing-list"
-        Abort.run[FileSystemException](missing.list).map {
+        Abort.run[FileSystemException](Path.run(missing.list)).map {
             case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
             case other                                    => fail(s"Expected FileNotFoundException, got $other")
         }
     }
 
     "walk(maxDepth=1) excludes grandchildren" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 childDir   = dir / "walk-depth1-child"
@@ -1577,19 +1585,19 @@ class PathTest extends kyo.test.Test[Any]:
                 val names = paths.toList.map(_.parts.last)
                 assert(names.contains("walk-depth1-child") && !names.contains("walk-depth1-grandchild.txt"))
             end for
-        }
+        })
     }
 
     "walk on non-existent path raises FileStructureException" in {
         val missing = Path / "kyo-nonexistent-dir-xyzzy-walk" / "missing-walk"
-        Abort.run[FileSystemException](Scope.run(missing.walk.run)).map {
+        Abort.run[FileSystemException](Path.run(Scope.run(missing.walk.run))).map {
             case Result.Failure(_: FileStructureException) => succeed("expected exception type")
             case other                                     => fail(s"Expected FileStructureException, got $other")
         }
     }
 
     "move with Replace.Existing overwrites destination" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "move-replace-src.txt"
@@ -1602,61 +1610,61 @@ class PathTest extends kyo.test.Test[Any]:
                 _          <- dir.removeAll
             yield assert(!srcExists && dstContent == "source-content")
             end for
-        }
+        })
     }
 
     "move with Atomicity.Required succeeds on same filesystem" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "move-atomic-src.txt"
                 dst = dir / "move-atomic-dst.txt"
                 _         <- src.write("atomic-move")
-                result    <- Abort.run[FileSystemException](src.move(dst, Path.MoveOptions(atomicity = Path.Atomicity.Required)))
+                result    <- Abort.run[FileSystemException](Path.run(src.move(dst, Path.MoveOptions(atomicity = Path.Atomicity.Required))))
                 dstExists <- dst.exists
                 _         <- dir.removeAll
             yield result match
                 case Result.Success(_) => assert(dstExists)
                 case other             => fail(s"Expected success, got $other")
             end for
-        }
+        })
     }
 
     "move with createFolders=false raises FileStructureException when parent missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "move-nocreate-src.txt"
                 dst = dir / "missing-move-parent" / "move-nocreate-dst.txt"
                 _      <- src.write("content")
-                result <- Abort.run[FileSystemException](src.move(dst, Path.MoveOptions(createFolders = false)))
+                result <- Abort.run[FileSystemException](Path.run(src.move(dst, Path.MoveOptions(createFolders = false))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileStructureException) => succeed("expected exception type")
                 case other                                     => fail(s"Expected FileStructureException, got $other")
             end for
-        }
+        })
     }
 
     "copy with Replace.Never raises FileAlreadyExistsException when destination exists" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "copy-nooverwrite-src.txt"
                 dst = dir / "copy-nooverwrite-dst.txt"
                 _      <- src.write("src-content")
                 _      <- dst.write("dst-content")
-                result <- Abort.run[FileSystemException](src.copy(dst, Path.CopyOptions(replace = Path.Replace.Never)))
+                result <- Abort.run[FileSystemException](Path.run(src.copy(dst, Path.CopyOptions(replace = Path.Replace.Never))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileAlreadyExistsException) => succeed("expected exception type")
                 case other                                         => fail(s"Expected FileAlreadyExistsException, got $other")
             end for
-        }
+        })
     }
 
     "copy with Replace.Existing overwrites destination" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "copy-replace-src.txt"
@@ -1668,45 +1676,45 @@ class PathTest extends kyo.test.Test[Any]:
                 _          <- dir.removeAll
             yield assert(dstContent == "new-source")
             end for
-        }
+        })
     }
 
     "copy with copyAttributes=true succeeds" in {
-        Scope.run {
+        Scope.run(Path.run {
             val text = "copy-attrs"
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "copy-attrs-src.txt"
                 dst = dir / "copy-attrs-dst.txt"
                 _          <- src.write(text)
-                result     <- Abort.run[FileSystemException](src.copy(dst, Path.CopyOptions(copyAttributes = true)))
+                result     <- Abort.run[FileSystemException](Path.run(src.copy(dst, Path.CopyOptions(copyAttributes = true))))
                 dstContent <- dst.read
                 _          <- dir.removeAll
             yield result match
                 case Result.Success(_) => assert(dstContent == text)
                 case other             => fail(s"Expected success, got $other")
             end for
-        }
+        })
     }
 
     "copy with createFolders=false raises FileStructureException when parent missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "copy-nocreate-src.txt"
                 dst = dir / "missing-copy-parent" / "copy-nocreate-dst.txt"
                 _      <- src.write("content")
-                result <- Abort.run[FileSystemException](src.copy(dst, Path.CopyOptions(createFolders = false)))
+                result <- Abort.run[FileSystemException](Path.run(src.copy(dst, Path.CopyOptions(createFolders = false))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileStructureException) => succeed("expected exception type")
                 case other                                     => fail(s"Expected FileStructureException, got $other")
             end for
-        }
+        })
     }
 
     "copy on non-empty directory does not copy children" in {
-        Scope.run {
+        Scope.run(Path.run {
             // Files.copy creates an empty dir at destination, so children are silently lost
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
@@ -1722,11 +1730,11 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(dstIsDir, "copy should create destination directory")
                 assert(!childExists, "copy does NOT copy children (Files.copy is not recursive)")
             end for
-        }
+        })
     }
 
     "copy on empty directory creates target directory" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "empty-src-dir"
@@ -1737,11 +1745,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result)
             end for
-        }
+        })
     }
 
     "copy on directory with nested children silently loses nested content" in {
-        Scope.run {
+        Scope.run(Path.run {
             // nested children are silently not copied
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
@@ -1757,11 +1765,11 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(dstIsDir, "copy should create destination directory")
                 assert(!subExists, "copy does NOT recurse into subdirectories")
             end for
-        }
+        })
     }
 
     "mkFile on existing file with content preserves the content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 file = dir / "mkfile-preserve.txt"
@@ -1771,28 +1779,28 @@ class PathTest extends kyo.test.Test[Any]:
                 _       <- dir.removeAll
             yield assert(content == "important data")
             end for
-        }
+        })
     }
 
     "copy to existing destination with Replace.Never raises FileAlreadyExistsException" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 src = dir / "copy-dup-src.txt"
                 dst = dir / "copy-dup-dst.txt"
                 _      <- src.write("content")
                 _      <- src.copy(dst)
-                result <- Abort.run[FileSystemException](src.copy(dst, Path.CopyOptions(replace = Path.Replace.Never)))
+                result <- Abort.run[FileSystemException](Path.run(src.copy(dst, Path.CopyOptions(replace = Path.Replace.Never))))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileAlreadyExistsException) => succeed("expected exception type")
                 case other                                         => fail(s"Expected FileAlreadyExistsException, got $other")
             end for
-        }
+        })
     }
 
     "walk on a regular file returns only that file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-dir-test")
                 file = dir / "walk-file.txt"
@@ -1803,7 +1811,7 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(paths.size == 1)
                 assert(paths.head == file)
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -1811,37 +1819,39 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "tail emits only new lines appended after stream opens" in {
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-path-edge-test")
-                file = dir / "tail.txt"
-                _ <- file.mkFile
-                tailFiber <- Fiber.initUnscoped(
-                    Scope.run(file.tail(50.millis).take(2).run)
-                )
-                _     <- control.advance(50.millis)
-                _     <- file.appendLines(Chunk("line-a", "line-b"))
-                _     <- control.advance(50.millis)
-                lines <- tailFiber.get
-                _     <- dir.removeAll
-            yield assert(lines.toList == List("line-a", "line-b"))
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-path-edge-test")
+                    file = dir / "tail.txt"
+                    _ <- file.mkFile
+                    tailFiber <- Fiber.initUnscoped(
+                        Path.run(Scope.run(file.tail(50.millis).take(2).run))
+                    )
+                    _     <- control.advance(50.millis)
+                    _     <- file.appendLines(Chunk("line-a", "line-b"))
+                    _     <- control.advance(50.millis)
+                    lines <- tailFiber.get
+                    _     <- dir.removeAll
+                yield assert(lines.toList == List("line-a", "line-b"))
+                end for
+            }
         }
     }
 
     "remove on non-empty directory raises FileDirectoryNotEmptyException" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-path-edge-test")
                 file = dir / "remove-nonempty.txt"
                 _      <- file.mkFile
-                result <- Abort.run[FileSystemException](dir.remove)
+                result <- Abort.run[FileSystemException](Path.run(dir.remove))
                 _      <- dir.removeAll
             yield result match
                 case Result.Failure(_: FileDirectoryNotEmptyException) => succeed("expected exception type")
                 case other                                             => fail(s"Expected FileDirectoryNotEmptyException, got $other")
             end for
-        }
+        })
     }
 
     "path / part infix syntax works" in {
@@ -1853,87 +1863,93 @@ class PathTest extends kyo.test.Test[Any]:
     }
 
     "tail (0-arg) emits new lines appended after stream opens" in {
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-path-edge-test")
-                file = dir / "tail-default.txt"
-                _         <- file.mkFile
-                tailFiber <- Fiber.initUnscoped(Scope.run(file.tail.take(2).run))
-                _         <- control.advance(100.millis)
-                _         <- file.appendLines(Chunk("line-x", "line-y"))
-                _         <- control.advance(100.millis)
-                lines     <- tailFiber.get
-                _         <- dir.removeAll
-            yield assert(lines.toList == List("line-x", "line-y"))
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-path-edge-test")
+                    file = dir / "tail-default.txt"
+                    _         <- file.mkFile
+                    tailFiber <- Fiber.initUnscoped(Path.run(Scope.run(file.tail.take(2).run)))
+                    _         <- control.advance(100.millis)
+                    _         <- file.appendLines(Chunk("line-x", "line-y"))
+                    _         <- control.advance(100.millis)
+                    lines     <- tailFiber.get
+                    _         <- dir.removeAll
+                yield assert(lines.toList == List("line-x", "line-y"))
+                end for
+            }
         }
     }
 
     "tail on non-existent file raises FileReadException" in {
         val file = Path / "kyo-nonexistent-dir-xyzzy" / "nonexistent-tail.txt"
-        Abort.run[FileSystemException](Scope.run(file.tail.run)).map {
+        Abort.run[FileSystemException](Path.run(Scope.run(file.tail.run))).map {
             case Result.Failure(_: FileReadException) => succeed("expected exception type")
             case other                                => fail(s"Expected FileReadException, got $other")
         }
     }
 
     "tail handles multi-byte UTF-8 characters at buffer boundary without corruption" in {
-        Clock.withTimeControl { control =>
-            // Use a small buffer to force multi-byte chars to split across reads
-            val multiByteContent = "café_naïve_über_" * 10 + "\n"
-            for
-                dir <- Path.tempDir("kyo-path-edge-test")
-                file = dir / "tail-utf8.txt"
-                _ <- file.mkFile
-                tailFiber <- Fiber.initUnscoped(
-                    Scope.run(file.tail(50.millis, 16.bytes).take(1).run)
-                )
-                _     <- control.advance(50.millis)
-                _     <- file.append(multiByteContent)
-                _     <- control.advance(50.millis)
-                lines <- tailFiber.get
-                _     <- dir.removeAll
-            yield
-                val text = lines.toList.mkString
-                assert(!text.contains("\uFFFD"), s"Found replacement character in: $text")
-                assert(text.contains("café"), s"Expected 'café' in output: $text")
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                // Use a small buffer to force multi-byte chars to split across reads
+                val multiByteContent = "café_naïve_über_" * 10 + "\n"
+                for
+                    dir <- Path.tempDir("kyo-path-edge-test")
+                    file = dir / "tail-utf8.txt"
+                    _ <- file.mkFile
+                    tailFiber <- Fiber.initUnscoped(
+                        Path.run(Scope.run(file.tail(50.millis, 16.bytes).take(1).run))
+                    )
+                    _     <- control.advance(50.millis)
+                    _     <- file.append(multiByteContent)
+                    _     <- control.advance(50.millis)
+                    lines <- tailFiber.get
+                    _     <- dir.removeAll
+                yield
+                    val text = lines.toList.mkString
+                    assert(!text.contains("\uFFFD"), s"Found replacement character in: $text")
+                    assert(text.contains("café"), s"Expected 'café' in output: $text")
+                end for
+            }
         }
     }
 
     "tail does not emit incomplete lines before newline arrives" in {
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-path-edge-test")
-                file = dir / "tail-partial.txt"
-                _ <- file.mkFile
-                tailFiber <- Fiber.initUnscoped(
-                    Scope.run(file.tail(50.millis).take(1).run)
+        Path.run {
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-path-edge-test")
+                    file = dir / "tail-partial.txt"
+                    _ <- file.mkFile
+                    tailFiber <- Fiber.initUnscoped(
+                        Path.run(Scope.run(file.tail(50.millis).take(1).run))
+                    )
+                    _     <- control.advance(50.millis)
+                    _     <- file.append("hello wor")
+                    _     <- control.advance(50.millis)
+                    _     <- file.append("ld\n")
+                    _     <- control.advance(50.millis)
+                    lines <- tailFiber.get
+                    _     <- dir.removeAll
+                yield assert(
+                    lines.toList == List("hello world"),
+                    s"Expected complete line 'hello world', got: ${lines.toList}"
                 )
-                _     <- control.advance(50.millis)
-                _     <- file.append("hello wor")
-                _     <- control.advance(50.millis)
-                _     <- file.append("ld\n")
-                _     <- control.advance(50.millis)
-                lines <- tailFiber.get
-                _     <- dir.removeAll
-            yield assert(
-                lines.toList == List("hello world"),
-                s"Expected complete line 'hello world', got: ${lines.toList}"
-            )
-            end for
+                end for
+            }
         }
     }
 
     "tail assembles lines from multiple partial writes" in {
-        Scope.run {
+        Scope.run(Path.run {
             Clock.withTimeControl { control =>
                 for
                     dir <- Path.tempDir("kyo-path-edge-test")
                     file = dir / "tail-multi-partial.txt"
                     _ <- file.mkFile
                     tailFiber <- Fiber.initUnscoped(
-                        Scope.run(file.tail(50.millis).take(2).run)
+                        Path.run(Scope.run(file.tail(50.millis).take(2).run))
                     )
                     _     <- control.advance(50.millis)
                     _     <- file.append("aaa")
@@ -1948,18 +1964,18 @@ class PathTest extends kyo.test.Test[Any]:
                 )
                 end for
             }
-        }
+        })
     }
 
     "tail does not emit empty string after complete line" in {
-        Scope.run {
+        Scope.run(Path.run {
             Clock.withTimeControl { control =>
                 for
                     dir <- Path.tempDir("kyo-path-edge-test")
                     file = dir / "tail-no-empty.txt"
                     _ <- file.mkFile
                     tailFiber <- Fiber.initUnscoped(
-                        Scope.run(file.tail(50.millis).take(1).run)
+                        Path.run(Scope.run(file.tail(50.millis).take(1).run))
                     )
                     _     <- control.advance(50.millis)
                     _     <- file.append("hello\n")
@@ -1972,27 +1988,29 @@ class PathTest extends kyo.test.Test[Any]:
                 )
                 end for
             }
-        }
+        })
     }
 
     "tail on rapidly growing file emits all lines without loss" in {
-        Clock.withTimeControl { control =>
-            val lineCount = 50
-            val expected  = (1 to lineCount).map(i => s"line-$i").toList
-            for
-                dir <- Path.tempDir("kyo-path-edge-test")
-                file = dir / "tail-rapid.txt"
-                _ <- file.mkFile
-                tailFiber <- Fiber.initUnscoped(
-                    Scope.run(file.tail(50.millis).take(lineCount).run)
-                )
-                _     <- control.advance(50.millis)
-                _     <- file.appendLines(Chunk.from(expected))
-                _     <- control.advance(50.millis)
-                lines <- tailFiber.get
-                _     <- dir.removeAll
-            yield assert(lines.toList == expected, s"Expected $lineCount lines, got ${lines.size}")
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                val lineCount = 50
+                val expected  = (1 to lineCount).map(i => s"line-$i").toList
+                for
+                    dir <- Path.tempDir("kyo-path-edge-test")
+                    file = dir / "tail-rapid.txt"
+                    _ <- file.mkFile
+                    tailFiber <- Fiber.initUnscoped(
+                        Path.run(Scope.run(file.tail(50.millis).take(lineCount).run))
+                    )
+                    _     <- control.advance(50.millis)
+                    _     <- file.appendLines(Chunk.from(expected))
+                    _     <- control.advance(50.millis)
+                    lines <- tailFiber.get
+                    _     <- dir.removeAll
+                yield assert(lines.toList == expected, s"Expected $lineCount lines, got ${lines.size}")
+                end for
+            }
         }
     }
 
@@ -2011,8 +2029,8 @@ class PathTest extends kyo.test.Test[Any]:
     private def writeUntil(
         control: Clock.TimeControl,
         step: Duration,
-        write: Unit < (Async & Abort[FileWriteException])
-    )(condition: Boolean < Async)(using Frame): Unit < (Async & Abort[FileWriteException]) =
+        write: Unit < (PathWrite & Async)
+    )(condition: Boolean < Async)(using Frame): Unit < (PathWrite & Async) =
         Loop.foreach {
             condition.map { done =>
                 if done then Loop.done
@@ -2025,8 +2043,8 @@ class PathTest extends kyo.test.Test[Any]:
         fiber: Fiber[A, S],
         control: Clock.TimeControl,
         step: Duration,
-        write: Unit < (Async & Abort[FileWriteException])
-    )(using Frame): Unit < (Async & Abort[FileWriteException]) =
+        write: Unit < (PathWrite & Async)
+    )(using Frame): Unit < (PathWrite & Async) =
         writeUntil(control, step, write)(fiber.done)
 
     /** Advances the controlled clock until `condition` holds, writing nothing.
@@ -2083,193 +2101,221 @@ class PathTest extends kyo.test.Test[Any]:
         fiber.done.map(done => if done then true else condition)
 
     "tailBytes with Origin.Start replays existing content then follows" in {
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-tailbytes")
-                file = dir / "log.txt"
-                _ <- file.write("one\ntwo\n")
-                fiber <- Fiber.initUnscoped(
-                    Scope.run(file.tailBytes(Path.Origin.Start, 50.millis).take(12).run)
-                )
-                _     <- writeUntilDone(fiber, control, 50.millis, file.append("three\n"))
-                bytes <- fiber.get
-                _     <- dir.removeAll
-            yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "one\ntwo\nthre")
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-tailbytes")
+                    file = dir / "log.txt"
+                    _ <- file.write("one\ntwo\n")
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Scope.run(file.tailBytes(Path.Origin.Start, 50.millis).take(12).run)
+                        )
+                    )
+                    _     <- writeUntilDone(fiber, control, 50.millis, file.append("three\n"))
+                    bytes <- fiber.get
+                    _     <- dir.removeAll
+                yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "one\ntwo\nthre")
+                end for
+            }
         }
     }
 
     "tailBytes with Origin.End skips existing content" in {
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-tailbytes")
-                file = dir / "log.txt"
-                _ <- file.write("old\n")
-                fiber <- Fiber.initUnscoped(
-                    Scope.run(file.tailBytes(Path.Origin.End, 50.millis).take(4).run)
-                )
-                _     <- writeUntilDone(fiber, control, 50.millis, file.append("new\n"))
-                bytes <- fiber.get
-                _     <- dir.removeAll
-            yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "new\n")
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-tailbytes")
+                    file = dir / "log.txt"
+                    _ <- file.write("old\n")
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Scope.run(file.tailBytes(Path.Origin.End, 50.millis).take(4).run)
+                        )
+                    )
+                    _     <- writeUntilDone(fiber, control, 50.millis, file.append("new\n"))
+                    bytes <- fiber.get
+                    _     <- dir.removeAll
+                yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "new\n")
+                end for
+            }
         }
     }
 
     "tailBytes with Origin.Offset resumes at the given byte" in {
-        for
-            dir <- Path.tempDir("kyo-tailbytes")
-            file = dir / "log.txt"
-            _     <- file.write("aaaabbbb")
-            bytes <- Scope.run(file.tailBytes(Path.Origin.Offset(4L), 50.millis).take(4).run)
-            _     <- dir.removeAll
-        yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "bbbb")
-        end for
+        Path.run {
+            for
+                dir <- Path.tempDir("kyo-tailbytes")
+                file = dir / "log.txt"
+                _     <- file.write("aaaabbbb")
+                bytes <- Scope.run(file.tailBytes(Path.Origin.Offset(4L), 50.millis).take(4).run)
+                _     <- dir.removeAll
+            yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "bbbb")
+            end for
+        }
     }
 
     "tailBytes with a negative Origin.Offset reads from the first byte" in {
-        // The offset is clamped to 0 rather than reaching the platform handle, where a negative
-        // position raises IllegalArgumentException on JVM and Native and is read as "current
-        // position" by Node. This case runs on every platform because the divergence is the defect.
-        for
-            dir <- Path.tempDir("kyo-tailbytes")
-            file = dir / "log.txt"
-            _     <- file.write("aaaabbbb")
-            bytes <- Scope.run(file.tailBytes(Path.Origin.Offset(-4L), 50.millis).take(4).run)
-            _     <- dir.removeAll
-        yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "aaaa")
-        end for
+        Path.run {
+            // The offset is clamped to 0 rather than reaching the platform handle, where a negative
+            // position raises IllegalArgumentException on JVM and Native and is read as "current
+            // position" by Node. This case runs on every platform because the divergence is the defect.
+            for
+                dir <- Path.tempDir("kyo-tailbytes")
+                file = dir / "log.txt"
+                _     <- file.write("aaaabbbb")
+                bytes <- Scope.run(file.tailBytes(Path.Origin.Offset(-4L), 50.millis).take(4).run)
+                _     <- dir.removeAll
+            yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "aaaa")
+            end for
+        }
     }
 
     "tailBytes with an Origin.Offset past the end of the file replays the whole file" in {
-        // Reading past the end is indistinguishable from a truncation, so the follower rewinds to 0.
-        // The rewind costs one poll delay before the replay, which is what bounds a size under-report
-        // that would otherwise re-arm the rewind on every poll.
-        for
-            dir <- Path.tempDir("kyo-tailbytes")
-            file = dir / "log.txt"
-            _     <- file.write("aaaabbbb")
-            bytes <- Scope.run(file.tailBytes(Path.Origin.Offset(1024L), 50.millis).take(8).run)
-            _     <- dir.removeAll
-        yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "aaaabbbb")
-        end for
+        Path.run {
+            // Reading past the end is indistinguishable from a truncation, so the follower rewinds to 0.
+            // The rewind costs one poll delay before the replay, which is what bounds a size under-report
+            // that would otherwise re-arm the rewind on every poll.
+            for
+                dir <- Path.tempDir("kyo-tailbytes")
+                file = dir / "log.txt"
+                _     <- file.write("aaaabbbb")
+                bytes <- Scope.run(file.tailBytes(Path.Origin.Offset(1024L), 50.millis).take(8).run)
+                _     <- dir.removeAll
+            yield assert(new String(bytes.toArray, StandardCharsets.UTF_8) == "aaaabbbb")
+            end for
+        }
     }
 
     "tailBytes sleeps one poll delay before replaying a rewind" in {
-        // A rewind is the one branch that can re-enter the read loop without new bytes having arrived,
-        // so it is the one branch still structurally able to replay a file without bound. The sleep is
-        // what bounds it, and what bounds a platform that under-reports a size instead of raising.
-        Clock.withTimeControl { control =>
-            val content = "0123456789"
-            for
-                dir <- Path.tempDir("kyo-tailbytes-rewind-sleep")
-                file = dir / "log.txt"
-                _    <- file.write(content)
-                seen <- AtomicRef.init(Chunk.empty[Byte])
-                // Starting past the end reads as a shrunk file, so the first poll rewinds to 0.
-                fiber <- Fiber.initUnscoped(
-                    Scope.run(
-                        file.tailBytes(Path.Origin.Offset(1024L), 50.millis)
-                            .take(content.length)
-                            .foreach(b => seen.updateAndGet(_.append(b)))
+        Path.run {
+            // A rewind is the one branch that can re-enter the read loop without new bytes having arrived,
+            // so it is the one branch still structurally able to replay a file without bound. The sleep is
+            // what bounds it, and what bounds a platform that under-reports a size instead of raising.
+            Clock.withTimeControl { control =>
+                val content = "0123456789"
+                for
+                    dir <- Path.tempDir("kyo-tailbytes-rewind-sleep")
+                    file = dir / "log.txt"
+                    _    <- file.write(content)
+                    seen <- AtomicRef.init(Chunk.empty[Byte])
+                    // Starting past the end reads as a shrunk file, so the first poll rewinds to 0.
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Scope.run(
+                                file.tailBytes(Path.Origin.Offset(1024L), 50.millis)
+                                    .take(content.length)
+                                    .foreach(b => seen.updateAndGet(_.append(b)))
+                            )
+                        )
                     )
-                )
-                // Real time to reach and take the rewind, but not one instant of virtual time.
-                _        <- settle(control, 100.millis)
-                _        <- settle(control, 100.millis)
-                _        <- settle(control, 100.millis)
-                parked   <- seen.get
-                _        <- advanceUntil(control, 50.millis)(fiber.done)
-                _        <- fiber.get
-                replayed <- seen.get
-                _        <- dir.removeAll
-            yield
-                // Zero wakeups offered, so zero bytes may be replayed. A rewind that continues the loop
-                // directly needs no wakeup and would have replayed the whole file during the settles.
-                assert(parked.isEmpty, s"Expected nothing replayed before a wakeup, got: ${parked.size} bytes")
-                // The rewind still replays, one poll delay later.
-                assert(new String(replayed.toArray, StandardCharsets.UTF_8) == content)
-            end for
+                    // Real time to reach and take the rewind, but not one instant of virtual time.
+                    _        <- settle(control, 100.millis)
+                    _        <- settle(control, 100.millis)
+                    _        <- settle(control, 100.millis)
+                    parked   <- seen.get
+                    _        <- advanceUntil(control, 50.millis)(fiber.done)
+                    _        <- fiber.get
+                    replayed <- seen.get
+                    _        <- dir.removeAll
+                yield
+                    // Zero wakeups offered, so zero bytes may be replayed. A rewind that continues the loop
+                    // directly needs no wakeup and would have replayed the whole file during the settles.
+                    assert(parked.isEmpty, s"Expected nothing replayed before a wakeup, got: ${parked.size} bytes")
+                    // The rewind still replays, one poll delay later.
+                    assert(new String(replayed.toArray, StandardCharsets.UTF_8) == content)
+                end for
+            }
         }
     }
 
     "tailBytes rewinds to the first byte and replays after the file is truncated" in {
-        Clock.withTimeControl { control =>
-            val original = "0123456789"
-            val replaced = "abcd"
-            for
-                dir <- Path.tempDir("kyo-tailbytes-truncate")
-                file = dir / "log.txt"
-                _    <- file.write(original)
-                seen <- AtomicRef.init(Chunk.empty[Byte])
-                fiber <- Fiber.initUnscoped(
-                    Scope.run(
-                        file.tailBytes(Path.Origin.Start, 50.millis)
-                            .take(original.length + replaced.length)
-                            .foreach(b => seen.updateAndGet(_.append(b)))
+        Path.run {
+            Clock.withTimeControl { control =>
+                val original = "0123456789"
+                val replaced = "abcd"
+                for
+                    dir <- Path.tempDir("kyo-tailbytes-truncate")
+                    file = dir / "log.txt"
+                    _    <- file.write(original)
+                    seen <- AtomicRef.init(Chunk.empty[Byte])
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Scope.run(
+                                file.tailBytes(Path.Origin.Start, 50.millis)
+                                    .take(original.length + replaced.length)
+                                    .foreach(b => seen.updateAndGet(_.append(b)))
+                            )
+                        )
                     )
-                )
-                // Wait until the original content has been replayed, so the truncation below is
-                // guaranteed to leave the follower's position past the new end of the file.
-                _ <- advanceUntil(control, 50.millis)(seen.get.map(_.size >= original.length))
-                _ <- file.truncate(0L)
-                // A single truncating write: the file never grows back past the follower's
-                // position, so the rewind fires on whichever poll comes next.
-                _     <- file.write(replaced)
-                _     <- advanceUntil(control, 50.millis)(fiber.done)
-                _     <- fiber.get
-                bytes <- seen.get
-                _     <- dir.removeAll
-            yield
-                // The replayed bytes follow the pre-truncation bytes with nothing in between: the
-                // rewind is invisible at the byte level, which is the contract a framer must know.
-                assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original + replaced)
-            end for
+                    // Wait until the original content has been replayed, so the truncation below is
+                    // guaranteed to leave the follower's position past the new end of the file.
+                    _ <- advanceUntil(control, 50.millis)(seen.get.map(_.size >= original.length))
+                    _ <- file.truncate(0L)
+                    // A single truncating write: the file never grows back past the follower's
+                    // position, so the rewind fires on whichever poll comes next.
+                    _     <- file.write(replaced)
+                    _     <- advanceUntil(control, 50.millis)(fiber.done)
+                    _     <- fiber.get
+                    bytes <- seen.get
+                    _     <- dir.removeAll
+                yield
+                    // The replayed bytes follow the pre-truncation bytes with nothing in between: the
+                    // rewind is invisible at the byte level, which is the contract a framer must know.
+                    assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original + replaced)
+                end for
+            }
         }
     }
 
     "tail behavior is unchanged after the tailBytes refactor" in {
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-tail-regression")
-                file = dir / "log.txt"
-                _     <- file.write("existing\n")
-                fiber <- Fiber.initUnscoped(Scope.run(file.tail(50.millis).take(2).run))
-                _     <- writeUntilDone(fiber, control, 50.millis, file.append("first\r\nsecond\n"))
-                lines <- fiber.get
-                _     <- dir.removeAll
-            yield assert(lines == Chunk("first", "second"))
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-tail-regression")
+                    file = dir / "log.txt"
+                    _     <- file.write("existing\n")
+                    fiber <- Fiber.initUnscoped(Path.runReadOnly(Scope.run(file.tail(50.millis).take(2).run)))
+                    _     <- writeUntilDone(fiber, control, 50.millis, file.append("first\r\nsecond\n"))
+                    lines <- fiber.get
+                    _     <- dir.removeAll
+                yield assert(lines == Chunk("first", "second"))
+                end for
+            }
         }
     }
 
     "tail discards a pending partial line when the file is truncated" in {
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-tail-truncate-pending")
-                file = dir / "log.txt"
-                _     <- file.mkFile
-                lines <- AtomicRef.init(Chunk.empty[String])
-                tailFiber <- Fiber.initUnscoped(
-                    Scope.run(file.tail(50.millis).take(2).foreach(line => lines.updateAndGet(_.append(line))))
-                )
-                _ <- control.advance(50.millis) // let the follower open the empty file and park on its first poll
-                // One complete line plus text with no newline, written in a single call so that the
-                // read which produces "seen" necessarily also buffers "partial" as pending text.
-                _ <- file.write("seen\npartial")
-                // Emitting "seen" is the observable proof that the follower read past the newline,
-                // so the truncation below cannot silently land before the pending text exists.
-                _ <- advanceUntil(control, 50.millis)(lines.get.map(_.nonEmpty))
-                // A truncating write, and the only one: the file stays at 6 bytes, below the
-                // follower's position of 12, so the reset fires no matter how it is scheduled.
-                _       <- file.write("clean\n")
-                _       <- advanceUntil(control, 50.millis)(tailFiber.done)
-                _       <- tailFiber.get
-                emitted <- lines.get
-                _       <- dir.removeAll
-            // "partialclean" here would mean the pending text survived the rewind.
-            yield assert(emitted == Chunk("seen", "clean"))
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-tail-truncate-pending")
+                    file = dir / "log.txt"
+                    _     <- file.mkFile
+                    lines <- AtomicRef.init(Chunk.empty[String])
+                    tailFiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Scope.run(file.tail(50.millis).take(2).foreach(line => lines.updateAndGet(_.append(line))))
+                        )
+                    )
+                    _ <- control.advance(50.millis) // let the follower open the empty file and park on its first poll
+                    // One complete line plus text with no newline, written in a single call so that the
+                    // read which produces "seen" necessarily also buffers "partial" as pending text.
+                    _ <- file.write("seen\npartial")
+                    // Emitting "seen" is the observable proof that the follower read past the newline,
+                    // so the truncation below cannot silently land before the pending text exists.
+                    _ <- advanceUntil(control, 50.millis)(lines.get.map(_.nonEmpty))
+                    // A truncating write, and the only one: the file stays at 6 bytes, below the
+                    // follower's position of 12, so the reset fires no matter how it is scheduled.
+                    _       <- file.write("clean\n")
+                    _       <- advanceUntil(control, 50.millis)(tailFiber.done)
+                    _       <- tailFiber.get
+                    emitted <- lines.get
+                    _       <- dir.removeAll
+                // "partialclean" here would mean the pending text survived the rewind.
+                yield assert(emitted == Chunk("seen", "clean"))
+                end for
+            }
         }
     }
 
@@ -2286,192 +2332,212 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "tailBytes does not replay the original file after the name is rotated and recreated" in {
-        assume(!Platform.isWindows, "renaming an open file is POSIX descriptor behavior")
-        Clock.withTimeControl { control =>
-            val original = "0123456789"
-            for
-                dir <- Path.tempDir("kyo-tailbytes-rotate-recreate")
-                file    = dir / "log.txt"
-                rotated = dir / "log.txt.1"
-                _    <- file.write(original)
-                seen <- AtomicRef.init(Chunk.empty[Byte])
-                fiber <- Fiber.initUnscoped(
-                    Scope.run(
-                        file.tailBytes(Path.Origin.Start, 50.millis)
-                            .take(original.length + 1)
-                            .foreach(b => seen.updateAndGet(_.append(b)))
+        Path.run {
+            assume(!Platform.isWindows, "renaming an open file is POSIX descriptor behavior")
+            Clock.withTimeControl { control =>
+                val original = "0123456789"
+                for
+                    dir <- Path.tempDir("kyo-tailbytes-rotate-recreate")
+                    file    = dir / "log.txt"
+                    rotated = dir / "log.txt.1"
+                    _    <- file.write(original)
+                    seen <- AtomicRef.init(Chunk.empty[Byte])
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Scope.run(
+                                file.tailBytes(Path.Origin.Start, 50.millis)
+                                    .take(original.length + 1)
+                                    .foreach(b => seen.updateAndGet(_.append(b)))
+                            )
+                        )
                     )
-                )
-                // The whole file has been replayed, so the follower's cursor sits at the end of the
-                // inode it holds and the rotation below cannot land before the handle exists.
-                _ <- advanceUntil(control, 50.millis)(doneOr(fiber)(seen.get.map(_.size >= original.length)))
-                _ <- file.move(rotated)
-                // The rotation's replacement: a fresh, empty inode under the original name. A size
-                // read by path now reports 0 against a cursor of 10 and calls that a truncation on
-                // every poll, which replays the handle's ten bytes without ever sleeping.
-                _     <- file.mkFile
-                _     <- advanceTimes(control, 50.millis, 10)
-                done  <- fiber.done
-                bytes <- seen.get
-                _     <- fiber.interrupt
-                _     <- dir.removeAll
-            yield
-                // An eleventh byte can only be a replay: nothing was ever appended to the followed
-                // inode. Ten wakeups could not produce it, and a loop that does not sleep needs none.
-                assert(!done)
-                assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original)
-            end for
+                    // The whole file has been replayed, so the follower's cursor sits at the end of the
+                    // inode it holds and the rotation below cannot land before the handle exists.
+                    _ <- advanceUntil(control, 50.millis)(doneOr(fiber)(seen.get.map(_.size >= original.length)))
+                    _ <- file.move(rotated)
+                    // The rotation's replacement: a fresh, empty inode under the original name. A size
+                    // read by path now reports 0 against a cursor of 10 and calls that a truncation on
+                    // every poll, which replays the handle's ten bytes without ever sleeping.
+                    _     <- file.mkFile
+                    _     <- advanceTimes(control, 50.millis, 10)
+                    done  <- fiber.done
+                    bytes <- seen.get
+                    _     <- fiber.interrupt
+                    _     <- dir.removeAll
+                yield
+                    // An eleventh byte can only be a replay: nothing was ever appended to the followed
+                    // inode. Ten wakeups could not produce it, and a loop that does not sleep needs none.
+                    assert(!done)
+                    assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original)
+                end for
+            }
         }
     }
 
     "tailBytes keeps following the original file after it is renamed away" in {
-        assume(!Platform.isWindows, "renaming an open file is POSIX descriptor behavior")
-        Clock.withTimeControl { control =>
-            val original = "0123456789"
-            val appended = "abc"
-            for
-                dir <- Path.tempDir("kyo-tailbytes-rename")
-                file    = dir / "log.txt"
-                rotated = dir / "log.txt.1"
-                _    <- file.write(original)
-                seen <- AtomicRef.init(Chunk.empty[Byte])
-                fiber <- Fiber.initUnscoped(
-                    Abort.run[FileReadException](
-                        Scope.run(
-                            file.tailBytes(Path.Origin.Start, 50.millis)
-                                .take(original.length + appended.length)
-                                .foreach(b => seen.updateAndGet(_.append(b)))
+        Path.run {
+            assume(!Platform.isWindows, "renaming an open file is POSIX descriptor behavior")
+            Clock.withTimeControl { control =>
+                val original = "0123456789"
+                val appended = "abc"
+                for
+                    dir <- Path.tempDir("kyo-tailbytes-rename")
+                    file    = dir / "log.txt"
+                    rotated = dir / "log.txt.1"
+                    _    <- file.write(original)
+                    seen <- AtomicRef.init(Chunk.empty[Byte])
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Abort.run[FileReadException](
+                                Scope.run(
+                                    file.tailBytes(Path.Origin.Start, 50.millis)
+                                        .take(original.length + appended.length)
+                                        .foreach(b => seen.updateAndGet(_.append(b)))
+                                )
+                            )
                         )
                     )
-                )
-                _ <- advanceUntil(control, 50.millis)(doneOr(fiber)(seen.get.map(_.size >= original.length)))
-                _ <- file.move(rotated)
-                // Polls against a name that resolves to nothing, with no new bytes to distract the
-                // loop from reaching the branch that measures the file.
-                _       <- advanceTimes(control, 50.millis, 5)
-                stopped <- fiber.done
-                // Written through the new name, which is the same inode the handle holds.
-                _       <- rotated.append(appended)
-                _       <- advanceUntil(control, 50.millis)(fiber.done)
-                outcome <- fiber.get
-                bytes   <- seen.get
-                _       <- dir.removeAll
-            yield
-                // A size read by path raises on each of those polls, because the old name is gone.
-                assert(!stopped)
-                assert(outcome == Result.succeed(()))
-                assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original + appended)
-            end for
+                    _ <- advanceUntil(control, 50.millis)(doneOr(fiber)(seen.get.map(_.size >= original.length)))
+                    _ <- file.move(rotated)
+                    // Polls against a name that resolves to nothing, with no new bytes to distract the
+                    // loop from reaching the branch that measures the file.
+                    _       <- advanceTimes(control, 50.millis, 5)
+                    stopped <- fiber.done
+                    // Written through the new name, which is the same inode the handle holds.
+                    _       <- rotated.append(appended)
+                    _       <- advanceUntil(control, 50.millis)(fiber.done)
+                    outcome <- fiber.get
+                    bytes   <- seen.get
+                    _       <- dir.removeAll
+                yield
+                    // A size read by path raises on each of those polls, because the old name is gone.
+                    assert(!stopped)
+                    assert(outcome == Result.succeed(()))
+                    assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original + appended)
+                end for
+            }
         }
     }
 
     "tailBytes keeps following the original file after the name is replaced by another file" in {
-        assume(!Platform.isWindows, "replacing an open file is POSIX descriptor behavior")
-        Clock.withTimeControl { control =>
-            val original = "0123456789"
-            // Shorter than the follower's cursor, which is where a size read by path reads as a
-            // truncation and replays the handle's content instead of doing nothing.
-            val replacement = "new\n"
-            for
-                dir <- Path.tempDir("kyo-tailbytes-replace")
-                file     = dir / "log.txt"
-                incoming = dir / "log.txt.incoming"
-                _    <- file.write(original)
-                _    <- incoming.write(replacement)
-                seen <- AtomicRef.init(Chunk.empty[Byte])
-                fiber <- Fiber.initUnscoped(
-                    Scope.run(
-                        file.tailBytes(Path.Origin.Start, 50.millis)
-                            .take(original.length + 1)
-                            .foreach(b => seen.updateAndGet(_.append(b)))
+        Path.run {
+            assume(!Platform.isWindows, "replacing an open file is POSIX descriptor behavior")
+            Clock.withTimeControl { control =>
+                val original = "0123456789"
+                // Shorter than the follower's cursor, which is where a size read by path reads as a
+                // truncation and replays the handle's content instead of doing nothing.
+                val replacement = "new\n"
+                for
+                    dir <- Path.tempDir("kyo-tailbytes-replace")
+                    file     = dir / "log.txt"
+                    incoming = dir / "log.txt.incoming"
+                    _    <- file.write(original)
+                    _    <- incoming.write(replacement)
+                    seen <- AtomicRef.init(Chunk.empty[Byte])
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Scope.run(
+                                file.tailBytes(Path.Origin.Start, 50.millis)
+                                    .take(original.length + 1)
+                                    .foreach(b => seen.updateAndGet(_.append(b)))
+                            )
+                        )
                     )
-                )
-                _     <- advanceUntil(control, 50.millis)(doneOr(fiber)(seen.get.map(_.size >= original.length)))
-                _     <- incoming.move(file, Path.MoveOptions(replace = Path.Replace.Existing))
-                _     <- advanceTimes(control, 50.millis, 10)
-                done  <- fiber.done
-                bytes <- seen.get
-                _     <- fiber.interrupt
-                _     <- dir.removeAll
-            yield
-                // Neither the replacement's content nor a replay of the original: the handle holds an
-                // inode that no longer has a name and that never grows again.
-                assert(!done)
-                assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original)
-            end for
+                    _     <- advanceUntil(control, 50.millis)(doneOr(fiber)(seen.get.map(_.size >= original.length)))
+                    _     <- incoming.move(file, Path.MoveOptions(replace = Path.Replace.Existing))
+                    _     <- advanceTimes(control, 50.millis, 10)
+                    done  <- fiber.done
+                    bytes <- seen.get
+                    _     <- fiber.interrupt
+                    _     <- dir.removeAll
+                yield
+                    // Neither the replacement's content nor a replay of the original: the handle holds an
+                    // inode that no longer has a name and that never grows again.
+                    assert(!done)
+                    assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original)
+                end for
+            }
         }
     }
 
     "tailBytes waits rather than aborting after the followed file is deleted" in {
-        assume(!Platform.isWindows, "unlinking an open file is POSIX descriptor behavior")
-        Clock.withTimeControl { control =>
-            val original = "0123456789"
-            for
-                dir <- Path.tempDir("kyo-tailbytes-delete")
-                file = dir / "log.txt"
-                _    <- file.write(original)
-                seen <- AtomicRef.init(Chunk.empty[Byte])
-                fiber <- Fiber.initUnscoped(
-                    Scope.run(
-                        file.tailBytes(Path.Origin.Start, 50.millis)
-                            .take(original.length + 1)
-                            .foreach(b => seen.updateAndGet(_.append(b)))
+        Path.run {
+            assume(!Platform.isWindows, "unlinking an open file is POSIX descriptor behavior")
+            Clock.withTimeControl { control =>
+                val original = "0123456789"
+                for
+                    dir <- Path.tempDir("kyo-tailbytes-delete")
+                    file = dir / "log.txt"
+                    _    <- file.write(original)
+                    seen <- AtomicRef.init(Chunk.empty[Byte])
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Scope.run(
+                                file.tailBytes(Path.Origin.Start, 50.millis)
+                                    .take(original.length + 1)
+                                    .foreach(b => seen.updateAndGet(_.append(b)))
+                            )
+                        )
                     )
-                )
-                _     <- advanceUntil(control, 50.millis)(doneOr(fiber)(seen.get.map(_.size >= original.length)))
-                _     <- file.removeExisting
-                _     <- advanceTimes(control, 50.millis, 10)
-                done  <- fiber.done
-                bytes <- seen.get
-                _     <- fiber.interrupt
-                _     <- dir.removeAll
-            yield
-                // An unlinked inode still measures, so the follower polls an empty file forever. A
-                // finished fiber here would mean either an abort or an emission, and there is neither.
-                assert(!done)
-                assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original)
-            end for
+                    _     <- advanceUntil(control, 50.millis)(doneOr(fiber)(seen.get.map(_.size >= original.length)))
+                    _     <- file.removeExisting
+                    _     <- advanceTimes(control, 50.millis, 10)
+                    done  <- fiber.done
+                    bytes <- seen.get
+                    _     <- fiber.interrupt
+                    _     <- dir.removeAll
+                yield
+                    // An unlinked inode still measures, so the follower polls an empty file forever. A
+                    // finished fiber here would mean either an abort or an emission, and there is neither.
+                    assert(!done)
+                    assert(new String(bytes.toArray, StandardCharsets.UTF_8) == original)
+                end for
+            }
         }
     }
 
     "tailBytes with Origin.End starts at the end of the handle's file and follows it across a rename" in {
-        assume(!Platform.isWindows, "renaming an open file is POSIX descriptor behavior")
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-tailbytes-end-handle")
-                file    = dir / "log.txt"
-                rotated = dir / "log.txt.1"
-                // Digits, so that any byte of the pre-existing content is recognisable in the output.
-                _    <- file.write("0123456789")
-                seen <- AtomicRef.init(Chunk.empty[Byte])
-                fiber <- Fiber.initUnscoped(
-                    Abort.run[FileReadException](
-                        Scope.run(
-                            file.tailBytes(Path.Origin.End, 50.millis)
-                                .foreach(b => seen.updateAndGet(_.append(b)))
+        Path.run {
+            assume(!Platform.isWindows, "renaming an open file is POSIX descriptor behavior")
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-tailbytes-end-handle")
+                    file    = dir / "log.txt"
+                    rotated = dir / "log.txt.1"
+                    // Digits, so that any byte of the pre-existing content is recognisable in the output.
+                    _    <- file.write("0123456789")
+                    seen <- AtomicRef.init(Chunk.empty[Byte])
+                    fiber <- Fiber.initUnscoped(
+                        Path.runReadOnly(
+                            Abort.run[FileReadException](
+                                Scope.run(
+                                    file.tailBytes(Path.Origin.End, 50.millis)
+                                        .foreach(b => seen.updateAndGet(_.append(b)))
+                                )
+                            )
                         )
                     )
-                )
-                // One emission proves the handle is open and its start position already fixed, so the
-                // rename below cannot land before the handle exists.
-                _ <- writeUntil(control, 50.millis, file.append("a"))(doneOr(fiber)(seen.get.map(_.nonEmpty)))
-                _ <- file.move(rotated)
-                _ <- writeUntil(control, 50.millis, rotated.append("b"))(
-                    doneOr(fiber)(seen.get.map(_.exists(_ == 'b'.toByte)))
-                )
-                done  <- fiber.done
-                bytes <- seen.get
-                _     <- fiber.interrupt
-                _     <- dir.removeAll
-            yield
-                val text = new String(bytes.toArray, StandardCharsets.UTF_8)
-                // Still running: the rename did not raise, because nothing resolved the old name.
-                assert(!done)
-                // No digit: the start position was the end of the inode the handle holds.
-                assert(text.forall(c => c == 'a' || c == 'b'), s"Expected only appended bytes, got: $text")
-                // A 'b' arrived through the new name, so the follower stayed with the same inode.
-                assert(text.contains('b'))
-            end for
+                    // One emission proves the handle is open and its start position already fixed, so the
+                    // rename below cannot land before the handle exists.
+                    _ <- writeUntil(control, 50.millis, file.append("a"))(doneOr(fiber)(seen.get.map(_.nonEmpty)))
+                    _ <- file.move(rotated)
+                    _ <- writeUntil(control, 50.millis, rotated.append("b"))(
+                        doneOr(fiber)(seen.get.map(_.exists(_ == 'b'.toByte)))
+                    )
+                    done  <- fiber.done
+                    bytes <- seen.get
+                    _     <- fiber.interrupt
+                    _     <- dir.removeAll
+                yield
+                    val text = new String(bytes.toArray, StandardCharsets.UTF_8)
+                    // Still running: the rename did not raise, because nothing resolved the old name.
+                    assert(!done)
+                    // No digit: the start position was the end of the inode the handle holds.
+                    assert(text.forall(c => c == 'a' || c == 'b'), s"Expected only appended bytes, got: $text")
+                    // A 'b' arrived through the new name, so the follower stayed with the same inode.
+                    assert(text.contains('b'))
+                end for
+            }
         }
     }
 
@@ -2480,7 +2546,7 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "readStream(charset) delegates to unsafe without infinite loop" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-deleg-stream")
                 file = dir / "rs-charset.txt"
@@ -2489,11 +2555,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toList.mkString.nonEmpty)
             end for
-        }
+        })
     }
 
     "readBytesStream delegates to unsafe without infinite loop" in {
-        Scope.run {
+        Scope.run(Path.run {
             val data = Span.from(Array[Byte](1, 2, 3, 4, 5))
             for
                 dir <- Path.tempDir("kyo-deleg-stream")
@@ -2503,11 +2569,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toArray.nonEmpty)
             end for
-        }
+        })
     }
 
     "readLinesStream(charset) delegates to unsafe without infinite loop" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-deleg-stream")
                 file = dir / "rls-charset.txt"
@@ -2517,28 +2583,30 @@ class PathTest extends kyo.test.Test[Any]:
                 _           <- dir.removeAll
             yield assert(linesStream.toList == linesDirect.toList)
             end for
-        }
+        })
     }
 
     "tail(pollDelay) delegates to unsafe without infinite loop" in {
-        Clock.withTimeControl { control =>
-            for
-                dir <- Path.tempDir("kyo-deleg-stream")
-                file = dir / "tail-deleg.txt"
-                _         <- file.mkFile
-                tailFiber <- Fiber.initUnscoped(Scope.run(file.tail(50.millis).take(1).run))
-                _         <- control.advance(50.millis)
-                _         <- file.appendLines(Chunk("tail-line"))
-                _         <- control.advance(50.millis)
-                lines     <- tailFiber.get
-                _         <- dir.removeAll
-            yield assert(lines.toList == List("tail-line"))
-            end for
+        Path.run {
+            Clock.withTimeControl { control =>
+                for
+                    dir <- Path.tempDir("kyo-deleg-stream")
+                    file = dir / "tail-deleg.txt"
+                    _         <- file.mkFile
+                    tailFiber <- Fiber.initUnscoped(Path.run(Scope.run(file.tail(50.millis).take(1).run)))
+                    _         <- control.advance(50.millis)
+                    _         <- file.appendLines(Chunk("tail-line"))
+                    _         <- control.advance(50.millis)
+                    lines     <- tailFiber.get
+                    _         <- dir.removeAll
+                yield assert(lines.toList == List("tail-line"))
+                end for
+            }
         }
     }
 
     "walk(maxDepth, followLinks) delegates to unsafe without infinite loop" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-deleg-stream")
                 file = dir / "walk-deleg.txt"
@@ -2547,7 +2615,7 @@ class PathTest extends kyo.test.Test[Any]:
                 _     <- dir.removeAll
             yield assert(paths.toList.nonEmpty)
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -2559,76 +2627,86 @@ class PathTest extends kyo.test.Test[Any]:
     }
 
     "basePaths.tmp directory exists on disk" in {
-        Path.basePaths.tmp.exists.map(e => assert(e))
+        Path.runReadOnly(Path.basePaths.tmp.exists.map(e => assert(e)))
     }
 
     "Path.tempUnscoped creates a file that exists" in {
-        for
-            p      <- Path.tempUnscoped()
-            exists <- p.exists
-            _      <- p.remove
-        yield assert(exists)
+        Path.run {
+            for
+                p      <- Path.tempUnscoped()
+                exists <- p.exists
+                _      <- p.remove
+            yield assert(exists)
+        }
     }
 
     "Path.tempUnscoped with custom prefix and suffix" in {
-        for
-            p <- Path.tempUnscoped("myprefix", ".myext")
-            _ <- p.remove
-        yield assert(p.name.exists(n => n.startsWith("myprefix") && n.endsWith(".myext")))
+        Path.run {
+            for
+                p <- Path.tempUnscoped("myprefix", ".myext")
+                _ <- p.remove
+            yield assert(p.name.exists(n => n.startsWith("myprefix") && n.endsWith(".myext")))
+        }
     }
 
     "Path.tempDir creates a directory" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 p           <- Path.tempDir("kyotestdir")
                 isDirectory <- p.isDirectory
                 _           <- p.removeAll
             yield assert(isDirectory)
-        }
+        })
     }
 
     "Path.temp auto-deletes on scope close" in {
-        for
-            captured <- AtomicRef.init[Maybe[Path]](Absent)
-            _ <- Scope.run {
-                Path.temp().map { p =>
-                    captured.set(Present(p)).andThen(p)
+        Path.run {
+            for
+                captured <- AtomicRef.init[Maybe[Path]](Absent)
+                _ <- Scope.run {
+                    Path.temp().map { p =>
+                        captured.set(Present(p)).andThen(p)
+                    }
                 }
-            }
-            maybePath   <- captured.get
-            stillExists <- maybePath.get.exists
-        yield assert(!stillExists)
-        end for
+                maybePath   <- captured.get
+                stillExists <- maybePath.get.exists
+            yield assert(!stillExists)
+            end for
+        }
     }
 
     "Path.tempUnscoped survives scope close" in {
-        for
-            captured <- AtomicRef.init[Maybe[Path]](Absent)
-            _ <- Scope.run {
-                Path.tempUnscoped().map { p =>
-                    captured.set(Present(p)).andThen(p)
+        Path.run {
+            for
+                captured <- AtomicRef.init[Maybe[Path]](Absent)
+                _ <- Scope.run {
+                    Path.tempUnscoped().map { p =>
+                        captured.set(Present(p)).andThen(p)
+                    }
                 }
-            }
-            maybePath   <- captured.get
-            stillExists <- maybePath.get.exists
-            _           <- maybePath.get.remove
-        yield assert(stillExists)
-        end for
+                maybePath   <- captured.get
+                stillExists <- maybePath.get.exists
+                _           <- maybePath.get.remove
+            yield assert(stillExists)
+            end for
+        }
     }
 
     "Path.tempDirUnscoped survives scope close" in {
-        for
-            captured <- AtomicRef.init[Maybe[Path]](Absent)
-            _ <- Scope.run {
-                Path.tempDirUnscoped("kyotestdir-unscoped").map { p =>
-                    captured.set(Present(p)).andThen(p)
+        Path.run {
+            for
+                captured <- AtomicRef.init[Maybe[Path]](Absent)
+                _ <- Scope.run {
+                    Path.tempDirUnscoped("kyotestdir-unscoped").map { p =>
+                        captured.set(Present(p)).andThen(p)
+                    }
                 }
-            }
-            maybePath   <- captured.get
-            isDirectory <- maybePath.get.isDirectory
-            _           <- maybePath.get.removeAll
-        yield assert(isDirectory)
-        end for
+                maybePath   <- captured.get
+                isDirectory <- maybePath.get.isDirectory
+                _           <- maybePath.get.removeAll
+            yield assert(isDirectory)
+            end for
+        }
     }
 
     // =========================================================================
@@ -2758,7 +2836,7 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "readBytesStream on empty file yields empty chunk" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 file = dir / "empty.bin"
@@ -2767,11 +2845,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _         <- dir.removeAll
             yield assert(collected.isEmpty)
             end for
-        }
+        })
     }
 
     "readBytesStream over multiple buffer boundaries emits all bytes correctly" in {
-        Scope.run {
+        Scope.run(Path.run {
             val data = Span.fill(20000)(42.toByte) // > 2 full 8192-byte buffers
             for
                 dir <- Path.tempDir("kyo-test")
@@ -2781,11 +2859,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _         <- dir.removeAll
             yield assert(collected.size == 20000)
             end for
-        }
+        })
     }
 
     "readStream with multi-byte UTF-8 near buffer boundary" in {
-        Scope.run {
+        Scope.run(Path.run {
             // Write 8190 ASCII chars + a 4-byte emoji (😀, U+1F600)
             // Total: 8194 bytes, which spans two 8192-byte reads.
             // If the implementation splits the UTF-8 sequence across reads and decodes
@@ -2800,11 +2878,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _        <- dir.removeAll
             yield assert(streamed.mkString == eager)
             end for
-        }
+        })
     }
 
     "readLinesStream on empty file yields empty chunk" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 file = dir / "empty-lines.txt"
@@ -2813,11 +2891,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _         <- dir.removeAll
             yield assert(collected.isEmpty)
             end for
-        }
+        })
     }
 
     "readLinesStream on file with trailing newline matches readLines" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 file = dir / "trailing-nl.txt"
@@ -2827,11 +2905,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _           <- dir.removeAll
             yield assert(streamLines.toList == eagerLines.toList)
             end for
-        }
+        })
     }
 
     "walk on empty directory emits only the root" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir   <- Path.tempDir("kyo-test")
                 paths <- Scope.run(dir.walk.run)
@@ -2840,11 +2918,11 @@ class PathTest extends kyo.test.Test[Any]:
                 // walk should at minimum contain the root directory itself
                 assert(paths.size == 1 && paths.head == dir)
             end for
-        }
+        })
     }
 
     "tail continues after file truncation" in {
-        Scope.run {
+        Scope.run(Path.run {
             // Start tail, write initial content, truncate the file, then append new data.
             // The question is whether tail picks up the new content or gets confused after
             // truncation (the file position may be beyond EOF).
@@ -2856,7 +2934,7 @@ class PathTest extends kyo.test.Test[Any]:
                     file = dir / "tail-truncate.txt"
                     _ <- file.write("initial content\n")
                     tailFiber <- Fiber.initUnscoped(
-                        Scope.run(file.tail(50.millis).take(1).run)
+                        Path.run(Scope.run(file.tail(50.millis).take(1).run))
                     )
                     _     <- control.advance(50.millis) // wake up tail's first poll (sees nothing new, initial content is skipped)
                     _     <- file.truncate(0L)          // truncate to empty
@@ -2868,7 +2946,7 @@ class PathTest extends kyo.test.Test[Any]:
                 yield assert(lines.toList == List("after-truncate"))
                 end for
             }
-        }
+        })
     }
 
     // =========================================================================
@@ -2906,7 +2984,7 @@ class PathTest extends kyo.test.Test[Any]:
     // Each chunk read from readBytesStream must be an independent copy, not aliased
     // to the same mutable read buffer.
     "readBytesStream chunks are independent copies, with no reuse of the read buffer" in {
-        Scope.run {
+        Scope.run(Path.run {
             // Write a pattern where the value at offset i is (i % 256).toByte
             val size = 20000
             val data = Span.from((0 until size).map(i => (i % 256).toByte).toArray)
@@ -2930,14 +3008,14 @@ class PathTest extends kyo.test.Test[Any]:
                 }
                 assert(offset == size, s"Expected $size bytes total, got $offset")
             end for
-        }
+        })
     }
 
     // Inspired by fs2 #2966: the file handle should be released when a stream is
     // interrupted early (e.g. by take).  On Unix we verify the handle is released
     // by successfully writing to the same file after the interrupted read.
     "file handle is released when readBytesStream is interrupted by take" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-test")
                 file = dir / "interrupt.bin"
@@ -2953,14 +3031,14 @@ class PathTest extends kyo.test.Test[Any]:
             yield
                 assert(firstChunks.nonEmpty)
                 assert(content == "replaced")
-        }
+        })
     }
 
     // Inspired by fs2 #1005: buffer reuse corruption.
     // Each byte in the read-back must match the pattern used to write the file.
     // A failure here means chunks alias the same mutable read buffer.
     "readBytesStream chunks are independent copies of the read buffer" in {
-        Scope.run {
+        Scope.run(Path.run {
             val size    = 20000
             val pattern = Span.from(Array.tabulate[Byte](size)(i => (i % 251).toByte))
             for
@@ -2976,13 +3054,13 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(collected.size == size)
                 assert(mismatches.isEmpty, mismatches.mkString(", "))
             end for
-        }
+        })
     }
 
     // Inspired by fs2 #2966: file handle must be released on early stream termination.
     // After taking only the first chunk, the handle should be freed so further writes succeed.
     "file handle is released when readBytesStream terminates early" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-handle-release")
                 file = dir / "large.bin"
@@ -2995,13 +3073,13 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(firstChunk.nonEmpty)
                 assert(finalContent == "overwritten")
             end for
-        }
+        })
     }
 
     // Inspired by fs2 #1371: appendLines must append to existing content written by write(),
     // not overwrite from position 0.
     "appendLines actually appends to existing content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-appendlines")
                 file = dir / "appended.txt"
@@ -3013,7 +3091,7 @@ class PathTest extends kyo.test.Test[Any]:
                 assert(result.contains("first"), s"'first' was lost; appendLines may have overwritten from position 0")
                 assert(result.contains("second"), s"'second' was not written")
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -3072,18 +3150,18 @@ class PathTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "safe exists delegates to unsafe without infinite loop" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir    <- Path.tempDir("kyo-deleg")
                 result <- dir.exists
                 _      <- dir.removeAll
             yield assert(result == true)
             end for
-        }
+        })
     }
 
     "safe read delegates to unsafe without infinite loop" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-deleg")
                 file = dir / "deleg-read.txt"
@@ -3092,11 +3170,11 @@ class PathTest extends kyo.test.Test[Any]:
                 _       <- dir.removeAll
             yield assert(content == "hello")
             end for
-        }
+        })
     }
 
     "safe write delegates to unsafe without infinite loop" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-deleg")
                 file = dir / "deleg-write.txt"
@@ -3105,7 +3183,7 @@ class PathTest extends kyo.test.Test[Any]:
                 _       <- dir.removeAll
             yield assert(content == "test")
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -3119,7 +3197,7 @@ class PathTest extends kyo.test.Test[Any]:
         else Command("id", "-u").text.map(_.trim == "0")
 
     "removeAll raises error when subdirectory is permission-denied" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 root <- isRoot
                 _ <-
@@ -3131,7 +3209,7 @@ class PathTest extends kyo.test.Test[Any]:
                             _      <- sub.mkDir
                             _      <- (sub / "child.txt").write("data")
                             _      <- Command("chmod", "000", sub.toString).waitFor
-                            result <- Abort.run[FileSystemException](dir.removeAll)
+                            result <- Abort.run[FileSystemException](Path.run(dir.removeAll))
                             _      <- Command("chmod", "755", sub.toString).waitFor
                             _      <- dir.removeAll
                         yield result match
@@ -3140,11 +3218,11 @@ class PathTest extends kyo.test.Test[Any]:
                                 fail("removeAll should fail when subdirectory is inaccessible, but it succeeded silently")
                         end for
             yield ()
-        }
+        })
     }
 
     "removeAll raises error when files cannot be deleted" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 root <- isRoot
                 _ <-
@@ -3156,7 +3234,7 @@ class PathTest extends kyo.test.Test[Any]:
                             _      <- sub.mkDir
                             _      <- (sub / "guarded.txt").write("data")
                             _      <- Command("chmod", "555", sub.toString).waitFor
-                            result <- Abort.run[FileSystemException](dir.removeAll)
+                            result <- Abort.run[FileSystemException](Path.run(dir.removeAll))
                             _      <- Command("chmod", "755", sub.toString).waitFor
                             _      <- dir.removeAll
                         yield result match
@@ -3165,7 +3243,7 @@ class PathTest extends kyo.test.Test[Any]:
                                 fail("removeAll should fail when files cannot be deleted, but it succeeded silently")
                         end for
             yield ()
-        }
+        })
     }
 
     // =========================================================================
@@ -3189,217 +3267,237 @@ class PathTest extends kyo.test.Test[Any]:
     private def utf8(s: String): Chunk[Byte] = Chunk.from(s.getBytes(StandardCharsets.UTF_8))
 
     "openWrite with append true adds to content the file already holds, across several writes" in {
-        import AllowUnsafe.embrace.danger
-        for
-            dir <- Path.tempDir("kyo-openwrite-append")
-            file = dir / "log.txt"
-            _ <- file.write("AAAAAAAAAA")
-            _ =
-                val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
-                try
-                    assert(handle.writeBytes(utf8("BB")).isSuccess)
-                    assert(handle.writeBytes(utf8("CC")).isSuccess)
-                    assert(handle.writeString("DD", StandardCharsets.UTF_8).isSuccess)
-                    handle.finish()
-                finally handle.close()
-                end try
-            content <- file.read
-            _       <- dir.removeAll
-        yield assert(content == "AAAAAAAAAABBCCDD")
-        end for
-    }
-
-    "openWrite with append true creates a missing file and accumulates across writes" in {
-        import AllowUnsafe.embrace.danger
-        for
-            dir <- Path.tempDir("kyo-openwrite-append-create")
-            file = dir / "created.txt"
-            existedBefore <- file.exists
-            _ =
-                val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
-                try
-                    assert(handle.writeBytes(utf8("one")).isSuccess)
-                    assert(handle.writeBytes(utf8("two")).isSuccess)
-                    assert(handle.writeBytes(utf8("three")).isSuccess)
-                    handle.finish()
-                finally handle.close()
-                end try
-            content <- file.read
-            _       <- dir.removeAll
-        yield
-            assert(!existedBefore)
-            assert(content == "onetwothree")
-        end for
-    }
-
-    "openWrite with append true resumes at the end after the file is reopened" in {
-        import AllowUnsafe.embrace.danger
-        for
-            dir <- Path.tempDir("kyo-openwrite-append-reopen")
-            file = dir / "rounds.txt"
-            _ =
-                (0 until 4).foreach { round =>
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            for
+                dir <- Path.tempDir("kyo-openwrite-append")
+                file = dir / "log.txt"
+                _ <- file.write("AAAAAAAAAA")
+                _ =
                     val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
                     try
-                        assert(handle.writeBytes(utf8(s"r$round-")).isSuccess)
-                        assert(handle.writeBytes(utf8(s"$round;")).isSuccess)
+                        assert(handle.writeBytes(utf8("BB")).isSuccess)
+                        assert(handle.writeBytes(utf8("CC")).isSuccess)
+                        assert(handle.writeString("DD", StandardCharsets.UTF_8).isSuccess)
                         handle.finish()
                     finally handle.close()
                     end try
-                }
-            content <- file.read
-            _       <- dir.removeAll
-        yield assert(content == "r0-0;r1-1;r2-2;r3-3;")
-        end for
+                content <- file.read
+                _       <- dir.removeAll
+            yield assert(content == "AAAAAAAAAABBCCDD")
+            end for
+        }
+    }
+
+    "openWrite with append true creates a missing file and accumulates across writes" in {
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            for
+                dir <- Path.tempDir("kyo-openwrite-append-create")
+                file = dir / "created.txt"
+                existedBefore <- file.exists
+                _ =
+                    val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
+                    try
+                        assert(handle.writeBytes(utf8("one")).isSuccess)
+                        assert(handle.writeBytes(utf8("two")).isSuccess)
+                        assert(handle.writeBytes(utf8("three")).isSuccess)
+                        handle.finish()
+                    finally handle.close()
+                    end try
+                content <- file.read
+                _       <- dir.removeAll
+            yield
+                assert(!existedBefore)
+                assert(content == "onetwothree")
+            end for
+        }
+    }
+
+    "openWrite with append true resumes at the end after the file is reopened" in {
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            for
+                dir <- Path.tempDir("kyo-openwrite-append-reopen")
+                file = dir / "rounds.txt"
+                _ =
+                    (0 until 4).foreach { round =>
+                        val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
+                        try
+                            assert(handle.writeBytes(utf8(s"r$round-")).isSuccess)
+                            assert(handle.writeBytes(utf8(s"$round;")).isSuccess)
+                            handle.finish()
+                        finally handle.close()
+                        end try
+                    }
+                content <- file.read
+                _       <- dir.removeAll
+            yield assert(content == "r0-0;r1-1;r2-2;r3-3;")
+            end for
+        }
     }
 
     "openWrite with append false empties the file before the first write" in {
-        import AllowUnsafe.embrace.danger
-        for
-            dir <- Path.tempDir("kyo-openwrite-truncate")
-            file = dir / "replaced.txt"
-            _ <- file.write("original content that is much longer than the replacement")
-            _ =
-                val handle = file.unsafe.openWrite(append = false, Path.WriteOptions(createFolders = false)).getOrThrow
-                try
-                    assert(handle.writeBytes(utf8("new")).isSuccess)
-                    handle.finish()
-                finally handle.close()
-                end try
-            content <- file.read
-            _       <- dir.removeAll
-        yield assert(content == "new")
-        end for
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            for
+                dir <- Path.tempDir("kyo-openwrite-truncate")
+                file = dir / "replaced.txt"
+                _ <- file.write("original content that is much longer than the replacement")
+                _ =
+                    val handle = file.unsafe.openWrite(append = false, Path.WriteOptions(createFolders = false)).getOrThrow
+                    try
+                        assert(handle.writeBytes(utf8("new")).isSuccess)
+                        handle.finish()
+                    finally handle.close()
+                    end try
+                content <- file.read
+                _       <- dir.removeAll
+            yield assert(content == "new")
+            end for
+        }
     }
 
     "openWrite with append false writes successive chunks in order rather than over each other" in {
-        import AllowUnsafe.embrace.danger
-        for
-            dir <- Path.tempDir("kyo-openwrite-order")
-            file = dir / "ordered.txt"
-            _ <- file.write("zzzzzzzzzzzzzzzzzzzz")
-            _ =
-                val handle = file.unsafe.openWrite(append = false, Path.WriteOptions(createFolders = false)).getOrThrow
-                try
-                    assert(handle.writeBytes(utf8("ab")).isSuccess)
-                    assert(handle.writeBytes(utf8("cd")).isSuccess)
-                    assert(handle.writeString("ef", StandardCharsets.UTF_8).isSuccess)
-                    handle.finish()
-                finally handle.close()
-                end try
-            content <- file.read
-            _       <- dir.removeAll
-        yield assert(content == "abcdef")
-        end for
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            for
+                dir <- Path.tempDir("kyo-openwrite-order")
+                file = dir / "ordered.txt"
+                _ <- file.write("zzzzzzzzzzzzzzzzzzzz")
+                _ =
+                    val handle = file.unsafe.openWrite(append = false, Path.WriteOptions(createFolders = false)).getOrThrow
+                    try
+                        assert(handle.writeBytes(utf8("ab")).isSuccess)
+                        assert(handle.writeBytes(utf8("cd")).isSuccess)
+                        assert(handle.writeString("ef", StandardCharsets.UTF_8).isSuccess)
+                        handle.finish()
+                    finally handle.close()
+                    end try
+                content <- file.read
+                _       <- dir.removeAll
+            yield assert(content == "abcdef")
+            end for
+        }
     }
 
     "openWrite keeps its position accounting exact over many chunks" in {
-        import AllowUnsafe.embrace.danger
-        val chunks   = 128
-        val chunkLen = 64
-        val expected = (0 until chunks).map(i => (0 until chunkLen).map(_ => ('a' + (i % 26)).toChar).mkString).mkString
-        for
-            dir <- Path.tempDir("kyo-openwrite-chunks")
-            file = dir / "chunks.bin"
-            // Existing content the appending handle must land after, so a position that starts at
-            // zero shows up as a shortfall in `size` as well as in the bytes.
-            preamble = "PREAMBLE"
-            _ <- file.write(preamble)
-            _ =
-                val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
-                try
-                    (0 until chunks).foreach { i =>
-                        val text = (0 until chunkLen).map(_ => ('a' + (i % 26)).toChar).mkString
-                        assert(handle.writeBytes(utf8(text)).isSuccess)
-                    }
-                    handle.finish()
-                finally handle.close()
-                end try
-            size    <- file.size
-            content <- file.read
-            _       <- dir.removeAll
-        yield
-            assert(size == (preamble.length + chunks * chunkLen).toLong)
-            assert(content == preamble + expected)
-        end for
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            val chunks   = 128
+            val chunkLen = 64
+            val expected = (0 until chunks).map(i => (0 until chunkLen).map(_ => ('a' + (i % 26)).toChar).mkString).mkString
+            for
+                dir <- Path.tempDir("kyo-openwrite-chunks")
+                file = dir / "chunks.bin"
+                // Existing content the appending handle must land after, so a position that starts at
+                // zero shows up as a shortfall in `size` as well as in the bytes.
+                preamble = "PREAMBLE"
+                _ <- file.write(preamble)
+                _ =
+                    val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
+                    try
+                        (0 until chunks).foreach { i =>
+                            val text = (0 until chunkLen).map(_ => ('a' + (i % 26)).toChar).mkString
+                            assert(handle.writeBytes(utf8(text)).isSuccess)
+                        }
+                        handle.finish()
+                    finally handle.close()
+                    end try
+                size    <- file.size
+                content <- file.read
+                _       <- dir.removeAll
+            yield
+                assert(size == (preamble.length + chunks * chunkLen).toLong)
+                assert(content == preamble + expected)
+            end for
+        }
     }
 
     "openWrite writing an empty chunk leaves the file unchanged and the handle usable" in {
-        import AllowUnsafe.embrace.danger
-        for
-            dir <- Path.tempDir("kyo-openwrite-empty")
-            file = dir / "empty-write.txt"
-            _ <- file.write("head")
-            _ =
-                val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
-                try
-                    assert(handle.writeBytes(Chunk.empty[Byte]).isSuccess)
-                    assert(handle.writeBytes(utf8("tail")).isSuccess)
-                    handle.finish()
-                finally handle.close()
-                end try
-            content <- file.read
-            _       <- dir.removeAll
-        yield assert(content == "headtail")
-        end for
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            for
+                dir <- Path.tempDir("kyo-openwrite-empty")
+                file = dir / "empty-write.txt"
+                _ <- file.write("head")
+                _ =
+                    val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false)).getOrThrow
+                    try
+                        assert(handle.writeBytes(Chunk.empty[Byte]).isSuccess)
+                        assert(handle.writeBytes(utf8("tail")).isSuccess)
+                        handle.finish()
+                    finally handle.close()
+                    end try
+                content <- file.read
+                _       <- dir.removeAll
+            yield assert(content == "headtail")
+            end for
+        }
     }
 
     "openWrite writes a string in the charset it is given" in {
-        import AllowUnsafe.embrace.danger
-        val text = "café"
-        for
-            dir <- Path.tempDir("kyo-openwrite-charset")
-            latin = dir / "latin1.txt"
-            _ =
-                val handle = latin.unsafe.openWrite(append = false, Path.WriteOptions(createFolders = false)).getOrThrow
-                try
-                    assert(handle.writeString(text, StandardCharsets.ISO_8859_1).isSuccess)
-                    handle.finish()
-                finally handle.close()
-                end try
-            bytes <- latin.readBytes
-            _     <- dir.removeAll
-        yield
-            // ISO-8859-1 encodes é as one byte; UTF-8 would have produced five bytes, not four.
-            assert(bytes.toArray.toSeq == text.getBytes(StandardCharsets.ISO_8859_1).toSeq)
-            assert(bytes.size == 4)
-        end for
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            val text = "café"
+            for
+                dir <- Path.tempDir("kyo-openwrite-charset")
+                latin = dir / "latin1.txt"
+                _ =
+                    val handle = latin.unsafe.openWrite(append = false, Path.WriteOptions(createFolders = false)).getOrThrow
+                    try
+                        assert(handle.writeString(text, StandardCharsets.ISO_8859_1).isSuccess)
+                        handle.finish()
+                    finally handle.close()
+                    end try
+                bytes <- latin.readBytes
+                _     <- dir.removeAll
+            yield
+                // ISO-8859-1 encodes é as one byte; UTF-8 would have produced five bytes, not four.
+                assert(bytes.toArray.toSeq == text.getBytes(StandardCharsets.ISO_8859_1).toSeq)
+                assert(bytes.size == 4)
+            end for
+        }
     }
 
     "openWrite with createFolders true creates the missing parent directories" in {
-        import AllowUnsafe.embrace.danger
-        for
-            dir <- Path.tempDir("kyo-openwrite-create-folders")
-            file = dir / "a" / "b" / "deep.txt"
-            _ =
-                val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = true)).getOrThrow
-                try
-                    assert(handle.writeBytes(utf8("deep")).isSuccess)
-                    assert(handle.writeBytes(utf8("-file")).isSuccess)
-                    handle.finish()
-                finally handle.close()
-                end try
-            content <- file.read
-            _       <- dir.removeAll
-        yield assert(content == "deep-file")
-        end for
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            for
+                dir <- Path.tempDir("kyo-openwrite-create-folders")
+                file = dir / "a" / "b" / "deep.txt"
+                _ =
+                    val handle = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = true)).getOrThrow
+                    try
+                        assert(handle.writeBytes(utf8("deep")).isSuccess)
+                        assert(handle.writeBytes(utf8("-file")).isSuccess)
+                        handle.finish()
+                    finally handle.close()
+                    end try
+                content <- file.read
+                _       <- dir.removeAll
+            yield assert(content == "deep-file")
+            end for
+        }
     }
 
     "openWrite with createFolders false fails with FileNotFoundException when the parent is missing" in {
-        import AllowUnsafe.embrace.danger
-        for
-            dir <- Path.tempDir("kyo-openwrite-no-folders")
-            file   = dir / "missing" / "unreachable.txt"
-            result = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false))
-            exists <- file.exists
-            _      <- dir.removeAll
-        yield
-            assert(!exists)
-            result match
-                case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
-                case other                                    => fail(s"Expected FileNotFoundException, got $other")
-            end match
-        end for
+        Path.run {
+            import AllowUnsafe.embrace.danger
+            for
+                dir <- Path.tempDir("kyo-openwrite-no-folders")
+                file   = dir / "missing" / "unreachable.txt"
+                result = file.unsafe.openWrite(append = true, Path.WriteOptions(createFolders = false))
+                exists <- file.exists
+                _      <- dir.removeAll
+            yield
+                assert(!exists)
+                result match
+                    case Result.Failure(_: FileNotFoundException) => succeed("expected exception type")
+                    case other                                    => fail(s"Expected FileNotFoundException, got $other")
+                end match
+            end for
+        }
     }
 
 end PathTest

--- a/kyo-system/shared/src/test/scala/kyo/StreamSystemExtensionsTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/StreamSystemExtensionsTest.scala
@@ -9,7 +9,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "Stream[Byte].writeTo creates file with correct byte content" in {
-        Scope.run {
+        Scope.run(Path.run {
             val bytes = Array[Byte](10, 20, 30, 40, 50)
             for
                 dir <- Path.tempDir("kyo-stream-sink-test")
@@ -19,11 +19,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toArray.toList == bytes.toList)
             end for
-        }
+        })
     }
 
     "Stream[String].writeTo writes concatenated strings" in {
-        Scope.run {
+        Scope.run(Path.run {
             val parts = List("hello", ", ", "world")
             for
                 dir <- Path.tempDir("kyo-stream-sink-test")
@@ -33,11 +33,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == "hello, world")
             end for
-        }
+        })
     }
 
     "Stream[String].writeLinesTo writes each element as a line" in {
-        Scope.run {
+        Scope.run(Path.run {
             val lines = Chunk("alpha", "beta", "gamma")
             for
                 dir <- Path.tempDir("kyo-stream-sink-test")
@@ -47,11 +47,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == lines)
             end for
-        }
+        })
     }
 
     "Stream[String].writeTo with ISO-8859-1 charset encodes correctly" in {
-        Scope.run {
+        Scope.run(Path.run {
             val charset = StandardCharsets.ISO_8859_1
             val text    = "caf\u00e9"
             for
@@ -62,11 +62,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == text)
             end for
-        }
+        })
     }
 
     "Stream[String].writeLinesTo with ISO-8859-1 charset encodes correctly" in {
-        Scope.run {
+        Scope.run(Path.run {
             val charset = StandardCharsets.ISO_8859_1
             val lines   = Chunk("pr\u00e9", "deux\u00e8me")
             for
@@ -77,7 +77,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == lines)
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -85,7 +85,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "Stream[Byte].writeTo truncates existing content by default" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-append-test")
                 file = dir / "truncated.bin"
@@ -95,11 +95,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toArray.toList == List[Byte](9))
             end for
-        }
+        })
     }
 
     "Stream[Byte].writeTo with append adds to existing content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-append-test")
                 file = dir / "appended.bin"
@@ -109,11 +109,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result.toArray.toList == List[Byte](1, 2, 3, 4, 5))
             end for
-        }
+        })
     }
 
     "Stream[String].writeTo with append adds to existing content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-append-test")
                 file = dir / "appended.txt"
@@ -123,11 +123,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == "firstsecond")
             end for
-        }
+        })
     }
 
     "Stream[String].writeLinesTo with append adds lines to existing content" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-append-test")
                 file = dir / "appended-lines.txt"
@@ -137,11 +137,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == Chunk("first", "second", "third"))
             end for
-        }
+        })
     }
 
     "writeTo with append leaves existing content when the stream fails" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-append-test")
                 file = dir / "append-failure.txt"
@@ -163,7 +163,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 assert(exists)
                 assert(content == "keep me")
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -171,7 +171,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "writeTo creates missing parent directories by default" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-folders-test")
                 file = dir / "missing" / "nested" / "created.txt"
@@ -180,16 +180,18 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(result == "content")
             end for
-        }
+        })
     }
 
     "writeTo with createFolders = false fails when the parent directory is missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-folders-test")
                 file = dir / "missing" / "not-created.txt"
+                // The open failure comes from the backend, so the enclosing runner would raise it past this
+                // frame. Running a runner here is what puts the failure back where the assertion can see it.
                 result <- Abort.run[FileSystemException] {
-                    Scope.run(Stream.init(Chunk("content")).writeTo(file, options = Path.WriteOptions(createFolders = false)))
+                    Path.run(Scope.run(Stream.init(Chunk("content")).writeTo(file, options = Path.WriteOptions(createFolders = false))))
                 }
                 exists <- file.exists
                 _      <- dir.removeAll
@@ -197,16 +199,16 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 assert(result.isFailure)
                 assert(!exists)
             end for
-        }
+        })
     }
 
     "writeLinesTo with createFolders = false fails when the parent directory is missing" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-folders-test")
                 file = dir / "missing" / "not-created-lines.txt"
                 result <- Abort.run[FileSystemException] {
-                    Scope.run(Stream.init(Chunk("a", "b")).writeLinesTo(file, options = Path.WriteOptions(createFolders = false)))
+                    Path.run(Scope.run(Stream.init(Chunk("a", "b")).writeLinesTo(file, options = Path.WriteOptions(createFolders = false))))
                 }
                 exists <- file.exists
                 _      <- dir.removeAll
@@ -214,7 +216,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 assert(result.isFailure)
                 assert(!exists)
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -222,7 +224,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
     // =========================================================================
 
     "writeTo with empty byte stream creates an empty file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-sink-test")
                 file = dir / "empty-byte-stream.bin"
@@ -232,11 +234,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(exists && bytes.isEmpty)
             end for
-        }
+        })
     }
 
     "writeLinesTo with empty stream creates an empty file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-sink-test")
                 file = dir / "empty-lines-stream.txt"
@@ -246,7 +248,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                 _      <- dir.removeAll
             yield assert(exists && bytes.isEmpty)
             end for
-        }
+        })
     }
 
     // =========================================================================
@@ -255,7 +257,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
 
     // writeTo should not leave a file containing partial data when the input stream fails mid-flight.
     "writeTo does not leave file with partial data when stream fails mid-flight" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-stream-sink-test")
                 file = dir / "should-not-have-partial.txt"
@@ -272,7 +274,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                     }
                 }
                 exists <- file.exists
-                bytes  <- Abort.run[FileReadException](file.readBytes)
+                bytes  <- Abort.run[FileSystemException](Path.runReadOnly(file.readBytes))
                 _      <- dir.removeAll
             yield
                 assert(result.isFailure)
@@ -282,11 +284,11 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                     case Result.Success(b) => assert(b.isEmpty, s"Partial data left in file: ${b.size} bytes")
                     case Result.Failure(_) => () // file doesn't exist, also acceptable
             end for
-        }
+        })
     }
 
     "writeTo with failing stream does not leave corrupt partial file" in {
-        Scope.run {
+        Scope.run(Path.run {
             for
                 dir <- Path.tempDir("kyo-writeto-fail")
                 file = dir / "partial.bin"
@@ -305,7 +307,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                         failingStream.writeTo(file)
                     }
                 }
-                bytes <- Abort.run[FileReadException](file.readBytes)
+                bytes <- Abort.run[FileSystemException](Path.runReadOnly(file.readBytes))
                 _     <- dir.removeAll
             yield
                 assert(result.isFailure)
@@ -313,7 +315,7 @@ class StreamSystemExtensionsTest extends kyo.test.Test[Any]:
                     case Result.Success(b) => assert(b.isEmpty, s"Partial data found: ${b.size} bytes")
                     case Result.Failure(_) => ()
             end for
-        }
+        })
     }
 
 end StreamSystemExtensionsTest

--- a/kyo-tasty/js-wasm/src/test/scala/kyo/internal/TestClasspaths.scala
+++ b/kyo-tasty/js-wasm/src/test/scala/kyo/internal/TestClasspaths.scala
@@ -18,11 +18,11 @@ private[kyo] object TestClasspaths:
     def withClasspath[A, S](roots: Seq[String] = Seq.empty)(f: => A < S)(using Frame): A < (Async & Abort[TastyError] & S) =
         Scope.run {
             Abort.recover[FileSystemException] { e => Abort.fail(TastyError.SnapshotIoError(e.getMessage)) } {
-                Path.tempDir("kyo-test-fixtures").map { dir =>
+                Path.run(Path.tempDir("kyo-test-fixtures")).map { dir =>
                     val tastyDir     = dir / "root"
                     val javaClassDir = dir / "kyo" / "fixtures"
 
-                    def write(name: String, bytes: Array[Byte]): Unit < (Sync & Abort[FileWriteException]) =
+                    def write(name: String, bytes: Array[Byte]): Unit < PathWrite =
                         (tastyDir / name).writeBytes(Span.from(bytes))
 
                     val tastyFixtures: Chunk[(String, Array[Byte])] = Chunk(
@@ -112,26 +112,28 @@ private[kyo] object TestClasspaths:
                         "PortedBugFixture$package.tasty"    -> kyo.fixtures.Embedded.portedBugFixturePackageTasty
                     )
 
-                    tastyDir.mkDir.map { _ =>
-                        javaClassDir.mkDir.map { _ =>
-                            Kyo.foreach(tastyFixtures) { case (name, bytes) =>
-                                write(name, bytes)
-                            }.map { _ =>
-                                val bug71Dir = tastyDir / "portedBug71Outer" / "portedBug71Inner"
-                                bug71Dir.mkDir.map { _ =>
-                                    (bug71Dir / "Marker.tasty").writeBytes(
-                                        Span.from(kyo.fixtures.Embedded.portedBug71InnerMarkerTasty)
-                                    ).map { _ =>
-                                        // Java fixture: registered as a standalone root so the classpath walker's
-                                        // ".class" branch discovers it.
-                                        // Path "kyo/fixtures/JavaSimpleFixture.class" yields fully-qualified name
-                                        // "kyo.fixtures.JavaSimpleFixture" via classfilePathToFullName.
-                                        (javaClassDir / "JavaSimpleFixture.class").writeBytes(
-                                            Span.from(kyo.fixtures.EmbeddedJavaFixtures.javaSimpleFixtureClassfile)
+                    Path.run {
+                        tastyDir.mkDir.map { _ =>
+                            javaClassDir.mkDir.map { _ =>
+                                Kyo.foreach(tastyFixtures) { case (name, bytes) =>
+                                    write(name, bytes)
+                                }.map { _ =>
+                                    val bug71Dir = tastyDir / "portedBug71Outer" / "portedBug71Inner"
+                                    bug71Dir.mkDir.map { _ =>
+                                        (bug71Dir / "Marker.tasty").writeBytes(
+                                            Span.from(kyo.fixtures.Embedded.portedBug71InnerMarkerTasty)
                                         ).map { _ =>
-                                            Tasty.withClasspath(
-                                                Seq(tastyDir.toString, (javaClassDir / "JavaSimpleFixture.class").toString)
-                                            )(f)
+                                            // Java fixture: registered as a standalone root so the classpath walker's
+                                            // ".class" branch discovers it.
+                                            // Path "kyo/fixtures/JavaSimpleFixture.class" yields fully-qualified name
+                                            // "kyo.fixtures.JavaSimpleFixture" via classfilePathToFullName.
+                                            (javaClassDir / "JavaSimpleFixture.class").writeBytes(
+                                                Span.from(kyo.fixtures.EmbeddedJavaFixtures.javaSimpleFixtureClassfile)
+                                            ).map { _ =>
+                                                Tasty.withClasspath(
+                                                    Seq(tastyDir.toString, (javaClassDir / "JavaSimpleFixture.class").toString)
+                                                )(f)
+                                            }
                                         }
                                     }
                                 }

--- a/kyo-tasty/jvm/src/test/scala/kyo/WithClasspathCacheDirTest.scala
+++ b/kyo-tasty/jvm/src/test/scala/kyo/WithClasspathCacheDirTest.scala
@@ -5,7 +5,7 @@ class WithClasspathCacheDirTest extends kyo.test.Test[Any]:
 
     "withClasspath(roots, Present(cacheDir)) writes snapshot on miss, reads on hit" in {
         Scope.run {
-            Path.tempDir("kyo-wc-cachedir").map { tmpDirPath =>
+            Path.run(Path.tempDir("kyo-wc-cachedir")).map { tmpDirPath =>
                 val tmpDir = tmpDirPath.toString
                 System.property[String]("java.class.path").map { maybeCp =>
                     val cpRaw = maybeCp.getOrElse("")
@@ -21,16 +21,18 @@ class WithClasspathCacheDirTest extends kyo.test.Test[Any]:
                             }
                             .toSeq
                     // Fall back to all classpath entries if the fixtures jar is not separately discoverable.
-                    val rootsK: Chunk[Path] < (Sync & Abort[FileStructureException]) =
+                    val rootsK: Chunk[Path] < (Sync & Abort[FileSystemException]) =
                         if cpRoots.nonEmpty then Chunk.from(cpRoots).map(p => Path(p))
                         else
                             val candidates = cpRaw.split(Path.pathSeparator).toSeq
                             Kyo.collect(Chunk.from(candidates)) { p =>
                                 val pp = Path(p)
-                                pp.isRegularFile.map { isFile =>
-                                    pp.isDirectory.map { isDir =>
-                                        if (isFile && p.endsWith(".jar")) || isDir then Maybe(pp)
-                                        else Maybe.Absent
+                                Path.runReadOnly {
+                                    pp.isRegularFile.map { isFile =>
+                                        pp.isDirectory.map { isDir =>
+                                            if (isFile && p.endsWith(".jar")) || isDir then Maybe(pp)
+                                            else Maybe.Absent
+                                        }
                                     }
                                 }
                             }.map(_.take(1))
@@ -43,7 +45,7 @@ class WithClasspathCacheDirTest extends kyo.test.Test[Any]:
                                 Tasty.withClasspath(roots, Maybe.Present(tmpDir)) {
                                     Tasty.classpath.map(_.symbols.size)
                                 }.map { n2 =>
-                                    tmpDirPath.list(glob"*.krfl").map { krflFiles =>
+                                    Path.runReadOnly(tmpDirPath.list(glob"*.krfl")).map { krflFiles =>
                                         val krflCount = krflFiles.size
                                         assert(krflCount >= 1, s"at least one .krfl file must be written to $tmpDir; got $krflCount")
                                         assert(n1 == n2, s"both withClasspath calls must return same symbol count; got $n1 vs $n2")

--- a/kyo-tasty/jvm/src/test/scala/kyo/internal/TestClasspaths2Jvm.scala
+++ b/kyo-tasty/jvm/src/test/scala/kyo/internal/TestClasspaths2Jvm.scala
@@ -274,10 +274,10 @@ private[kyo] object TestClasspaths2Jvm:
                             kyo.internal.tasty.snapshot.SnapshotWriter.write(cp2, tmpB, digest2).map { _ =>
                                 val hexB  = kyo.internal.tasty.snapshot.DigestComputer.toHexString(digest2)
                                 val pathB = s"$tmpB/$hexB.krfl"
-                                Abort.recover[kyo.FileReadException](e => Abort.fail(TastyError.SnapshotIoError(e.getMessage)))(
-                                    Path(pathA).readBytes.map { spanA =>
-                                        Abort.recover[kyo.FileReadException](e => Abort.fail(TastyError.SnapshotIoError(e.getMessage)))(
-                                            Path(pathB).readBytes.map { spanB =>
+                                Abort.recover[kyo.FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(e.getMessage)))(
+                                    Path.runReadOnly(Path(pathA).readBytes).map { spanA =>
+                                        Abort.recover[kyo.FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(e.getMessage)))(
+                                            Path.runReadOnly(Path(pathB).readBytes).map { spanB =>
                                                 (spanA.toArray, spanB.toArray)
                                             }
                                         )

--- a/kyo-tasty/native/src/test/scala/kyo/NativeMmapReaderTest.scala
+++ b/kyo-tasty/native/src/test/scala/kyo/NativeMmapReaderTest.scala
@@ -14,7 +14,7 @@ class NativeMmapReaderTest extends kyo.test.Test[Any]:
         import AllowUnsafe.embrace.danger
         val path    = tmpPath("kyo-native-mmap-test-read-open.bin")
         val content = Array[Byte](0x42.toByte, 0x43.toByte, 0x44.toByte, 0x45.toByte)
-        Path(path).writeBytes(Span.from(content)).map { _ =>
+        Path.run(Path(path).writeBytes(Span.from(content))).map { _ =>
             Abort.run[TastyError](
                 Scope.run {
                     NativeMmapReader.init(path).map { view =>
@@ -37,7 +37,7 @@ class NativeMmapReaderTest extends kyo.test.Test[Any]:
         val content = Array[Byte](0x01.toByte, 0x02.toByte, 0x03.toByte, 0x04.toByte)
         // Capture the view reference outside the scope so we can read after the scope exits.
         var capturedView: MappedByteView = null
-        Path(path).writeBytes(Span.from(content)).map { _ =>
+        Path.run(Path(path).writeBytes(Span.from(content))).map { _ =>
             Abort.run[TastyError](
                 Scope.run {
                     NativeMmapReader.init(path).map { view =>

--- a/kyo-tasty/native/src/test/scala/kyo/internal/TestClasspaths.scala
+++ b/kyo-tasty/native/src/test/scala/kyo/internal/TestClasspaths.scala
@@ -18,11 +18,11 @@ private[kyo] object TestClasspaths:
     def withClasspath[A, S](roots: Seq[String] = Seq.empty)(f: => A < S)(using Frame): A < (Async & Abort[TastyError] & S) =
         Scope.run {
             Abort.recover[FileSystemException] { e => Abort.fail(TastyError.SnapshotIoError(e.getMessage)) } {
-                Path.tempDir("kyo-test-fixtures").map { dir =>
+                Path.run(Path.tempDir("kyo-test-fixtures")).map { dir =>
                     val tastyDir     = dir / "root"
                     val javaClassDir = dir / "kyo" / "fixtures"
 
-                    def write(name: String, bytes: Array[Byte]): Unit < (Sync & Abort[FileWriteException]) =
+                    def write(name: String, bytes: Array[Byte]): Unit < PathWrite =
                         (tastyDir / name).writeBytes(Span.from(bytes))
 
                     val tastyFixtures: Chunk[(String, Array[Byte])] = Chunk(
@@ -112,50 +112,52 @@ private[kyo] object TestClasspaths:
                         "PortedBugFixture$package.tasty"    -> kyo.fixtures.Embedded.portedBugFixturePackageTasty
                     )
 
-                    tastyDir.mkDir.map { _ =>
-                        javaClassDir.mkDir.map { _ =>
-                            Kyo.foreach(tastyFixtures) { case (name, bytes) =>
-                                write(name, bytes)
-                            }.map { _ =>
-                                val bug71Dir = tastyDir / "portedBug71Outer" / "portedBug71Inner"
-                                bug71Dir.mkDir.map { _ =>
-                                    (bug71Dir / "Marker.tasty").writeBytes(
-                                        Span.from(kyo.fixtures.Embedded.portedBug71InnerMarkerTasty)
-                                    ).map { _ =>
-                                        // Java fixture: registered as a standalone root so the classpath walker's
-                                        // ".class" branch discovers it.
-                                        // Path "kyo/fixtures/JavaSimpleFixture.class" yields fully-qualified name
-                                        // "kyo.fixtures.JavaSimpleFixture" via classfilePathToFullName.
-                                        (javaClassDir / "JavaSimpleFixture.class").writeBytes(
-                                            Span.from(kyo.fixtures.EmbeddedJavaFixtures.javaSimpleFixtureClassfile)
+                    Path.run {
+                        tastyDir.mkDir.map { _ =>
+                            javaClassDir.mkDir.map { _ =>
+                                Kyo.foreach(tastyFixtures) { case (name, bytes) =>
+                                    write(name, bytes)
+                                }.map { _ =>
+                                    val bug71Dir = tastyDir / "portedBug71Outer" / "portedBug71Inner"
+                                    bug71Dir.mkDir.map { _ =>
+                                        (bug71Dir / "Marker.tasty").writeBytes(
+                                            Span.from(kyo.fixtures.Embedded.portedBug71InnerMarkerTasty)
                                         ).map { _ =>
-                                            // Directory-enumeration barrier on Native: list every just-written
-                                            // directory before launching the classpath walker so each directory's
-                                            // inode is refreshed and all entries are visible to the subsequent
-                                            // Path.walk inside Tasty.withClasspath. Without this barrier, the
-                                            // POSIX readdir cache in the Scala Native NIO compat sometimes misses
-                                            // the last few writes when the same fiber writes then walks the same
-                                            // directory within microseconds.
-                                            //
-                                            // Two levels, matching the two-level write pattern: writes land inside
-                                            // tastyDir (root/) and inside javaClassDir (kyo/fixtures/), both under
-                                            // the parent temp dir. Flushing tastyDir, javaClassDir, and dir ensures
-                                            // root and kyo/ are both settled in the parent's readdir snapshot before
-                                            // the walk begins.
-                                            Abort.recover[FileStructureException](_ => ()) {
-                                                tastyDir.list.map(_ => ())
-                                            }.flatMap { _ =>
-                                                Abort.recover[FileStructureException](_ => ()) {
-                                                    javaClassDir.list.map(_ => ())
+                                            // Java fixture: registered as a standalone root so the classpath walker's
+                                            // ".class" branch discovers it.
+                                            // Path "kyo/fixtures/JavaSimpleFixture.class" yields fully-qualified name
+                                            // "kyo.fixtures.JavaSimpleFixture" via classfilePathToFullName.
+                                            (javaClassDir / "JavaSimpleFixture.class").writeBytes(
+                                                Span.from(kyo.fixtures.EmbeddedJavaFixtures.javaSimpleFixtureClassfile)
+                                            ).map { _ =>
+                                                // Directory-enumeration barrier on Native: list every just-written
+                                                // directory before launching the classpath walker so each directory's
+                                                // inode is refreshed and all entries are visible to the subsequent
+                                                // Path.walk inside Tasty.withClasspath. Without this barrier, the
+                                                // POSIX readdir cache in the Scala Native NIO compat sometimes misses
+                                                // the last few writes when the same fiber writes then walks the same
+                                                // directory within microseconds.
+                                                //
+                                                // Two levels, matching the two-level write pattern: writes land inside
+                                                // tastyDir (root/) and inside javaClassDir (kyo/fixtures/), both under
+                                                // the parent temp dir. Flushing tastyDir, javaClassDir, and dir ensures
+                                                // root and kyo/ are both settled in the parent's readdir snapshot before
+                                                // the walk begins.
+                                                Abort.recover[FileSystemException](_ => ()) {
+                                                    Path.runReadOnly(tastyDir.list.map(_ => ()))
+                                                }.flatMap { _ =>
+                                                    Abort.recover[FileSystemException](_ => ()) {
+                                                        Path.runReadOnly(javaClassDir.list.map(_ => ()))
+                                                    }
+                                                }.flatMap { _ =>
+                                                    Abort.recover[FileSystemException](_ => ()) {
+                                                        Path.runReadOnly(dir.list.map(_ => ()))
+                                                    }
+                                                }.map { _ =>
+                                                    Tasty.withClasspath(
+                                                        Seq(tastyDir.toString, (javaClassDir / "JavaSimpleFixture.class").toString)
+                                                    )(f)
                                                 }
-                                            }.flatMap { _ =>
-                                                Abort.recover[FileStructureException](_ => ()) {
-                                                    dir.list.map(_ => ())
-                                                }
-                                            }.map { _ =>
-                                                Tasty.withClasspath(
-                                                    Seq(tastyDir.toString, (javaClassDir / "JavaSimpleFixture.class").toString)
-                                                )(f)
                                             }
                                         }
                                     }

--- a/kyo-tasty/shared/src/main/scala/kyo/Tasty.scala
+++ b/kyo-tasty/shared/src/main/scala/kyo/Tasty.scala
@@ -130,14 +130,12 @@ object Tasty:
     def evictOlderThan(cacheDir: String, maxAge: Duration)(using Frame): Unit < (Sync & Abort[TastyError]) =
         val maxAgeMs = maxAge.toMillis
         // List all *.krfl files; wrap FileStructureException so the caller sees TastyError.SnapshotIoError.
-        Abort.recover[FileStructureException](e =>
-            Abort.fail(TastyError.SnapshotIoError(s"list $cacheDir: ${e.getMessage}"))
-        )(
-            Path(cacheDir).list(glob"*.krfl")
+        Abort.recover[FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(s"list $cacheDir: ${e.getMessage}")))(
+            Path.runReadOnly(Path(cacheDir).list(glob"*.krfl"))
         ).map { files =>
             // Collect (path, mtime) for each file; skip files whose stat call fails (concurrent-writer race).
             Kyo.collect(files) { p =>
-                Abort.run[FileReadException](p.stat).map {
+                Abort.run[FileSystemException](Path.runReadOnly(p.stat)).map {
                     case Result.Success(st) => Maybe((p, st.lastModifiedMs))
                     case _                  => Maybe.Absent
                 }
@@ -149,7 +147,7 @@ object Tasty:
                     Kyo.foreachDiscard(sorted.takeWhile { case (_, mtimeMs) => nowMs - mtimeMs > maxAgeMs }) {
                         case (p, _) =>
                             // Absorb errors: a missing file means a concurrent writer already replaced it.
-                            Abort.run[FileStructureException](p.remove).map(_ => Kyo.unit)
+                            Abort.run[FileSystemException](Path.run(p.remove)).map(_ => Kyo.unit)
                     }
                 }
             }
@@ -4985,7 +4983,7 @@ object Tasty:
                 case Result.Success(digest) =>
                     val hexDigest    = SnapshotDigest.toHexString(digest)
                     val snapshotPath = s"$cacheDir/$hexDigest.krfl"
-                    Abort.recover[FileReadException](_ => false)(Path(snapshotPath).exists).map { exists =>
+                    Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(Path(snapshotPath).exists)).map { exists =>
                         if exists then
                             // Try to load from snapshot using mmap on JVM/Native, heap on JS.
                             Abort.run[TastyError](SnapshotReader.readMapped(snapshotPath)).map {

--- a/kyo-tasty/shared/src/main/scala/kyo/internal/tasty/query/ClasspathOrchestrator.scala
+++ b/kyo-tasty/shared/src/main/scala/kyo/internal/tasty/query/ClasspathOrchestrator.scala
@@ -202,7 +202,7 @@ object ClasspathOrchestrator:
         Kyo.foreach(roots) { root =>
             if root.startsWith("jrt:/") then Sync.defer(true)
             else
-                Abort.recover[FileReadException](_ => false)(Path(root).exists).map { ex =>
+                Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(Path(root).exists)).map { ex =>
                     if !ex && mode == Tasty.ErrorMode.FailFast then Abort.fail(TastyError.FileNotFound(root))
                     else Sync.defer(ex) // true = root exists; false = missing (only in SoftFail)
                 }
@@ -260,7 +260,7 @@ object ClasspathOrchestrator:
             Kyo.foreach(roots) { root =>
                 if root.startsWith("jrt:/") then Sync.defer(true)
                 else
-                    Abort.recover[FileReadException](_ => false)(Path(root).exists).map { ex =>
+                    Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(Path(root).exists)).map { ex =>
                         if !ex && mode == Tasty.ErrorMode.FailFast then Abort.fail(TastyError.FileNotFound(root))
                         else Sync.defer(ex)
                     }
@@ -515,9 +515,7 @@ object ClasspathOrchestrator:
                 }
             else
                 // Directory, direct .tasty file, or direct .class file: use Path walk.
-                Abort.recover[FileStructureException](err =>
-                    Abort.fail(TastyError.SnapshotIoError(s"list $root: ${err.getMessage}"))
-                ) {
+                Abort.recover[FileSystemException](err => Abort.fail(TastyError.SnapshotIoError(s"list $root: ${err.getMessage}"))) {
                     if root.endsWith(".tasty") || root.endsWith("module-info.class") then
                         Sync.defer(Chunk(root))
                     else if root.endsWith(".class") && !root.endsWith("module-info.class") then
@@ -525,7 +523,7 @@ object ClasspathOrchestrator:
                     else
                         // Path.walk returns a Stream requiring Scope; Scope.run discharges the Scope.
                         Scope.run {
-                            Path(root).walk.run.map { paths =>
+                            Path.runReadOnly(Path(root).walk.run).map { paths =>
                                 Chunk.from(paths.toSeq.filter { p =>
                                     val name = p.name.getOrElse("")
                                     suffixes.exists(name.endsWith)
@@ -667,10 +665,8 @@ object ClasspathOrchestrator:
         else if entryPath.startsWith("jrt:/") then
             ZipHandle.readJrtEntry(entryPath).map(Span.fromUnsafe)
         else
-            Abort.recover[FileReadException](err =>
-                Abort.fail(TastyError.SnapshotIoError(s"read $entryPath: ${err.getMessage}"))
-            ) {
-                Path(entryPath).readBytes
+            Abort.recover[FileSystemException](err => Abort.fail(TastyError.SnapshotIoError(s"read $entryPath: ${err.getMessage}"))) {
+                Path.runReadOnly(Path(entryPath).readBytes)
             }
         end if
     end readEntryBytes
@@ -2448,7 +2444,7 @@ object ClasspathOrchestrator:
                         // For jar entries, try reading and treat IOException as absent.
                         Sync.defer(true) // attempt the read; soft-fail handles the error
                     else
-                        Abort.recover[FileReadException](_ => false)(Path(companionPath).exists)
+                        Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(Path(companionPath).exists))
                     end if
                 end companionExistsEffect
                 companionExistsEffect.map { exists =>
@@ -2838,36 +2834,18 @@ object ClasspathOrchestrator:
                             case Result.Success(digest) =>
                                 val hexDigest    = SnapshotDigest.toHexString(digest)
                                 val snapshotPath = s"$dir/$hexDigest.krfl"
-                                Abort.recover[FileReadException](_ => false)(Path(snapshotPath).exists).map {
-                                    exists =>
-                                        if exists then
-                                            Abort.run[TastyError](SnapshotReader.readMapped(snapshotPath)).map {
-                                                case Result.Success(coldCp) =>
-                                                    // Snapshot load: body store is empty; bodyTree returns Absent.
-                                                    val merged = if bundledCp.symbols.isEmpty then coldCp
-                                                    else BundledSnapshotProbe.mergePartialInto(bundledCp, coldCp)
-                                                    Binding(merged, Maybe.Present(DecodeContext.fresh()))
-                                                case Result.Failure(_) | Result.Panic(_) =>
-                                                    // Snapshot unreadable; fall through to cold load.
-                                                    initWithBodies(coldRoots, mode, concurrency).map {
-                                                        (coldCp, bodyStore, positionsStore, declarationRangeStore, parentOccurrenceStore) =>
-                                                            val merged = if bundledCp.symbols.isEmpty then coldCp
-                                                            else BundledSnapshotProbe.mergePartialInto(bundledCp, coldCp)
-                                                            Binding(
-                                                                merged,
-                                                                Maybe.Present(DecodeContext.fresh(
-                                                                    bodyStore,
-                                                                    positionsStore,
-                                                                    declarationRangeStore,
-                                                                    parentOccurrenceStore
-                                                                ))
-                                                            )
-                                                    }
-                                            }
-                                        else
-                                            initWithBodies(coldRoots, mode, concurrency).map {
-                                                (coldCp, bodyStore, positionsStore, declarationRangeStore, parentOccurrenceStore) =>
-                                                    Abort.run[TastyError](SnapshotWriter.write(coldCp, dir, digest)).andThen {
+                                Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(Path(snapshotPath).exists)).map { exists =>
+                                    if exists then
+                                        Abort.run[TastyError](SnapshotReader.readMapped(snapshotPath)).map {
+                                            case Result.Success(coldCp) =>
+                                                // Snapshot load: body store is empty; bodyTree returns Absent.
+                                                val merged = if bundledCp.symbols.isEmpty then coldCp
+                                                else BundledSnapshotProbe.mergePartialInto(bundledCp, coldCp)
+                                                Binding(merged, Maybe.Present(DecodeContext.fresh()))
+                                            case Result.Failure(_) | Result.Panic(_) =>
+                                                // Snapshot unreadable; fall through to cold load.
+                                                initWithBodies(coldRoots, mode, concurrency).map {
+                                                    (coldCp, bodyStore, positionsStore, declarationRangeStore, parentOccurrenceStore) =>
                                                         val merged = if bundledCp.symbols.isEmpty then coldCp
                                                         else BundledSnapshotProbe.mergePartialInto(bundledCp, coldCp)
                                                         Binding(
@@ -2879,8 +2857,25 @@ object ClasspathOrchestrator:
                                                                 parentOccurrenceStore
                                                             ))
                                                         )
-                                                    }
-                                            }
+                                                }
+                                        }
+                                    else
+                                        initWithBodies(coldRoots, mode, concurrency).map {
+                                            (coldCp, bodyStore, positionsStore, declarationRangeStore, parentOccurrenceStore) =>
+                                                Abort.run[TastyError](SnapshotWriter.write(coldCp, dir, digest)).andThen {
+                                                    val merged = if bundledCp.symbols.isEmpty then coldCp
+                                                    else BundledSnapshotProbe.mergePartialInto(bundledCp, coldCp)
+                                                    Binding(
+                                                        merged,
+                                                        Maybe.Present(DecodeContext.fresh(
+                                                            bodyStore,
+                                                            positionsStore,
+                                                            declarationRangeStore,
+                                                            parentOccurrenceStore
+                                                        ))
+                                                    )
+                                                }
+                                        }
                                 }
                         }
             // If no cold roots remain (all roots had bundled snapshots), return the merged bundled classpath directly.

--- a/kyo-tasty/shared/src/main/scala/kyo/internal/tasty/snapshot/DigestComputer.scala
+++ b/kyo-tasty/shared/src/main/scala/kyo/internal/tasty/snapshot/DigestComputer.scala
@@ -150,8 +150,8 @@ object DigestComputer:
         collectAllFiles(roots).map { files =>
             val sorted = files.sortBy(identity)
             Kyo.foreach(sorted) { path =>
-                Abort.recover[FileReadException](e => Abort.fail(TastyError.SnapshotIoError(s"read $path: ${e.getMessage}"))) {
-                    Path(path).readBytes.map(span => (path, span))
+                Abort.recover[FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(s"read $path: ${e.getMessage}"))) {
+                    Path.runReadOnly(Path(path).readBytes).map(span => (path, span))
                 }
             }.map { pairs =>
                 var acc = 0L
@@ -230,8 +230,8 @@ object DigestComputer:
     )(using Frame): Seq[(String, Long, Long)] < (Sync & Abort[TastyError]) =
         collectFiles(roots).map { files =>
             Kyo.foreach(files) { path =>
-                Abort.recover[FileReadException](e => Abort.fail(TastyError.SnapshotIoError(s"stat $path: ${e.getMessage}"))) {
-                    Path(path).stat.map(st => (path, st.lastModifiedMs, st.sizeBytes))
+                Abort.recover[FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(s"stat $path: ${e.getMessage}"))) {
+                    Path.runReadOnly(Path(path).stat).map(st => (path, st.lastModifiedMs, st.sizeBytes))
                 }
             }
         }
@@ -248,7 +248,7 @@ object DigestComputer:
         roots: Seq[String]
     )(using Frame): Seq[String] < (Sync & Abort[TastyError]) =
         Kyo.foreach(roots) { root =>
-            Abort.recover[FileReadException](_ => false)(Path(root).exists).map { ex =>
+            Abort.recover[FileSystemException](_ => false)(Path.runReadOnly(Path(root).exists)).map { ex =>
                 if !ex then Sync.defer(Seq.empty[String])
                 else
                     Sync.Unsafe.defer {

--- a/kyo-tasty/shared/src/main/scala/kyo/internal/tasty/snapshot/SnapshotReader.scala
+++ b/kyo-tasty/shared/src/main/scala/kyo/internal/tasty/snapshot/SnapshotReader.scala
@@ -35,8 +35,8 @@ object SnapshotReader:
         path: String,
         expectedDigest: Maybe[Array[Byte]] = Maybe.Absent
     )(using Frame): Tasty.Classpath < (Sync & Abort[TastyError]) =
-        Abort.recover[FileReadException](e => Abort.fail(TastyError.SnapshotIoError(s"read $path: ${e.getMessage}")))(
-            Path(path).readBytes
+        Abort.recover[FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(s"read $path: ${e.getMessage}")))(
+            Path.runReadOnly(Path(path).readBytes)
         ).map { bytes =>
             expectedDigest match
                 case Maybe.Absent =>

--- a/kyo-tasty/shared/src/main/scala/kyo/internal/tasty/snapshot/SnapshotWriter.scala
+++ b/kyo-tasty/shared/src/main/scala/kyo/internal/tasty/snapshot/SnapshotWriter.scala
@@ -61,23 +61,19 @@ object SnapshotWriter:
                 val tmpName   = s"$cacheDir/$hexDigest-$unique.krfl"
                 val finalName = s"$cacheDir/$hexDigest.krfl"
                 Sync.defer(Span.fromUnsafe(serialize(classpath, digest))).map { span =>
-                    Abort.recover[FileStructureException](e =>
-                        Abort.fail(TastyError.SnapshotIoError(s"mkDir $cacheDir: ${e.getMessage}"))
-                    )(
-                        Path(cacheDir).mkDir
+                    Abort.recover[FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(s"mkDir $cacheDir: ${e.getMessage}")))(
+                        Path.run(Path(cacheDir).mkDir)
                     ).map { _ =>
-                        Abort.recover[FileWriteException](e =>
-                            Abort.fail(TastyError.SnapshotIoError(s"write $tmpName: ${e.getMessage}"))
-                        )(
-                            Path(tmpName).writeBytes(span)
+                        Abort.recover[FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(s"write $tmpName: ${e.getMessage}")))(
+                            Path.run(Path(tmpName).writeBytes(span))
                         ).map { _ =>
-                            Abort.recover[FileStructureException](e =>
+                            Abort.recover[FileSystemException](e =>
                                 Abort.fail(TastyError.SnapshotIoError(s"move $tmpName: ${e.getMessage}"))
                             )(
-                                Path(tmpName).move(
+                                Path.run(Path(tmpName).move(
                                     Path(finalName),
                                     Path.MoveOptions(atomicity = Path.Atomicity.Required)
-                                )
+                                ))
                             )
                         }
                     }

--- a/kyo-tasty/shared/src/test/scala/kyo/ClasspathOrchestratorPipelineTest.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/ClasspathOrchestratorPipelineTest.scala
@@ -99,8 +99,8 @@ class ClasspathOrchestratorPipelineTest extends kyo.test.Test[Any]:
     "strict mode raises Abort[TastyError] for corrupted tasty file without hanging" in {
         // FailFast mode requires real filesystem roots. Use a temp dir with a corrupt file.
         Scope.run {
-            Path.tempDir("kyo-pipe-failfast").map { dir =>
-                (dir / "Corrupt.tasty").writeBytes(Span.from(Array[Byte](0, 1, 2, 3, 4, 5))).map { _ =>
+            Path.run(Path.tempDir("kyo-pipe-failfast")).map { dir =>
+                Path.run((dir / "Corrupt.tasty").writeBytes(Span.from(Array[Byte](0, 1, 2, 3, 4, 5)))).map { _ =>
                     Scope.run {
                         Abort.run[TastyError](ClasspathOrchestrator.init(Seq(dir.toString), Tasty.ErrorMode.FailFast, 1)).map {
                             case Result.Failure(_: TastyError) =>

--- a/kyo-tasty/shared/src/test/scala/kyo/CollisionFidelity2Test.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/CollisionFidelity2Test.scala
@@ -119,11 +119,13 @@ class CollisionFidelity2Test extends Fidelity2TestBase:
     "FailFast collision raises TastyError.FullNameCollisionError" in {
         // Write collision bytes to temp dirs: root1 and root2 each contain the same fixtures.
         Scope.run {
-            Path.tempDir("kyo-col-root1").map { root1 =>
-                Path.tempDir("kyo-col-root2").map { root2 =>
-                    Kyo.foreach(Chunk.from(fixtureBytes)) { (name, bytes) =>
-                        (root1 / s"$name.tasty").writeBytes(Span.from(bytes)).map { _ =>
-                            (root2 / s"$name.tasty").writeBytes(Span.from(bytes))
+            Path.run(Path.tempDir("kyo-col-root1")).map { root1 =>
+                Path.run(Path.tempDir("kyo-col-root2")).map { root2 =>
+                    Path.run {
+                        Kyo.foreach(Chunk.from(fixtureBytes)) { (name, bytes) =>
+                            (root1 / s"$name.tasty").writeBytes(Span.from(bytes)).map { _ =>
+                                (root2 / s"$name.tasty").writeBytes(Span.from(bytes))
+                            }
                         }
                     }
                         .map { _ =>

--- a/kyo-tasty/shared/src/test/scala/kyo/ConcurrentSnapshotIoTest.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/ConcurrentSnapshotIoTest.scala
@@ -19,7 +19,7 @@ class ConcurrentSnapshotIoTest extends kyo.test.Test[Any]:
     "concurrent snapshot reader+writer: reader sees pre- or post-write, not corrupt" in {
         val digest = Array[Byte](0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57)
         Scope.run {
-            Path.tempDir("kyo-conc-snap").map { dir =>
+            Path.run(Path.tempDir("kyo-conc-snap")).map { dir =>
                 val tmpDir       = dir.toString
                 val hexDigest    = DigestComputer.toHexString(digest)
                 val snapshotPath = s"$tmpDir/$hexDigest.krfl"

--- a/kyo-tasty/shared/src/test/scala/kyo/ConfirmationFidelity2Test.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/ConfirmationFidelity2Test.scala
@@ -106,12 +106,12 @@ class ConfirmationFidelity2Test extends Fidelity2TestBase:
     "findClass(kyo.fixtures.JavaSimpleFixture) returns Present with isJava via temp dir" in {
         // Write the .class file to a temp dir and use ClasspathOrchestrator.init with a real path.
         Scope.run {
-            Path.tempDir("kyo-cf2-java").map { tmpDir =>
+            Path.run(Path.tempDir("kyo-cf2-java")).map { tmpDir =>
                 val subDir = tmpDir / "kyo" / "fixtures"
-                subDir.mkDir.map { _ =>
-                    (subDir / "JavaSimpleFixture.class").writeBytes(
+                Path.run(subDir.mkDir).map { _ =>
+                    Path.run((subDir / "JavaSimpleFixture.class").writeBytes(
                         Span.from(kyo.fixtures.EmbeddedJavaFixtures.javaSimpleFixtureClassfile)
-                    ).map { _ =>
+                    )).map { _ =>
                         Scope.run {
                             Abort.run[TastyError](
                                 ClasspathOrchestrator.init(

--- a/kyo-tasty/shared/src/test/scala/kyo/DecoderFidelity5Phase04Test.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/DecoderFidelity5Phase04Test.scala
@@ -381,7 +381,7 @@ class DecoderFidelity5Phase04Test extends kyo.test.Test[Any]:
 
     "evictOlderThan on empty cache dir completes without error" in {
         Scope.run {
-            Path.tempDir("kyo-df5-evict-empty").map { dir =>
+            Path.run(Path.tempDir("kyo-df5-evict-empty")).map { dir =>
                 Abort.run[TastyError](Tasty.evictOlderThan(dir.toString, 1.millis)).map {
                     case Result.Success(_) => succeed
                     case Result.Failure(e) => fail(s"Unexpected error: $e")
@@ -414,7 +414,7 @@ class DecoderFidelity5Phase04Test extends kyo.test.Test[Any]:
         val d    = Duration.fromJava(jDur)
         assert(d.toMillis == 5000L, s"Duration.toMillis mismatch: ${d.toMillis}")
         Scope.run {
-            Path.tempDir("kyo-df5-evict-dur").map { dir =>
+            Path.run(Path.tempDir("kyo-df5-evict-dur")).map { dir =>
                 Abort.run[TastyError](Tasty.evictOlderThan(dir.toString, d)).map {
                     case Result.Success(_) => succeed
                     case Result.Failure(e) => fail(s"Unexpected error: $e")

--- a/kyo-tasty/shared/src/test/scala/kyo/DecoderFidelity5Wave2Test.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/DecoderFidelity5Wave2Test.scala
@@ -174,12 +174,12 @@ class DecoderFidelity5Wave2Test extends kyo.test.Test[Any]:
 
     "snapshot write to unwritable path produces SnapshotIoError" in {
         // Create a temp file and attempt to use it as a cache directory.
-        // Path.mkDir on a path occupied by a regular file fails with FileStructureException,
+        // Path.mkDir on a path occupied by a regular file fails with FileSystemException,
         // which SnapshotWriter wraps as SnapshotIoError.
         Scope.run {
-            Path.tempDir("kyo-dfw2-fail").map { tmpDir =>
+            Path.run(Path.tempDir("kyo-dfw2-fail")).map { tmpDir =>
                 val fileAsDir = tmpDir / "not-a-dir"
-                fileAsDir.mkFile.map { _ =>
+                Path.run(fileAsDir.mkFile).map { _ =>
                     TestClasspaths.withClasspath()(Tasty.classpath).map { classpath =>
                         val digest = Array.fill[Byte](8)(0x33.toByte)
                         Abort.run[TastyError](SnapshotWriter.write(classpath, fileAsDir.toString, digest)).map {

--- a/kyo-tasty/shared/src/test/scala/kyo/DigestComputerTest.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/DigestComputerTest.scala
@@ -38,15 +38,15 @@ class DigestComputerTest extends kyo.test.Test[Any]:
     // directory root compute is deterministic and sensitive to file-set changes.
     "directory root compute is deterministic and detects added file" in {
         Scope.run {
-            Path.tempDir("kyo-dct").map { dir =>
+            Path.run(Path.tempDir("kyo-dct")).map { dir =>
                 val file = dir / "Foo.tasty"
-                file.writeBytes(Span.from(Array[Byte](1, 2, 3, 4))).map { _ =>
+                Path.run(file.writeBytes(Span.from(Array[Byte](1, 2, 3, 4)))).map { _ =>
                     val root = dir.toString
                     Abort.run[TastyError] {
                         DigestComputer.compute(Seq(root)).map { d1 =>
                             DigestComputer.compute(Seq(root)).map { d2 =>
                                 val file2 = dir / "Bar.tasty"
-                                file2.writeBytes(Span.from(Array[Byte](5, 6, 7, 8))).map { _ =>
+                                Path.run(file2.writeBytes(Span.from(Array[Byte](5, 6, 7, 8)))).map { _ =>
                                     DigestComputer.compute(Seq(root)).map { d3 =>
                                         (d1, d2, d3)
                                     }

--- a/kyo-tasty/shared/src/test/scala/kyo/DigestEqualityTest.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/DigestEqualityTest.scala
@@ -16,11 +16,11 @@ class DigestEqualityTest extends kyo.test.Test[Any]:
 
     "compute on real files is deterministic across two calls" in {
         Scope.run {
-            Path.tempDir("kyo-deq").map { dir =>
+            Path.run(Path.tempDir("kyo-deq")).map { dir =>
                 val fileA = dir / "Alpha.tasty"
                 val fileB = dir / "Beta.tasty"
-                fileA.writeBytes(Span.from(Array[Byte](0x01, 0x02, 0x03, 0x04, 0x05))).map { _ =>
-                    fileB.writeBytes(Span.from(Array[Byte](0x10, 0x20, 0x30, 0x40))).map { _ =>
+                Path.run(fileA.writeBytes(Span.from(Array[Byte](0x01, 0x02, 0x03, 0x04, 0x05)))).map { _ =>
+                    Path.run(fileB.writeBytes(Span.from(Array[Byte](0x10, 0x20, 0x30, 0x40)))).map { _ =>
                         val root = dir.toString
                         Abort.run[TastyError] {
                             DigestComputer.compute(Seq(root)).map { d1 =>
@@ -46,14 +46,14 @@ class DigestEqualityTest extends kyo.test.Test[Any]:
 
     "compute result changes when a file is added to the root" in {
         Scope.run {
-            Path.tempDir("kyo-deq-add").map { dir =>
+            Path.run(Path.tempDir("kyo-deq-add")).map { dir =>
                 val fileA = dir / "Alpha.tasty"
-                fileA.writeBytes(Span.from(Array[Byte](0x01, 0x02, 0x03))).map { _ =>
+                Path.run(fileA.writeBytes(Span.from(Array[Byte](0x01, 0x02, 0x03)))).map { _ =>
                     val root = dir.toString
                     Abort.run[TastyError] {
                         DigestComputer.compute(Seq(root)).map { d1 =>
                             val fileB = dir / "Beta.tasty"
-                            fileB.writeBytes(Span.from(Array[Byte](0x04, 0x05, 0x06))).map { _ =>
+                            Path.run(fileB.writeBytes(Span.from(Array[Byte](0x04, 0x05, 0x06)))).map { _ =>
                                 DigestComputer.compute(Seq(root)).map { d2 =>
                                     (d1, d2)
                                 }

--- a/kyo-tasty/shared/src/test/scala/kyo/ErrorFidelity2Test.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/ErrorFidelity2Test.scala
@@ -54,7 +54,7 @@ class ErrorFidelity2Test extends Fidelity2TestBase:
     "SoftFail missing root accumulates FileNotFound in classpath.errors" in {
         // Use a real temp dir with a non-existent sub-path to trigger FileNotFound.
         Scope.run {
-            Path.tempDir("kyo-err-f2-missing").map { tmp =>
+            Path.run(Path.tempDir("kyo-err-f2-missing")).map { tmp =>
                 val missing = (tmp / "no-such-root").toString
                 Scope.run {
                     ClasspathOrchestrator.init(Seq(missing), Tasty.ErrorMode.SoftFail, 1).map { classpath =>
@@ -83,7 +83,7 @@ class ErrorFidelity2Test extends Fidelity2TestBase:
 
     "FailFast missing root still raises FileNotFound" in {
         Scope.run {
-            Path.tempDir("kyo-err-f2-failfast").map { tmp =>
+            Path.run(Path.tempDir("kyo-err-f2-failfast")).map { tmp =>
                 val missing = (tmp / "no-such-root").toString
                 Scope.run {
                     Abort.run[TastyError](ClasspathOrchestrator.init(Seq(missing), Tasty.ErrorMode.FailFast, 1)).map { result =>

--- a/kyo-tasty/shared/src/test/scala/kyo/EvictOlderThanTest.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/EvictOlderThanTest.scala
@@ -19,20 +19,20 @@ class EvictOlderThanTest extends kyo.test.Test[Any]:
 
     "evictOlderThan deletes old .krfl files and keeps recent ones" in {
         Scope.run {
-            Path.tempDir("kyo-evict-old").map { dir =>
+            Path.run(Path.tempDir("kyo-evict-old")).map { dir =>
                 val old1   = dir / "aaa.krfl"
                 val old2   = dir / "bbb.krfl"
                 val recent = dir / "ccc.krfl"
-                old1.writeBytes(Span.from(Array[Byte](1, 2, 3))).map { _ =>
-                    old1.setLastModified(staleMs).map { _ =>
-                        old2.writeBytes(Span.from(Array[Byte](4, 5, 6))).map { _ =>
-                            old2.setLastModified(staleMs).map { _ =>
-                                recent.writeBytes(Span.from(Array[Byte](7, 8, 9))).map { _ =>
+                Path.run(old1.writeBytes(Span.from(Array[Byte](1, 2, 3)))).map { _ =>
+                    Path.run(old1.setLastModified(staleMs)).map { _ =>
+                        Path.run(old2.writeBytes(Span.from(Array[Byte](4, 5, 6)))).map { _ =>
+                            Path.run(old2.setLastModified(staleMs)).map { _ =>
+                                Path.run(recent.writeBytes(Span.from(Array[Byte](7, 8, 9)))).map { _ =>
                                     Abort.run[TastyError](Tasty.evictOlderThan(dir.toString, maxAge)).map {
                                         case Result.Success(_) =>
-                                            old1.exists.map { e1 =>
-                                                old2.exists.map { e2 =>
-                                                    recent.exists.map { er =>
+                                            Path.runReadOnly(old1.exists).map { e1 =>
+                                                Path.runReadOnly(old2.exists).map { e2 =>
+                                                    Path.runReadOnly(recent.exists).map { er =>
                                                         assert(!e1, s"old aaa.krfl must be deleted; exists=$e1")
                                                         assert(!e2, s"old bbb.krfl must be deleted; exists=$e2")
                                                         assert(er, s"recent ccc.krfl must remain; exists=$er")
@@ -56,16 +56,14 @@ class EvictOlderThanTest extends kyo.test.Test[Any]:
 
     "evictOlderThan removes old files completely (no residual paths)" in {
         Scope.run {
-            Path.tempDir("kyo-evict-res").map { dir =>
+            Path.run(Path.tempDir("kyo-evict-res")).map { dir =>
                 val old1 = dir / "aaaa.krfl"
-                old1.writeBytes(Span.from(Array[Byte](1, 2, 3))).map { _ =>
-                    old1.setLastModified(staleMs).map { _ =>
+                Path.run(old1.writeBytes(Span.from(Array[Byte](1, 2, 3)))).map { _ =>
+                    Path.run(old1.setLastModified(staleMs)).map { _ =>
                         Abort.run[TastyError](
                             Tasty.evictOlderThan(dir.toString, maxAge).map { _ =>
-                                Abort.recover[FileStructureException](e =>
-                                    Abort.fail(TastyError.SnapshotIoError(s"list: ${e.getMessage}"))
-                                )(
-                                    Path(dir.toString).list(glob"*.krfl")
+                                Abort.recover[FileSystemException](e => Abort.fail(TastyError.SnapshotIoError(s"list: ${e.getMessage}")))(
+                                    Path.runReadOnly(Path(dir.toString).list(glob"*.krfl"))
                                 )
                             }
                         ).map {
@@ -88,22 +86,22 @@ class EvictOlderThanTest extends kyo.test.Test[Any]:
 
     "evictOlderThan removes stale files; no .deleting residue paths appear" in {
         Scope.run {
-            Path.tempDir("kyo-evict-nodot").map { dir =>
+            Path.run(Path.tempDir("kyo-evict-nodot")).map { dir =>
                 val old1   = dir / "old1.krfl"
                 val old2   = dir / "old2.krfl"
                 val recent = dir / "recent.krfl"
-                old1.writeBytes(Span.from(Array[Byte](1, 2, 3))).map { _ =>
-                    old1.setLastModified(staleMs).map { _ =>
-                        old2.writeBytes(Span.from(Array[Byte](4, 5, 6))).map { _ =>
-                            old2.setLastModified(staleMs).map { _ =>
-                                recent.writeBytes(Span.from(Array[Byte](7, 8, 9))).map { _ =>
+                Path.run(old1.writeBytes(Span.from(Array[Byte](1, 2, 3)))).map { _ =>
+                    Path.run(old1.setLastModified(staleMs)).map { _ =>
+                        Path.run(old2.writeBytes(Span.from(Array[Byte](4, 5, 6)))).map { _ =>
+                            Path.run(old2.setLastModified(staleMs)).map { _ =>
+                                Path.run(recent.writeBytes(Span.from(Array[Byte](7, 8, 9)))).map { _ =>
                                     Abort.run[TastyError](Tasty.evictOlderThan(dir.toString, maxAge)).map {
                                         case Result.Success(_) =>
-                                            old1.exists.map { e1 =>
-                                                old2.exists.map { e2 =>
-                                                    recent.exists.map { er =>
-                                                        Abort.recover[FileStructureException](_ => Chunk.empty[Path])(
-                                                            Path(dir.toString).list
+                                            Path.runReadOnly(old1.exists).map { e1 =>
+                                                Path.runReadOnly(old2.exists).map { e2 =>
+                                                    Path.runReadOnly(recent.exists).map { er =>
+                                                        Abort.recover[FileSystemException](_ => Chunk.empty[Path])(
+                                                            Path.runReadOnly(Path(dir.toString).list)
                                                         ).map { remaining =>
                                                             val names = remaining.map(_.toString)
                                                             assert(!e1, s"old1 must be absent; exists=$e1")
@@ -134,7 +132,7 @@ class EvictOlderThanTest extends kyo.test.Test[Any]:
 
     "evictOlderThan on an empty directory is a no-op (Success)" in {
         Scope.run {
-            Path.tempDir("kyo-evict-empty").map { dir =>
+            Path.run(Path.tempDir("kyo-evict-empty")).map { dir =>
                 Abort.run[TastyError](Tasty.evictOlderThan(dir.toString, maxAge)).map {
                     case Result.Success(_) =>
                         succeed

--- a/kyo-tasty/shared/src/test/scala/kyo/Inv009BehavioralTest.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/Inv009BehavioralTest.scala
@@ -185,12 +185,12 @@ class Inv009BehavioralTest extends kyo.test.Test[Any]:
         val maxAge  = 60.seconds
         val staleMs = 1_000_000_000_000L // 2001-09-08 UTC
         Scope.run {
-            Path.tempDir("inv009-evict").map { dir =>
+            Path.run(Path.tempDir("inv009-evict")).map { dir =>
                 val staleFile = dir / "stale.krfl"
                 val freshFile = dir / "fresh.krfl"
-                staleFile.writeBytes(Span.from(Array[Byte](0x01))).map { _ =>
-                    staleFile.setLastModified(staleMs).map { _ =>
-                        freshFile.writeBytes(Span.from(Array[Byte](0x02))).map { _ =>
+                Path.run(staleFile.writeBytes(Span.from(Array[Byte](0x01)))).map { _ =>
+                    Path.run(staleFile.setLastModified(staleMs)).map { _ =>
+                        Path.run(freshFile.writeBytes(Span.from(Array[Byte](0x02)))).map { _ =>
                             Abort.run[TastyError](
                                 Tasty.evictOlderThan(dir.toString, maxAge)
                             ).map { result =>
@@ -199,8 +199,8 @@ class Inv009BehavioralTest extends kyo.test.Test[Any]:
                                     case Result.Failure(e) =>
                                         fail(s"evictOlderThan must not abort; got $e")
                                     case Result.Success(_) =>
-                                        staleFile.exists.map { staleExists =>
-                                            freshFile.exists.map { freshExists =>
+                                        Path.runReadOnly(staleFile.exists).map { staleExists =>
+                                            Path.runReadOnly(freshFile.exists).map { freshExists =>
                                                 assert(
                                                     !staleExists,
                                                     s"stale.krfl must have been deleted by evictOlderThan"
@@ -223,9 +223,9 @@ class Inv009BehavioralTest extends kyo.test.Test[Any]:
 
     "withClasspath(roots) cold-load reads from the filesystem" in {
         Scope.run {
-            Path.tempDir("inv009-cold").map { tmpDir =>
+            Path.run(Path.tempDir("inv009-cold")).map { tmpDir =>
                 val tastyFile = tmpDir / "PlainClass.tasty"
-                tastyFile.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty)).map { _ =>
+                Path.run(tastyFile.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty))).map { _ =>
                     Abort.run[TastyError](
                         Tasty.withClasspath(Seq(tmpDir.toString)) {
                             Tasty.classpath.map(_.symbols.size)

--- a/kyo-tasty/shared/src/test/scala/kyo/QueryApiTest.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/QueryApiTest.scala
@@ -313,8 +313,8 @@ class QueryApiTest extends kyo.test.Test[Any]:
     "strict mode fails with TastyError for corrupt TASTy" in {
         // FailFast mode: write a corrupt file to a temp dir and use ClasspathOrchestrator.init.
         Scope.run {
-            Path.tempDir("kyo-qa-failfast").map { dir =>
-                (dir / "Corrupt.tasty").writeBytes(Span.from(Array[Byte](0, 1, 2, 3, 4, 5))).map { _ =>
+            Path.run(Path.tempDir("kyo-qa-failfast")).map { dir =>
+                Path.run((dir / "Corrupt.tasty").writeBytes(Span.from(Array[Byte](0, 1, 2, 3, 4, 5)))).map { _ =>
                     Scope.run {
                         Abort.run[TastyError](ClasspathOrchestrator.init(Seq(dir.toString), Tasty.ErrorMode.FailFast, 1)).map {
                             case Result.Success(_) =>
@@ -354,7 +354,7 @@ class QueryApiTest extends kyo.test.Test[Any]:
     // SoftFail with a real missing root produces FileNotFound in classpath.errors.
     "missing root produces FileNotFound in classpath.errors" in {
         Scope.run {
-            Path.tempDir("kyo-qa-missing").map { tmp =>
+            Path.run(Path.tempDir("kyo-qa-missing")).map { tmp =>
                 val missing = (tmp / "no-such-root").toString
                 Scope.run {
                     ClasspathOrchestrator.init(Seq(missing), Tasty.ErrorMode.SoftFail, 1).map { classpath =>

--- a/kyo-tasty/shared/src/test/scala/kyo/SnapshotRoundTripTest.scala
+++ b/kyo-tasty/shared/src/test/scala/kyo/SnapshotRoundTripTest.scala
@@ -113,9 +113,9 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
         // Path.mkDir on a path where a file already exists fails with FileStructureException,
         // which SnapshotWriter wraps as SnapshotIoError.
         Scope.run {
-            Path.tempDir("kyo-srt-fail").map { tmpDir =>
+            Path.run(Path.tempDir("kyo-srt-fail")).map { tmpDir =>
                 val fileAsDir = tmpDir / "not-a-dir"
-                fileAsDir.mkFile.map { _ =>
+                Path.run(fileAsDir.mkFile).map { _ =>
                     Abort.run[TastyError](
                         Tasty.withPickles(Chunk(plainClassPickle)) {
                             Tasty.classpath.map { classpath =>
@@ -142,7 +142,7 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
         val digest = Array[Byte](0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11)
         val hex    = DigestComputer.toHexString(digest)
         Scope.run {
-            Path.tempDir("kyo-srt-conc").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-conc")).map { dir =>
                 val cacheDir = dir.toString
                 val finalKey = s"$cacheDir/$hex.krfl"
                 Abort.run[TastyError](
@@ -159,7 +159,7 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
                 ).map {
                     case Result.Success(_) =>
                         // Both writers completed; the final snapshot file must exist and be valid
-                        Abort.run[FileReadException](Path(finalKey).exists).map {
+                        Abort.run[FileSystemException](Path.runReadOnly(Path(finalKey).exists)).map {
                             case Result.Success(exists) =>
                                 assert(exists, s"Expected snapshot file at $finalKey after concurrent writes")
                                 succeed
@@ -170,7 +170,7 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
                         }
                     case Result.Failure(e) =>
                         // One writer may fail with SnapshotIoError (rename collision); final file must still exist
-                        Abort.run[FileReadException](Path(finalKey).exists).map {
+                        Abort.run[FileSystemException](Path.runReadOnly(Path(finalKey).exists)).map {
                             case Result.Success(exists) =>
                                 assert(exists, s"Expected snapshot file at $finalKey even after partial failure")
                                 succeed
@@ -218,7 +218,7 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
         val digest = Array[Byte](0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27)
         val hex    = DigestComputer.toHexString(digest)
         Scope.run {
-            Path.tempDir("kyo-srt-cold").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-cold")).map { dir =>
                 val cacheDir = dir.toString
                 val snapPath = s"$cacheDir/$hex.krfl"
                 Abort.run[TastyError](
@@ -229,7 +229,7 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
                     }
                 ).map {
                     case Result.Success(_) =>
-                        Abort.run[FileReadException](Path(snapPath).exists).map {
+                        Abort.run[FileSystemException](Path.runReadOnly(Path(snapPath).exists)).map {
                             case Result.Success(exists) =>
                                 assert(exists, s"Expected snapshot file at $snapPath after write")
                                 succeed
@@ -253,22 +253,22 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
         val staleMs = 1_000_000_000_000L
         val maxAge  = 60.seconds
         Scope.run {
-            Path.tempDir("kyo-srt-evict").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-evict")).map { dir =>
                 val f1  = dir / "aabbccdd01020304.krfl"
                 val f2  = dir / "1122334455667788.krfl"
                 val txt = dir / "other.txt"
-                f1.writeBytes(Span.from(Array[Byte](1, 2, 3, 4))).map { _ =>
-                    f1.setLastModified(staleMs).map { _ =>
-                        f2.writeBytes(Span.from(Array[Byte](5, 6, 7, 8))).map { _ =>
-                            f2.setLastModified(staleMs).map { _ =>
-                                txt.writeBytes(Span.from(Array[Byte](9, 10))).map { _ =>
+                Path.run(f1.writeBytes(Span.from(Array[Byte](1, 2, 3, 4)))).map { _ =>
+                    Path.run(f1.setLastModified(staleMs)).map { _ =>
+                        Path.run(f2.writeBytes(Span.from(Array[Byte](5, 6, 7, 8)))).map { _ =>
+                            Path.run(f2.setLastModified(staleMs)).map { _ =>
+                                Path.run(txt.writeBytes(Span.from(Array[Byte](9, 10)))).map { _ =>
                                     Abort.run[TastyError](
                                         Tasty.evictOlderThan(dir.toString, maxAge)
                                     ).map {
                                         case Result.Success(_) =>
-                                            f1.exists.map { e1 =>
-                                                f2.exists.map { e2 =>
-                                                    txt.exists.map { et =>
+                                            Path.runReadOnly(f1.exists).map { e1 =>
+                                                Path.runReadOnly(f2.exists).map { e2 =>
+                                                    Path.runReadOnly(txt.exists).map { et =>
                                                         assert(!e1, s"aabbccdd01020304.krfl must be evicted; exists=$e1")
                                                         assert(!e2, s"1122334455667788.krfl must be evicted; exists=$e2")
                                                         assert(et, s"other.txt must NOT be evicted; exists=$et")
@@ -292,9 +292,9 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
 
     "DigestComputer.compute for the same roots is deterministic" in {
         Scope.run {
-            Path.tempDir("kyo-srt-det").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-det")).map { dir =>
                 val file = dir / "PlainClass.tasty"
-                file.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty)).map { _ =>
+                Path.run(file.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty))).map { _ =>
                     val root = dir.toString
                     Abort.run[TastyError] {
                         DigestComputer.compute(Seq(root)).map { digest1 =>
@@ -318,14 +318,14 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
 
     "DigestComputer.compute for different file sets returns different digests" in {
         Scope.run {
-            Path.tempDir("kyo-srt-diff").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-diff")).map { dir =>
                 val file = dir / "PlainClass.tasty"
                 val root = dir.toString
-                file.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty)).map { _ =>
+                Path.run(file.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty))).map { _ =>
                     Abort.run[TastyError] {
                         DigestComputer.compute(Seq(root)).map { digest1 =>
                             // Overwrite with different-length content so size (and thus digest) differs.
-                            file.writeBytes(Span.from(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8))).map { _ =>
+                            Path.run(file.writeBytes(Span.from(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8)))).map { _ =>
                                 DigestComputer.compute(Seq(root)).map { digest2 =>
                                     (digest1, digest2)
                                 }
@@ -818,12 +818,12 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
 
     "DigestComputer.compute on real root returns same digest for two successive calls" in {
         Scope.run {
-            Path.tempDir("kyo-srt-det2").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-det2")).map { dir =>
                 val fileA = dir / "A.tasty"
                 val fileB = dir / "B.tasty"
                 val root  = dir.toString
-                fileA.writeBytes(Span.from(Array[Byte](1, 2, 3))).map { _ =>
-                    fileB.writeBytes(Span.from(Array[Byte](4, 5, 6))).map { _ =>
+                Path.run(fileA.writeBytes(Span.from(Array[Byte](1, 2, 3)))).map { _ =>
+                    Path.run(fileB.writeBytes(Span.from(Array[Byte](4, 5, 6)))).map { _ =>
                         Abort.run[TastyError] {
                             DigestComputer.compute(Seq(root)).map { d1 =>
                                 DigestComputer.compute(Seq(root)).map { d2 =>
@@ -846,14 +846,14 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
 
     "DigestComputer.compute detects additional file in root (different digest)" in {
         Scope.run {
-            Path.tempDir("kyo-srt-add").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-add")).map { dir =>
                 val fileA = dir / "A.tasty"
                 val root  = dir.toString
-                fileA.writeBytes(Span.from(Array[Byte](1, 2, 3))).map { _ =>
+                Path.run(fileA.writeBytes(Span.from(Array[Byte](1, 2, 3)))).map { _ =>
                     Abort.run[TastyError] {
                         DigestComputer.compute(Seq(root)).map { d1 =>
                             val fileB = dir / "B.tasty"
-                            fileB.writeBytes(Span.from(Array[Byte](4, 5, 6, 7, 8))).map { _ =>
+                            Path.run(fileB.writeBytes(Span.from(Array[Byte](4, 5, 6, 7, 8)))).map { _ =>
                                 DigestComputer.compute(Seq(root)).map { d2 =>
                                     (d1, d2)
                                 }
@@ -874,13 +874,13 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
 
     "DigestComputer.compute on two real roots is root-order independent" in {
         Scope.run {
-            Path.tempDir("kyo-srt-ord").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-ord")).map { dir =>
                 val root1 = dir / "root1"
                 val root2 = dir / "root2"
                 val fileX = root1 / "X.tasty"
                 val fileY = root2 / "Y.tasty"
-                fileX.writeBytes(Span.from(Array[Byte](10, 20, 30))).map { _ =>
-                    fileY.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty)).map { _ =>
+                Path.run(fileX.writeBytes(Span.from(Array[Byte](10, 20, 30)))).map { _ =>
+                    Path.run(fileY.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty))).map { _ =>
                         Abort.run[TastyError] {
                             DigestComputer.compute(Seq(root1.toString, root2.toString)).map { d1 =>
                                 DigestComputer.compute(Seq(root2.toString, root1.toString)).map { d2 =>
@@ -903,10 +903,10 @@ class SnapshotRoundTripTest extends kyo.test.Test[Any]:
 
     "DigestComputer.compute on directory root returns same digest for two successive calls" in {
         Scope.run {
-            Path.tempDir("kyo-srt-dir").map { dir =>
+            Path.run(Path.tempDir("kyo-srt-dir")).map { dir =>
                 val file = dir / "PlainClass.tasty"
                 val root = dir.toString
-                file.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty)).map { _ =>
+                Path.run(file.writeBytes(Span.from(kyo.fixtures.Embedded.plainClassTasty))).map { _ =>
                     Abort.run[TastyError] {
                         DigestComputer.compute(Seq(root)).map { d1 =>
                             DigestComputer.compute(Seq(root)).map { d2 =>

--- a/kyo-ui/shared/src/test/scala/demo/FlamegraphDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/FlamegraphDemo.scala
@@ -353,7 +353,7 @@ object FlamegraphDemo extends KyoApp:
     run {
         val port = args.headMaybe.flatMap(s => Maybe.fromOption(s.toIntOption)).getOrElse(0)
         for
-            folded <- profilePath.read
+            folded <- Path.runReadOnly(profilePath.read)
             tree = parse(folded)
             handlers <- UI.runHandlers("/")(app(tree))
             server   <- HttpServer.init(port, "localhost")(handlers*)

--- a/kyo-website/jvm/src/main/scala/kyo/website/WebsiteGenerator.scala
+++ b/kyo-website/jvm/src/main/scala/kyo/website/WebsiteGenerator.scala
@@ -110,7 +110,7 @@ object WebsiteGenerator:
       */
     private def readRequiredManifesto(repoRoot: Path)(using Frame): String < (Sync & Abort[WebsiteException]) =
         val path = repoRoot / "MANIFESTO.md"
-        Abort.run[FileReadException](path.read).map {
+        Abort.run[FileSystemException](Path.runReadOnly(path.read)).map {
             case Result.Success(md) => md
             case Result.Failure(_)  => Abort.fail(WebsiteReadmeException(path, WebsiteReadmeException.ReadmeFailure.Missing))
             case p: Result.Panic    => Abort.error(p)
@@ -691,14 +691,14 @@ object WebsiteGenerator:
         WebsitePage.wrap(opts)(view).take(1).run.map(_.headMaybe.getOrElse(""))
 
     private def writeRoute(path: Path, html: String)(using Frame): Unit < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileWriteException](path.write(html)).map {
+        Abort.run[FileSystemException](Path.run(path.write(html))).map {
             case Result.Success(_) => ()
             case Result.Failure(e) => Abort.fail(WebsiteEmitException(path.toString, e))
             case p: Result.Panic   => Abort.error(p)
         }
 
     private def writeString(route: String, path: Path, content: String)(using Frame): Unit < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileWriteException](path.write(content)).map {
+        Abort.run[FileSystemException](Path.run(path.write(content))).map {
             case Result.Success(_) => ()
             case Result.Failure(e) => Abort.fail(WebsiteEmitException(route, e))
             case p: Result.Panic   => Abort.error(p)
@@ -811,10 +811,7 @@ object WebsiteGenerator:
         writeString("robots.txt", outDir / "robots.txt", buildRobotsTxt())
 
     private def copyFile(route: String, src: Path, dst: Path)(using Frame): Unit < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileStructureException](src.copy(
-            dst,
-            Path.CopyOptions(replace = Path.Replace.Existing)
-        )).map {
+        Abort.run[FileSystemException](Path.run(src.copy(dst, Path.CopyOptions(replace = Path.Replace.Existing)))).map {
             case Result.Success(_) => ()
             case Result.Failure(e) => Abort.fail(WebsiteEmitException(route, e))
             case p: Result.Panic   => Abort.error(p)

--- a/kyo-website/jvm/src/main/scala/kyo/website/WebsiteMain.scala
+++ b/kyo-website/jvm/src/main/scala/kyo/website/WebsiteMain.scala
@@ -199,7 +199,7 @@ object WebsiteMain extends KyoApp:
     private def listSnapshotDirs(contentDir: Path, currentTag: String)(using
         Frame
     ): Chunk[Path] < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileStructureException](contentDir.list).map {
+        Abort.run[FileSystemException](Path.runReadOnly(contentDir.list)).map {
             case Result.Success(paths) =>
                 val byName =
                     paths.toSeq
@@ -241,7 +241,7 @@ object WebsiteMain extends KyoApp:
         flagValue(theArgs, "--bundle-dir") match
             case Present(dir) => dir
             case Absent =>
-                Abort.run[FileStructureException](discoverBundleDir(repoRoot)).map {
+                Abort.run[FileSystemException](discoverBundleDir(repoRoot)).map {
                     case Result.Success(dir) => dir
                     case Result.Failure(e)   => Abort.fail(WebsiteEmitException("bundle-dir discovery", e))
                     case p: Result.Panic     => Abort.error(p)
@@ -254,24 +254,28 @@ object WebsiteMain extends KyoApp:
     // deterministic regardless of the platform's filesystem listing order. The `isDirectory` guard
     // runs before any `.list` call so a regular file whose name matches the predicate is silently
     // skipped rather than causing a `FileNotADirectoryException`.
-    private def childDirsMatching(dir: Path, p: String => Boolean)(using Frame): Chunk[Path] < (Sync & Abort[FileStructureException]) =
-        dir.list.map(entries =>
-            Kyo.foreach(entries)(d => d.isDirectory.map(_ -> d)).map(
-                _.collect { case (true, d) if d.name.exists(p) => d }.sortBy(_.toString)
+    private def childDirsMatching(dir: Path, p: String => Boolean)(using Frame): Chunk[Path] < (Sync & Abort[FileSystemException]) =
+        Path.runReadOnly {
+            dir.list.map(entries =>
+                Kyo.foreach(entries)(d => d.isDirectory.map(_ -> d)).map(
+                    _.collect { case (true, d) if d.name.exists(p) => d }.sortBy(_.toString)
+                )
             )
-        )
+        }
 
-    private def discoverBundleDir(repoRoot: String)(using Frame): String < (Sync & Abort[FileStructureException]) =
+    private def discoverBundleDir(repoRoot: String)(using Frame): String < (Sync & Abort[FileSystemException]) =
         val fallback  = Path(repoRoot, "kyo-website-bundle", "js", "target", "scala-3.8.3", "kyo-website-bundle-opt")
         val targetDir = Path(repoRoot, "kyo-website-bundle", "js", "target")
-        targetDir.isDirectory.map {
-            case false => fallback.toString
-            case true =>
-                for
-                    scalaDirs   <- childDirsMatching(targetDir, _.startsWith("scala-"))
-                    optDirs     <- Kyo.foreach(scalaDirs)(childDirsMatching(_, _.endsWith("-opt"))).map(_.flattenChunk)
-                    flaggedMain <- Kyo.foreach(optDirs)(d => (d / "main.js").isRegularFile.map(_ -> d))
-                yield flaggedMain.collect { case (true, d) => d.toString }.headMaybe.getOrElse(fallback.toString)
+        Path.runReadOnly {
+            targetDir.isDirectory.map {
+                case false => fallback.toString
+                case true =>
+                    for
+                        scalaDirs   <- childDirsMatching(targetDir, _.startsWith("scala-"))
+                        optDirs     <- Kyo.foreach(scalaDirs)(childDirsMatching(_, _.endsWith("-opt"))).map(_.flattenChunk)
+                        flaggedMain <- Kyo.foreach(optDirs)(d => (d / "main.js").isRegularFile.map(_ -> d))
+                    yield flaggedMain.collect { case (true, d) => d.toString }.headMaybe.getOrElse(fallback.toString)
+            }
         }
     end discoverBundleDir
 
@@ -288,7 +292,7 @@ object WebsiteMain extends KyoApp:
         flagValue(theArgs, "--repo-root") match
             case Present(dir) => dir
             case Absent =>
-                Abort.run[FileStructureException](discoverRepoRoot()).map {
+                Abort.run[FileSystemException](discoverRepoRoot()).map {
                     case Result.Success(dir) => dir
                     case Result.Failure(e)   => Abort.fail(WebsiteEmitException("repo-root discovery", e))
                     case p: Result.Panic     => Abort.error(p)
@@ -296,11 +300,11 @@ object WebsiteMain extends KyoApp:
         end match
     end parseRepoRoot
 
-    private def discoverRepoRoot()(using Frame): String < (Sync & Abort[FileStructureException]) =
+    private def discoverRepoRoot()(using Frame): String < (Sync & Abort[FileSystemException]) =
         System.property[String]("user.dir", ".").map { userDir =>
-            val start                             = Path(userDir)
-            def isRoot(dir: Path): Boolean < Sync = (dir / "build.sbt").isRegularFile
-            def walkUp(dir: Path): Maybe[Path] < Sync =
+            val start                                 = Path(userDir)
+            def isRoot(dir: Path): Boolean < PathRead = (dir / "build.sbt").isRegularFile
+            def walkUp(dir: Path): Maybe[Path] < PathRead =
                 isRoot(dir).map {
                     case true => Present(dir)
                     case false =>
@@ -308,7 +312,7 @@ object WebsiteMain extends KyoApp:
                             case Present(p) => walkUp(p)
                             case Absent     => Absent
                 }
-            walkUp(start).map(_.map(_.toString).getOrElse(userDir))
+            Path.runReadOnly(walkUp(start).map(_.map(_.toString).getOrElse(userDir)))
         }
     end discoverRepoRoot
 

--- a/kyo-website/jvm/src/test/scala/kyo/website/DocsMarkdownTest.scala
+++ b/kyo-website/jvm/src/test/scala/kyo/website/DocsMarkdownTest.scala
@@ -95,11 +95,11 @@ class DocsMarkdownTest extends WebsiteTest:
     // ---- Two-space nested list ----
 
     "two-space nested list does not flatten" in {
-        val source = "- Exception\n  - FileException\n  - TimeoutException\n"
+        val source = "- Exception\n  - FileSystemException\n  - TimeoutException\n"
         for html <- transpileHtml(source)
         yield
             assert(html.contains("<ul"), s"Expected ul: $html")
-            assert(html.contains("FileException"), s"Expected sub-item: $html")
+            assert(html.contains("FileSystemException"), s"Expected sub-item: $html")
             // Two nested <ul> tags means the list is nested.
             assert(html.indexOf("<ul") != html.lastIndexOf("<ul"), s"Expected nested ul: $html")
         end for

--- a/kyo-website/jvm/src/test/scala/kyo/website/WebsiteGeneratorTest.scala
+++ b/kyo-website/jvm/src/test/scala/kyo/website/WebsiteGeneratorTest.scala
@@ -84,14 +84,14 @@ class WebsiteGeneratorTest extends WebsiteTest:
         WebsiteGenerator.emit(content, outDir, WebsiteGenerator.Config(repoRoot, bundleDir))
 
     private def readFile(path: Path)(using Frame): String < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileReadException](path.read).map {
+        Abort.run[FileSystemException](Path.runReadOnly(path.read)).map {
             case Result.Success(s) => s
             case Result.Failure(e) => Abort.fail(WebsiteEmitException(path.toString, e))
             case p: Result.Panic   => Abort.error(p)
         }
 
     private def fileExists(path: Path)(using Frame): Boolean < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileReadException](path.exists).map {
+        Abort.run[FileSystemException](Path.runReadOnly(path.exists)).map {
             case Result.Success(b) => b
             case Result.Failure(e) => Abort.fail(WebsiteEmitException(path.toString, e))
             case p: Result.Panic   => Abort.error(p)
@@ -866,7 +866,7 @@ class WebsiteGeneratorTest extends WebsiteTest:
             // and the /latest/ overview).
             latestSlugPages <-
                 val latestDir = out / "latest"
-                Abort.run[FileReadException | FileStructureException] {
+                Abort.run[FileSystemException](Path.runReadOnly {
                     latestDir.exists.map {
                         case false => 0
                         case true =>
@@ -874,7 +874,7 @@ class WebsiteGeneratorTest extends WebsiteTest:
                                 Kyo.foreach(entries)(_.isDirectory).map(_.count(identity))
                             }
                     }
-                }.map {
+                }).map {
                     case Result.Success(n) => n
                     case Result.Failure(e) => Abort.fail(WebsiteEmitException(latestDir.toString, e))
                     case p: Result.Panic   => Abort.error(p)

--- a/kyo-website/jvm/src/test/scala/kyo/website/WebsiteMainTest.scala
+++ b/kyo-website/jvm/src/test/scala/kyo/website/WebsiteMainTest.scala
@@ -39,14 +39,14 @@ class WebsiteMainTest extends WebsiteTest:
         )(d => Sync.defer(deleteDir(d))).map(d => Path(d.toString))
 
     private def readFile(path: Path)(using Frame): String < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileReadException](path.read).map {
+        Abort.run[FileSystemException](Path.runReadOnly(path.read)).map {
             case Result.Success(s) => s
             case Result.Failure(e) => Abort.fail(WebsiteEmitException(path.toString, e))
             case p: Result.Panic   => Abort.error(p)
         }
 
     private def fileExists(path: Path)(using Frame): Boolean < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileReadException](path.exists).map {
+        Abort.run[FileSystemException](Path.runReadOnly(path.exists)).map {
             case Result.Success(b) => b
             case Result.Failure(e) => Abort.fail(WebsiteEmitException(path.toString, e))
             case p: Result.Panic   => Abort.error(p)

--- a/kyo-website/shared/src/main/scala/kyo/website/WebsiteContent.scala
+++ b/kyo-website/shared/src/main/scala/kyo/website/WebsiteContent.scala
@@ -56,7 +56,7 @@ object WebsiteContent:
     // ---- Private helpers ----
 
     private def readRequired(path: Path)(using Frame): String < (Sync & Abort[WebsiteException]) =
-        Abort.run[FileReadException](path.read).map {
+        Abort.run[FileSystemException](Path.runReadOnly(path.read)).map {
             case Result.Success(s) => s
             case Result.Failure(_) => Abort.fail(WebsiteReadmeException(path, WebsiteReadmeException.ReadmeFailure.Missing))
             case p: Result.Panic   => Abort.error(p)

--- a/kyo-website/shared/src/test/scala/kyo/website/WebsiteContentTest.scala
+++ b/kyo-website/shared/src/test/scala/kyo/website/WebsiteContentTest.scala
@@ -73,12 +73,14 @@ class WebsiteContentTest extends WebsiteTest:
     private def fromRepoResult(
         files: Seq[(String, String)],
         version: WebsiteVersion = version1
-    )(using Frame): Result[WebsiteException, WebsiteContent] < (Sync & Scope & Abort[FileStructureException | FileWriteException]) =
-        Path.tempDir("kyo-fromrepo-test").map { root =>
-            Kyo.foreachDiscard(Chunk.from(files)) { case (rel, body) =>
-                (root / rel).write(body)
-            }.map { _ =>
-                Abort.run[WebsiteException](WebsiteContent.fromRepo(root, version))
+    )(using Frame): Result[WebsiteException, WebsiteContent] < (Sync & Scope & Abort[FileSystemException]) =
+        Path.run {
+            Path.tempDir("kyo-fromrepo-test").map { root =>
+                Kyo.foreachDiscard(Chunk.from(files)) { case (rel, body) =>
+                    (root / rel).write(body)
+                }.map { _ =>
+                    Abort.run[WebsiteException](WebsiteContent.fromRepo(root, version))
+                }
             }
         }
 
@@ -275,12 +277,13 @@ class WebsiteContentTest extends WebsiteTest:
     //      fixed here cannot regress: slug is the DIRECTORY, platform columns are JVM/JS/Native/WASM) ----
 
     /** A copy of the real root README `## Modules` section's `### Core` group (README.md lines 268 to
-      * 284): the `## Modules` heading and intro prose, the `### Core` heading and prose, then the GFM
-      * table with the real `[kyo-core]` / `[kyo-prelude]` / `[kyo-data]` / `[kyo-kernel]` /
-      * `[kyo-scheduler]` rows and the real `| Module | JVM | JS | Native | WASM | Identity |` 6-column
-      * header (alignment padding included). The table rows are copied exactly so the parser is tested
-      * against the current real format (including the WASM column added when WebAssembly became a
-      * published platform), not a fixture written to the code's old three-platform assumptions.
+      * 279): the `## Modules` heading and intro prose, the `### Core` heading and prose, then the GFM
+      * table with the real `[kyo-core]` / `[kyo-system]` / `[kyo-prelude]` / `[kyo-data]` /
+      * `[kyo-kernel]` / `[kyo-scheduler]` rows and the real `| Module | JVM | JS | Native | WASM |
+      * Identity |` 6-column header (alignment padding included). The table rows are copied exactly so
+      * the parser is tested against the current real format (including the WASM column added when
+      * WebAssembly became a published platform), not a fixture written to the code's old three-platform
+      * assumptions.
       */
     private val realCoreReadme =
         """# Kyo
@@ -295,7 +298,8 @@ class WebsiteContentTest extends WebsiteTest:
           |
           || Module                                       | JVM | JS  | Native | WASM | Identity                                                                                                  |
           || -------------------------------------------- | --- | --- | ------ | ---- | --------------------------------------------------------------------------------------------------------- |
-          || [kyo-core](kyo-core/README.md)               | ✅   | ✅   | ✅      | ✅   | I/O and concurrency: `Sync`, `Async`, `Scope`, `Fiber`, `Channel`, `Hub`, `Queue`, `Clock`, `Log`, `Path` |
+          || [kyo-core](kyo-core/README.md)               | ✅   | ✅   | ✅      | ✅   | I/O and concurrency: `Sync`, `Async`, `Scope`, `Fiber`, `Channel`, `Hub`, `Queue`, `Clock`, `Log`         |
+          || [kyo-system](kyo-system/README.md)           | ✅  | ✅  | ✅     | ✅   | File system, OS processes, and environment: `Path`, `Command`, `Process`, `System`, `FileSystemException`        |
           || [kyo-prelude](kyo-prelude/README.md)         | ✅   | ✅   | ✅      | ✅   | Strictly-pure effect layer: `Abort`, `Env`, `Var`, `Memo`, `Choice`, `Emit`, `Poll`, `Stream`, `Layer`    |
           || [kyo-data](kyo-data/README.md)               | ✅   | ✅   | ✅      | ✅   | Low-allocation values: `Maybe`, `Result`, `Chunk`, `Span`, `Duration`, `Instant`, `Schedule`, `TypeMap`  |
           || [kyo-kernel](kyo-kernel/README.md)           | ✅   | ✅   | ✅      | ✅   | Algebraic-effects substrate; defines `A < S`, `ArrowEffect`, `ContextEffect`, multi-shot continuations    |
@@ -307,6 +311,7 @@ class WebsiteContentTest extends WebsiteTest:
             result <- fromRepoResult(Seq(
                 "README.md"               -> realCoreReadme,
                 "kyo-core/README.md"      -> "# kyo-core\n\nI/O and concurrency.",
+                "kyo-system/README.md"    -> "# kyo-system\n\nFile system, OS processes, and environment.",
                 "kyo-prelude/README.md"   -> "# kyo-prelude\n\nPure effect layer.",
                 "kyo-data/README.md"      -> "# kyo-data\n\nLow-allocation values.",
                 "kyo-kernel/README.md"    -> "# kyo-kernel\n\nEffect substrate.",
@@ -320,7 +325,7 @@ class WebsiteContentTest extends WebsiteTest:
                 val slugs = core.modules.map(_.slug)
                 // The slug is the module DIRECTORY, NOT the verbatim link target `kyo-core/README.md`.
                 assert(
-                    slugs == Chunk("kyo-core", "kyo-prelude", "kyo-data", "kyo-kernel", "kyo-scheduler"),
+                    slugs == Chunk("kyo-core", "kyo-system", "kyo-prelude", "kyo-data", "kyo-kernel", "kyo-scheduler"),
                     s"slugs: $slugs"
                 )
                 assert(!slugs.exists(_.contains("README.md")), s"no slug may carry the README.md suffix: $slugs")
@@ -335,7 +340,7 @@ class WebsiteContentTest extends WebsiteTest:
                 // The module READMEs are read from `root/<slug>/README.md` (no Missing abort).
                 assert(
                     core.modules.map(_.readme.linesIterator.next()) ==
-                        Chunk("# kyo-core", "# kyo-prelude", "# kyo-data", "# kyo-kernel", "# kyo-scheduler"),
+                        Chunk("# kyo-core", "# kyo-system", "# kyo-prelude", "# kyo-data", "# kyo-kernel", "# kyo-scheduler"),
                     "module READMEs must be read"
                 )
             case other => fail(s"expected Success on the real README format, got $other")


### PR DESCRIPTION
### What this adds

The capability flip. Reads carry `PathRead` and writes carry `PathWrite`, discharged by `Path.run` and `Path.runReadOnly` against the host backend, or by `Path.runWith` and `Path.runReadOnlyWith` against any other `FileSystem`. A function's effect row now states whether it touches the disk and whether it can modify it, and a caller can substitute the backend without changing the code under test.

`PathWrite <: PathRead`, so a write-capable context also satisfies reads, and `Path.runReadOnly` rejects a program containing a write at the call site rather than at runtime.

Every module that used the direct `Path` API moves to the capability form, which is why this is the widest pull request in the stack. `Path.tail`, `Path.tailBytes` and `Path.Origin` migrate with it and open through the installed read service.

### What the new callsites look like

An operation no longer names its own failure. It names the authority it needs:

```scala
// before
val text: String < (Sync & Abort[FileReadException])       = config.read
val done: Unit   < (Sync & Abort[FileWriteException])      = out.write(text)
val kids: Chunk[Path] < (Sync & Abort[FileStructureException]) = dir.list

// after
val text: String      < PathRead  = config.read
val done: Unit        < PathWrite = out.write(text)
val kids: Chunk[Path] < PathRead  = dir.list
```

A runner discharges the capability and folds the three per-operation failure types into the `FileSystemException` umbrella:

```scala
val loaded: String < (Sync & Abort[FileSystemException]) =
    Path.runReadOnly(config.read)

val saved: Unit < (Sync & Abort[FileSystemException]) =
    Path.run(out.write(text))
```

An existing `Abort.run` or `Abort.recover` at a callsite keeps its shape. It moves to the umbrella type and gains a runner inside it, because the failure is raised by the runner rather than by the operation:

```scala
// before
Abort.run[FileWriteException](path.write(html)).map {
    case Result.Success(_) => ...
    case Result.Failure(e) => ...
}

// after
Abort.run[FileSystemException](Path.run(path.write(html))).map {
    case Result.Success(_) => ...
    case Result.Failure(e) => ...
}
```

A public API that reads on the caller's behalf stops choosing the filesystem for them. It declares `PathRead` and lets the caller pick the runner:

```scala
// before
def init(locales: Seq[Locale], start: Locale)(dir: Path): I18n < (Sync & Abort[FileReadException])

// after
def init(locales: Seq[Locale], start: Locale)(dir: Path): I18n < (PathRead & Sync)
```

Which is what makes the backend substitutable. The same call runs against the host or against a supplied `FileSystem`, with no change to the code under test:

```scala
// production: the Local-selected backend, which defaults to the host
Path.runReadOnly(I18n.init(locales, Locale.en)(bundleDir))

// a test: any FileSystem.Read, with the same program
Path.runReadOnlyWith(fixtureFileSystem)(I18n.init(locales, Locale.en)(bundleDir))
```

Temporary paths go through the service too, so a substituted backend owns them the same way it owns everything else:

```scala
val tmpFile: Path < (PathWrite & Sync & Scope) = Path.temp("kyo-build-", ".json")
val tmpDir:  Path < (PathWrite & Sync & Scope) = Path.tempDir("kyo-build-")
```

Streaming reads, follow streams and the stream sinks carry the capability the same way:

```scala
val lines: Stream[String, PathRead & Scope & Sync]  = config.readLinesStream
val live:  Stream[String, PathRead & Async & Scope] = log.tail(pollDelay = 100.millis)
val sink:  Unit < (Scope & PathWrite & Sync)        = Stream.init(rows).writeLinesTo(out)

val records: Stream[Event, PathRead & Scope & Async & Abort[DecodeException]] =
    Jsonl.watch[Event](path, from = Path.Origin.End)
```

One consequence is worth knowing before reading the diff. A backend failure is raised by the runner, not by the frame that suspended the operation, so an `Abort.run` nested inside a runner cannot observe it. Code that needs to inspect a filesystem failure runs its own runner at the point it wants to catch:

```scala
result <- Abort.run[FileSystemException] {
    Path.run(Scope.run(stream.writeTo(file, options = Path.WriteOptions(createFolders = false))))
}
```

### What changed, module by module

**kyo-system** carries the change. `Path.Op` gains the operation ADT for both capabilities plus `Op.Raise`, so a failure the read loop detects itself lands on the runner's `Abort` rather than adding an `Abort` row to every follower. Every extension method on `Path` suspends instead of calling the unsafe tier directly. The four runners (`run`, `runReadOnly`, `runWith`, `runReadOnlyWith`) and the `Isolate` instances that let a capability cross a fiber boundary are new. `Path.temp` and `Path.tempDir` both move from `PathDirectories` onto `Path` and carry `PathWrite`. Each suspends its own op (`Op.Temp`, `Op.TempDir`), the service vends a removal handle (`TempFileHandle`, `TempDirHandle`), and the `Scope` finalizer removes through the service that created the entry, so a temp path made by one backend is never deleted by another. The `tempUnscoped` and `tempDirUnscoped` variants stay host primitives on purpose: an entry whose lifetime the caller owns has no scope for a service-vended handle to hang from. `StreamSystemExtensions` opens its handle through `Path.Op.OpenWrite` and writes through `Path.Op.WriteChunk` and `Path.Op.WriteString`; because the failure now arrives at the runner, the append-preserving `finish()` moves into a single `Scope` finalizer that reads the computation's outcome, which also makes it independent of the finalizer parallelism `Scope.run` was given. `PathCapabilityTest` is new and pins each method's row, including the negative law that a write program does not compile under `runReadOnly`. `PathSnapshotTest` becomes `FileSystemSnapshotTest` and drives the backend directly. README and CONTRIBUTING are rewritten around the runner table.

**kyo-schema-json** moves the JSONL file surface onto the capability: `Jsonl.read`, `readResults`, `watch`, `watchResults`, `write` and `append` carry `PathRead` or `PathWrite` instead of `Abort[FileReadException]` or `Abort[FileWriteException]`, and the decode failure stays on its own `Abort[DecodeException]`. `writeAll` reifies its fold and re-raises through `Path.Op.Raise` once the handle is released, so the caller's row stays `PathWrite` and the runner reports the failure exactly as it would report a suspended operation.

**kyo-core** exposes `Stream.fromInputStream` publicly, which the file sinks need now that they are typed in terms of the capability rather than the concrete handle.

**kyo-tasty** routes the snapshot cache through runners: listing, `stat`, `remove` and `exists` each wrap in `Path.runReadOnly` or `Path.run` and recover on `FileSystemException` instead of the three separate types. `ClasspathOrchestrator`, `SnapshotReader`, `SnapshotWriter` and `DigestComputer` follow. A classpath fidelity test is pinned to scala-library so the count only moves on a deliberate stdlib bump.

**kyo-doctest** wraps one runner per operation rather than one per block, because each `Abort.recover` there carries a distinct operation label in its `IoError` message and a shared runner would lose which operation failed.

**kyo-browser** moves `Image.writeFileBinary` and `writeFileBase64` to `Abort[FileSystemException]` with the write discharged inside, so the public signature does not leak a capability the caller never asked for. `BrowserLauncher` and `ChromeDownloader` follow, and the download tests take their temp directories through the host runner.

**kyo-ai** collapses the Claude and Codex completion error unions from `FileStructureException | FileReadException | FileWriteException` to the single `FileSystemException`, and the MCP bridge config write is discharged where it happens so the config file stays an implementation detail rather than a capability the caller must grant.

**kyo-website** and **kyo-i18n** move their read and write paths to the umbrella type with runners at the boundary. `I18n.init` declares `PathRead` so a caller can load bundles from a substituted filesystem.

**kyo-aeron**, **kyo-jsonrpc**, **kyo-pod**, **kyo-net**, **kyo-ffi**, **kyo-http**, **kyo-ui**, **kyo-markdown**, **kyo-schema-ion**, **kyo-stats-machine**, **kyo-sql-mysql** and **kyo-sql-postgres** are callsite migrations: temp directories, socket cleanup, fixture reads and container binds move to the runner form with no behavior change. `PosixStructs` additionally stops reaching into `SystemPlatformSpecific` and reads the architecture through the public `kyo.System` unsafe boundary.

**build.sbt** promotes the `kyo-system` edge from test scope to compile scope for every module whose main sources now use `Path`, and consolidates the split `dependsOn` calls those modules had accumulated.

### Stack

Part of the path-capability stack: process fixes, filesystem vocabulary, abstraction, capability flip, channels, locks, watch, durability, confinement, in-memory, zip, then overlay (#1799). Merge bottom up; GitHub retargets the stack above each merge.

The lower branches (#1856, #1857, #1852, #1854, #1888, #1861, #1862, #1863) have landed, so this branch is now a single commit rebased onto `main`. The original incremental development history remains visible in #1799's earlier timeline and in the backup refs recorded in the working notes.
