### PR TITLE
[kyo-system] read and write a file at an offset

### DIFF
--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -40,7 +40,7 @@ kyo-system/
 ## Filesystem authority and selection
 
 `FileSystem.Read[S]` contains only inspection and read operations. `FileSystem.Write[S]` extends it
-with mutation and structure changes.
+with mutation, typed write channels, and structure changes.
 
 The built-in factories are:
 
@@ -102,6 +102,19 @@ Movement and copying use `Path.MoveOptions` and `Path.CopyOptions`. File writes 
 `Path.WriteOptions`. Add policy fields to these values instead of restoring Boolean argument
 clusters. Required atomicity must either succeed atomically or fail before mutating the target.
 
+## Scoped channels
+
+`Path.ReadChannel[S]`, `Path.WriteChannel[S]`, and `Path.ReadWriteChannel[S]` expose positioned
+operations according to authority. Acquisition occurs through the matching `FileSystem` tier and is
+owned by `Scope`. Public channels do not expose `close`; resource release belongs to the acquiring
+scope.
+
+`FileSystem.WriteOpen` separates capability from existence policy:
+
+- `Existing` requires an existing regular file.
+- `Create` opens an existing file or creates it.
+- `CreateNew` fails if any target already exists.
+
 ## Error contracts
 
 `FileSystemException` is the umbrella. Concrete exceptions mix in only the marker traits for the
@@ -137,6 +150,7 @@ Use the reusable suites for backend laws:
 
 - `FileSystemReadTestSuite`
 - `FileSystemWriteTestSuite`
+- `FileSystemChannelTestSuite`
 
 Test capability rows with `typeCheck` and `typeCheckErrors`. Never use sleeps or blocking primitives
 to make scheduling tests pass.

--- a/kyo-system/README.md
+++ b/kyo-system/README.md
@@ -50,6 +50,23 @@ val scalaFiles =
     }
 ```
 
+### Typed channels
+
+Positioned channels are acquired directly from a backend and owned by `Scope`. Read, write, and
+read-write channels expose only their corresponding capabilities. `WriteOpen` makes file existence
+policy explicit:
+
+```scala
+import kyo.*
+
+val positioned =
+    Scope.run {
+        FileSystem.host.openReadWriteChannel(Path("index.bin"), FileSystem.WriteOpen.CreateNew).map { channel =>
+            channel.writeAt(0L, Span.from(Array[Byte](1, 2, 3))).andThen(channel.readAt(0L, 3))
+        }
+    }
+```
+
 ## File paths
 
 Before reading or writing, you need a path value that identifies the target without touching the disk. `Path` is an immutable value built with the `/` operator or the `apply` factory; pure accessors like `parts` and `parent` require no capability.

--- a/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -13,6 +13,7 @@ import scala.scalajs.js.typedarray.Uint8Array
 @js.native
 @JSImport("node:fs", JSImport.Namespace)
 private[kyo] object NodeFs extends js.Object:
+    val constants: NodeFsConstants                                                             = js.native
     def existsSync(path: String): Boolean                                                      = js.native
     def realpathSync(path: String): String                                                     = js.native
     def statSync(path: String): NodeStats                                                      = js.native
@@ -32,22 +33,37 @@ private[kyo] object NodeFs extends js.Object:
     def rmdirSync(path: String): Unit                                                          = js.native
     def truncateSync(path: String, len: Double): Unit                                          = js.native
     def openSync(path: String, flags: String): Int                                             = js.native
+    def openSync(path: String, flags: Int): Int                                                = js.native
     def readSync(fd: Int, buffer: Uint8Array, offset: Int, length: Int, position: Double): Int = js.native
     // Declared without a trailing position argument, which is the whole point: Node then writes at the
     // file description's own cursor, the only offset `O_APPEND` acts on. `NodeWriteHandle` must call this
     // overload, since a positioned write on a descriptor opened to append is silent data loss.
-    def writeSync(fd: Int, buffer: Uint8Array, offset: Int, length: Int): Int     = js.native
-    def writeSync(fd: Int, data: String, position: Double, encoding: String): Int = js.native
-    def closeSync(fd: Int): Unit                                                  = js.native
-    def fsyncSync(fd: Int): Unit                                                  = js.native
-    def fstatSync(fd: Int): NodeStats                                             = js.native
-    def symlinkSync(target: String, path: String): Unit                           = js.native
-    def readlinkSync(path: String): String                                        = js.native
-    def mkdtempSync(prefix: String): String                                       = js.native
-    def writeFileSync(path: String, data: String): Unit                           = js.native
-    def utimesSync(path: String, atime: Double, mtime: Double): Unit              = js.native
-    def lutimesSync(path: String, atime: Double, mtime: Double): Unit             = js.native
+    def writeSync(fd: Int, buffer: Uint8Array, offset: Int, length: Int): Int = js.native
+    // The positioned overloads exist for `NodeRawChannel` alone, whose whole contract is that a call
+    // never moves the descriptor's own cursor. No append path may reach them.
+    def writeSync(fd: Int, buffer: Uint8Array, offset: Int, length: Int, position: Double): Int = js.native
+    def writeSync(fd: Int, data: String, position: Double, encoding: String): Int               = js.native
+    def closeSync(fd: Int): Unit                                                                = js.native
+    def fsyncSync(fd: Int): Unit                                                                = js.native
+    def fdatasyncSync(fd: Int): Unit                                                            = js.native
+    def fstatSync(fd: Int): NodeStats                                                           = js.native
+    def ftruncateSync(fd: Int, len: Double): Unit                                               = js.native
+    def symlinkSync(target: String, path: String): Unit                                         = js.native
+    def chmodSync(path: String, mode: Int): Unit                                                = js.native
+    def readlinkSync(path: String): String                                                      = js.native
+    def mkdtempSync(prefix: String): String                                                     = js.native
+    def writeFileSync(path: String, data: String): Unit                                         = js.native
+    def utimesSync(path: String, atime: Double, mtime: Double): Unit                            = js.native
+    def lutimesSync(path: String, atime: Double, mtime: Double): Unit                           = js.native
 end NodeFs
+
+@js.native
+private[kyo] trait NodeFsConstants extends js.Object:
+    val O_WRONLY: Int = js.native
+    val O_RDWR: Int   = js.native
+    val O_CREAT: Int  = js.native
+    val O_EXCL: Int   = js.native
+end NodeFsConstants
 
 @js.native
 trait NodeStats extends js.Object:
@@ -131,6 +147,14 @@ private[kyo] object NodeError:
             case "EISDIR"           => FileIsADirectoryException(path)
             case "EINVAL"           => FileInvalidPathException(path.toString, FileSystemOperation.Write)
             case _                  => FileIOException(path, FileSystemOperation.Write, e)
+
+    def translateSync(path: Path, e: js.JavaScriptException)(using Frame): FileWriteException =
+        codeOf(e) match
+            case "ENOENT"           => FileNotFoundException(path)
+            case "EACCES" | "EPERM" => FileAccessDeniedException(path)
+            case "EISDIR"           => FileIsADirectoryException(path)
+            case "EINVAL"           => FileInvalidPathException(path.toString, FileSystemOperation.Sync)
+            case _                  => FileIOException(path, FileSystemOperation.Sync, e)
 
     def translateFs(path: Path, operation: FileSystemOperation, e: js.JavaScriptException)(using Frame): FileStructureException =
         codeOf(e) match
@@ -504,6 +528,45 @@ final private[kyo] class NodePathUnsafe(raw: String) extends Path.Unsafe:
             new NodeWriteHandle(fd, safe)
         }
 
+    // --- Positioned channel ---
+
+    // Numeric non-append flags preserve explicit readSync/writeSync positions. Combining O_CREAT
+    // with the requested access mode creates atomically without truncating existing content.
+    private def openRawChannel(mode: Path.RawChannelAccess): Path.RawChannel =
+        val constants = NodeFs.constants
+        mode match
+            case Path.RawChannelAccess.Read =>
+                new NodeRawChannel(NodeFs.openSync(pathStr, "r"), safe)
+            case Path.RawChannelAccess.Write(open) =>
+                if open != FileSystem.WriteOpen.Existing then ensureParent()
+                val flags = open match
+                    case FileSystem.WriteOpen.Existing  => constants.O_WRONLY
+                    case FileSystem.WriteOpen.Create    => constants.O_WRONLY | constants.O_CREAT
+                    case FileSystem.WriteOpen.CreateNew => constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL
+                new NodeRawChannel(NodeFs.openSync(pathStr, flags), safe)
+            case Path.RawChannelAccess.ReadWrite(open) =>
+                if open != FileSystem.WriteOpen.Existing then ensureParent()
+                val flags = open match
+                    case FileSystem.WriteOpen.Existing  => constants.O_RDWR
+                    case FileSystem.WriteOpen.Create    => constants.O_RDWR | constants.O_CREAT
+                    case FileSystem.WriteOpen.CreateNew => constants.O_RDWR | constants.O_CREAT | constants.O_EXCL
+                new NodeRawChannel(NodeFs.openSync(pathStr, flags), safe)
+        end match
+    end openRawChannel
+
+    def openReadChannelRaw()(using AllowUnsafe, Frame): Result[FileReadException, Path.RawChannel] =
+        catchRead(openRawChannel(Path.RawChannelAccess.Read))
+    def openWriteChannelRaw(open: FileSystem.WriteOpen)(using
+        AllowUnsafe,
+        Frame
+    ): Result[FileWriteException | FileStructureException, Path.RawChannel] =
+        catchChannelWrite(openRawChannel(Path.RawChannelAccess.Write(open)))
+    def openReadWriteChannelRaw(open: FileSystem.WriteOpen)(using
+        AllowUnsafe,
+        Frame
+    ): Result[FileReadException | FileWriteException | FileStructureException, Path.RawChannel] =
+        catchChannelWrite(openRawChannel(Path.RawChannelAccess.ReadWrite(open)))
+
     // --- Private helpers ---
 
     /** Splits content by newlines, dropping a single trailing empty element if the content ends with '\n'. This matches the behaviour of
@@ -546,6 +609,16 @@ final private[kyo] class NodePathUnsafe(raw: String) extends Path.Unsafe:
     private def catchWrite[A](expr: => A)(using Frame): Result[FileWriteException, A] =
         try Result.succeed(expr)
         catch
+            case e: js.JavaScriptException => Result.fail(NodeError.translateWrite(safe, e))
+            case e: Throwable              => Result.panic(e)
+
+    private def catchChannelWrite[A](expr: => A)(using Frame): Result[FileWriteException | FileStructureException, A] =
+        try Result.succeed(expr)
+        catch
+            case e: js.JavaScriptException
+                if !js.isUndefined(e.exception.asInstanceOf[js.Dynamic].code) &&
+                    e.exception.asInstanceOf[js.Dynamic].code.asInstanceOf[String] == "EEXIST" =>
+                Result.fail(FileAlreadyExistsException(safe))
             case e: js.JavaScriptException => Result.fail(NodeError.translateWrite(safe, e))
             case e: Throwable              => Result.panic(e)
 
@@ -748,6 +821,71 @@ final private[kyo] class NodeWriteHandle(fd: Int, path: Path) extends Path.Write
     end close
 
 end NodeWriteHandle
+
+// --- NodeRawChannel ---
+
+/** Concrete positioned raw channel backed by a Node.js file descriptor, using `readSync`/
+  * `writeSync`'s explicit `position` argument so no call moves the fd's own read/write cursor.
+  */
+final private[kyo] class NodeRawChannel(fd: Int, path: Path) extends Path.RawChannel:
+
+    private val closed = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+    def readAt(pos: Long, len: Int)(using AllowUnsafe, Frame): Result[FileReadException, Array[Byte]] =
+        try
+            val uint8 = new Uint8Array(len)
+            var total = 0
+            var eof   = false
+            while total < len && !eof do
+                val n = NodeFs.readSync(fd, uint8, total, len - total, (pos + total).toDouble)
+                if n == 0 then eof = true else total += n
+            val out = new Array[Byte](total)
+            var i   = 0
+            while i < total do
+                out(i) = uint8(i).toByte
+                i += 1
+            Result.succeed(out)
+        catch
+            case e: js.JavaScriptException => Result.fail(NodeError.translateRead(path, e))
+            case e: Throwable              => Result.panic(e)
+
+    def writeAt(pos: Long, bytes: Array[Byte])(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =
+        try
+            val uint8   = bytesToUint8Array(bytes)
+            var written = 0
+            while written < bytes.length do
+                written += NodeFs.writeSync(fd, uint8, written, bytes.length - written, (pos + written).toDouble)
+            Result.unit
+        catch
+            case e: js.JavaScriptException => Result.fail(NodeError.translateWrite(path, e))
+            case e: Throwable              => Result.panic(e)
+
+    def sync(metadata: Boolean)(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =
+        try
+            if metadata then NodeFs.fsyncSync(fd) else NodeFs.fdatasyncSync(fd)
+            Result.unit
+        catch
+            case e: js.JavaScriptException => Result.fail(NodeError.translateSync(path, e))
+            case e: Throwable              => Result.panic(e)
+
+    def truncate(size: Long)(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =
+        try
+            NodeFs.ftruncateSync(fd, size.toDouble)
+            Result.unit
+        catch
+            case e: js.JavaScriptException => Result.fail(NodeError.translateWrite(path, e))
+            case e: Throwable              => Result.panic(e)
+
+    def size()(using AllowUnsafe, Frame): Result[FileReadException, Long] =
+        try Result.succeed(NodeFs.fstatSync(fd).size.toLong)
+        catch
+            case e: js.JavaScriptException => Result.fail(NodeError.translateRead(path, e))
+            case e: Throwable              => Result.panic(e)
+
+    def close()(using AllowUnsafe): Unit =
+        if closed.compareAndSet(false, true) then NodeFs.closeSync(fd)
+
+end NodeRawChannel
 
 // --- Byte / Uint8Array conversion helpers ---
 

--- a/kyo-system/js/src/test/scala/kyo/PathNodeTest.scala
+++ b/kyo-system/js/src/test/scala/kyo/PathNodeTest.scala
@@ -4,6 +4,75 @@ import kyo.internal.NodeFs
 
 class PathNodeTest extends kyo.test.Test[Any]:
 
+    private def bytes(ints: Int*): Span[Byte] = Span.from(ints.map(_.toByte).toArray)
+
+    "Node write-only Existing does not require read permission" in {
+        Scope.run {
+            Path.run {
+                Path.tempDir("kyo-node-write-only").map { dir =>
+                    val path = dir / "write-only.bin"
+                    path.writeBytes(bytes(1)).andThen {
+                        Sync.Unsafe.defer(NodeFs.chmodSync(path.unsafe.show, 128)).andThen {
+                            FileSystem.host.openWriteChannel(path, FileSystem.WriteOpen.Existing).map(_.writeAt(0L, bytes(9)))
+                        }.andThen {
+                            Sync.Unsafe.defer(NodeFs.chmodSync(path.unsafe.show, 384)).andThen {
+                                path.readBytes.map(content => assert(content.is(bytes(9))))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "Node Create preserves existing content and CreateNew remains exclusive" in {
+        Scope.run {
+            Path.run {
+                Path.tempDir("kyo-node-create-flags").map { dir =>
+                    val path = dir / "create.bin"
+                    path.writeBytes(bytes(1, 2, 3)).andThen {
+                        FileSystem.host.openWriteChannel(path, FileSystem.WriteOpen.Create).andThen {
+                            path.readBytes.map(content => assert(content.is(bytes(1, 2, 3))))
+                        }.andThen {
+                            Abort.run[FileSystemException](FileSystem.host.openWriteChannel(path, FileSystem.WriteOpen.CreateNew)).map {
+                                case Result.Failure(_: FileAlreadyExistsException) => assert(true)
+                                case other => assert(false, s"expected exclusive CreateNew failure, got $other")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "concurrent Node Create acquisitions preserve existing content" in {
+        Scope.run {
+            Path.run {
+                Path.tempDir("kyo-node-concurrent-create").map { dir =>
+                    val path = dir / "create.bin"
+                    path.writeBytes(bytes(1, 2, 3)).andThen {
+                        for
+                            gate <- Latch.init(1)
+                            fibers <- Kyo.fill(32)(Fiber.initUnscoped {
+                                gate.await.andThen {
+                                    Abort.run[FileSystemException](
+                                        FileSystem.host.openWriteChannel(path, FileSystem.WriteOpen.Create)
+                                    )
+                                }
+                            })
+                            _       <- gate.release
+                            results <- Kyo.foreach(fibers)(_.get)
+                            content <- path.readBytes
+                        yield
+                            assert(results.forall(_.isSuccess))
+                            assert(content.is(bytes(1, 2, 3)))
+                        end for
+                    }
+                }
+            }
+        }
+    }
+
     "Node copy honors followLinks for symbolic links" in {
         Scope.run(Path.run {
             for

--- a/kyo-system/js/src/test/scala/kyo/internal/PathPlatformSpecificJsTest.scala
+++ b/kyo-system/js/src/test/scala/kyo/internal/PathPlatformSpecificJsTest.scala
@@ -1,0 +1,14 @@
+package kyo.internal
+
+import kyo.*
+
+class PathPlatformSpecificJsTest extends kyo.test.Test[Any]:
+
+    "raw channel synchronization reports the Sync operation" in {
+        Sync.Unsafe.defer(new NodeRawChannel(-1, Path("sync-classification.bin")).sync(metadata = true)).map {
+            case Result.Failure(error: FileIOException) => assert(error.operation == FileSystemOperation.Sync)
+            case other                                  => fail(s"expected FileIOException, got $other")
+        }
+    }
+
+end PathPlatformSpecificJsTest

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -305,6 +305,37 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
             new NioWriteHandle(FileChannel.open(jpath, opts*), safe)
         }
 
+    // --- Positioned channel ---
+
+    private def openRawChannel(mode: Path.RawChannelAccess): Path.RawChannel =
+        def writeOptions(open: FileSystem.WriteOpen): Array[StandardOpenOption] = open match
+            case FileSystem.WriteOpen.Existing => Array(StandardOpenOption.WRITE)
+            case FileSystem.WriteOpen.Create =>
+                ensureParent(jpath)
+                Array(StandardOpenOption.WRITE, StandardOpenOption.CREATE)
+            case FileSystem.WriteOpen.CreateNew =>
+                ensureParent(jpath)
+                Array(StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)
+        val opts: Array[StandardOpenOption] = mode match
+            case Path.RawChannelAccess.Read            => Array(StandardOpenOption.READ)
+            case Path.RawChannelAccess.Write(open)     => writeOptions(open)
+            case Path.RawChannelAccess.ReadWrite(open) => Array(StandardOpenOption.READ) ++ writeOptions(open)
+        new NioRawChannel(FileChannel.open(jpath, opts*), safe)
+    end openRawChannel
+
+    def openReadChannelRaw()(using AllowUnsafe, Frame): Result[FileReadException, Path.RawChannel] =
+        catchRead(openRawChannel(Path.RawChannelAccess.Read))
+    def openWriteChannelRaw(open: FileSystem.WriteOpen)(using
+        AllowUnsafe,
+        Frame
+    ): Result[FileWriteException | FileStructureException, Path.RawChannel] =
+        catchChannelWrite(openRawChannel(Path.RawChannelAccess.Write(open)))
+    def openReadWriteChannelRaw(open: FileSystem.WriteOpen)(using
+        AllowUnsafe,
+        Frame
+    ): Result[FileReadException | FileWriteException | FileStructureException, Path.RawChannel] =
+        catchChannelWrite(openRawChannel(Path.RawChannelAccess.ReadWrite(open)))
+
     // --- Helpers ---
 
     private def ensureParent(p: java.nio.file.Path): Unit =
@@ -379,6 +410,16 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
             case e: IOException => Result.fail(FileIOException(safe, FileSystemOperation.Write, e))
             case e: Throwable   => Result.panic(e)
 
+    private def catchChannelWrite[A](expr: => A)(using Frame): Result[FileWriteException | FileStructureException, A] =
+        try Result.succeed(expr)
+        catch
+            case e: IOException if NioExceptionBoundary.isInterrupted(e)  => Result.panic(e)
+            case e: java.nio.file.FileAlreadyExistsException              => Result.fail(FileAlreadyExistsException(safe))
+            case e: IOException if NioExceptionBoundary.isFileNotFound(e) => Result.fail(FileNotFoundException(safe))
+            case e: AccessDeniedException                                 => Result.fail(FileAccessDeniedException(safe))
+            case e: IOException => Result.fail(FileIOException(safe, FileSystemOperation.Channel, e))
+            case e: Throwable   => Result.panic(e)
+
     private def catchFs[A](operation: FileSystemOperation)(expr: => A)(using Frame): Result[FileStructureException, A] =
         try Result.succeed(expr)
         catch
@@ -441,6 +482,69 @@ final private[kyo] class NioWriteHandle(channel: FileChannel, path: Path) extend
     end close
 
 end NioWriteHandle
+
+/** Concrete positioned raw channel backed by a `java.nio.channels.FileChannel`, using the
+  * positioned `read(ByteBuffer, long)`/`write(ByteBuffer, long)` overloads so no call moves
+  * the channel's own file-position cursor.
+  */
+final private[kyo] class NioRawChannel(channel: FileChannel, path: Path) extends Path.RawChannel:
+
+    def readAt(pos: Long, len: Int)(using AllowUnsafe, Frame): Result[FileReadException, Array[Byte]] =
+        try
+            val buf   = java.nio.ByteBuffer.allocate(len)
+            var total = 0
+            var eof   = false
+            while total < len && !eof do
+                val n = channel.read(buf, pos + total)
+                if n < 0 then eof = true else total += n
+            val out = new Array[Byte](total)
+            buf.flip()
+            buf.get(out)
+            Result.succeed(out)
+        catch
+            case e: IOException if NioExceptionBoundary.isInterrupted(e) => Result.panic(e)
+            case e: IOException                                          => Result.fail(FileIOException(path, FileSystemOperation.Read, e))
+            case e: Throwable                                            => Result.panic(e)
+
+    def writeAt(pos: Long, bytes: Array[Byte])(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =
+        try
+            val buf     = java.nio.ByteBuffer.wrap(bytes)
+            var written = 0
+            while buf.hasRemaining do written += channel.write(buf, pos + written)
+            Result.unit
+        catch
+            case e: IOException if NioExceptionBoundary.isInterrupted(e) => Result.panic(e)
+            case e: IOException                                          => Result.fail(FileIOException(path, FileSystemOperation.Write, e))
+            case e: Throwable                                            => Result.panic(e)
+
+    def sync(metadata: Boolean)(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =
+        try
+            channel.force(metadata)
+            Result.unit
+        catch
+            case e: IOException if NioExceptionBoundary.isInterrupted(e) => Result.panic(e)
+            case e: IOException                                          => Result.fail(FileIOException(path, FileSystemOperation.Sync, e))
+            case e: Throwable                                            => Result.panic(e)
+
+    def truncate(size: Long)(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =
+        try
+            discard(channel.truncate(size))
+            Result.unit
+        catch
+            case e: IOException if NioExceptionBoundary.isInterrupted(e) => Result.panic(e)
+            case e: IOException                                          => Result.fail(FileIOException(path, FileSystemOperation.Write, e))
+            case e: Throwable                                            => Result.panic(e)
+
+    def size()(using AllowUnsafe, Frame): Result[FileReadException, Long] =
+        try Result.succeed(channel.size())
+        catch
+            case e: IOException if NioExceptionBoundary.isInterrupted(e) => Result.panic(e)
+            case e: IOException => Result.fail(FileIOException(path, FileSystemOperation.Inspect, e))
+            case e: Throwable   => Result.panic(e)
+
+    def close()(using AllowUnsafe): Unit = channel.close()
+
+end NioRawChannel
 
 /** Concrete read handle backed by a `java.nio.channels.FileChannel`.
   *

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -3,9 +3,9 @@ package kyo
 import java.nio.charset.Charset
 
 /** Filesystem backend capabilities, effect-polymorphic in the backend effect `S`. [[Read]] exposes
-  * inspection and content reads. [[Write]] extends it with mutation and structure operations.
-  * Each public operation records the applicable typed failure category in its effect row and
-  * accepts a call-site [[Frame]].
+  * inspection, content reads, and channels. [[Write]] extends it with mutation and structure
+  * operations. Each public operation records the applicable typed failure category in its effect
+  * row and accepts a call-site [[Frame]].
   *
   * @see [[Path.runReadOnlyWith]] for installing a read capability
   * @see [[Path.runWith]] for installing a write capability
@@ -74,6 +74,13 @@ object FileSystem:
         def list(path: Path, glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using
             Frame
         ): Chunk[Path] < (S & Abort[FileReadException | FileStructureException])
+
+        /** Opens `path` for positioned reads. The channel is closed when the current [[Scope]] exits. */
+        def openReadChannel(path: Path)(using Frame): Path.ReadChannel[S] < (S & Scope & Abort[FileReadException])
+
+        private[kyo] def openReadChannelUnscoped(path: Path)(using
+            Frame
+        ): (Path.ReadChannel[S], () => Unit < (Sync & S)) < (S & Abort[FileReadException])
     end Read
 
     abstract class Write[S] extends Read[S]:
@@ -122,6 +129,28 @@ object FileSystem:
         def tempDir(prefix: String)(using Frame): Path.TempDirHandle < (S & Abort[FileStructureException])
         def temp(prefix: String, suffix: String)(using Frame): Path.TempFileHandle < (S & Abort[FileStructureException])
 
+        /** Opens `path` for positioned writes according to `open`. The channel is closed when the
+          * current [[Scope]] exits.
+          */
+        def openWriteChannel(path: Path, open: FileSystem.WriteOpen)(using
+            Frame
+        ): Path.WriteChannel[S] < (S & Scope & Abort[FileWriteException | FileStructureException])
+
+        /** Opens `path` for positioned reads and writes according to `open`. The channel is closed
+          * when the current [[Scope]] exits.
+          */
+        def openReadWriteChannel(path: Path, open: FileSystem.WriteOpen)(using
+            Frame
+        ): Path.ReadWriteChannel[S] < (S & Scope & Abort[FileReadException | FileWriteException | FileStructureException])
+
+        private[kyo] def openReadWriteChannelUnscoped(path: Path, open: FileSystem.WriteOpen)(using
+            Frame
+        )
+            : (
+                Path.ReadWriteChannel[S],
+                () => Unit < (Sync & S)
+            ) < (S & Abort[FileReadException | FileWriteException | FileStructureException])
+
     end Write
 
     private val local = Local.init[FileSystem.Write[Any]](
@@ -156,6 +185,22 @@ object FileSystem:
 
     private[kyo] def letReadErased[A, S, FS](fileSystem: FileSystem.Read[FS])(value: A < S)(using Frame): A < S =
         readLocal.let(fileSystem.asInstanceOf[FileSystem.Read[Any]])(value)
+
+    /** File existence policy for positioned write-channel acquisition.
+      *
+      * `Existing` requires an existing regular file. `Create` opens an existing file or creates
+      * an absent one. `CreateNew` creates a new file and fails when the path already exists.
+      * None of these policies truncates an existing file.
+      *
+      * The policy is separate from the channel capability: callers choose write-only or
+      * read-write acquisition through distinct methods, and then choose how absence or prior
+      * existence should be handled with this value.
+      */
+    enum WriteOpen derives CanEqual:
+        case Existing
+        case Create
+        case CreateNew
+    end WriteOpen
 
     /** Default host backend: delegates every op to [[Path.Unsafe]], translating the concrete
       * `Result[File*Exception, A]` into `Abort[FileSystemException]`, so it preserves current

--- a/kyo-system/shared/src/main/scala/kyo/FileSystemException.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystemException.scala
@@ -2,7 +2,7 @@ package kyo
 
 /** Operations recorded by generic filesystem failures. */
 enum FileSystemOperation derives CanEqual:
-    case Exists, Inspect, RealPath, Read, Write, List, Walk, Create, Move, Copy, Remove
+    case Exists, Inspect, RealPath, Read, Write, List, Walk, Create, Move, Copy, Remove, Channel, Sync
 
 /** Base type for failures reported by filesystem capabilities. */
 sealed abstract class FileSystemException(message: String, cause: Throwable | String = "")(using Frame)

--- a/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
@@ -1,5 +1,6 @@
 package kyo
 
+import java.io.IOException
 import java.nio.charset.Charset
 import kyo.internal.Platform
 
@@ -204,5 +205,70 @@ private[kyo] object HostFileSystem:
                     // Unsafe: host delete of the created temp file at Scope exit
                     def remove()(using AllowUnsafe): Unit = discard(file.unsafe.remove())
             }
+
+        private def invalid(path: Path, operation: FileSystemOperation, detail: String)(using Frame): FileIOException =
+            FileIOException(path, operation, new IOException(detail))
+
+        private def readChannelFrom(path: Path, raw: Path.RawChannel): Path.ReadChannel[Sync] =
+            new Path.ReadChannel[Sync]:
+                def readAt(position: Long, length: Int)(using Frame): Span[Byte] < (Sync & Abort[FileReadException]) =
+                    if position < 0L || length < 0 then Abort.fail(invalid(path, FileSystemOperation.Read, "negative channel read bounds"))
+                    else Sync.Unsafe.defer(Abort.get(raw.readAt(position, length))).map(Span.from)
+                def size(using Frame): Long < (Sync & Abort[FileReadException]) =
+                    Sync.Unsafe.defer(Abort.get(raw.size()))
+
+        private def writeChannelFrom(path: Path, raw: Path.RawChannel): Path.WriteChannel[Sync] =
+            new Path.WriteChannel[Sync]:
+                def writeAt(position: Long, bytes: Span[Byte])(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+                    if position < 0L then Abort.fail(invalid(path, FileSystemOperation.Write, "negative channel write position"))
+                    else Sync.Unsafe.defer(Abort.get(raw.writeAt(position, bytes.toArray)))
+                def sync(metadata: Boolean)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+                    Sync.Unsafe.defer(Abort.get(raw.sync(metadata)))
+                def truncate(size: Long)(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+                    if size < 0L then Abort.fail(invalid(path, FileSystemOperation.Write, "negative channel truncate size"))
+                    else Sync.Unsafe.defer(Abort.get(raw.truncate(size)))
+
+        private def readWriteChannelFrom(path: Path, raw: Path.RawChannel): Path.ReadWriteChannel[Sync] =
+            new Path.ReadWriteChannel[Sync]:
+                private val read  = readChannelFrom(path, raw)
+                private val write = writeChannelFrom(path, raw)
+                def readAt(position: Long, length: Int)(using Frame): Span[Byte] < (Sync & Abort[FileReadException]) =
+                    read.readAt(position, length)
+                def size(using Frame): Long < (Sync & Abort[FileReadException]) = read.size
+                def writeAt(position: Long, bytes: Span[Byte])(using Frame): Unit < (Sync & Abort[FileWriteException]) =
+                    write.writeAt(position, bytes)
+                def sync(metadata: Boolean)(using Frame): Unit < (Sync & Abort[FileWriteException]) = write.sync(metadata)
+                def truncate(size: Long)(using Frame): Unit < (Sync & Abort[FileWriteException])    = write.truncate(size)
+
+        def openReadChannel(path: Path)(using Frame): Path.ReadChannel[Sync] < (Sync & Scope & Abort[FileReadException]) =
+            Scope.acquireRelease(Sync.Unsafe.defer(Abort.get(path.unsafe.openReadChannelRaw())))(raw => Sync.Unsafe.defer(raw.close()))
+                .map(readChannelFrom(path, _))
+        def openWriteChannel(path: Path, open: FileSystem.WriteOpen)(using
+            Frame
+        ): Path.WriteChannel[Sync] < (Sync & Scope & Abort[FileWriteException | FileStructureException]) =
+            Scope.acquireRelease(Sync.Unsafe.defer(Abort.get(path.unsafe.openWriteChannelRaw(open))))(raw => Sync.Unsafe.defer(raw.close()))
+                .map(writeChannelFrom(path, _))
+        def openReadWriteChannel(path: Path, open: FileSystem.WriteOpen)(using
+            Frame
+        ): Path.ReadWriteChannel[Sync] < (Sync & Scope & Abort[FileReadException | FileWriteException | FileStructureException]) =
+            Scope.acquireRelease(Sync.Unsafe.defer(Abort.get(path.unsafe.openReadWriteChannelRaw(open))))(raw =>
+                Sync.Unsafe.defer(raw.close())
+            )
+                .map(readWriteChannelFrom(path, _))
+        private[kyo] def openReadChannelUnscoped(path: Path)(using
+            Frame
+        ): (Path.ReadChannel[Sync], () => Unit < Sync) < (Sync & Abort[FileReadException]) =
+            Sync.Unsafe.defer(Abort.get(path.unsafe.openReadChannelRaw())).map(raw =>
+                (readChannelFrom(path, raw), () => Sync.Unsafe.defer(raw.close()))
+            )
+        private[kyo] def openReadWriteChannelUnscoped(path: Path, open: FileSystem.WriteOpen)(using
+            Frame
+        ): (
+            Path.ReadWriteChannel[Sync],
+            () => Unit < Sync
+        ) < (Sync & Abort[FileReadException | FileWriteException | FileStructureException]) =
+            Sync.Unsafe.defer(Abort.get(path.unsafe.openReadWriteChannelRaw(open))).map(raw =>
+                (readWriteChannelFrom(path, raw), () => Sync.Unsafe.defer(raw.close()))
+            )
     end HostFileSystem
 end HostFileSystem

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -486,6 +486,67 @@ object Path extends PathPlatformSpecific:
         def remove()(using AllowUnsafe): Unit
     end TempFileHandle
 
+    /** A Scope-managed positioned read capability into an open file.
+      *
+      * Reads use absolute offsets and never advance an implicit cursor, so independent callers may
+      * safely choose their own positions. A read may return fewer bytes than requested at end of
+      * file. The capability intentionally has no mutation surface.
+      *
+      * The [[Scope]] active during acquisition owns the underlying resource. Operations after its
+      * exit fail through [[FileReadException]].
+      *
+      * @tparam S the backend's own effect
+      */
+    trait ReadChannel[S]:
+        /** Reads up to `length` bytes at absolute offset `position`. Tolerates short reads: the
+          * returned `Span`'s length is less than `length` when `position + length` exceeds the file's
+          * current size.
+          */
+        def readAt(position: Long, length: Int)(using Frame): Span[Byte] < (S & Abort[FileReadException])
+
+        /** Returns the channel's current view of length. */
+        def size(using Frame): Long < (S & Abort[FileReadException])
+    end ReadChannel
+
+    /** A Scope-managed positioned write capability into an open file.
+      *
+      * Writes use absolute offsets and zero-fill a gap beyond the current end. Truncation and
+      * explicit synchronization are available, while reads and size inspection are intentionally
+      * absent from this capability.
+      *
+      * The [[Scope]] active during acquisition owns the underlying resource. Operations after its
+      * exit fail through [[FileWriteException]].
+      *
+      * @tparam S the backend's own effect
+      */
+    trait WriteChannel[S]:
+        /** Writes `bytes` at absolute offset `position`. A gap between the channel's current length
+          * and `position` is zero-filled.
+          */
+        def writeAt(position: Long, bytes: Span[Byte])(using Frame): Unit < (S & Abort[FileWriteException])
+
+        /** Persists prior writes, optionally including file metadata. */
+        def sync(metadata: Boolean)(using Frame): Unit < (S & Abort[FileWriteException])
+
+        /** Truncates the channel's target to `size`, discarding trailing bytes when `size` is
+          * smaller than the current length.
+          */
+        def truncate(size: Long)(using Frame): Unit < (S & Abort[FileWriteException])
+    end WriteChannel
+
+    /** A Scope-managed channel combining positioned read and write capabilities.
+      *
+      * This is the capability for algorithms that need to inspect and mutate the same open file.
+      * It preserves the precise read and write failure rows of its two parent capabilities rather
+      * than widening every operation to a common filesystem error.
+      *
+      * The [[Scope]] active during acquisition owns the underlying resource. There is no explicit
+      * close operation on the public channel.
+      *
+      * @tparam S the backend's own effect
+      */
+    trait ReadWriteChannel[S] extends ReadChannel[S] with WriteChannel[S]
+
     // --- Safe extension methods ---
 
     extension (self: Path)
@@ -1339,6 +1400,18 @@ object Path extends PathPlatformSpecific:
         /** Opens a write handle for streaming byte or string output. The caller must close the handle via `Scope.acquireRelease`. */
         def openWrite(append: Boolean, options: WriteOptions)(using AllowUnsafe, Frame): Result[FileWriteException, Path.WriteHandle]
 
+        // --- Positioned channel (abstract -- platform provides the concrete channel) ---
+
+        private[kyo] def openReadChannelRaw()(using AllowUnsafe, Frame): Result[FileReadException, Path.RawChannel]
+        private[kyo] def openWriteChannelRaw(open: FileSystem.WriteOpen)(using
+            AllowUnsafe,
+            Frame
+        ): Result[FileWriteException | FileStructureException, Path.RawChannel]
+        private[kyo] def openReadWriteChannelRaw(open: FileSystem.WriteOpen)(using
+            AllowUnsafe,
+            Frame
+        ): Result[FileReadException | FileWriteException | FileStructureException, Path.RawChannel]
+
         /** Lifts this `Unsafe` value back into the safe `Path` opaque type. */
         def safe: Path = this
 
@@ -1473,5 +1546,39 @@ object Path extends PathPlatformSpecific:
         /** Closes the walker, releasing all OS resources. */
         def close()(using AllowUnsafe): Unit
     end WalkHandle
+
+    // --- Raw channel -- platform-provided positioned I/O backing typed channels ---
+
+    private[kyo] enum RawChannelAccess derives CanEqual:
+        case Read
+        case Write(open: FileSystem.WriteOpen)
+        case ReadWrite(open: FileSystem.WriteOpen)
+    end RawChannelAccess
+
+    /** A raw positioned-I/O channel returned by the private unsafe acquisition methods. Platform
+      * implementations provide the concrete class; `FileSystem` backends wrap it as the
+      * public typed channel capabilities.
+      */
+    abstract private[kyo] class RawChannel:
+        /** Reads up to `len` bytes at absolute offset `pos`. Returns fewer bytes than `len`
+          * on a short read.
+          */
+        def readAt(pos: Long, len: Int)(using AllowUnsafe, Frame): Result[FileReadException, Array[Byte]]
+
+        /** Writes `bytes` at absolute offset `pos`. */
+        def writeAt(pos: Long, bytes: Array[Byte])(using AllowUnsafe, Frame): Result[FileWriteException, Unit]
+
+        /** Durably persists every prior `writeAt` call on this channel. */
+        def sync(metadata: Boolean)(using AllowUnsafe, Frame): Result[FileWriteException, Unit]
+
+        /** Truncates the channel's target to `size`. */
+        def truncate(size: Long)(using AllowUnsafe, Frame): Result[FileWriteException, Unit]
+
+        /** Returns the channel's current view of length. */
+        def size()(using AllowUnsafe, Frame): Result[FileReadException, Long]
+
+        /** Closes the channel, releasing all OS resources. */
+        def close()(using AllowUnsafe): Unit
+    end RawChannel
 
 end Path

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemChannelTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemChannelTestSuite.scala
@@ -1,0 +1,36 @@
+package kyo
+
+/** Reusable contract for typed positioned channels on mutable backends. */
+abstract class FileSystemChannelTestSuite extends kyo.test.Test[Any]:
+
+    private given Frame = Frame.internal
+
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException])
+
+    "channel suite supports positioned sparse writes and short reads" in {
+        createFileSystem.map { (fileSystem, root) =>
+            Scope.run {
+                fileSystem.openReadWriteChannel(root / "positioned.bin", FileSystem.WriteOpen.Create).map { channel =>
+                    channel.writeAt(3L, Span(7.toByte)).andThen {
+                        channel.readAt(0L, 10).map(bytes => assert(bytes.is(Span(0.toByte, 0.toByte, 0.toByte, 7.toByte))))
+                    }
+                }
+            }
+        }
+    }
+
+    "channel suite enforces create-new atomically" in {
+        createFileSystem.map { (fileSystem, root) =>
+            val path = root / "create-new.bin"
+            Scope.run(fileSystem.openWriteChannel(path, FileSystem.WriteOpen.Create)).andThen {
+                Abort.run[FileSystemException](Scope.run(fileSystem.openWriteChannel(path, FileSystem.WriteOpen.CreateNew))).map {
+                    case Result.Failure(_: FileAlreadyExistsException) => assert(true)
+                    case other                                         => assert(false, s"expected FileAlreadyExistsException, got $other")
+                }
+            }
+        }
+    }
+
+end FileSystemChannelTestSuite

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
@@ -8,9 +8,10 @@ class FileSystemConformanceDeclarationTest extends kyo.test.Test[Any]:
     "all declared conformance suites are public shared types" in {
         val suites = Chunk(
             classOf[FileSystemReadTestSuite],
-            classOf[FileSystemWriteTestSuite]
+            classOf[FileSystemWriteTestSuite],
+            classOf[FileSystemChannelTestSuite]
         )
-        assert(suites.size == 2)
+        assert(suites.size == 3)
     }
 
     "a read-only fixture cannot select write members" in {

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
@@ -34,6 +34,13 @@ class HostFileSystemWriteConformanceTest extends FileSystemWriteTestSuite:
         FileSystemConformanceFixtures.host("kyo-host-write-suite")
 end HostFileSystemWriteConformanceTest
 
+class HostFileSystemChannelConformanceTest extends FileSystemChannelTestSuite:
+    protected def createFileSystem(using
+        Frame
+    ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
+        FileSystemConformanceFixtures.host("kyo-host-channel-suite")
+end HostFileSystemChannelConformanceTest
+
 /** Minimal user-defined backend fixture that deliberately exposes only the read tier. */
 final class UserReadOnlyFileSystemFixture(delegate: FileSystem.Read[Sync]) extends FileSystem.Read[Sync]:
     // Delegated by name, not `export delegate.*`. A wildcard emits one forwarder per member in an
@@ -47,6 +54,8 @@ final class UserReadOnlyFileSystemFixture(delegate: FileSystem.Read[Sync]) exten
     export delegate.isSymbolicLink
     export delegate.list
     export delegate.openRead
+    export delegate.openReadChannel
+    export delegate.openReadChannelUnscoped
     export delegate.openReadLines
     export delegate.openWalk
     export delegate.read

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemReadTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemReadTestSuite.scala
@@ -160,4 +160,12 @@ abstract class FileSystemReadTestSuite extends kyo.test.Test[Any]:
         }
     }
 
+    "read suite releases scoped channels" in {
+        createFileSystem.map { (fileSystem, file, _) =>
+            Scope.run(fileSystem.openReadChannel(file)).map { channel =>
+                Abort.run[FileReadException](channel.readAt(0L, 1)).map(result => assert(result.isFailure))
+            }
+        }
+    }
+
 end FileSystemReadTestSuite

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemTest.scala
@@ -36,9 +36,14 @@ class FileSystemTest extends kyo.test.Test[Any]:
         export delegate.mkFile
         export delegate.move
         export delegate.openRead
+        export delegate.openReadChannel
+        export delegate.openReadChannelUnscoped
         export delegate.openReadLines
+        export delegate.openReadWriteChannel
+        export delegate.openReadWriteChannelUnscoped
         export delegate.openWalk
         export delegate.openWrite
+        export delegate.openWriteChannel
         export delegate.readBytes
         export delegate.readLines
         export delegate.realPath

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemWriteTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemWriteTestSuite.scala
@@ -80,4 +80,12 @@ abstract class FileSystemWriteTestSuite extends kyo.test.Test[Any]:
         }
     }
 
+    "write suite releases scoped channels" in {
+        createFileSystem.map { (fileSystem, root) =>
+            Scope.run(fileSystem.openWriteChannel(root / "scoped.bin", FileSystem.WriteOpen.Create)).map { channel =>
+                Abort.run[FileWriteException](channel.writeAt(0L, Span(1.toByte))).map(result => assert(result.isFailure))
+            }
+        }
+    }
+
 end FileSystemWriteTestSuite

--- a/kyo-system/shared/src/test/scala/kyo/PathChannelTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathChannelTest.scala
@@ -1,0 +1,233 @@
+package kyo
+
+import scala.compiletime.testing.typeCheckErrors
+
+/** Tests for typed, Scope-managed positioned file channels. */
+class PathChannelTest extends kyo.test.Test[Any]:
+
+    private def bytes(ints: Int*): Span[Byte] = Span.from(ints.map(_.toByte).toArray)
+
+    private def hostTempDir(prefix: String): Path < (Sync & Scope & Abort[FileSystemException]) =
+        Scope.acquireRelease(FileSystem.host.tempDir(prefix))(h => Sync.Unsafe.defer(h.remove())).map(_.path)
+
+    "typed channel capabilities are enforced by the compiler" in {
+        val readPositive = typeCheckErrors("""
+            def use[S](channel: kyo.Path.ReadChannel[S])(using kyo.Frame) =
+                (channel.readAt(0L, 1), channel.size)
+        """)
+        val readNegative = typeCheckErrors("""
+            def use[S](channel: kyo.Path.ReadChannel[S])(using kyo.Frame) =
+                (channel.writeAt(0L, kyo.Span.empty[Byte]), channel.truncate(0L), channel.sync(metadata = false))
+        """)
+        val writePositive = typeCheckErrors("""
+            def use[S](channel: kyo.Path.WriteChannel[S])(using kyo.Frame) =
+                (channel.writeAt(0L, kyo.Span.empty[Byte]), channel.truncate(0L), channel.sync(metadata = true))
+        """)
+        val writeNegative = typeCheckErrors("""
+            def use[S](channel: kyo.Path.WriteChannel[S])(using kyo.Frame) =
+                (channel.readAt(0L, 1), channel.size)
+        """)
+        val readWritePositive = typeCheckErrors("""
+            def use[S](channel: kyo.Path.ReadWriteChannel[S])(using kyo.Frame) =
+                (channel.readAt(0L, 1), channel.size, channel.writeAt(0L, kyo.Span.empty[Byte]),
+                    channel.truncate(0L), channel.sync(metadata = false))
+        """)
+        assert(readPositive.isEmpty)
+        assert(readNegative.nonEmpty)
+        assert(writePositive.isEmpty)
+        assert(writeNegative.nonEmpty)
+        assert(readWritePositive.isEmpty)
+    }
+
+    "filesystem tiers expose only their permitted acquisitions" in {
+        val readPositive = typeCheckErrors("""
+            def use[S](fs: kyo.FileSystem.Read[S], path: kyo.Path)(using kyo.Frame) = fs.openReadChannel(path)
+        """)
+        val readNegative = typeCheckErrors("""
+            def use[S](fs: kyo.FileSystem.Read[S], path: kyo.Path)(using kyo.Frame) =
+                (fs.openWriteChannel(path, kyo.FileSystem.WriteOpen.Existing),
+                    fs.openReadWriteChannel(path, kyo.FileSystem.WriteOpen.Existing))
+        """)
+        val writePositive = typeCheckErrors("""
+            def use[S](fs: kyo.FileSystem.Write[S], path: kyo.Path)(using kyo.Frame) =
+                (fs.openReadChannel(path), fs.openWriteChannel(path, kyo.FileSystem.WriteOpen.Existing),
+                    fs.openReadWriteChannel(path, kyo.FileSystem.WriteOpen.Create))
+        """)
+        assert(readPositive.isEmpty)
+        assert(readNegative.nonEmpty)
+        assert(writePositive.isEmpty)
+    }
+
+    "host read-write channels perform positioned short reads and sparse writes" in {
+        def exercise[S](fs: FileSystem.Write[S], path: Path)(using Frame): Unit < (S & Scope & Abort[FileSystemException]) =
+            fs.openReadWriteChannel(path, FileSystem.WriteOpen.Create).map { channel =>
+                channel.writeAt(3L, bytes(7)).andThen {
+                    channel.readAt(0L, 10).map(result => assert(result.is(bytes(0, 0, 0, 7))))
+                }
+            }
+        Scope.run {
+            hostTempDir("kyo-typed-channel").map(dir => exercise(FileSystem.host, dir / "host.bin"))
+        }
+    }
+
+    "truncate, size, and both sync policies preserve content" in {
+        Scope.run {
+            hostTempDir("kyo-channel-truncate").map { dir =>
+                val fs = FileSystem.host
+                fs.openReadWriteChannel(dir / "size.bin", FileSystem.WriteOpen.Create).map { channel =>
+                    channel.writeAt(0L, bytes(1, 2, 3, 4)).andThen(channel.sync(metadata = false)).andThen {
+                        channel.truncate(2L).andThen(channel.sync(metadata = true)).andThen {
+                            channel.size.map(size => assert(size == 2L)).andThen {
+                                channel.readAt(0L, 8).map(result => assert(result.is(bytes(1, 2))))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "open policies distinguish existing, create, and create-new" in {
+        Scope.run {
+            hostTempDir("kyo-channel-open-policy").map { dir =>
+                val fs   = FileSystem.host
+                val path = dir / "policy.bin"
+                val missing = Seq(
+                    Abort.run[FileSystemException](fs.openReadChannel(path)),
+                    Abort.run[FileSystemException](fs.openWriteChannel(path, FileSystem.WriteOpen.Existing)),
+                    Abort.run[FileSystemException](fs.openReadWriteChannel(path, FileSystem.WriteOpen.Existing))
+                )
+                Kyo.collectAll(missing).map(_.foreach {
+                    case Result.Failure(_: FileNotFoundException) => assert(true)
+                    case other                                    => assert(false, s"expected missing-file failure, got $other")
+                }).andThen(fs.openWriteChannel(path, FileSystem.WriteOpen.Create)).andThen {
+                    Abort.run[FileSystemException](fs.openWriteChannel(path, FileSystem.WriteOpen.CreateNew)).map {
+                        case Result.Failure(_: FileAlreadyExistsException) => assert(true)
+                        case other                                         => assert(false, s"expected already-exists failure, got $other")
+                    }
+                }
+            }
+        }.andThen {
+            Scope.run {
+                hostTempDir("kyo-channel-policy").map { dir =>
+                    val path = dir / "policy.bin"
+                    Abort.run[FileSystemException](FileSystem.host.openReadWriteChannel(path, FileSystem.WriteOpen.Existing)).map {
+                        case Result.Failure(_: FileNotFoundException) => assert(true)
+                        case other                                    => assert(false, s"expected host missing-file failure, got $other")
+                    }.andThen(FileSystem.host.openWriteChannel(path, FileSystem.WriteOpen.Create)).andThen {
+                        Abort.run[FileSystemException](FileSystem.host.openReadWriteChannel(path, FileSystem.WriteOpen.CreateNew)).map {
+                            case Result.Failure(_: FileAlreadyExistsException) => assert(true)
+                            case other => assert(false, s"expected host already-exists failure, got $other")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "CreateNew admits exactly one concurrent creator" in {
+        def contend(fs: FileSystem.Write[Sync], path: Path)(using Frame): Int < (Sync & Async & Scope) =
+            for
+                gate <- Latch.init(1)
+                fibers <- Kyo.fill(32)(Fiber.initUnscoped {
+                    gate.await.andThen(Abort.run[FileSystemException](fs.openWriteChannel(path, FileSystem.WriteOpen.CreateNew)))
+                })
+                _       <- gate.release
+                results <- Kyo.foreach(fibers)(_.get)
+            yield
+                val successes = results.count(_.isSuccess)
+                val failures  = results.collect { case Result.Failure(e) => e }
+                assert(failures.forall(_.isInstanceOf[FileAlreadyExistsException]))
+                successes
+            end for
+        end contend
+
+        Scope.run {
+            hostTempDir("kyo-channel-create-new-race").map { dir =>
+                contend(FileSystem.host, dir / "create-new-race.bin").map(count => assert(count == 1))
+            }
+        }
+    }
+
+    "invalid positions, lengths, and truncation bounds fail in typed channels" in {
+        Scope.run {
+            hostTempDir("kyo-channel-bounds").map { dir =>
+                val fs = FileSystem.host
+                fs.openReadWriteChannel(dir / "bounds.bin", FileSystem.WriteOpen.Create).map { channel =>
+                    val failures = Seq(
+                        Abort.run[FileSystemException](channel.readAt(-1L, 1)),
+                        Abort.run[FileSystemException](channel.readAt(0L, -1)),
+                        Abort.run[FileSystemException](channel.writeAt(-1L, bytes(1))),
+                        Abort.run[FileSystemException](channel.truncate(-1L))
+                    )
+                    Kyo.collectAll(failures).map(_.foreach {
+                        case Result.Failure(_: FileIOException) => assert(true)
+                        case other                              => assert(false, s"expected typed FileIOException, got $other")
+                    })
+                }
+            }
+        }
+    }
+
+    "scope release closes host channels" in {
+        Scope.run {
+            hostTempDir("kyo-channel-close").map { dir =>
+                val path = dir / "closed.bin"
+                FileSystem.host.openReadWriteChannelUnscoped(path, FileSystem.WriteOpen.Create).map { case (channel, release) =>
+                    release().andThen {
+                        Abort.run[FileSystemException](channel.writeAt(0L, bytes(1))).map {
+                            case Result.Failure(_: FileIOException) => assert(true)
+                            case other                              => assert(false, s"expected closed host failure, got $other")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "unscoped release is idempotent and leaves a typed closed channel" in {
+        Scope.run {
+            hostTempDir("kyo-channel-double-release").map { dir =>
+                val path = dir / "double-release.bin"
+                FileSystem.host.openReadWriteChannelUnscoped(path, FileSystem.WriteOpen.Create).map { case (channel, release) =>
+                    release().andThen(release()).andThen {
+                        Abort.run[FileSystemException](channel.writeAt(0L, bytes(1))).map {
+                            case Result.Failure(_: FileIOException) => assert(true)
+                            case other => assert(false, s"expected typed closed failure after double release, got $other")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "interrupting channel use releases the handle exactly once" in {
+        hostTempDir("kyo-channel-interrupt").map { dir =>
+            val fs   = FileSystem.host
+            val path = dir / "interrupted.bin"
+            fs.mkFile(path).andThen {
+                for
+                    ready  <- Latch.init(1)
+                    hold   <- Latch.init(1)
+                    closes <- AtomicInt.init(0)
+                    fiber <- Fiber.initUnscoped {
+                        Scope.run {
+                            fs.openReadChannelUnscoped(path).map { case (channel, release) =>
+                                Scope.acquireRelease(channel)(_ => release().andThen(closes.incrementAndGet.unit)).map { _ =>
+                                    ready.release.andThen(hold.await)
+                                }
+                            }
+                        }
+                    }
+                    _           <- ready.await
+                    interrupted <- fiber.interrupt
+                    _           <- assertEventually(closes.get.map(_ == 1))
+                    count       <- closes.get
+                yield
+                    assert(interrupted)
+                    assert(count == 1)
+                end for
+            }
+        }
+    }
+end PathChannelTest


### PR DESCRIPTION
### What this adds

Positioned file access. `Path.ReadChannel[S]`, `Path.WriteChannel[S]` and `Path.ReadWriteChannel[S]` expose reads and writes at absolute offsets over an open file, so a caller can read a header, skip past it, and overwrite a record in place without loading the file into memory or rewriting it.

Every operation names its own offset and no call moves an implicit cursor, so two callers holding the same channel cannot disturb each other's position. `readAt` tolerates a short read at end of file and returns fewer bytes than requested rather than failing. `writeAt` zero-fills a gap past the current end, so a sparse write is an ordinary write.

### What the new callsites look like

A channel is acquired from a backend rather than from a `Path`, which is what keeps it substitutable like every other filesystem operation:

```scala
import kyo.*

val positioned =
    Scope.run {
        FileSystem.host.openReadWriteChannel(Path("index.bin"), FileSystem.WriteOpen.CreateNew).map { channel =>
            channel.writeAt(0L, Span.from(Array[Byte](1, 2, 3))).andThen(channel.readAt(0L, 3))
        }
    }
```

Acquisition takes two independent decisions and keeps them separate. The method chooses the capability, and `FileSystem.WriteOpen` chooses what should happen about existence:

- `Existing` requires an existing regular file.
- `Create` opens an existing file or creates an absent one.
- `CreateNew` creates the file and fails when the path is already taken.

None of the three truncates an existing file. `CreateNew` is atomic against a concurrent creator, through `CREATE_NEW` on the JVM and Native and `O_EXCL` on Node, so exactly one of two racing openers wins and the loser sees `FileAlreadyExistsException`.

Capability is enforced at the type level in both directions. A `ReadChannel` has no `writeAt`, `truncate` or `sync`; a `WriteChannel` has no `readAt` or `size`. A `FileSystem.Read` backend vends `openReadChannel` and nothing else, so a read-only backend cannot hand out a write channel:

```scala
// compiles
def inspect[S](fs: FileSystem.Read[S], path: Path)(using Frame) = fs.openReadChannel(path)

// rejected at the call site
def mutate[S](fs: FileSystem.Read[S], path: Path)(using Frame) =
    fs.openWriteChannel(path, FileSystem.WriteOpen.Existing)
```

`ReadWriteChannel` extends both parents and keeps their distinct failure rows rather than widening every operation to one filesystem error. A read on a read-write channel still fails through `Abort[FileReadException]` and a write through `Abort[FileWriteException]`, so a caller recovering from one does not silently catch the other.

Lifetime belongs to the `Scope` active at acquisition. The public channels expose no `close`, so a channel cannot outlive the scope that owns it, and there is no way to close one twice.

### What changed

**`Path`** gains the three channel traits plus a private `RawChannel` and `RawChannelAccess`. `RawChannel` is the single narrow surface a platform must implement (`readAt`, `writeAt`, `sync`, `truncate`, `size`, `close`) and it stays `private[kyo]`; the public capabilities are assembled from it rather than exposing it.

**`FileSystem`** grows the acquisitions along its existing tier split. `Read` gains `openReadChannel`, `Write` gains `openWriteChannel` and `openReadWriteChannel`, and the `WriteOpen` enum is new. The unscoped variants stay `private[kyo]`: they hand back a release function for the cases inside the module that own the lifetime themselves, and they are not part of the public surface.

**`HostFileSystem`** wraps the raw channel into the typed capabilities and validates bounds at the boundary, so a negative position, length or truncation size fails through the channel's own typed error instead of reaching the OS.

**`FileSystemOperation`** gains `Channel` and `Sync` so an acquisition failure and a `force`/`fsync` failure name what they were doing instead of borrowing `Read` or `Write`.

**JVM and Native** implement `NioRawChannel` over `FileChannel`, using the positioned `read(ByteBuffer, long)` and `write(ByteBuffer, long)` overloads, which by contract do not touch the channel's own file-position cursor. Both loop until the request is satisfied, since a single call may transfer fewer bytes than asked.

**JS and Wasm** implement `NodeRawChannel` over a Node file descriptor, passing `readSync`/`writeSync` an explicit `position` for the same reason. Opening uses numeric flags rather than mode strings, because the string modes carry truncation and append semantics that a positioned channel must not have. The facade declares those position parameters as `Double`: JavaScript has no 64-bit integer and Scala.js compiles `Long` to a two-word object rather than a JS number, so the conversion happens once at the boundary and the arithmetic above it stays in `Long`.

**Tests.** `PathChannelTest` covers the capability and tier laws with `typeCheckErrors`, positioned short reads and sparse writes, the three open policies, concurrent `CreateNew`, invalid bounds, scope release, idempotent unscoped release, and release exactly once under interrupt. `FileSystemChannelTestSuite` is the reusable cross-backend contract, joining `FileSystemReadTestSuite` and `FileSystemWriteTestSuite`, so every mutable backend added later inherits the same laws.

### Stack

Part of the path-capability stack: process fixes, filesystem vocabulary, abstraction, capability flip, channels, locks, watch, durability, confinement, in-memory, zip, then overlay (#1799). Merge bottom up; GitHub retargets the stack above each merge.

The lower branches (#1856, #1857, #1852, #1854, #1888, #1861, #1862, #1863, #1864) have landed, so this branch is now a single commit rebased onto `main`. The original incremental development history remains visible in #1799's earlier timeline and in the backup refs recorded in the working notes.
