### PR TITLE
[kyo-system] take an advisory lock on a path

### DIFF
--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -161,9 +161,9 @@ source. Platform tests are reserved for genuine host integration differences.
 
 Use the reusable suites for backend laws:
 
-- `FileSystemReadTestSuite`
-- `FileSystemWriteTestSuite`
-- `FileSystemChannelTestSuite`
+- `FileSystemReadTest`
+- `FileSystemWriteTest`
+- `FileSystemChannelTest`
 - `FileSystemLockTest`
 
 Test capability rows with `typeCheck` and `typeCheckErrors`. Use deterministic `Async` coordination

--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -121,7 +121,8 @@ Locks are advisory, scope-managed values. `Path.LockMode` selects shared or excl
 `Path.LockWait` selects immediate, unbounded, or deadline-bounded acquisition. Fiber waiting must use
 `Async`; never block an OS thread. Ownership checks and cleanup failures remain typed.
 
-Every backend claims a sentinel sibling (`<resolved path>.kyo-lock`), never the data file. POSIX
+Every backend claims a sentinel sibling (`<resolved path>.kyo-lock` by default; the suffix is an
+optional parameter and part of the lock's identity), never the data file. POSIX
 `fcntl` record locks are process-wide and the OS releases every lock the process holds on a file
 when the process closes any handle to that file, silently and undetectably; locking a file the
 caller also reads or writes would therefore drop the claim on the first touch. The sentinel is a

--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -121,6 +121,12 @@ Locks are advisory, scope-managed values. `Path.LockMode` selects shared or excl
 `Path.LockWait` selects immediate, unbounded, or deadline-bounded acquisition. Fiber waiting must use
 `Async`; never block an OS thread. Ownership checks and cleanup failures remain typed.
 
+POSIX `fcntl` record locks (JVM and Native on Linux and macOS) are process-wide: the OS releases
+every lock the process holds on a file when the process closes any handle to that file, silently
+and undetectably. Documented on `Path.Lock`: callers lock a sentinel path, never the data path
+they read or write. Windows locks are handle-scoped; the Node backend uses a lockfile protocol.
+Neither is affected.
+
 ## Error contracts
 
 `FileSystemException` is the umbrella. Concrete exceptions mix in only the marker traits for the
@@ -158,7 +164,7 @@ Use the reusable suites for backend laws:
 - `FileSystemReadTestSuite`
 - `FileSystemWriteTestSuite`
 - `FileSystemChannelTestSuite`
-- `FileSystemLockTestSuite`
+- `FileSystemLockTest`
 
 Test capability rows with `typeCheck` and `typeCheckErrors`. Use deterministic `Async` coordination
 for lock tests. Never use sleeps or blocking primitives to make scheduling tests pass.

--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -121,11 +121,13 @@ Locks are advisory, scope-managed values. `Path.LockMode` selects shared or excl
 `Path.LockWait` selects immediate, unbounded, or deadline-bounded acquisition. Fiber waiting must use
 `Async`; never block an OS thread. Ownership checks and cleanup failures remain typed.
 
-POSIX `fcntl` record locks (JVM and Native on Linux and macOS) are process-wide: the OS releases
-every lock the process holds on a file when the process closes any handle to that file, silently
-and undetectably. Documented on `Path.Lock`: callers lock a sentinel path, never the data path
-they read or write. Windows locks are handle-scoped; the Node backend uses a lockfile protocol.
-Neither is affected.
+Every backend claims a sentinel sibling (`<resolved path>.kyo-lock`), never the data file. POSIX
+`fcntl` record locks are process-wide and the OS releases every lock the process holds on a file
+when the process closes any handle to that file, silently and undetectably; locking a file the
+caller also reads or writes would therefore drop the claim on the first touch. The sentinel is a
+file data I/O never opens, which closes that hole by construction, and it is the convention the
+Node lockfile protocol already used. The lock does not exclude a foreign process that locks the
+data file directly through the OS.
 
 ## Error contracts
 

--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -115,6 +115,12 @@ scope.
 - `Create` opens an existing file or creates it.
 - `CreateNew` fails if any target already exists.
 
+## Locks
+
+Locks are advisory, scope-managed values. `Path.LockMode` selects shared or exclusive compatibility.
+`Path.LockWait` selects immediate, unbounded, or deadline-bounded acquisition. Fiber waiting must use
+`Async`; never block an OS thread. Ownership checks and cleanup failures remain typed.
+
 ## Error contracts
 
 `FileSystemException` is the umbrella. Concrete exceptions mix in only the marker traits for the
@@ -123,6 +129,7 @@ operations that can raise them:
 - `FileReadException`
 - `FileWriteException`
 - `FileStructureException`
+- `FileLockException`
 
 Use `FileIOException(path, operation, cause)` only when no more precise leaf describes the failure.
 Preserve `Result.Panic` as a panic. Do not translate interruption, programmer defects, or unexpected
@@ -151,9 +158,10 @@ Use the reusable suites for backend laws:
 - `FileSystemReadTestSuite`
 - `FileSystemWriteTestSuite`
 - `FileSystemChannelTestSuite`
+- `FileSystemLockTestSuite`
 
-Test capability rows with `typeCheck` and `typeCheckErrors`. Never use sleeps or blocking primitives
-to make scheduling tests pass.
+Test capability rows with `typeCheck` and `typeCheckErrors`. Use deterministic `Async` coordination
+for lock tests. Never use sleeps or blocking primitives to make scheduling tests pass.
 
 Before submission, run the affected module tests on all four platforms and the module doctest. Read
 formatted files again after sbt completes because compilation formats sources.

--- a/kyo-system/README.md
+++ b/kyo-system/README.md
@@ -70,17 +70,16 @@ val positioned =
 ### Locks
 
 Advisory locks are scope-managed. Choose shared or exclusive compatibility and an explicit waiting
-policy. On POSIX platforms the JVM and Native locks are `fcntl` record locks, which the operating
-system silently releases when the process closes any other handle to the locked file, so lock a
-sentinel path and perform the I/O on the data path:
+policy. The claim is taken on a sentinel sibling of the path (`state.bin.kyo-lock` here), never on
+the path itself, so reading and writing the locked path while holding the lock is safe:
 
 ```scala
 import kyo.*
 
 val guarded = Scope.run {
     Path.run {
-        Path("state.lock").lock(Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
-            Path("state.bin").read.map(data => lock.check.andThen(Path("state.bin").write(data)))
+        Path("state.bin").lock(Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+            Path("state.bin").write("next").andThen(lock.check)
         }
     }
 }

--- a/kyo-system/README.md
+++ b/kyo-system/README.md
@@ -67,6 +67,21 @@ val positioned =
     }
 ```
 
+### Locks
+
+Advisory locks are scope-managed. Choose shared or exclusive compatibility and an explicit waiting
+policy:
+
+```scala
+import kyo.*
+
+val guarded = Scope.run {
+    Path.runReadOnly {
+        Path("state.bin").lock(Path.LockMode.Exclusive, Path.LockWait.Immediate).map(_.check)
+    }
+}
+```
+
 ## File paths
 
 Before reading or writing, you need a path value that identifies the target without touching the disk. `Path` is an immutable value built with the `/` operator or the `apply` factory; pure accessors like `parts` and `parent` require no capability.
@@ -314,6 +329,7 @@ val deleted: Boolean < (Sync & Abort[FileSystemException]) =
 | `FileReadException` | Inspection and content reads |
 | `FileWriteException` | Content mutation and synchronization |
 | `FileStructureException` | Creation, removal, copying, and movement |
+| `FileLockException` | Advisory lock acquisition and ownership |
 
 Each concrete exception implements only the marker traits that apply to it. After `Path.runReadOnly`, the runner folds the markers into `Abort[FileSystemException]`:
 

--- a/kyo-system/README.md
+++ b/kyo-system/README.md
@@ -70,14 +70,18 @@ val positioned =
 ### Locks
 
 Advisory locks are scope-managed. Choose shared or exclusive compatibility and an explicit waiting
-policy:
+policy. On POSIX platforms the JVM and Native locks are `fcntl` record locks, which the operating
+system silently releases when the process closes any other handle to the locked file, so lock a
+sentinel path and perform the I/O on the data path:
 
 ```scala
 import kyo.*
 
 val guarded = Scope.run {
-    Path.runReadOnly {
-        Path("state.bin").lock(Path.LockMode.Exclusive, Path.LockWait.Immediate).map(_.check)
+    Path.run {
+        Path("state.lock").lock(Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+            Path("state.bin").read.map(data => lock.check.andThen(Path("state.bin").write(data)))
+        }
     }
 }
 ```

--- a/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -27,6 +27,7 @@ private[kyo] object NodeFs extends js.Object:
     def mkdirSync(path: String, options: js.Dynamic): Unit                                     = js.native
     def readdirSync(path: String): js.Array[String]                                            = js.native
     def renameSync(oldPath: String, newPath: String): Unit                                     = js.native
+    def linkSync(existingPath: String, newPath: String): Unit                                  = js.native
     def copyFileSync(src: String, dest: String, flags: Int): Unit                              = js.native
     def unlinkSync(path: String): Unit                                                         = js.native
     def rmSync(path: String, options: js.Dynamic): Unit                                        = js.native
@@ -83,6 +84,7 @@ private[kyo] object NodePath extends js.Object:
     def resolve(paths: String*): String   = js.native
     def isAbsolute(path: String): Boolean = js.native
     def join(paths: String*): String      = js.native
+    def basename(path: String): String    = js.native
     def dirname(path: String): String     = js.native
     def sep: String                       = js.native
     def delimiter: String                 = js.native
@@ -93,6 +95,7 @@ end NodePath
 private[kyo] object NodeOs extends js.Object:
     def tmpdir(): String   = js.native
     def homedir(): String  = js.native
+    def hostname(): String = js.native
     def platform(): String = js.native
 end NodeOs
 
@@ -166,7 +169,331 @@ private[kyo] object NodeError:
             case "EINVAL"           => FileInvalidPathException(path.toString, operation)
             case _                  => FileIOException(path, operation, e)
 
+    /** Distinguishes the O_EXCL lockfile contention code (`EEXIST`) from every other filesystem
+      * error `Path.Unsafe.lock` can raise.
+      */
+    def translateLock(path: Path, e: js.JavaScriptException)(using Frame): FileLockException =
+        codeOf(e) match
+            case "EEXIST" => FileLockUnavailableException(path)
+            case "EINVAL" => FileInvalidPathException(path.toString, FileSystemOperation.Lock)
+            case _        => FileIOException(path, FileSystemOperation.Lock, e)
+
 end NodeError
+
+// --- Node advisory lock protocol ---
+
+private[kyo] object NodePathLock:
+
+    final private[kyo] case class Owner(host: String, pid: Int, token: String) derives CanEqual:
+        def render: String = s"$host\n$pid\n$token"
+
+    private object Owner:
+        def parse(value: String): Maybe[Owner] =
+            value.split("\n", -1).toSeq match
+                case Seq(host, pid, token) if host.nonEmpty && token.nonEmpty =>
+                    pid.toIntOption.fold[Maybe[Owner]](Absent)(value => Present(Owner(host, value, token)))
+                case _ => Absent
+    end Owner
+
+    private def currentOwner(): Owner =
+        val bytes = NodeCrypto.randomBytes(16)
+        val token = bytes.applyDynamic("toString")("hex").asInstanceOf[String]
+        Owner(
+            NodeOs.hostname(),
+            js.Dynamic.global.process.selectDynamic("pid").asInstanceOf[Int],
+            token
+        )
+    end currentOwner
+
+    private def exists(path: String): Boolean = NodeFs.existsSync(path)
+
+    private def ownerAt(path: String): Maybe[Owner] =
+        try Owner.parse(NodeFs.readFileSync(path, "utf8"))
+        catch case _: js.JavaScriptException => Absent
+
+    private def processIsDead(owner: Owner): Boolean =
+        if owner.host != NodeOs.hostname() then false
+        else
+            try
+                discard(js.Dynamic.global.process.applyDynamic("kill")(owner.pid, 0))
+                false
+            catch
+                case e: js.JavaScriptException => NodeError.codeOf(e) == "ESRCH"
+
+    private def encodeHost(host: String): String =
+        host.toCharArray.iterator.map { char =>
+            val hex = Integer.toHexString(char.toInt)
+            "0" * (4 - hex.length) + hex
+        }.mkString
+
+    private def decodeHost(encoded: String): Maybe[String] =
+        if encoded.isEmpty || encoded.length % 4 != 0 then Absent
+        else
+            try Present(encoded.grouped(4).map(value => Integer.parseInt(value, 16).toChar).mkString)
+            catch case _: NumberFormatException => Absent
+
+    private[kyo] def publicationPath(path: String, host: String, pid: Int, token: String): String =
+        path + ".publish." + encodeHost(host) + "." + pid + "." + token
+
+    private def publicationPath(path: String, owner: Owner): String =
+        publicationPath(path, owner.host, owner.pid, owner.token)
+
+    private def publicationOwner(path: String): Maybe[Owner] =
+        val marker = ".publish."
+        val index  = path.lastIndexOf(marker)
+        if index < 0 then Absent
+        else
+            path.substring(index + marker.length).split("\\.", -1).toSeq match
+                case Seq(host, pid, token) if token.nonEmpty =>
+                    decodeHost(host).flatMap(decoded =>
+                        pid.toIntOption.filter(_ > 0).fold[Maybe[Owner]](Absent)(value => Present(Owner(decoded, value, token)))
+                    )
+                case _ => Absent
+        end if
+    end publicationOwner
+
+    private[kyo] def reclaimIfProvenDead(path: String, beforeMove: () => Unit = () => ()): Boolean =
+        ownerAt(path) match
+            case Present(expected) if processIsDead(expected) =>
+                val quarantine = path + ".reclaim." + currentOwner().token
+                try
+                    beforeMove()
+                    NodeFs.renameSync(path, quarantine)
+                    ownerAt(quarantine) match
+                        case Present(actual) if actual == expected && processIsDead(actual) =>
+                            NodeFs.unlinkSync(quarantine)
+                            true
+                        case _ => false
+                    end match
+                catch case _: js.JavaScriptException => false
+                end try
+            case _ => false
+
+    private def withCleanup[A](
+        target: Path,
+        primary: Result[FileLockException, A],
+        cleanup: Result[FileLockException, Unit]
+    )(using Frame): Result[FileLockException, A] =
+        cleanup match
+            case Result.Success(_) => primary
+            case Result.Failure(cleanup) =>
+                primary match
+                    case Result.Success(_)       => Result.fail(cleanup)
+                    case Result.Failure(primary) => Result.fail(FileLockCleanupException(target, primary, cleanup))
+                    case Result.Panic(primary) =>
+                        primary.addSuppressed(cleanup)
+                        Result.panic(primary)
+            case Result.Panic(cleanup) =>
+                primary match
+                    case Result.Success(_) => Result.panic(cleanup)
+                    case Result.Failure(primary) =>
+                        cleanup.addSuppressed(primary)
+                        Result.panic(cleanup)
+                    case Result.Panic(primary) =>
+                        primary.addSuppressed(cleanup)
+                        Result.panic(primary)
+    end withCleanup
+
+    private def publications(path: String): Seq[String] =
+        val parent = NodePath.dirname(path)
+        val prefix = NodePath.basename(path) + ".publish."
+        NodeFs.readdirSync(parent).toSeq
+            .filter(_.startsWith(prefix))
+            .map(NodePath.join(parent, _))
+    end publications
+
+    private def reclaimPublicationIfProvenDead(path: String): Boolean =
+        publicationOwner(path) match
+            case Present(owner) if processIsDead(owner) =>
+                try
+                    NodeFs.unlinkSync(path)
+                    true
+                catch case _: js.JavaScriptException => false
+            case _ => false
+
+    private def publicationBlocked(path: String): Boolean =
+        publications(path).foreach(reclaimPublicationIfProvenDead)
+        publications(path).exists(exists)
+
+    private def claimPublications(base: String): Seq[String] =
+        val parent = NodePath.dirname(base)
+        val prefix = NodePath.basename(base) + "."
+        NodeFs.readdirSync(parent).toSeq
+            .filter(name => name.startsWith(prefix) && name.contains(".publish."))
+            .map(NodePath.join(parent, _))
+    end claimPublications
+
+    private def create(
+        target: Path,
+        path: String,
+        owner: Owner,
+        beforeCleanup: String => Unit
+    )(using Frame): Result[FileLockException, Boolean] =
+        val temporary      = publicationPath(path, owner)
+        var temporaryOwned = false
+        val published: Result[FileLockException, Boolean] =
+            try
+                if publicationBlocked(path) then Result.succeed(false)
+                else
+                    NodeFs.writeFileSync(temporary, owner.render, js.Dynamic.literal(flag = "wx"))
+                    temporaryOwned = true
+                    NodeFs.linkSync(temporary, path)
+                    Result.succeed(true)
+            catch
+                case e: js.JavaScriptException if NodeError.codeOf(e) == "EEXIST" => Result.succeed(false)
+                case e: js.JavaScriptException                                    => Result.fail(NodeError.translateLock(target, e))
+                case e: Throwable                                                 => Result.panic(e)
+        val cleanup =
+            if !temporaryOwned then Result.unit
+            else
+                try
+                    beforeCleanup(temporary)
+                    NodeFs.unlinkSync(temporary)
+                    Result.unit
+                catch
+                    case e: js.JavaScriptException if NodeError.codeOf(e) == "ENOENT" => Result.unit
+                    case e: js.JavaScriptException                                    => Result.fail(NodeError.translateLock(target, e))
+                    case e: Throwable                                                 => Result.panic(e)
+        cleanup match
+            case Result.Success(_) => published
+            case cleanupFailure =>
+                published match
+                    case Result.Success(true) =>
+                        withCleanup(target, cleanupFailure, releaseOwned(target, path, owner)) match
+                            case Result.Success(_)     => Result.fail(FileLockOwnershipLostException(target))
+                            case Result.Failure(error) => Result.fail(error)
+                            case Result.Panic(error)   => Result.panic(error)
+                    case _ => withCleanup(target, published, cleanup)
+        end match
+    end create
+
+    private def acquireGate(target: Path, gate: String, owner: Owner, beforeCleanup: String => Unit)(using
+        Frame
+    ): Result[FileLockException, Boolean] =
+        try
+            val parent = NodePath.dirname(gate)
+            val name   = NodePath.basename(gate)
+            def gates = NodeFs.readdirSync(parent).toSeq
+                .filter(value => value == name || value.startsWith(name + ".reclaim."))
+                .map(NodePath.join(parent, _))
+            gates.foreach(reclaimIfProvenDead(_))
+            if gates.exists(exists) then Result.succeed(false) else create(target, gate, owner, beforeCleanup)
+        catch
+            case e: js.JavaScriptException => Result.fail(NodeError.translateLock(target, e))
+            case e: Throwable              => Result.panic(e)
+    end acquireGate
+
+    private def releaseOwned(target: Path, path: String, owner: Owner)(using Frame): Result[FileLockException, Unit] =
+        try
+            Owner.parse(NodeFs.readFileSync(path, "utf8")) match
+                case Present(found) if found == owner =>
+                    NodeFs.unlinkSync(path)
+                    Result.unit
+                case _ => Result.fail(FileLockOwnershipLostException(target))
+        catch
+            case e: js.JavaScriptException if NodeError.codeOf(e) == "ENOENT" =>
+                Result.fail(FileLockOwnershipLostException(target))
+            case e: js.JavaScriptException => Result.fail(NodeError.translateLock(target, e))
+            case e: Throwable              => Result.panic(e)
+        end try
+    end releaseOwned
+
+    private def conflictingClaims(base: String, mode: Path.LockMode): Seq[String] =
+        val parent          = NodePath.dirname(base)
+        val name            = NodePath.basename(base)
+        val exclusiveName   = name + ".exclusive"
+        val sharedNameStart = name + ".shared."
+        val names           = NodeFs.readdirSync(parent).toSeq
+        val exclusiveClaims = names.filter(value =>
+            value == exclusiveName ||
+                value.startsWith(exclusiveName + ".reclaim.") ||
+                value.startsWith(exclusiveName + ".publish.")
+        )
+            .map(NodePath.join(parent, _))
+        val shared =
+            if mode == Path.LockMode.Shared then Seq.empty
+            else
+                names.filter(value => value.startsWith(sharedNameStart))
+                    .map(NodePath.join(parent, _))
+        exclusiveClaims ++ shared
+    end conflictingClaims
+
+    def acquire(
+        target: Path,
+        pathStr: String,
+        mode: Path.LockMode,
+        beforeGateRelease: (String, String) => Unit = (_, _) => (),
+        beforePublishCleanup: String => Unit = _ => ()
+    )(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock] =
+        val base                                 = pathStr + ".kyo-lock"
+        val gate                                 = base + ".gate"
+        val gateOwner                            = currentOwner()
+        var gateAcquired                         = false
+        var createdClaim: Maybe[(String, Owner)] = Absent
+        val acquired: Result[FileLockException, Path.RawLock] =
+            try
+                acquireGate(target, gate, gateOwner, beforePublishCleanup) match
+                    case Result.Failure(error) => Result.fail(error)
+                    case Result.Panic(error)   => Result.panic(error)
+                    case Result.Success(false) => Result.fail(FileLockUnavailableException(target))
+                    case Result.Success(true) =>
+                        gateAcquired = true
+                        claimPublications(base).foreach(reclaimPublicationIfProvenDead)
+                        val result =
+                            if claimPublications(base).exists(exists) then
+                                Result.fail(FileLockUnavailableException(target))
+                            else
+                                val conflicts = conflictingClaims(base, mode).filter(exists)
+                                conflicts.foreach(reclaimIfProvenDead(_))
+                                if conflictingClaims(base, mode).exists(exists) then
+                                    Result.fail(FileLockUnavailableException(target))
+                                else
+                                    val owner = currentOwner()
+                                    val claim = mode match
+                                        case Path.LockMode.Exclusive => base + ".exclusive"
+                                        case Path.LockMode.Shared    => base + ".shared." + owner.token
+                                    create(target, claim, owner, beforePublishCleanup) match
+                                        case Result.Success(true) =>
+                                            createdClaim = Present((claim, owner))
+                                            Result.succeed(new NodeRawLock(target, claim, owner, mode))
+                                        case Result.Success(false) => Result.fail(FileLockUnavailableException(target))
+                                        case Result.Failure(error) => Result.fail(error)
+                                        case Result.Panic(error)   => Result.panic(error)
+                                    end match
+                                end if
+                        end result
+                        beforeGateRelease(gate, createdClaim.fold("")(_._1))
+                        result
+                end match
+            catch
+                case e: js.JavaScriptException => Result.fail(NodeError.translateLock(target, e))
+                case e: Throwable              => Result.panic(e)
+            end try
+        end acquired
+        if !gateAcquired then acquired
+        else
+            releaseOwned(target, gate, gateOwner) match
+                case Result.Success(_) => acquired
+                case Result.Failure(error) =>
+                    val gateFailure: Result[FileLockException, Path.RawLock] = Result.fail(error)
+                    createdClaim match
+                        case Present((claim, owner)) => withCleanup(target, gateFailure, releaseOwned(target, claim, owner))
+                        case Absent                  => gateFailure
+                case Result.Panic(error) =>
+                    val gateFailure: Result[FileLockException, Path.RawLock] = Result.panic(error)
+                    createdClaim match
+                        case Present((claim, owner)) => withCleanup(target, gateFailure, releaseOwned(target, claim, owner))
+                        case Absent                  => gateFailure
+            end match
+        end if
+    end acquire
+
+    private[kyo] def owns(claim: String, owner: Owner): Boolean = ownerAt(claim).exists(_ == owner)
+
+    private[kyo] def release(target: Path, claim: String, owner: Owner)(using Frame): Result[FileLockException, Unit] =
+        releaseOwned(target, claim, owner)
+
+end NodePathLock
 
 // --- NodePathUnsafe ---
 
@@ -567,6 +894,14 @@ final private[kyo] class NodePathUnsafe(raw: String) extends Path.Unsafe:
     ): Result[FileReadException | FileWriteException | FileStructureException, Path.RawChannel] =
         catchChannelWrite(openRawChannel(Path.RawChannelAccess.ReadWrite(open)))
 
+    // --- Advisory lock ---
+
+    // Node has no OS advisory lock primitive. NodePathLock uses owner-tagged O_EXCL control files
+    // for portable shared and exclusive claims, and only reclaims claims proven to belong to a dead
+    // process on the local host.
+    def lock(mode: Path.LockMode)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock] =
+        NodePathLock.acquire(safe, pathStr, mode)
+
     // --- Private helpers ---
 
     /** Splits content by newlines, dropping a single trailing empty element if the content ends with '\n'. This matches the behaviour of
@@ -886,6 +1221,29 @@ final private[kyo] class NodeRawChannel(fd: Int, path: Path) extends Path.RawCha
         if closed.compareAndSet(false, true) then NodeFs.closeSync(fd)
 
 end NodeRawChannel
+
+// --- NodeRawLock ---
+
+/** Concrete advisory lock backed by an owner-tagged O_EXCL control file. Shared handles use
+  * independent claims, while exclusive handles use the path's single exclusive claim.
+  */
+final private[kyo] class NodeRawLock(
+    path: Path,
+    claim: String,
+    owner: NodePathLock.Owner,
+    mode: Path.LockMode
+) extends Path.RawLock:
+    def isExclusive: Boolean = mode == Path.LockMode.Exclusive
+
+    def check()(using AllowUnsafe, Frame): Result[FileLockException, Unit] =
+        if NodePathLock.owns(claim, owner) then Result.unit
+        else Result.fail(FileLockOwnershipLostException(path))
+
+    // Unsafe: removes only this handle's owner-tagged claim. Missing and mismatched claims report
+    // ownership loss; filesystem failures retain their typed lock error.
+    def release()(using AllowUnsafe, Frame): Result[FileLockException, Unit] =
+        NodePathLock.release(path, claim, owner)
+end NodeRawLock
 
 // --- Byte / Uint8Array conversion helpers ---
 

--- a/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -422,10 +422,11 @@ private[kyo] object NodePathLock:
         target: Path,
         pathStr: String,
         mode: Path.LockMode,
+        sentinelSuffix: String = Path.defaultLockSuffix,
         beforeGateRelease: (String, String) => Unit = (_, _) => (),
         beforePublishCleanup: String => Unit = _ => ()
     )(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock] =
-        val base                                 = pathStr + ".kyo-lock"
+        val base                                 = pathStr + sentinelSuffix
         val gate                                 = base + ".gate"
         val gateOwner                            = currentOwner()
         var gateAcquired                         = false
@@ -899,8 +900,8 @@ final private[kyo] class NodePathUnsafe(raw: String) extends Path.Unsafe:
     // Node has no OS advisory lock primitive. NodePathLock uses owner-tagged O_EXCL control files
     // for portable shared and exclusive claims, and only reclaims claims proven to belong to a dead
     // process on the local host.
-    def lock(mode: Path.LockMode)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock] =
-        NodePathLock.acquire(safe, pathStr, mode)
+    def lock(mode: Path.LockMode, sentinelSuffix: String)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock] =
+        NodePathLock.acquire(safe, pathStr, mode, sentinelSuffix)
 
     // --- Private helpers ---
 

--- a/kyo-system/js/src/test/scala/kyo/HostFileSystemSymlinkJsTest.scala
+++ b/kyo-system/js/src/test/scala/kyo/HostFileSystemSymlinkJsTest.scala
@@ -8,7 +8,7 @@ import kyo.internal.NodeFs
   * `isSymbolicLink`. Running the same contract here is what keeps the symlink-escape fix asserted on
   * this platform rather than inferred from the JVM passing.
   */
-class HostFileSystemSymlinkJsTest extends FileSystemReadTestSuite:
+class HostFileSystemSymlinkJsTest extends FileSystemReadTest:
 
     override protected def realPathRequiresExistence: Boolean = true
     override protected def supportsSymbolicLinks: Boolean     = true

--- a/kyo-system/js/src/test/scala/kyo/internal/PathPlatformSpecificLockJsTest.scala
+++ b/kyo-system/js/src/test/scala/kyo/internal/PathPlatformSpecificLockJsTest.scala
@@ -1,0 +1,236 @@
+package kyo.internal
+
+import kyo.*
+
+class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
+
+    private def withTarget[A](use: String => A < Sync)(using Frame): A < Sync =
+        Sync.Unsafe.defer {
+            val dir = NodeFs.mkdtempSync(NodePath.join(NodeOs.tmpdir(), "kyo-lock-stale-"))
+            Sync.ensure(Sync.Unsafe.defer(NodeFs.rmSync(dir, scala.scalajs.js.Dynamic.literal(recursive = true, force = true)))) {
+                use(NodePath.join(dir, "target.bin"))
+            }
+        }
+
+    "proven same-host dead owner is reclaimed" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val stale = target + ".kyo-lock.exclusive"
+                NodeFs.writeFileSync(stale, s"${NodeOs.hostname()}\n2147483647\ndead-owner")
+                val acquired = new NodePathUnsafe(target).lock(Path.LockMode.Shared)
+                acquired match
+                    case Result.Success(lock) =>
+                        assert(!lock.isExclusive)
+                        assert(lock.release().isSuccess)
+                    case other => assert(false, s"expected reclaimed shared lock, got $other")
+                end match
+            }
+        }
+    }
+
+    "foreign-host owner fails closed" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val claim = target + ".kyo-lock.exclusive"
+                NodeFs.writeFileSync(claim, "different-host\n2147483647\nforeign-owner")
+                new NodePathUnsafe(target).lock(Path.LockMode.Shared) match
+                    case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(claim))
+                    case other                                           => assert(false, s"expected unavailable foreign claim, got $other")
+            }
+        }
+    }
+
+    "unreadable owner fails closed" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val claim = target + ".kyo-lock.exclusive"
+                NodeFs.writeFileSync(claim, "invalid-owner-record")
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                    case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(claim))
+                    case other => assert(false, s"expected unavailable unreadable claim, got $other")
+            }
+        }
+    }
+
+    "stale gate reclamation cannot delete a replacement owner" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val gate = target + ".kyo-lock.gate"
+                NodeFs.writeFileSync(gate, s"${NodeOs.hostname()}\n2147483647\ndead-gate")
+                val reclaimed = NodePathLock.reclaimIfProvenDead(
+                    gate,
+                    () =>
+                        NodeFs.unlinkSync(gate)
+                        NodeFs.writeFileSync(gate, "different-host\n1\nlive-replacement")
+                )
+                assert(!reclaimed)
+                val prefix = NodePath.basename(gate) + ".reclaim."
+                assert(NodeFs.readdirSync(NodePath.dirname(gate)).toSeq.exists(_.startsWith(prefix)))
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                    case Result.Failure(_: FileLockUnavailableException) => assert(true)
+                    case other => assert(false, s"expected replacement gate to remain authoritative, got $other")
+            }
+        }
+    }
+
+    "gate acquisition errors remain typed" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val missing = NodePath.join(target + "-missing", "target.bin")
+                new NodePathUnsafe(missing).lock(Path.LockMode.Exclusive) match
+                    case Result.Failure(_: FileLockException) => assert(true)
+                    case other                                => assert(false, s"expected typed lock failure, got $other")
+            }
+        }
+    }
+
+    "removing an owned claim surfaces ownership loss on release" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                    case Result.Success(lock) =>
+                        NodeFs.unlinkSync(target + ".kyo-lock.exclusive")
+                        assert(lock.check().isFailure)
+                        lock.release() match
+                            case Result.Failure(_: FileLockOwnershipLostException) => assert(true)
+                            case other => assert(false, s"expected ownership loss from missing claim, got $other")
+                    case other => assert(false, s"expected acquired lock, got $other")
+            }
+        }
+    }
+
+    "a publication from a separate live worker blocks without serial litter growth" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val gate = target + ".kyo-lock.gate"
+                val publication = NodePathLock.publicationPath(
+                    gate,
+                    NodeOs.hostname(),
+                    scala.scalajs.js.Dynamic.global.process.selectDynamic("pid").asInstanceOf[Int],
+                    "separate-worker"
+                )
+                NodeFs.writeFileSync(publication, "partial")
+                (0 until 64).foreach { _ =>
+                    new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                        case Result.Failure(_: FileLockUnavailableException) => assert(true)
+                        case other => assert(false, s"expected live worker publication to block, got $other")
+                }
+                val publications = NodeFs.readdirSync(NodePath.dirname(gate)).toSeq
+                    .filter(_.startsWith(NodePath.basename(gate) + ".publish."))
+                assert(publications == Seq(NodePath.basename(publication)))
+            }
+        }
+    }
+
+    "malformed and foreign publications fail closed" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val gate      = target + ".kyo-lock.gate"
+                val malformed = target + ".kyo-lock.shared.partial.publish.malformed"
+                NodeFs.writeFileSync(malformed, "partial-owner")
+                new NodePathUnsafe(target).lock(Path.LockMode.Shared) match
+                    case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(malformed))
+                    case other => assert(false, s"expected malformed publication to block, got $other")
+                NodeFs.unlinkSync(malformed)
+                val invalidPid = NodePathLock.publicationPath(gate, NodeOs.hostname(), -2147483647, "invalid-pid")
+                NodeFs.writeFileSync(invalidPid, "partial-owner")
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                    case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(invalidPid))
+                    case other => assert(false, s"expected invalid publication pid to block, got $other")
+                NodeFs.unlinkSync(invalidPid)
+                val foreign = NodePathLock.publicationPath(gate, "different-host", 1, "foreign-worker")
+                NodeFs.writeFileSync(foreign, "partial-owner")
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                    case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(foreign))
+                    case other => assert(false, s"expected foreign publication to block, got $other")
+            }
+        }
+    }
+
+    "a publication owned by a proven dead process is reclaimed from its filename" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val gate = target + ".kyo-lock.gate"
+                val publication = NodePathLock.publicationPath(
+                    gate,
+                    NodeOs.hostname(),
+                    2147483647,
+                    "dead-worker"
+                )
+                NodeFs.writeFileSync(publication, "partial-owner")
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                    case Result.Success(lock) =>
+                        assert(!NodeFs.existsSync(publication))
+                        assert(lock.release().isSuccess)
+                    case other => assert(false, s"expected dead publication reclamation, got $other")
+                end match
+            }
+        }
+    }
+
+    "live publication cleanup failure is typed and rolls back the claim" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val result = NodePathLock.acquire(
+                    Path(target),
+                    target,
+                    Path.LockMode.Exclusive,
+                    beforePublishCleanup = temporary =>
+                        if temporary.contains(".exclusive.publish.") then
+                            NodeFs.unlinkSync(temporary)
+                            NodeFs.mkdirSync(temporary, scala.scalajs.js.Dynamic.literal())
+                )
+                result match
+                    case Result.Failure(_: FileIOException) =>
+                        assert(!NodeFs.existsSync(target + ".kyo-lock.exclusive"))
+                    case other => assert(false, s"expected typed publication cleanup failure, got $other")
+                end match
+            }
+        }
+    }
+
+    "gate cleanup failure cannot return a healthy claim" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val result = NodePathLock.acquire(
+                    Path(target),
+                    target,
+                    Path.LockMode.Exclusive,
+                    (gate, _) =>
+                        NodeFs.unlinkSync(gate)
+                        NodeFs.writeFileSync(gate, "different-host\n1\nreplacement-gate")
+                )
+                result match
+                    case Result.Failure(_: FileLockOwnershipLostException) =>
+                        assert(!NodeFs.existsSync(target + ".kyo-lock.exclusive"))
+                    case other => assert(false, s"expected typed gate cleanup failure, got $other")
+                end match
+            }
+        }
+    }
+
+    "gate cleanup and claim rollback failures are both reported" in {
+        withTarget { target =>
+            Sync.Unsafe.defer {
+                val result = NodePathLock.acquire(
+                    Path(target),
+                    target,
+                    Path.LockMode.Exclusive,
+                    (gate, claim) =>
+                        NodeFs.unlinkSync(gate)
+                        NodeFs.writeFileSync(gate, "different-host\n1\nreplacement-gate")
+                        NodeFs.unlinkSync(claim)
+                        NodeFs.writeFileSync(claim, "different-host\n1\nreplacement-claim")
+                )
+                result match
+                    case Result.Failure(error: FileLockCleanupException) =>
+                        assert(error.primary.isInstanceOf[FileLockOwnershipLostException])
+                        assert(error.cleanup.isInstanceOf[FileLockOwnershipLostException])
+                        assert(NodeFs.existsSync(target + ".kyo-lock.exclusive"))
+                    case other => assert(false, s"expected combined cleanup failure, got $other")
+                end match
+            }
+        }
+    }
+
+end PathPlatformSpecificLockJsTest

--- a/kyo-system/js/src/test/scala/kyo/internal/PathPlatformSpecificLockJsTest.scala
+++ b/kyo-system/js/src/test/scala/kyo/internal/PathPlatformSpecificLockJsTest.scala
@@ -17,7 +17,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
             Sync.Unsafe.defer {
                 val stale = target + ".kyo-lock.exclusive"
                 NodeFs.writeFileSync(stale, s"${NodeOs.hostname()}\n2147483647\ndead-owner")
-                val acquired = new NodePathUnsafe(target).lock(Path.LockMode.Shared)
+                val acquired = new NodePathUnsafe(target).lock(Path.LockMode.Shared, Path.defaultLockSuffix)
                 acquired match
                     case Result.Success(lock) =>
                         assert(!lock.isExclusive)
@@ -33,7 +33,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
             Sync.Unsafe.defer {
                 val claim = target + ".kyo-lock.exclusive"
                 NodeFs.writeFileSync(claim, "different-host\n2147483647\nforeign-owner")
-                new NodePathUnsafe(target).lock(Path.LockMode.Shared) match
+                new NodePathUnsafe(target).lock(Path.LockMode.Shared, Path.defaultLockSuffix) match
                     case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(claim))
                     case other                                           => assert(false, s"expected unavailable foreign claim, got $other")
             }
@@ -45,7 +45,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
             Sync.Unsafe.defer {
                 val claim = target + ".kyo-lock.exclusive"
                 NodeFs.writeFileSync(claim, "invalid-owner-record")
-                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive, Path.defaultLockSuffix) match
                     case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(claim))
                     case other => assert(false, s"expected unavailable unreadable claim, got $other")
             }
@@ -66,7 +66,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
                 assert(!reclaimed)
                 val prefix = NodePath.basename(gate) + ".reclaim."
                 assert(NodeFs.readdirSync(NodePath.dirname(gate)).toSeq.exists(_.startsWith(prefix)))
-                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive, Path.defaultLockSuffix) match
                     case Result.Failure(_: FileLockUnavailableException) => assert(true)
                     case other => assert(false, s"expected replacement gate to remain authoritative, got $other")
             }
@@ -77,7 +77,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
         withTarget { target =>
             Sync.Unsafe.defer {
                 val missing = NodePath.join(target + "-missing", "target.bin")
-                new NodePathUnsafe(missing).lock(Path.LockMode.Exclusive) match
+                new NodePathUnsafe(missing).lock(Path.LockMode.Exclusive, Path.defaultLockSuffix) match
                     case Result.Failure(_: FileLockException) => assert(true)
                     case other                                => assert(false, s"expected typed lock failure, got $other")
             }
@@ -87,7 +87,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
     "removing an owned claim surfaces ownership loss on release" in {
         withTarget { target =>
             Sync.Unsafe.defer {
-                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive, Path.defaultLockSuffix) match
                     case Result.Success(lock) =>
                         NodeFs.unlinkSync(target + ".kyo-lock.exclusive")
                         assert(lock.check().isFailure)
@@ -111,7 +111,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
                 )
                 NodeFs.writeFileSync(publication, "partial")
                 (0 until 64).foreach { _ =>
-                    new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                    new NodePathUnsafe(target).lock(Path.LockMode.Exclusive, Path.defaultLockSuffix) match
                         case Result.Failure(_: FileLockUnavailableException) => assert(true)
                         case other => assert(false, s"expected live worker publication to block, got $other")
                 }
@@ -128,19 +128,19 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
                 val gate      = target + ".kyo-lock.gate"
                 val malformed = target + ".kyo-lock.shared.partial.publish.malformed"
                 NodeFs.writeFileSync(malformed, "partial-owner")
-                new NodePathUnsafe(target).lock(Path.LockMode.Shared) match
+                new NodePathUnsafe(target).lock(Path.LockMode.Shared, Path.defaultLockSuffix) match
                     case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(malformed))
                     case other => assert(false, s"expected malformed publication to block, got $other")
                 NodeFs.unlinkSync(malformed)
                 val invalidPid = NodePathLock.publicationPath(gate, NodeOs.hostname(), -2147483647, "invalid-pid")
                 NodeFs.writeFileSync(invalidPid, "partial-owner")
-                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive, Path.defaultLockSuffix) match
                     case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(invalidPid))
                     case other => assert(false, s"expected invalid publication pid to block, got $other")
                 NodeFs.unlinkSync(invalidPid)
                 val foreign = NodePathLock.publicationPath(gate, "different-host", 1, "foreign-worker")
                 NodeFs.writeFileSync(foreign, "partial-owner")
-                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive, Path.defaultLockSuffix) match
                     case Result.Failure(_: FileLockUnavailableException) => assert(NodeFs.existsSync(foreign))
                     case other => assert(false, s"expected foreign publication to block, got $other")
             }
@@ -158,7 +158,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
                     "dead-worker"
                 )
                 NodeFs.writeFileSync(publication, "partial-owner")
-                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive) match
+                new NodePathUnsafe(target).lock(Path.LockMode.Exclusive, Path.defaultLockSuffix) match
                     case Result.Success(lock) =>
                         assert(!NodeFs.existsSync(publication))
                         assert(lock.release().isSuccess)
@@ -196,7 +196,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
                     Path(target),
                     target,
                     Path.LockMode.Exclusive,
-                    (gate, _) =>
+                    beforeGateRelease = (gate, _) =>
                         NodeFs.unlinkSync(gate)
                         NodeFs.writeFileSync(gate, "different-host\n1\nreplacement-gate")
                 )
@@ -216,7 +216,7 @@ class PathPlatformSpecificLockJsTest extends kyo.test.Test[Any]:
                     Path(target),
                     target,
                     Path.LockMode.Exclusive,
-                    (gate, claim) =>
+                    beforeGateRelease = (gate, claim) =>
                         NodeFs.unlinkSync(gate)
                         NodeFs.writeFileSync(gate, "different-host\n1\nreplacement-gate")
                         NodeFs.unlinkSync(claim)

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -351,10 +351,9 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
     // arriving under different names then open two channels to one file, which the JVM refuses as an
     // overlapping claim: a lock the contract grants, denied.
     //
-    // toRealPath resolves links but requires the file to exist, and lock() creates it. Falling back
-    // to the parent's real path plus the file name covers the not-yet-created case, since a link in
-    // the ancestry still collapses. When neither resolves, the normalized absolute path is the best
-    // name available and matches the previous behaviour.
+    // toRealPath resolves links but requires the file to exist. Falling back to the parent's real
+    // path plus the file name covers the not-yet-created case, since a link in the ancestry still
+    // collapses. When neither resolves, the normalized absolute path is the best name available.
     private def registryKey(using AllowUnsafe): String =
         val absolute = jpath.toAbsolutePath.normalize()
         try absolute.toRealPath().toString
@@ -369,6 +368,16 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
                 end if
         end try
     end registryKey
+
+    // The claim is taken on a sentinel sibling, never on the data file. POSIX releases every fcntl
+    // lock a process holds on a file when the process closes any handle to that file, so a lock on
+    // the data file itself evaporates the moment the same process reads or writes it. The sentinel
+    // is a file data I/O never opens, which closes that hole by construction. The suffix matches
+    // the one the Node backend already claims, so every backend agrees on what is locked, and it
+    // hangs off the resolved registry key so two names for one data file still claim one sentinel.
+    // The sentinel may outlive the process as an empty artifact; the lock on it dies with the
+    // process, so a leftover file is inert.
+    private def sentinel(key: String): String = key + ".kyo-lock"
 
     // Collapses the pending answer onto a failure, which is all a caller that cannot wait can do
     // with it. Callers that can wait take lockAttempt instead.
@@ -394,9 +403,10 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
             case NioPathLockRegistry.Reservation.First =>
                 settled {
                     try
-                        ensureParent(jpath)
+                        val sentinelPath = java.nio.file.Path.of(sentinel(key))
+                        ensureParent(sentinelPath)
                         val ch =
-                            FileChannel.open(jpath, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE)
+                            FileChannel.open(sentinelPath, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE)
                         try
                             val fl =
                                 try ch.tryLock(0L, Long.MaxValue, !isExclusive)

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -377,19 +377,21 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
     // hangs off the resolved registry key so two names for one data file still claim one sentinel.
     // The sentinel may outlive the process as an empty artifact; the lock on it dies with the
     // process, so a leftover file is inert.
-    private def sentinel(key: String): String = key + ".kyo-lock"
+    private def sentinel(key: String, suffix: String): String = key + suffix
 
     // Collapses the pending answer onto a failure, which is all a caller that cannot wait can do
     // with it. Callers that can wait take lockAttempt instead.
-    def lock(mode: Path.LockMode)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock] =
-        lockAttempt(mode) match
+    def lock(mode: Path.LockMode, sentinelSuffix: String)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock] =
+        lockAttempt(mode, sentinelSuffix) match
             case Path.LockAttempt.Acquired(raw) => Result.succeed(raw)
             case Path.LockAttempt.Pending       => Result.fail(FileLockUnavailableException(safe))
             case Path.LockAttempt.Failed(error) => error
 
-    override private[kyo] def lockAttempt(mode: Path.LockMode)(using AllowUnsafe, Frame): Path.LockAttempt =
+    override private[kyo] def lockAttempt(mode: Path.LockMode, sentinelSuffix: String)(using AllowUnsafe, Frame): Path.LockAttempt =
         val isExclusive = mode == Path.LockMode.Exclusive
-        val key         = registryKey
+        // The suffix is part of the lock's identity: claims under different suffixes contend on
+        // different sentinel files, so the registry keys on the sentinel, not on the data path.
+        val key = sentinel(registryKey, sentinelSuffix)
         def settled(result: Result[FileLockException, Path.RawLock]): Path.LockAttempt =
             result match
                 case Result.Success(raw)   => Path.LockAttempt.Acquired(raw)
@@ -403,7 +405,7 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
             case NioPathLockRegistry.Reservation.First =>
                 settled {
                     try
-                        val sentinelPath = java.nio.file.Path.of(sentinel(key))
+                        val sentinelPath = java.nio.file.Path.of(key)
                         ensureParent(sentinelPath)
                         val ch =
                             FileChannel.open(sentinelPath, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE)

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -4,6 +4,7 @@ import java.io.InterruptedIOException
 import java.io.IOException
 import java.nio.channels.ClosedByInterruptException
 import java.nio.channels.FileChannel
+import java.nio.channels.OverlappingFileLockException
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.nio.file.AccessDeniedException
@@ -336,6 +337,103 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
     ): Result[FileReadException | FileWriteException | FileStructureException, Path.RawChannel] =
         catchChannelWrite(openRawChannel(Path.RawChannelAccess.ReadWrite(open)))
 
+    // --- Advisory lock ---
+
+    // POSIX advisory locks (fcntl, backing FileChannel.tryLock on Scala Native's javalib) do not
+    // exclude the owning process from reacquiring its own lock; a second same-process tryLock
+    // simply succeeds instead of throwing OverlappingFileLockException there (unlike the JVM's own
+    // in-process FileLockTable). NioPathLockRegistry enforces same-process exclusion explicitly on
+    // every platform, mirroring kyo.internal.FileJournalCore's heldRoots registry (kyo-eventlog);
+    // the platform tryLock call still provides genuine cross-process exclusion underneath it.
+    // The registry key has to name the file, not the route taken to it. Path.make already normalizes
+    // away "." and ".." segments, so the remaining way to reach one file under two names is a
+    // symbolic link, and an unresolved key gives each name an entry of its own. Two shared claims
+    // arriving under different names then open two channels to one file, which the JVM refuses as an
+    // overlapping claim: a lock the contract grants, denied.
+    //
+    // toRealPath resolves links but requires the file to exist, and lock() creates it. Falling back
+    // to the parent's real path plus the file name covers the not-yet-created case, since a link in
+    // the ancestry still collapses. When neither resolves, the normalized absolute path is the best
+    // name available and matches the previous behaviour.
+    private def registryKey(using AllowUnsafe): String =
+        val absolute = jpath.toAbsolutePath.normalize()
+        try absolute.toRealPath().toString
+        catch
+            case _: IOException =>
+                val parent = absolute.getParent
+                val name   = absolute.getFileName
+                if parent == null || name == null then absolute.toString
+                else
+                    try parent.toRealPath().resolve(name).toString
+                    catch case _: IOException => absolute.toString
+                end if
+        end try
+    end registryKey
+
+    // Collapses the pending answer onto a failure, which is all a caller that cannot wait can do
+    // with it. Callers that can wait take lockAttempt instead.
+    def lock(mode: Path.LockMode)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock] =
+        lockAttempt(mode) match
+            case Path.LockAttempt.Acquired(raw) => Result.succeed(raw)
+            case Path.LockAttempt.Pending       => Result.fail(FileLockUnavailableException(safe))
+            case Path.LockAttempt.Failed(error) => error
+
+    override private[kyo] def lockAttempt(mode: Path.LockMode)(using AllowUnsafe, Frame): Path.LockAttempt =
+        val isExclusive = mode == Path.LockMode.Exclusive
+        val key         = registryKey
+        def settled(result: Result[FileLockException, Path.RawLock]): Path.LockAttempt =
+            result match
+                case Result.Success(raw)   => Path.LockAttempt.Acquired(raw)
+                case Result.Failure(error) => Path.LockAttempt.Failed(Result.Failure(error))
+                case panic: Result.Panic   => Path.LockAttempt.Failed(panic)
+        NioPathLockRegistry.reserve(key, isExclusive) match
+            case NioPathLockRegistry.Reservation.Denied  => Path.LockAttempt.Failed(Result.fail(FileLockUnavailableException(safe)))
+            case NioPathLockRegistry.Reservation.Pending => Path.LockAttempt.Pending
+            case NioPathLockRegistry.Reservation.SharedExisting =>
+                Path.LockAttempt.Acquired(new NioRawLock(key, isExclusive))
+            case NioPathLockRegistry.Reservation.First =>
+                settled {
+                    try
+                        ensureParent(jpath)
+                        val ch =
+                            FileChannel.open(jpath, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE)
+                        try
+                            val fl =
+                                try ch.tryLock(0L, Long.MaxValue, !isExclusive)
+                                catch case _: OverlappingFileLockException => null
+                            if fl == null then
+                                ch.close()
+                                NioPathLockRegistry.abort(key)
+                                Result.fail(FileLockUnavailableException(safe))
+                            else
+                                NioPathLockRegistry.install(key, fl, ch)
+                                Result.succeed(new NioRawLock(key, isExclusive))
+                            end if
+                        catch
+                            case e: IOException if NioExceptionBoundary.isInterrupted(e) =>
+                                discard(Result.catching[Throwable](ch.close()))
+                                NioPathLockRegistry.abort(key)
+                                Result.panic(e)
+                            case e: IOException =>
+                                ch.close()
+                                NioPathLockRegistry.abort(key)
+                                Result.fail(FileIOException(safe, FileSystemOperation.Lock, e))
+                        end try
+                    catch
+                        case e: IOException if NioExceptionBoundary.isInterrupted(e) =>
+                            NioPathLockRegistry.abort(key)
+                            Result.panic(e)
+                        case e: IOException =>
+                            NioPathLockRegistry.abort(key)
+                            Result.fail(FileIOException(safe, FileSystemOperation.Lock, e))
+                        case e: Throwable =>
+                            NioPathLockRegistry.abort(key)
+                            Result.panic(e)
+                    end try
+                }
+        end match
+    end lockAttempt
+
     // --- Helpers ---
 
     private def ensureParent(p: java.nio.file.Path): Unit =
@@ -545,6 +643,204 @@ final private[kyo] class NioRawChannel(channel: FileChannel, path: Path) extends
     def close()(using AllowUnsafe): Unit = channel.close()
 
 end NioRawChannel
+
+/** Concrete advisory lock backed by a `java.nio.channels.FileLock`. The backing `FileChannel` is
+  * opened solely to hold the lock and is closed on release, alongside the `FileLock` itself and
+  * this key's [[NioPathLockRegistry]] entry.
+  */
+final private[kyo] class NioRawLock(key: String, requestedExclusive: Boolean) extends Path.RawLock:
+    def isExclusive: Boolean = requestedExclusive
+
+    def check()(using AllowUnsafe, Frame): Result[FileLockException, Unit] =
+        if NioPathLockRegistry.isOwned(key, requestedExclusive) then Result.unit
+        else Result.fail(FileLockOwnershipLostException(Path(key)))
+
+    def release()(using AllowUnsafe, Frame): Result[FileLockException, Unit] =
+        NioPathLockRegistry.release(key, requestedExclusive)
+    end release
+end NioRawLock
+
+/** Process-wide registry of advisory-lock keys currently held, keyed by canonical path string.
+  * Enforces same-process exclusion explicitly (see the rationale on `NioPathUnsafe.lock`),
+  * mirroring `kyo.internal.FileJournalCore.heldRoots` (kyo-eventlog). `-1` means exclusively held;
+  * a positive count is the number of concurrent shared holders; absent means unlocked.
+  */
+private[kyo] object NioPathLockRegistry:
+    final private case class Resource(
+        lock: java.nio.channels.FileLock,
+        channel: FileChannel,
+        releaseLock: () => Unit,
+        closeChannel: () => Unit,
+        lockReleased: Boolean,
+        channelClosed: Boolean,
+        cleaning: Boolean
+    )
+
+    final private case class Entry(
+        isExclusive: Boolean,
+        count: Int,
+        resource: Maybe[Resource]
+    )
+
+    enum Reservation derives CanEqual:
+        case Denied
+        case First
+        case SharedExisting
+
+        /** A compatible acquisition holds the entry but has not installed its resource yet.
+          *
+          * Distinct from `Denied`, which reports a genuine conflict: this says the answer is not
+          * settled rather than negative, and the caller resolves it by asking again once the
+          * installer has either installed or aborted.
+          */
+        case Pending
+    end Reservation
+
+    // Unsafe: one process-wide registry must exist before any concurrent acquisition can race.
+    private val held: AtomicRef.Unsafe[Map[String, Entry]] =
+        import AllowUnsafe.embrace.danger
+        AtomicRef.Unsafe.init(Map.empty[String, Entry])
+
+    @scala.annotation.tailrec
+    private[kyo] def reserve(key: String, isExclusive: Boolean)(using AllowUnsafe): Reservation =
+        val snap = held.get()
+        snap.get(key) match
+            case None =>
+                val next = snap.updated(key, Entry(isExclusive, 1, Absent))
+                if held.compareAndSet(snap, next) then Reservation.First else reserve(key, isExclusive)
+            case Some(Entry(false, count, Present(resource))) if !isExclusive && !resource.cleaning =>
+                val next = snap.updated(key, Entry(false, count + 1, Present(resource)))
+                if held.compareAndSet(snap, next) then Reservation.SharedExisting else reserve(key, isExclusive)
+            // A shared acquisition holds the entry and is still opening its channel. This request is
+            // shared too, so the two are compatible and the contract grants both; the only reason an
+            // answer cannot be given yet is that the resource to share does not exist. Reported as
+            // pending rather than joined here: joining would hand back a claim on a lock that may
+            // still fail to be taken, leaving the joiner believing it holds cross-process exclusion
+            // it never had. The caller asks again once the installer has installed or aborted.
+            case Some(Entry(false, _, Absent)) if !isExclusive => Reservation.Pending
+            case _                                             => Reservation.Denied
+        end match
+    end reserve
+
+    private[kyo] def install(key: String, lock: java.nio.channels.FileLock, channel: FileChannel)(using AllowUnsafe): Unit =
+        install(key, lock, channel, () => lock.release(), () => channel.close())
+
+    @scala.annotation.tailrec
+    private[kyo] def install(
+        key: String,
+        lock: java.nio.channels.FileLock,
+        channel: FileChannel,
+        releaseLock: () => Unit,
+        closeChannel: () => Unit
+    )(using AllowUnsafe): Unit =
+        val snap = held.get()
+        snap.get(key) match
+            case Some(entry) if entry.resource.isEmpty =>
+                val resource = Resource(
+                    lock,
+                    channel,
+                    releaseLock,
+                    closeChannel,
+                    lockReleased = false,
+                    channelClosed = false,
+                    cleaning = false
+                )
+                val next = snap.updated(key, entry.copy(resource = Present(resource)))
+                if !held.compareAndSet(snap, next) then install(key, lock, channel, releaseLock, closeChannel)
+            case _ =>
+                discard(Result.catching[Throwable](lock.release()))
+                discard(Result.catching[Throwable](channel.close()))
+        end match
+    end install
+
+    @scala.annotation.tailrec
+    private[kyo] def abort(key: String)(using AllowUnsafe): Unit =
+        val snap = held.get()
+        if snap.contains(key) && !held.compareAndSet(snap, snap - key) then abort(key)
+    end abort
+
+    private[kyo] def isOwned(key: String, isExclusive: Boolean)(using AllowUnsafe): Boolean =
+        held.get().get(key).exists(entry =>
+            entry.isExclusive == isExclusive && entry.resource.exists(resource => !resource.lockReleased && resource.lock.isValid)
+        )
+
+    @scala.annotation.tailrec
+    private[kyo] def release(key: String, isExclusive: Boolean)(using AllowUnsafe, Frame): Result[FileLockException, Unit] =
+        val snap = held.get()
+        snap.get(key) match
+            case Some(entry) if entry.isExclusive == isExclusive =>
+                if entry.count > 1 then
+                    if held.compareAndSet(snap, snap.updated(key, entry.copy(count = entry.count - 1))) then Result.unit
+                    else release(key, isExclusive)
+                else
+                    entry.resource match
+                        case Present(resource) if resource.cleaning =>
+                            Result.fail(FileIOException(
+                                Path(key),
+                                FileSystemOperation.Lock,
+                                new IOException("lock release is already in progress")
+                            ))
+                        case Present(resource) =>
+                            val claimed = entry.copy(resource = Present(resource.copy(cleaning = true)))
+                            if !held.compareAndSet(snap, snap.updated(key, claimed)) then release(key, isExclusive)
+                            else cleanup(key, entry, resource.copy(cleaning = true))
+                        case Absent =>
+                            Result.fail(FileLockOwnershipLostException(Path(key)))
+            case _ => Result.fail(FileLockOwnershipLostException(Path(key)))
+        end match
+    end release
+
+    private def cleanup(key: String, entry: Entry, start: Resource)(using AllowUnsafe, Frame): Result[FileLockException, Unit] =
+        var resource = start
+        if !resource.lockReleased then
+            try
+                resource.releaseLock()
+                resource = resource.copy(lockReleased = true)
+            catch
+                case e: IOException =>
+                    restoreAfterFailure(key, entry, resource.copy(cleaning = false))
+                    return Result.fail(FileIOException(Path(key), FileSystemOperation.Lock, e))
+                case e: Throwable =>
+                    restoreAfterFailure(key, entry, resource.copy(cleaning = false))
+                    return Result.panic(e)
+        end if
+        if !resource.channelClosed then
+            try
+                resource.closeChannel()
+                resource = resource.copy(channelClosed = true)
+            catch
+                case e: IOException =>
+                    restoreAfterFailure(key, entry, resource.copy(cleaning = false))
+                    return Result.fail(FileIOException(Path(key), FileSystemOperation.Lock, e))
+                case e: Throwable =>
+                    restoreAfterFailure(key, entry, resource.copy(cleaning = false))
+                    return Result.panic(e)
+        end if
+        removeReleased(key, entry.isExclusive)
+        Result.unit
+    end cleanup
+
+    @scala.annotation.tailrec
+    private def restoreAfterFailure(key: String, original: Entry, resource: Resource)(using AllowUnsafe): Unit =
+        val snap = held.get()
+        snap.get(key) match
+            case Some(current) if current.isExclusive == original.isExclusive && current.count == original.count =>
+                if !held.compareAndSet(snap, snap.updated(key, current.copy(resource = Present(resource)))) then
+                    restoreAfterFailure(key, original, resource)
+            case _ => ()
+        end match
+    end restoreAfterFailure
+
+    @scala.annotation.tailrec
+    private def removeReleased(key: String, isExclusive: Boolean)(using AllowUnsafe): Unit =
+        val snap = held.get()
+        snap.get(key) match
+            case Some(entry) if entry.isExclusive == isExclusive =>
+                if !held.compareAndSet(snap, snap - key) then removeReleased(key, isExclusive)
+            case _ => ()
+        end match
+    end removeReleased
+end NioPathLockRegistry
 
 /** Concrete read handle backed by a `java.nio.channels.FileChannel`.
   *

--- a/kyo-system/jvm/src/test/scala/kyo/HostFileSystemSymlinkJvmTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/HostFileSystemSymlinkJvmTest.scala
@@ -9,7 +9,7 @@ import java.nio.file.Paths as JPaths
   * from a platform source set. Without a fixture that can create one, the suite's link assertions are
   * one-sided and a backend that stopped resolving links entirely would still pass.
   */
-class HostFileSystemSymlinkJvmTest extends FileSystemReadTestSuite:
+class HostFileSystemSymlinkJvmTest extends FileSystemReadTest:
 
     override protected def realPathRequiresExistence: Boolean = true
     override protected def supportsSymbolicLinks: Boolean     = true

--- a/kyo-system/jvm/src/test/scala/kyo/HostFileSystemSymlinkJvmTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/HostFileSystemSymlinkJvmTest.scala
@@ -29,3 +29,38 @@ class HostFileSystemSymlinkJvmTest extends FileSystemReadTestSuite:
         FileSystemConformanceFixtures.hostRead
 
 end HostFileSystemSymlinkJvmTest
+
+/** The host lock registry enforces same-process exclusion through a map keyed by path, so two names
+  * for one file are two entries unless the key resolves links first. Link creation has no public
+  * operation, which is why this sits in a platform source set rather than in the shared lock suite.
+  */
+class HostFileSystemLockAliasJvmTest extends kyo.test.Test[Any]:
+
+    "a symlinked alias of a path shares its lock registry entry" in {
+        Scope.run {
+            Path.run(Path.tempDir("host-lock-alias")).map { dir =>
+                val target = dir / "real.bin"
+                val alias  = dir / "link.bin"
+                FileSystem.host.write(target, "contents", Path.WriteOptions()).andThen {
+                    // Unsafe: creates a real symbolic link, which no Path operation exposes
+                    Sync.Unsafe.defer {
+                        discard(JFiles.createSymbolicLink(JPaths.get(alias.unsafe.show), JPaths.get(target.unsafe.show)))
+                    }
+                }.andThen {
+                    // Two shared claims on one file are compatible, so both must be granted. Keyed on
+                    // the name as written, the alias took an entry of its own, opened a second channel
+                    // to the same file, and the JVM refused the overlapping claim. That is a denial of
+                    // a lock the contract grants, not a conflict.
+                    Scope.run {
+                        FileSystem.host.tryLock(target, Path.LockMode.Shared).map { first =>
+                            assert(first.isDefined, "the first shared claim on the target was refused")
+                            FileSystem.host.tryLock(alias, Path.LockMode.Shared).map { second =>
+                                assert(second.isDefined, "the alias was refused a shared claim its target already holds")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+end HostFileSystemLockAliasJvmTest

--- a/kyo-system/jvm/src/test/scala/kyo/internal/PathPlatformSpecificLockJVMTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/internal/PathPlatformSpecificLockJVMTest.scala
@@ -155,9 +155,9 @@ class PathPlatformSpecificLockInstallWindowJVMTest extends kyo.test.Test[Any]:
     "a pending reservation is waited out rather than reported as a conflict" in {
         Sync.Unsafe.defer {
             val file = Files.createTempFile("kyo-lock-pending-", ".bin")
-            // Matches the key tryLock derives, which resolves the path. The file exists, so the
-            // resolved form is its real path.
-            (file, file.toRealPath().toString, Path.of(file))
+            // Matches the key tryLock derives: the resolved path plus the sentinel suffix. The file
+            // exists, so the resolved form is its real path.
+            (file, file.toRealPath().toString + Path.defaultLockSuffix, Path.of(file))
         }.map { (file, key, path) =>
             // Stands in for an acquisition that has reserved its entry and is still opening its
             // channel. Driving it from the registry rather than from a second fiber keeps the window

--- a/kyo-system/jvm/src/test/scala/kyo/internal/PathPlatformSpecificLockJVMTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/internal/PathPlatformSpecificLockJVMTest.scala
@@ -1,0 +1,206 @@
+package kyo.internal
+
+import java.io.IOException
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import kyo.*
+
+class PathPlatformSpecificLockJVMTest extends kyo.test.Test[Any]:
+
+    "native release failure remains typed and retryable" in {
+        Sync.Unsafe.defer {
+            val path     = Files.createTempFile("kyo-lock-release-", ".bin")
+            val key      = path.toString
+            val channel  = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE)
+            var attempts = 0
+            val lock = new FileLock(channel, 0L, Long.MaxValue, false):
+                private var valid    = true
+                def isValid: Boolean = valid
+                def release(): Unit =
+                    attempts += 1
+                    if attempts == 1 then throw new IOException("injected release failure")
+                    valid = false
+                end release
+            try
+                assert(NioPathLockRegistry.reserve(key, true) == NioPathLockRegistry.Reservation.First)
+                NioPathLockRegistry.install(key, lock, channel)
+                val raw = new NioRawLock(key, true)
+                raw.release() match
+                    case Result.Failure(_: FileIOException) => assert(true)
+                    case other                              => assert(false, s"expected typed release failure, got $other")
+                assert(NioPathLockRegistry.isOwned(key, true))
+                assert(raw.release().isSuccess)
+                assert(attempts == 2)
+                assert(!NioPathLockRegistry.isOwned(key, true))
+            finally
+                NioPathLockRegistry.abort(key)
+                if channel.isOpen then channel.close()
+                discard(Files.deleteIfExists(path))
+            end try
+        }
+    }
+
+    "registry ownership loss reaches check and release" in {
+        Sync.Unsafe.defer {
+            val key = Files.createTempFile("kyo-lock-loss-", ".bin").toString
+            assert(NioPathLockRegistry.reserve(key, true) == NioPathLockRegistry.Reservation.First)
+            NioPathLockRegistry.abort(key)
+            val raw = new NioRawLock(key, true)
+            assert(raw.check().isFailure)
+            raw.release() match
+                case Result.Failure(_: FileLockOwnershipLostException) => assert(true)
+                case other => assert(false, s"expected ownership loss from absent registry entry, got $other")
+            discard(Files.deleteIfExists(java.nio.file.Path.of(key)))
+        }
+    }
+
+    "channel close failure remains typed and retries only unfinished cleanup" in {
+        Sync.Unsafe.defer {
+            val path     = Files.createTempFile("kyo-lock-close-", ".bin")
+            val key      = path.toString
+            val channel  = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE)
+            var releases = 0
+            var closes   = 0
+            val lock = new FileLock(channel, 0L, Long.MaxValue, false):
+                private var valid    = true
+                def isValid: Boolean = valid
+                def release(): Unit =
+                    releases += 1
+                    valid = false
+            try
+                assert(NioPathLockRegistry.reserve(key, true) == NioPathLockRegistry.Reservation.First)
+                NioPathLockRegistry.install(
+                    key,
+                    lock,
+                    channel,
+                    () => lock.release(),
+                    () =>
+                        closes += 1
+                        if closes == 1 then throw new IOException("injected close failure")
+                        channel.close()
+                )
+                val raw = new NioRawLock(key, true)
+                raw.release() match
+                    case Result.Failure(_: FileIOException) => assert(true)
+                    case other                              => assert(false, s"expected typed close failure, got $other")
+                assert(releases == 1)
+                assert(closes == 1)
+                assert(raw.release().isSuccess)
+                assert(releases == 1)
+                assert(closes == 2)
+            finally
+                NioPathLockRegistry.abort(key)
+                if channel.isOpen then channel.close()
+                discard(Files.deleteIfExists(path))
+            end try
+        }
+    }
+
+end PathPlatformSpecificLockJVMTest
+
+/** The interval between a reservation being taken and its underlying lock being installed.
+  *
+  * `reserve` returns `First` and the caller then opens a channel and takes the platform lock, so
+  * for that span the entry exists with no resource behind it. A shared request arriving in that
+  * span is compatible with the shared acquisition already under way, and the contract grants it.
+  */
+class PathPlatformSpecificLockInstallWindowJVMTest extends kyo.test.Test[Any]:
+
+    "a shared request during another shared acquisition's install window is not denied" in {
+        Sync.Unsafe.defer {
+            val key = Files.createTempFile("kyo-lock-window-", ".bin").toString
+            try
+                // The first shared acquisition reserves and has not installed yet, which is exactly
+                // the state the caller is in while it opens its channel.
+                assert(NioPathLockRegistry.reserve(key, false) == NioPathLockRegistry.Reservation.First)
+
+                // A second shared request lands here. It is compatible with the first, so denying it
+                // refuses a lock the contract grants. Pending says the answer is not settled yet.
+                val second = NioPathLockRegistry.reserve(key, false)
+                assert(
+                    second == NioPathLockRegistry.Reservation.Pending,
+                    s"a compatible shared request in the install window got $second"
+                )
+
+                // An exclusive request in the same window genuinely conflicts with the shared
+                // acquisition under way, so it stays denied rather than becoming pending.
+                assert(
+                    NioPathLockRegistry.reserve(key, true) == NioPathLockRegistry.Reservation.Denied,
+                    "an exclusive request was told to wait for a shared acquisition it conflicts with"
+                )
+            finally
+                NioPathLockRegistry.abort(key)
+                discard(Files.deleteIfExists(java.nio.file.Path.of(key)))
+            end try
+        }
+    }
+
+    "a shared request during an exclusive acquisition's install window stays denied" in {
+        Sync.Unsafe.defer {
+            val key = Files.createTempFile("kyo-lock-window-excl-", ".bin").toString
+            try
+                assert(NioPathLockRegistry.reserve(key, true) == NioPathLockRegistry.Reservation.First)
+                assert(
+                    NioPathLockRegistry.reserve(key, false) == NioPathLockRegistry.Reservation.Denied,
+                    "a shared request was told to wait for an exclusive acquisition it conflicts with"
+                )
+            finally
+                NioPathLockRegistry.abort(key)
+                discard(Files.deleteIfExists(java.nio.file.Path.of(key)))
+            end try
+        }
+    }
+    "a pending reservation is waited out rather than reported as a conflict" in {
+        Sync.Unsafe.defer {
+            val file = Files.createTempFile("kyo-lock-pending-", ".bin")
+            // Matches the key tryLock derives, which resolves the path. The file exists, so the
+            // resolved form is its real path.
+            (file, file.toRealPath().toString, Path.of(file))
+        }.map { (file, key, path) =>
+            // Stands in for an acquisition that has reserved its entry and is still opening its
+            // channel. Driving it from the registry rather than from a second fiber keeps the window
+            // open for as long as the assertions need, with nothing parked on a thread to hold it.
+            Sync.Unsafe.defer(NioPathLockRegistry.reserve(key, false)).map { reserved =>
+                assert(reserved == NioPathLockRegistry.Reservation.First)
+                // Under time control the backend's retry delay is virtual, so the waiter advances
+                // only when this test advances it. That is what makes the "has not answered yet"
+                // check below mean something without spending wall-clock time on it: every retry
+                // the waiter is allowed to take has already happened when the check runs.
+                Clock.withTimeControl { control =>
+                    Fiber.initUnscoped(Scope.run(FileSystem.host.tryLock(path, Path.LockMode.Shared).map(_.isDefined))).map { fiber =>
+                        Loop.repeat(20)(control.advance(1.milli)).andThen(fiber.poll).map { answered =>
+                            // Answering here is the defect: the claim under way is shared, this request
+                            // is shared, and the two are compatible. Absent would be a conflict reported
+                            // where none exists.
+                            assert(answered.isEmpty, "tryLock answered while a compatible claim was still installing")
+                            Sync.Unsafe.defer {
+                                val channel = FileChannel.open(file, StandardOpenOption.READ, StandardOpenOption.WRITE)
+                                NioPathLockRegistry.install(key, channel.tryLock(0L, Long.MaxValue, true), channel)
+                            }.andThen {
+                                // A background advancer, not a bounded batch: the waiter checks the
+                                // registry and then registers its next sleep, and a bounded batch can
+                                // finish inside that gap, leaving a sleep no advance ever reaches.
+                                Fiber.initUnscoped(Loop.forever(control.advance(1.milli))).map { advancer =>
+                                    fiber.get.map { acquired =>
+                                        advancer.interrupt.andThen {
+                                            assert(acquired, "the retry did not pick up the claim once it was installed")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }.map { result =>
+                // The manual reservation above is still counted; drop it so the entry does not
+                // outlive the test.
+                Sync.Unsafe.defer {
+                    discard(NioPathLockRegistry.release(key, false))
+                    discard(Files.deleteIfExists(file))
+                }.andThen(result)
+            }
+        }
+    }
+end PathPlatformSpecificLockInstallWindowJVMTest

--- a/kyo-system/native/src/test/scala/kyo/HostFileSystemSymlinkNativeTest.scala
+++ b/kyo-system/native/src/test/scala/kyo/HostFileSystemSymlinkNativeTest.scala
@@ -9,7 +9,7 @@ import java.nio.file.Paths as JPaths
   * Native test created a symbolic link, so the symlink-escape fix was asserted on one platform
   * and assumed on this one.
   */
-class HostFileSystemSymlinkNativeTest extends FileSystemReadTestSuite:
+class HostFileSystemSymlinkNativeTest extends FileSystemReadTest:
 
     override protected def realPathRequiresExistence: Boolean = true
     override protected def supportsSymbolicLinks: Boolean     = true

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -124,12 +124,17 @@ object FileSystem:
           * it would deny a lock the contract grants. Waiting out that span is bounded and does not
           * depend on any holder releasing, unlike [[lock]], which waits for exactly that.
           */
-        def tryLock(path: Path, mode: Path.LockMode)(using
+        def tryLock(path: Path, mode: Path.LockMode, sentinelSuffix: String = Path.defaultLockSuffix)(using
             Frame
         ): Maybe[Path.Lock] < (S & Sync & Async & Scope & Abort[FileReadException | FileLockException])
 
         /** Acquires a scoped advisory lock according to `wait`. Waiting modes suspend the fiber. */
-        def lock(path: Path, mode: Path.LockMode, wait: Path.LockWait = Path.LockWait.UntilAvailable)(using
+        def lock(
+            path: Path,
+            mode: Path.LockMode,
+            wait: Path.LockWait = Path.LockWait.UntilAvailable,
+            sentinelSuffix: String = Path.defaultLockSuffix
+        )(using
             Frame
         ): Path.Lock < (S & Async & Scope & Abort[FileReadException | FileLockException])
 

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -3,7 +3,7 @@ package kyo
 import java.nio.charset.Charset
 
 /** Filesystem backend capabilities, effect-polymorphic in the backend effect `S`. [[Read]] exposes
-  * inspection, content reads, and channels. [[Write]] extends it with mutation and structure
+  * inspection, content reads, channels, and locks. [[Write]] extends it with mutation and structure
   * operations. Each public operation records the applicable typed failure category in its effect
   * row and accepts a call-site [[Frame]].
   *
@@ -11,6 +11,44 @@ import java.nio.charset.Charset
   * @see [[Path.runWith]] for installing a write capability
   */
 object FileSystem:
+
+    // Retry pacing for the waiting lock modes. Async.sleep, not Clock.sleep: the latter hands back
+    // the timer Fiber rather than suspending on it, so discarding it would turn these retry loops
+    // into busy spins that contend with the very lock holder they are waiting on.
+    private val lockRetryDelay = 1.millis
+
+    private[kyo] def awaitLock[S](path: Path, wait: Path.LockWait)(
+        attempt: => Maybe[Path.Lock] < (S & Sync & Scope & Abort[FileReadException | FileLockException])
+    )(using Frame): Path.Lock < (S & Async & Scope & Abort[FileReadException | FileLockException]) =
+        def unavailable: Path.Lock < Abort[FileLockException] = Abort.fail(FileLockUnavailableException(path))
+
+        def untilAvailable: Path.Lock < (S & Async & Scope & Abort[FileReadException | FileLockException]) =
+            attempt.map {
+                case Present(lock) => lock
+                case Absent        => Async.sleep(lockRetryDelay).andThen(untilAvailable)
+            }
+
+        def until(deadline: Clock.Deadline, timeout: Duration)
+            : Path.Lock < (S & Async & Scope & Abort[FileReadException | FileLockException]) =
+            deadline.isOverdue.map {
+                case true => Abort.fail(FileLockTimeoutException(path, timeout))
+                case false =>
+                    attempt.map {
+                        case Present(lock) => lock
+                        case Absent        => Async.sleep(lockRetryDelay).andThen(until(deadline, timeout))
+                    }
+            }
+
+        wait match
+            case Path.LockWait.Immediate =>
+                attempt.map {
+                    case Present(lock) => lock
+                    case Absent        => unavailable
+                }
+            case Path.LockWait.UntilAvailable  => untilAvailable
+            case Path.LockWait.Until(deadline) => deadline.timeLeft.map(until(deadline, _))
+        end match
+    end awaitLock
 
     abstract class Read[S]:
         def defaultCaseSensitivity(using Frame): Glob.CaseSensitivity < S
@@ -77,6 +115,23 @@ object FileSystem:
 
         /** Opens `path` for positioned reads. The channel is closed when the current [[Scope]] exits. */
         def openReadChannel(path: Path)(using Frame): Path.ReadChannel[S] < (S & Scope & Abort[FileReadException])
+
+        /** Attempts to acquire a scoped advisory lock without waiting for a conflicting holder.
+          *
+          * `Async` is in the row because "without waiting" is about conflicting holders, not about
+          * suspension: a backend that merges same-process claims onto one platform lock has a span
+          * in which a compatible claim is being taken but is not yet shareable, and answering during
+          * it would deny a lock the contract grants. Waiting out that span is bounded and does not
+          * depend on any holder releasing, unlike [[lock]], which waits for exactly that.
+          */
+        def tryLock(path: Path, mode: Path.LockMode)(using
+            Frame
+        ): Maybe[Path.Lock] < (S & Sync & Async & Scope & Abort[FileReadException | FileLockException])
+
+        /** Acquires a scoped advisory lock according to `wait`. Waiting modes suspend the fiber. */
+        def lock(path: Path, mode: Path.LockMode, wait: Path.LockWait = Path.LockWait.UntilAvailable)(using
+            Frame
+        ): Path.Lock < (S & Async & Scope & Abort[FileReadException | FileLockException])
 
         private[kyo] def openReadChannelUnscoped(path: Path)(using
             Frame

--- a/kyo-system/shared/src/main/scala/kyo/FileSystemException.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystemException.scala
@@ -2,7 +2,7 @@ package kyo
 
 /** Operations recorded by generic filesystem failures. */
 enum FileSystemOperation derives CanEqual:
-    case Exists, Inspect, RealPath, Read, Write, List, Walk, Create, Move, Copy, Remove, Channel, Sync
+    case Exists, Inspect, RealPath, Read, Write, List, Walk, Create, Move, Copy, Remove, Channel, Sync, Lock
 
 /** Base type for failures reported by filesystem capabilities. */
 sealed abstract class FileSystemException(message: String, cause: Throwable | String = "")(using Frame)
@@ -11,6 +11,7 @@ sealed abstract class FileSystemException(message: String, cause: Throwable | St
 sealed trait FileReadException      extends FileSystemException
 sealed trait FileWriteException     extends FileSystemException
 sealed trait FileStructureException extends FileSystemException
+sealed trait FileLockException      extends FileSystemException
 
 case class FileNotFoundException(path: Path)(using Frame)
     extends FileSystemException(s"File or directory not found: $path")
@@ -18,7 +19,7 @@ case class FileNotFoundException(path: Path)(using Frame)
 
 case class FileAccessDeniedException(path: Path)(using Frame)
     extends FileSystemException(s"Permission denied: $path")
-    with FileReadException with FileWriteException with FileStructureException
+    with FileReadException with FileWriteException with FileStructureException with FileLockException
     derives CanEqual
 
 case class FileIsADirectoryException(path: Path)(using Frame)
@@ -39,17 +40,37 @@ case class FileDirectoryNotEmptyException(path: Path)(using Frame)
 
 case class FileInvalidPathException(input: String, operation: FileSystemOperation)(using Frame)
     extends FileSystemException(s"Invalid path for $operation: $input")
-    with FileReadException with FileWriteException with FileStructureException
+    with FileReadException with FileWriteException with FileStructureException with FileLockException
     derives CanEqual
 
 case class FileIOException(path: Path, operation: FileSystemOperation, diagnosticCause: Throwable)(using Frame)
     extends FileSystemException(s"I/O error during $operation on $path", diagnosticCause)
-    with FileReadException with FileWriteException with FileStructureException
+    with FileReadException with FileWriteException with FileStructureException with FileLockException
     derives CanEqual
 
 case class FileAtomicMoveUnsupportedException(source: Path, target: Path)(using Frame)
     extends FileSystemException(s"Required atomic move from $source to $target is unsupported")
     with FileStructureException derives CanEqual
+
+case class FileLockUnavailableException(path: Path)(using Frame)
+    extends FileSystemException(s"Lock unavailable on $path")
+    with FileLockException derives CanEqual
+
+case class FileLockTimeoutException(path: Path, timeout: Duration)(using Frame)
+    extends FileSystemException(s"Timed out acquiring lock on $path after $timeout")
+    with FileLockException derives CanEqual
+
+case class FileLockOwnershipLostException(path: Path)(using Frame)
+    extends FileSystemException(s"Lock ownership lost on $path")
+    with FileLockException derives CanEqual
+
+private[kyo] case class FileLockCleanupException(
+    path: Path,
+    primary: FileLockException,
+    cleanup: FileLockException
+)(using Frame)
+    extends FileSystemException(s"Multiple lock cleanup failures on $path: ${primary.getMessage}; ${cleanup.getMessage}", primary)
+    with FileLockException derives CanEqual
 
 object FileSystemException:
     given Render[FileSystemException] with

--- a/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
@@ -8,6 +8,34 @@ private[kyo] object HostFileSystem:
 
     def apply(): FileSystem.Write[Sync] = new HostFileSystem
 
+    // Fires inside the claim node in tryLock, once the OS lock is held and recorded and before
+    // tryLock returns. Default no-op; private[kyo] so tests in this package can reach it, and
+    // single-writer, meaning one test sets and clears it at a time.
+    //
+    // The position is the whole point. An interrupt requested here is delivered at the next
+    // safepoint, which is after the acquisition has produced the lock, and that is the only
+    // instant at which registering the finalizer before the claim differs observably from
+    // registering it afterwards. Without an injection point here a test can only interrupt from
+    // outside, where the interrupt lands before the claim is ever made and every ordering looks
+    // alike.
+    private[kyo] var afterClaimHook: () => Unit = () => ()
+
+    // The claim/finalizer handshake for tryLock. Empty means nothing claimed yet; Claimed carries
+    // the lock the finalizer must release; Drained means the finalizer has already run and no claim
+    // can ever be recorded again. The tombstone is what makes a claim arriving after the drain
+    // observable inside the claim node itself, where it can still release what it just took.
+    private enum LockHolder derives CanEqual:
+        case Empty
+        case Claimed(lock: Path.Lock)
+        case Drained
+    end LockHolder
+
+    // The window a pending reservation waits on is one channel open plus one platform lock call, so
+    // it clears in well under a millisecond. The budget is generous against that rather than tuned:
+    // its job is to terminate at all when an entry is never going to resolve, not to time the window.
+    private val pendingLockRetries: Int         = 100
+    private val pendingLockRetryDelay: Duration = 1.milli
+
     /** Determines case sensitivity by asking the volume rather than the operating system.
       *
       * The two are not the same question. macOS default volumes are case-insensitive while the
@@ -270,5 +298,127 @@ private[kyo] object HostFileSystem:
             Sync.Unsafe.defer(Abort.get(path.unsafe.openReadWriteChannelRaw(open))).map(raw =>
                 (readWriteChannelFrom(path, raw), () => Sync.Unsafe.defer(raw.close()))
             )
+
+        private[kyo] def lockFrom(path: Path, raw: Path.RawLock, grantedMode: Path.LockMode, state: AtomicInt): Path.Lock =
+            val owner = Path.LockOwnership.fresh()
+            new Path.Lock:
+                def mode: Path.LockMode           = grantedMode
+                def ownership: Path.LockOwnership = owner
+
+                def check(using Frame): Unit < (Sync & Abort[FileLockException]) =
+                    state.get.map {
+                        case 0 => Sync.Unsafe.defer(Abort.get(raw.check()))
+                        case _ => Abort.fail(FileLockOwnershipLostException(path))
+                    }
+
+                def release(candidate: Path.LockOwnership)(using Frame): Unit < (Sync & Abort[FileLockException]) =
+                    if !Path.LockOwnership.same(owner, candidate) then Abort.fail(FileLockOwnershipLostException(path))
+                    else
+                        // Unsafe: claiming the release and performing it happen in one node, so no
+                        // interrupt can land between them.
+                        //
+                        // The previous form moved through an intermediate "releasing" state across
+                        // several suspensions. An interrupt in that window left the state there
+                        // permanently: the lock was neither released nor releasable, and a concurrent
+                        // releaser looped on it with no yield and no exit, so a Scope finalizer
+                        // waiting on that release never returned. Claiming straight to "released"
+                        // removes the state that could be stranded and the loop that spun on it.
+                        //
+                        // Release stays single-shot and idempotent: whoever wins the compare-and-set
+                        // performs it, and a later or concurrent caller finds it already claimed and
+                        // returns. A failed release restores the held state so it can be retried.
+                        Sync.Unsafe.defer {
+                            if state.unsafe.compareAndSet(0, 2) then
+                                val outcome = raw.release()
+                                if !outcome.isSuccess then state.unsafe.set(0)
+                                outcome
+                            else Result.succeed(())
+                        }.map(Abort.get(_))
+            end new
+        end lockFrom
+
+        def tryLock(path: Path, mode: Path.LockMode)(using
+            Frame
+        ): Maybe[Path.Lock] < (Sync & Async & Scope & Abort[FileLockException]) =
+            // Deliberately not Scope.acquireRelease. That runs acquire, then registers the finalizer
+            // in a continuation, and an interrupt landing between the two leaves the OS lock held and
+            // the registry entry installed with nothing in existence able to release either: the path
+            // is unacquirable for the life of the process and a descriptor leaks.
+            //
+            // Registering first inverts the problem. The finalizer exists before anything is claimed
+            // and releases whatever it finds recorded, so an interrupt before the claim finds nothing
+            // to do, and one after it finds a lock the finalizer already owns. The claim and its
+            // recording sit in a single unsafe node with no safepoint between them, which is the only
+            // interval that would otherwise be exposed.
+            //
+            // The general form of this belongs in Scope.acquireRelease, which has the same window for
+            // every caller in kyo. Widening that signature to carry Async.mask is a kyo-core change
+            // with a far wider blast radius than this defect, so it is left for its own work.
+            val acquire =
+                Sync.Unsafe.defer(AtomicRef.Unsafe.init[LockHolder](LockHolder.Empty)).map { holder =>
+                    Scope.ensure {
+                        // Drained is permanent: after this getAndSet no claim can be recorded, so a
+                        // slice that outruns the interrupt and still reaches the claim node observes
+                        // the tombstone and releases in place rather than stranding the lock.
+                        Sync.Unsafe.defer(holder.getAndSet(LockHolder.Drained)).map {
+                            case LockHolder.Claimed(lock) => lock.release(lock.ownership)
+                            case _                        => ()
+                        }
+                    }.andThen {
+                        // A shared claim can arrive while another shared claim is between reserving
+                        // its registry entry and installing the platform lock behind it. The two are
+                        // compatible, so refusing there denies a lock the contract grants; the entry
+                        // simply has nothing to share yet. The backend reports that as pending and
+                        // this retries, since it clears without anyone releasing anything.
+                        //
+                        // Bounded on purpose. An acquisition interrupted after it reserves but before
+                        // it can withdraw leaves an entry nothing else clears, and an unbounded retry
+                        // would turn a permanent denial into a permanent hang. Exhausting the budget
+                        // reports the claim unavailable, which is what this returned before.
+                        //
+                        // The attempt returns a Result rather than branching after the node: the
+                        // claim and its recording have to stay in one node with no safepoint between
+                        // them, so the decision to retry has to leave the node as a value.
+                        def attempt(remaining: Int): Path.Lock < (Sync & Async & Abort[FileLockException]) =
+                            // Unsafe: the raw claim and the record of it are plain statements in one
+                            // node, so no interrupt can observe a claim the finalizer cannot see.
+                            Sync.Unsafe.defer {
+                                path.unsafe.lockAttempt(mode) match
+                                    case Path.LockAttempt.Acquired(raw) =>
+                                        val lock = lockFrom(path, raw, mode, AtomicInt.Unsafe.init(0).safe)
+                                        if holder.compareAndSet(LockHolder.Empty, LockHolder.Claimed(lock)) then
+                                            afterClaimHook()
+                                            Result.succeed(Present(lock))
+                                        else
+                                            // The finalizer has already drained: this slice outran the
+                                            // interrupt, and nothing downstream of this node will run
+                                            // again. Release here, in the same node as the claim, and
+                                            // report the attempt unavailable; the recover below folds
+                                            // that to Absent, which is true, since no lock was granted.
+                                            raw.release() match
+                                                case Result.Success(_)     => Result.fail(FileLockUnavailableException(path))
+                                                case Result.Failure(error) => Result.fail(error)
+                                                case panic: Result.Panic   => panic
+                                            end match
+                                        end if
+                                    case Path.LockAttempt.Pending       => Result.succeed(Absent)
+                                    case Path.LockAttempt.Failed(error) => error
+                            }.map {
+                                case Result.Success(Present(lock)) => lock
+                                case Result.Success(Absent) =>
+                                    if remaining <= 0 then Abort.fail(FileLockUnavailableException(path))
+                                    else Async.sleep(pendingLockRetryDelay).andThen(attempt(remaining - 1))
+                                case failed => Abort.get(failed.map(_ => null.asInstanceOf[Path.Lock]))
+                            }
+                        attempt(pendingLockRetries)
+                    }
+                }.map(Maybe(_))
+            Abort.recover[FileLockUnavailableException](_ => Absent)(acquire)
+        end tryLock
+
+        def lock(path: Path, mode: Path.LockMode, wait: Path.LockWait)(using
+            Frame
+        ): Path.Lock < (Sync & Async & Scope & Abort[FileReadException | FileLockException]) =
+            FileSystem.awaitLock(path, wait)(tryLock(path, mode))
     end HostFileSystem
 end HostFileSystem

--- a/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
@@ -337,7 +337,17 @@ private[kyo] object HostFileSystem:
             end new
         end lockFrom
 
-        def tryLock(path: Path, mode: Path.LockMode)(using
+        def tryLock(path: Path, mode: Path.LockMode, sentinelSuffix: String)(using
+            Frame
+        ): Maybe[Path.Lock] < (Sync & Async & Scope & Abort[FileLockException]) =
+            // The suffix names the sentinel sibling and escapes nothing: empty would put the claim
+            // on the data file itself, resurrecting the POSIX unlock-on-close hazard, and a
+            // separator would move it into another directory.
+            if sentinelSuffix.isEmpty || sentinelSuffix.exists(c => c == '/' || c == '\\') then
+                Abort.fail(FileInvalidPathException(sentinelSuffix, FileSystemOperation.Lock))
+            else tryLockValidated(path, mode, sentinelSuffix)
+
+        private def tryLockValidated(path: Path, mode: Path.LockMode, sentinelSuffix: String)(using
             Frame
         ): Maybe[Path.Lock] < (Sync & Async & Scope & Abort[FileLockException]) =
             // Deliberately not Scope.acquireRelease. That runs acquire, then registers the finalizer
@@ -383,7 +393,7 @@ private[kyo] object HostFileSystem:
                             // Unsafe: the raw claim and the record of it are plain statements in one
                             // node, so no interrupt can observe a claim the finalizer cannot see.
                             Sync.Unsafe.defer {
-                                path.unsafe.lockAttempt(mode) match
+                                path.unsafe.lockAttempt(mode, sentinelSuffix) match
                                     case Path.LockAttempt.Acquired(raw) =>
                                         val lock = lockFrom(path, raw, mode, AtomicInt.Unsafe.init(0).safe)
                                         if holder.compareAndSet(LockHolder.Empty, LockHolder.Claimed(lock)) then
@@ -414,11 +424,11 @@ private[kyo] object HostFileSystem:
                     }
                 }.map(Maybe(_))
             Abort.recover[FileLockUnavailableException](_ => Absent)(acquire)
-        end tryLock
+        end tryLockValidated
 
-        def lock(path: Path, mode: Path.LockMode, wait: Path.LockWait)(using
+        def lock(path: Path, mode: Path.LockMode, wait: Path.LockWait, sentinelSuffix: String)(using
             Frame
         ): Path.Lock < (Sync & Async & Scope & Abort[FileReadException | FileLockException]) =
-            FileSystem.awaitLock(path, wait)(tryLock(path, mode))
+            FileSystem.awaitLock(path, wait)(tryLock(path, mode, sentinelSuffix))
     end HostFileSystem
 end HostFileSystem

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -452,15 +452,19 @@ object Path extends PathPlatformSpecific:
         }
     end restoreRead
 
-    private[kyo] def suspendTryLock(path: Path, mode: LockMode)(using Frame): Maybe[Lock] < (PathRead & Sync & Async & Scope) =
+    private[kyo] def suspendTryLock(path: Path, mode: LockMode, sentinelSuffix: String)(using
+        Frame
+    ): Maybe[Lock] < (PathRead & Sync & Async & Scope) =
         ArrowEffect.suspend(Tag[PathRead], Op.CurrentReadService()).map { service =>
-            restoreRead(Abort.run[FileSystemException](service.tryLock(path, mode)))
+            restoreRead(Abort.run[FileSystemException](service.tryLock(path, mode, sentinelSuffix)))
         }
     end suspendTryLock
 
-    private[kyo] def suspendLock(path: Path, mode: LockMode, wait: LockWait)(using Frame): Lock < (PathRead & Async & Scope) =
+    private[kyo] def suspendLock(path: Path, mode: LockMode, wait: LockWait, sentinelSuffix: String)(using
+        Frame
+    ): Lock < (PathRead & Async & Scope) =
         ArrowEffect.suspend(Tag[PathRead], Op.CurrentReadService()).map { service =>
-            restoreRead(Abort.run[FileSystemException](service.lock(path, mode, wait)))
+            restoreRead(Abort.run[FileSystemException](service.lock(path, mode, wait, sentinelSuffix)))
         }
     end suspendLock
 
@@ -575,6 +579,12 @@ object Path extends PathPlatformSpecific:
         case Shared
         case Exclusive
 
+    /** Suffix of the sentinel sibling an advisory lock claims. The claim is never taken on the
+      * data file itself, so I/O on the locked path cannot disturb it; the suffix names the sibling
+      * and is part of the lock's identity, so claims under different suffixes are independent.
+      */
+    val defaultLockSuffix: String = ".kyo-lock"
+
     /** Selects whether lock acquisition returns immediately or suspends until it can complete. */
     enum LockWait derives CanEqual:
         case Immediate
@@ -602,9 +612,11 @@ object Path extends PathPlatformSpecific:
       *
       * The claim is taken on a sentinel sibling of the path, never on the path itself, so holding
       * a lock and reading or writing the locked path from the same process is safe on every
-      * platform. The sentinel may remain on disk after the process exits; it is an empty artifact
-      * whose claim died with the process. The lock coordinates processes that use this API; it
-      * does not exclude a foreign process that locks the data file directly through the OS.
+      * platform. The sibling's suffix defaults to [[Path.defaultLockSuffix]] and is part of the
+      * lock's identity: claims under different suffixes are independent. The sentinel may remain
+      * on disk after the process exits; it is an empty artifact whose claim died with the process.
+      * The lock coordinates processes that use this API; it does not exclude a foreign process
+      * that locks the data file directly through the OS.
       */
     trait Lock:
         /** The compatibility mode granted to this handle. */
@@ -718,12 +730,18 @@ object Path extends PathPlatformSpecific:
           * shareable, and answering during it would report a conflict that does not exist. Waiting
           * out that span is bounded and needs no holder to release anything.
           */
-        def tryLock(mode: LockMode)(using Frame): Maybe[Lock] < (PathRead & Sync & Async & Scope) =
-            suspendTryLock(self, mode)
+        def tryLock(mode: LockMode, sentinelSuffix: String = Path.defaultLockSuffix)(using
+            Frame
+        ): Maybe[Lock] < (PathRead & Sync & Async & Scope) =
+            suspendTryLock(self, mode, sentinelSuffix)
 
         /** Acquires a scoped advisory lock according to `wait`. */
-        def lock(mode: LockMode, wait: LockWait = LockWait.UntilAvailable)(using Frame): Lock < (PathRead & Async & Scope) =
-            suspendLock(self, mode, wait)
+        def lock(
+            mode: LockMode,
+            wait: LockWait = LockWait.UntilAvailable,
+            sentinelSuffix: String = Path.defaultLockSuffix
+        )(using Frame): Lock < (PathRead & Async & Scope) =
+            suspendLock(self, mode, wait, sentinelSuffix)
 
         /** Returns this path resolved to its canonical real path, but only if that real path is contained
           * within `root` (after resolving `root`'s own symlinks).
@@ -1503,7 +1521,7 @@ object Path extends PathPlatformSpecific:
           * taken on a sentinel sibling of the path, never on the path itself. Platform
           * implementations provide the concrete lock.
           */
-        def lock(mode: LockMode)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock]
+        def lock(mode: LockMode, sentinelSuffix: String)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock]
 
         /** Attempts the lock, distinguishing a conflict from an answer that is not settled yet.
           *
@@ -1512,8 +1530,8 @@ object Path extends PathPlatformSpecific:
           * which a compatible claim is being taken but is not yet shareable, and refusing there
           * denies a lock the contract grants. Backends with no such span keep the default.
           */
-        private[kyo] def lockAttempt(mode: LockMode)(using AllowUnsafe, Frame): Path.LockAttempt =
-            lock(mode) match
+        private[kyo] def lockAttempt(mode: LockMode, sentinelSuffix: String)(using AllowUnsafe, Frame): Path.LockAttempt =
+            lock(mode, sentinelSuffix) match
                 case Result.Success(raw)   => Path.LockAttempt.Acquired(raw)
                 case Result.Failure(error) => Path.LockAttempt.Failed(Result.Failure(error))
                 case panic: Result.Panic   => Path.LockAttempt.Failed(panic)

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -599,6 +599,15 @@ object Path extends PathPlatformSpecific:
       *
       * Use [[check]] before a protected operation when the backend can lose external ownership.
       * It raises [[FileLockOwnershipLostException]] if the claim no longer belongs to this handle.
+      *
+      * On the JVM and Native on POSIX platforms (Linux, macOS), the lock is a process-wide
+      * `fcntl` record lock, and POSIX releases every lock the process holds on a file when the
+      * process closes any handle to that file. Reading or writing the locked path through this
+      * API, or through any other API, opens and closes such a handle, and the release is silent:
+      * neither the platform lock object nor [[check]] can observe it. While a lock is held, do
+      * not touch the locked file from the same process; lock a sentinel path next to the data
+      * instead and perform the I/O on the data path. Windows locks are handle-scoped and the
+      * Node backend uses a lockfile protocol, so neither has this behavior.
       */
     trait Lock:
         /** The compatibility mode granted to this handle. */

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -244,6 +244,7 @@ object Path extends PathPlatformSpecific:
         case OpenRead(path: Path)                                                           extends Op[Path.ReadHandle]
         case OpenReadLines(path: Path, charset: Charset)                                    extends Op[Path.LineReadHandle]
         case OpenWalk(path: Path, maxDepth: Int, followLinks: Boolean)                      extends Op[Path.WalkHandle]
+        case CurrentReadService()                                                           extends Op[FileSystem.Read[Any]]
         case Raise(error: Result.Error[FileSystemException])                                extends Op[Nothing]
         // write-group (suspend under Tag[PathWrite])
         case Write(path: Path, value: String, options: WriteOptions)                extends Op[Unit]
@@ -392,6 +393,7 @@ object Path extends PathPlatformSpecific:
             case Op.OpenRead(p)               => service.openRead(p)
             case Op.OpenReadLines(p, c)       => service.openReadLines(p, c)
             case Op.OpenWalk(p, d, f)         => service.openWalk(p, d, f)
+            case Op.CurrentReadService()      => FileSystem.useReadErased(selected => selected)
             case Op.Raise(error)              => Abort.error(error)
             case Op.Write(p, v, cf)           => service.write(p, v, cf)
             case Op.WriteBytes(p, v, options) => service.writeBytes(p, v, options)
@@ -437,9 +439,30 @@ object Path extends PathPlatformSpecific:
             case Op.OpenRead(p)              => service.openRead(p)
             case Op.OpenReadLines(p, c)      => service.openReadLines(p, c)
             case Op.OpenWalk(p, d, f)        => service.openWalk(p, d, f)
+            case Op.CurrentReadService()     => FileSystem.useReadErased(selected => selected)
             case Op.Raise(error)             => Abort.error(error)
             case _ => Abort.panic[FileSystemException](new IllegalStateException("PathWrite operation reached the PathRead handler"))
     end dispatchRead
+
+    private def restoreRead[A, S](value: Result[FileSystemException, A] < S)(using Frame): A < (PathRead & S) =
+        value.map {
+            case Result.Success(result) => result
+            case Result.Failure(error)  => ArrowEffect.suspend(Tag[PathRead], Op.Raise(Result.Failure(error)))
+            case panic: Result.Panic    => ArrowEffect.suspend(Tag[PathRead], Op.Raise(panic))
+        }
+    end restoreRead
+
+    private[kyo] def suspendTryLock(path: Path, mode: LockMode)(using Frame): Maybe[Lock] < (PathRead & Sync & Async & Scope) =
+        ArrowEffect.suspend(Tag[PathRead], Op.CurrentReadService()).map { service =>
+            restoreRead(Abort.run[FileSystemException](service.tryLock(path, mode)))
+        }
+    end suspendTryLock
+
+    private[kyo] def suspendLock(path: Path, mode: LockMode, wait: LockWait)(using Frame): Lock < (PathRead & Async & Scope) =
+        ArrowEffect.suspend(Tag[PathRead], Op.CurrentReadService()).map { service =>
+            restoreRead(Abort.run[FileSystemException](service.lock(path, mode, wait)))
+        }
+    end suspendLock
 
     // --- Scoped temp file and temp directory ---
 
@@ -547,6 +570,47 @@ object Path extends PathPlatformSpecific:
       */
     trait ReadWriteChannel[S] extends ReadChannel[S] with WriteChannel[S]
 
+    /** Selects the compatibility of an advisory path lock. */
+    enum LockMode derives CanEqual:
+        case Shared
+        case Exclusive
+
+    /** Selects whether lock acquisition returns immediately or suspends until it can complete. */
+    enum LockWait derives CanEqual:
+        case Immediate
+        case UntilAvailable
+        case Until(deadline: Clock.Deadline)
+    end LockWait
+
+    /** Opaque identity of one acquired lock claim. */
+    private[kyo] opaque type LockOwnership = AnyRef
+
+    private[kyo] object LockOwnership:
+        given CanEqual[LockOwnership, LockOwnership]                 = CanEqual.derived
+        def fresh(): LockOwnership                                   = new AnyRef
+        def same(left: LockOwnership, right: LockOwnership): Boolean = left eq right
+    end LockOwnership
+
+    /** A Scope-managed advisory lock on a path.
+      *
+      * Shared locks coexist with other shared locks. Exclusive locks conflict with every other
+      * holder. The acquiring [[Scope]] owns an opaque token and releases only the matching claim
+      * when it closes. There is intentionally no public manual-release operation.
+      *
+      * Use [[check]] before a protected operation when the backend can lose external ownership.
+      * It raises [[FileLockOwnershipLostException]] if the claim no longer belongs to this handle.
+      */
+    trait Lock:
+        /** The compatibility mode granted to this handle. */
+        def mode: LockMode
+
+        /** Verifies that this handle still owns its claim. */
+        def check(using Frame): Unit < (Sync & Abort[FileLockException])
+
+        private[kyo] def ownership: LockOwnership
+        private[kyo] def release(ownership: LockOwnership)(using Frame): Unit < (Sync & Abort[FileLockException])
+    end Lock
+
     // --- Safe extension methods ---
 
     extension (self: Path)
@@ -638,6 +702,22 @@ object Path extends PathPlatformSpecific:
           */
         inline def realPath(using inline frame: Frame): Path < PathRead =
             ArrowEffect.suspend(Tag[PathRead], Path.Op.RealPath(self))
+
+        /** Attempts to acquire a scoped advisory lock, returning `Absent` when an incompatible
+          * claim is already held.
+          *
+          * Never waits for that claim to be released, which is what [[lock]] is for. `Async` is in
+          * the row for a different reason: a backend that merges same-process claims onto one
+          * platform lock has a span in which a compatible claim is being taken but is not yet
+          * shareable, and answering during it would report a conflict that does not exist. Waiting
+          * out that span is bounded and needs no holder to release anything.
+          */
+        def tryLock(mode: LockMode)(using Frame): Maybe[Lock] < (PathRead & Sync & Async & Scope) =
+            suspendTryLock(self, mode)
+
+        /** Acquires a scoped advisory lock according to `wait`. */
+        def lock(mode: LockMode, wait: LockWait = LockWait.UntilAvailable)(using Frame): Lock < (PathRead & Async & Scope) =
+            suspendLock(self, mode, wait)
 
         /** Returns this path resolved to its canonical real path, but only if that real path is contained
           * within `root` (after resolving `root`'s own symlinks).
@@ -1412,6 +1492,25 @@ object Path extends PathPlatformSpecific:
             Frame
         ): Result[FileReadException | FileWriteException | FileStructureException, Path.RawChannel]
 
+        /** Acquires a raw advisory lock on this path in `mode`, non-blocking (fails
+          * immediately if the lock is held incompatibly rather than waiting). Platform
+          * implementations provide the concrete lock.
+          */
+        def lock(mode: LockMode)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock]
+
+        /** Attempts the lock, distinguishing a conflict from an answer that is not settled yet.
+          *
+          * `lock` collapses both onto a failure, which is the right shape for a caller that cannot
+          * wait. A backend that merges same-process claims onto one platform lock has a span in
+          * which a compatible claim is being taken but is not yet shareable, and refusing there
+          * denies a lock the contract grants. Backends with no such span keep the default.
+          */
+        private[kyo] def lockAttempt(mode: LockMode)(using AllowUnsafe, Frame): Path.LockAttempt =
+            lock(mode) match
+                case Result.Success(raw)   => Path.LockAttempt.Acquired(raw)
+                case Result.Failure(error) => Path.LockAttempt.Failed(Result.Failure(error))
+                case panic: Result.Panic   => Path.LockAttempt.Failed(panic)
+
         /** Lifts this `Unsafe` value back into the safe `Path` opaque type. */
         def safe: Path = this
 
@@ -1580,5 +1679,41 @@ object Path extends PathPlatformSpecific:
         /** Closes the channel, releasing all OS resources. */
         def close()(using AllowUnsafe): Unit
     end RawChannel
+
+    // --- Raw lock -- platform-provided advisory lock backing Path.Lock ---
+
+    /** A raw advisory lock returned by `Path.Unsafe.lock`. Platform implementations provide the
+      * concrete class; `FileSystem` backends wrap it as the public [[Path.Lock]].
+      */
+    abstract private[kyo] class RawLock:
+        /** `true` when this lock excludes every other holder, including other shared holders. */
+        def isExclusive: Boolean
+
+        /** Verifies that the platform claim is still owned. */
+        def check()(using AllowUnsafe, Frame): Result[FileLockException, Unit]
+
+        /** Releases the lock, freeing it for another acquirer. */
+        def release()(using AllowUnsafe, Frame): Result[FileLockException, Unit]
+    end RawLock
+
+    /** The outcome of a single non-blocking lock attempt.
+      *
+      * Separates "no" from "not yet", which `Result` alone cannot carry. Only [[Pending]] is worth
+      * retrying on its own: a conflict clears when the holder releases, which is the waiting
+      * caller's concern, while a pending answer clears without anyone releasing anything.
+      */
+    private[kyo] enum LockAttempt derives CanEqual:
+        /** The platform claim was taken and is held. */
+        case Acquired(raw: RawLock)
+
+        /** A compatible claim is mid-acquisition, so the answer is not settled. Asking again once
+          * that acquisition finishes yields a real answer; the retry must be bounded, since an
+          * acquisition interrupted before it can withdraw leaves an entry nothing else clears.
+          */
+        case Pending
+
+        /** A definite answer: an incompatible holder, or the attempt failed outright. */
+        case Failed(error: Result[FileLockException, Nothing])
+    end LockAttempt
 
 end Path

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -600,14 +600,11 @@ object Path extends PathPlatformSpecific:
       * Use [[check]] before a protected operation when the backend can lose external ownership.
       * It raises [[FileLockOwnershipLostException]] if the claim no longer belongs to this handle.
       *
-      * On the JVM and Native on POSIX platforms (Linux, macOS), the lock is a process-wide
-      * `fcntl` record lock, and POSIX releases every lock the process holds on a file when the
-      * process closes any handle to that file. Reading or writing the locked path through this
-      * API, or through any other API, opens and closes such a handle, and the release is silent:
-      * neither the platform lock object nor [[check]] can observe it. While a lock is held, do
-      * not touch the locked file from the same process; lock a sentinel path next to the data
-      * instead and perform the I/O on the data path. Windows locks are handle-scoped and the
-      * Node backend uses a lockfile protocol, so neither has this behavior.
+      * The claim is taken on a sentinel sibling of the path, never on the path itself, so holding
+      * a lock and reading or writing the locked path from the same process is safe on every
+      * platform. The sentinel may remain on disk after the process exits; it is an empty artifact
+      * whose claim died with the process. The lock coordinates processes that use this API; it
+      * does not exclude a foreign process that locks the data file directly through the OS.
       */
     trait Lock:
         /** The compatibility mode granted to this handle. */
@@ -1501,8 +1498,9 @@ object Path extends PathPlatformSpecific:
             Frame
         ): Result[FileReadException | FileWriteException | FileStructureException, Path.RawChannel]
 
-        /** Acquires a raw advisory lock on this path in `mode`, non-blocking (fails
-          * immediately if the lock is held incompatibly rather than waiting). Platform
+        /** Acquires a raw advisory lock for this path in `mode`, non-blocking (fails
+          * immediately if the lock is held incompatibly rather than waiting). The claim is
+          * taken on a sentinel sibling of the path, never on the path itself. Platform
           * implementations provide the concrete lock.
           */
         def lock(mode: LockMode)(using AllowUnsafe, Frame): Result[FileLockException, Path.RawLock]

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemChannelTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemChannelTest.scala
@@ -1,9 +1,7 @@
 package kyo
 
 /** Reusable contract for typed positioned channels on mutable backends. */
-abstract class FileSystemChannelTestSuite extends kyo.test.Test[Any]:
-
-    private given Frame = Frame.internal
+abstract class FileSystemChannelTest extends kyo.test.Test[Any]:
 
     protected def createFileSystem(using
         Frame
@@ -33,4 +31,4 @@ abstract class FileSystemChannelTestSuite extends kyo.test.Test[Any]:
         }
     }
 
-end FileSystemChannelTestSuite
+end FileSystemChannelTest

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
@@ -7,9 +7,9 @@ class FileSystemConformanceDeclarationTest extends kyo.test.Test[Any]:
 
     "all declared conformance suites are public shared types" in {
         val suites = Chunk(
-            classOf[FileSystemReadTestSuite],
-            classOf[FileSystemWriteTestSuite],
-            classOf[FileSystemChannelTestSuite],
+            classOf[FileSystemReadTest],
+            classOf[FileSystemWriteTest],
+            classOf[FileSystemChannelTest],
             classOf[FileSystemLockTest]
         )
         assert(suites.size == 4)

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
@@ -9,9 +9,10 @@ class FileSystemConformanceDeclarationTest extends kyo.test.Test[Any]:
         val suites = Chunk(
             classOf[FileSystemReadTestSuite],
             classOf[FileSystemWriteTestSuite],
-            classOf[FileSystemChannelTestSuite]
+            classOf[FileSystemChannelTestSuite],
+            classOf[FileSystemLockTestSuite]
         )
-        assert(suites.size == 3)
+        assert(suites.size == 4)
     }
 
     "a read-only fixture cannot select write members" in {

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
@@ -10,7 +10,7 @@ class FileSystemConformanceDeclarationTest extends kyo.test.Test[Any]:
             classOf[FileSystemReadTestSuite],
             classOf[FileSystemWriteTestSuite],
             classOf[FileSystemChannelTestSuite],
-            classOf[FileSystemLockTestSuite]
+            classOf[FileSystemLockTest]
         )
         assert(suites.size == 4)
     }

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
@@ -53,6 +53,7 @@ final class UserReadOnlyFileSystemFixture(delegate: FileSystem.Read[Sync]) exten
     export delegate.isRegularFile
     export delegate.isSymbolicLink
     export delegate.list
+    export delegate.lock
     export delegate.openRead
     export delegate.openReadChannel
     export delegate.openReadChannelUnscoped
@@ -64,6 +65,7 @@ final class UserReadOnlyFileSystemFixture(delegate: FileSystem.Read[Sync]) exten
     export delegate.realPath
     export delegate.size
     export delegate.stat
+    export delegate.tryLock
 end UserReadOnlyFileSystemFixture
 
 class UserReadOnlyFileSystemConformanceTest extends FileSystemReadTestSuite:

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
@@ -2,8 +2,6 @@ package kyo
 
 private object FileSystemConformanceFixtures:
 
-    private given Frame = Frame.internal
-
     def host(prefix: String)(using
         Frame
     ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
@@ -19,7 +17,7 @@ private object FileSystemConformanceFixtures:
 
 end FileSystemConformanceFixtures
 
-class HostFileSystemReadConformanceTest extends FileSystemReadTestSuite:
+class HostFileSystemReadConformanceTest extends FileSystemReadTest:
     override protected def realPathRequiresExistence: Boolean = true
     protected def createFileSystem(using
         Frame
@@ -27,14 +25,14 @@ class HostFileSystemReadConformanceTest extends FileSystemReadTestSuite:
         FileSystemConformanceFixtures.hostRead
 end HostFileSystemReadConformanceTest
 
-class HostFileSystemWriteConformanceTest extends FileSystemWriteTestSuite:
+class HostFileSystemWriteConformanceTest extends FileSystemWriteTest:
     protected def createFileSystem(using
         Frame
     ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
         FileSystemConformanceFixtures.host("kyo-host-write-suite")
 end HostFileSystemWriteConformanceTest
 
-class HostFileSystemChannelConformanceTest extends FileSystemChannelTestSuite:
+class HostFileSystemChannelConformanceTest extends FileSystemChannelTest:
     protected def createFileSystem(using
         Frame
     ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
@@ -68,7 +66,7 @@ final class UserReadOnlyFileSystemFixture(delegate: FileSystem.Read[Sync]) exten
     export delegate.tryLock
 end UserReadOnlyFileSystemFixture
 
-class UserReadOnlyFileSystemConformanceTest extends FileSystemReadTestSuite:
+class UserReadOnlyFileSystemConformanceTest extends FileSystemReadTest:
     override protected def realPathRequiresExistence: Boolean = true
     protected def createFileSystem(using
         Frame

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemExceptionTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemExceptionTest.scala
@@ -16,9 +16,12 @@ class FileSystemExceptionTest extends kyo.test.Test[Any]:
             FileDirectoryNotEmptyException(p),
             FileInvalidPathException("nul", FileSystemOperation.Read),
             FileIOException(p, FileSystemOperation.Read, cause),
-            FileAtomicMoveUnsupportedException(p, target)
+            FileAtomicMoveUnsupportedException(p, target),
+            FileLockUnavailableException(p),
+            FileLockTimeoutException(p, 10.millis),
+            FileLockOwnershipLostException(p)
         )
-        assert(values.size == 8)
+        assert(values.size == 11)
         assert(values(5).asInstanceOf[FileInvalidPathException].input == "nul")
         assert(values(6).asInstanceOf[FileIOException].operation == FileSystemOperation.Read)
         assert(values(6).getCause eq cause)
@@ -30,6 +33,8 @@ class FileSystemExceptionTest extends kyo.test.Test[Any]:
         assert(FileNotFoundException(p).isInstanceOf[FileReadException])
         assert(FileAlreadyExistsException(p).isInstanceOf[FileStructureException])
         assert(FileAtomicMoveUnsupportedException(p, Path("to")).isInstanceOf[FileStructureException])
+        assert(FileLockTimeoutException(p, 1.millis).isInstanceOf[FileLockException])
+        assert(FileLockOwnershipLostException(p).isInstanceOf[FileLockException])
     }
 
     "FileIsADirectoryException is FileReadException and FileWriteException but not FileStructureException" in {

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemLockTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemLockTest.scala
@@ -1,9 +1,7 @@
 package kyo
 
 /** Shared behavioral contract for [[FileSystem.Read]] lock implementations. */
-abstract class FileSystemLockTestSuite extends kyo.test.Test[Any]:
-
-    private given Frame = Frame.internal
+abstract class FileSystemLockTest extends kyo.test.Test[Any]:
 
     protected def withFileSystem(
         use: (FileSystem.Read[Sync], Path) => Unit < (Async & Sync & Scope & Abort[FileSystemException])
@@ -283,4 +281,4 @@ abstract class FileSystemLockTestSuite extends kyo.test.Test[Any]:
         }
     }
 
-end FileSystemLockTestSuite
+end FileSystemLockTest

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemLockTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemLockTest.scala
@@ -80,6 +80,18 @@ abstract class FileSystemLockTest extends kyo.test.Test[Any]:
     }
 
     "lifecycle" - {
+        "locking claims a sentinel sibling and leaves the data path untouched" in {
+            withFileSystem { (fileSystem, path) =>
+                Scope.run {
+                    fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { _ =>
+                        fileSystem.exists(path).map { dataExists =>
+                            assert(!dataExists, s"locking created the data file $path")
+                        }
+                    }
+                }
+            }
+        }
+
         "scope closure releases the owning claim" in {
             withFileSystem { (fileSystem, path) =>
                 Scope.run(fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).unit).andThen {

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemLockTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemLockTestSuite.scala
@@ -1,0 +1,286 @@
+package kyo
+
+/** Shared behavioral contract for [[FileSystem.Read]] lock implementations. */
+abstract class FileSystemLockTestSuite extends kyo.test.Test[Any]:
+
+    private given Frame = Frame.internal
+
+    protected def withFileSystem(
+        use: (FileSystem.Read[Sync], Path) => Unit < (Async & Sync & Scope & Abort[FileSystemException])
+    )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException])
+
+    private def assertImmediate(first: Path.LockMode, second: Path.LockMode, expected: Boolean)(using
+        kyo.test.AssertScope
+    ): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
+        withFileSystem { (fileSystem, path) =>
+            fileSystem.lock(path, first, Path.LockWait.Immediate).map { held =>
+                fileSystem.tryLock(path, second).map { attempted =>
+                    assert(held.mode == first)
+                    assert(attempted.isDefined == expected)
+                }
+            }
+        }
+
+    private def assertWaiting(first: Path.LockMode, second: Path.LockMode, compatible: Boolean)(using
+        kyo.test.AssertScope
+    ): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
+        withFileSystem { (fileSystem, path) =>
+            if compatible then
+                Scope.run {
+                    fileSystem.lock(path, first, Path.LockWait.Immediate).map { _ =>
+                        fileSystem.lock(path, second, Path.LockWait.UntilAvailable).map { acquired =>
+                            assert(acquired.mode == second)
+                        }
+                    }
+                }
+            else
+                Scope.run {
+                    fileSystem.lock(path, first, Path.LockWait.Immediate).map { _ =>
+                        fileSystem.tryLock(path, second).map { unavailable =>
+                            assert(unavailable.isEmpty)
+                            Fiber.initUnscoped(Scope.run(fileSystem.lock(path, second, Path.LockWait.UntilAvailable)))
+                                .map { waiter =>
+                                    waiter.poll.map { state =>
+                                        assert(state.isEmpty)
+                                        waiter
+                                    }
+                                }
+                        }
+                    }
+                }.map(_.get.map(acquired => assert(acquired.mode == second)))
+        }
+    end assertWaiting
+
+    "immediate compatibility" - {
+        "shared with shared succeeds" in {
+            assertImmediate(Path.LockMode.Shared, Path.LockMode.Shared, expected = true)
+        }
+        "shared with exclusive conflicts" in {
+            assertImmediate(Path.LockMode.Shared, Path.LockMode.Exclusive, expected = false)
+        }
+        "exclusive with shared conflicts" in {
+            assertImmediate(Path.LockMode.Exclusive, Path.LockMode.Shared, expected = false)
+        }
+        "exclusive with exclusive conflicts" in {
+            assertImmediate(Path.LockMode.Exclusive, Path.LockMode.Exclusive, expected = false)
+        }
+    }
+
+    "waiting compatibility" - {
+        "shared with shared succeeds" in {
+            assertWaiting(Path.LockMode.Shared, Path.LockMode.Shared, compatible = true)
+        }
+        "shared with exclusive waits for release" in {
+            assertWaiting(Path.LockMode.Shared, Path.LockMode.Exclusive, compatible = false)
+        }
+        "exclusive with shared waits for release" in {
+            assertWaiting(Path.LockMode.Exclusive, Path.LockMode.Shared, compatible = false)
+        }
+        "exclusive with exclusive waits for release" in {
+            assertWaiting(Path.LockMode.Exclusive, Path.LockMode.Exclusive, compatible = false)
+        }
+    }
+
+    "lifecycle" - {
+        "scope closure releases the owning claim" in {
+            withFileSystem { (fileSystem, path) =>
+                Scope.run(fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).unit).andThen {
+                    Scope.run(fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+                        assert(lock.mode == Path.LockMode.Exclusive)
+                    })
+                }
+            }
+        }
+
+        "cancelled waiter leaves no ownership claim" in {
+            withFileSystem { (fileSystem, path) =>
+                Scope.run {
+                    fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { _ =>
+                        Latch.init(1).map { started =>
+                            Fiber.initUnscoped(
+                                started.release.andThen(
+                                    Scope.run(fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.UntilAvailable))
+                                )
+                            ).map { waiter =>
+                                started.await.andThen(waiter.interrupt).map { interrupted =>
+                                    assert(interrupted)
+                                }
+                            }
+                        }
+                    }
+                }.andThen {
+                    Scope.run(fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+                        assert(lock.mode == Path.LockMode.Exclusive)
+                    })
+                }
+            }
+        }
+
+        "deadline timeout is driven by Clock" in {
+            Clock.withTimeControl { control =>
+                withFileSystem { (fileSystem, path) =>
+                    Scope.run {
+                        fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { _ =>
+                            Clock.deadline(10.millis).map { deadline =>
+                                Latch.init(1).map { started =>
+                                    Fiber.initUnscoped(
+                                        started.release.andThen(
+                                            Abort.run[FileLockException](
+                                                Scope.run(fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Until(deadline)))
+                                            )
+                                        )
+                                    ).map { waiter =>
+                                        // A background advancer, not a bounded advance count: the waiter's poll loop
+                                        // checks the deadline and then registers its sleep, and a bounded batch of
+                                        // advances can complete inside that gap, leaving a sleep no advance ever
+                                        // reaches (the FiberTest gather pattern).
+                                        started.await.andThen(Fiber.initUnscoped(Loop.forever(control.advance(1.milli)))).map {
+                                            advancer =>
+                                                waiter.get.map { result =>
+                                                    advancer.interrupt.andThen {
+                                                        result match
+                                                            case Result.Failure(_: FileLockTimeoutException) => assert(true)
+                                                            case other => assert(false, s"expected FileLockTimeoutException, got $other")
+                                                    }
+                                                }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "an already-expired deadline cannot grant a free lock" in {
+            Clock.withTimeControl { control =>
+                withFileSystem { (fileSystem, path) =>
+                    Clock.deadline(Duration.Zero).map { deadline =>
+                        control.advance(1.nano).andThen {
+                            Abort.run[FileLockException](
+                                Scope.run(fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Until(deadline)))
+                            ).map {
+                                case Result.Failure(_: FileLockTimeoutException) => assert(true)
+                                case other                                       => assert(false, s"expected expired deadline, got $other")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "expiry before a retry prevents another acquisition attempt" in {
+            Clock.withTimeControl { control =>
+                val path  = Path("deadline-retry.bin")
+                val token = Path.LockOwnership.fresh()
+                val available = new Path.Lock:
+                    def mode: Path.LockMode                                          = Path.LockMode.Exclusive
+                    def ownership: Path.LockOwnership                                = token
+                    def check(using Frame): Unit < Sync                              = ()
+                    def release(owner: Path.LockOwnership)(using Frame): Unit < Sync = ()
+                Clock.deadline(1.milli).map { deadline =>
+                    AtomicInt.init(0).map { attempts =>
+                        Latch.init(1).map { firstAttempt =>
+                            Latch.init(1).map { finishFirstAttempt =>
+                                val attempt = attempts.incrementAndGet.map {
+                                    case 1 => firstAttempt.release.andThen(finishFirstAttempt.await).andThen(Absent)
+                                    case _ => Present(available)
+                                }
+                                Fiber.initUnscoped(
+                                    Abort.run[FileLockException](Scope.run(FileSystem.awaitLock(
+                                        path,
+                                        Path.LockWait.Until(deadline)
+                                    )(attempt)))
+                                ).map { waiter =>
+                                    // Background advancer for the same reason as the deadline test above: the retry
+                                    // sleep registers after the expiry check, and a bounded advance batch can finish
+                                    // inside that gap.
+                                    firstAttempt.await.andThen(control.advance(2.millis)).andThen(finishFirstAttempt.release)
+                                        .andThen(Fiber.initUnscoped(Loop.forever(control.advance(2.millis)))).map { advancer =>
+                                            waiter.get.map { result =>
+                                                advancer.interrupt.andThen {
+                                                    result match
+                                                        case Result.Failure(_: FileLockTimeoutException) => ()
+                                                        case other => assert(false, s"expected expiry before retry, got $other")
+                                                    attempts.get.map(count => assert(count == 1))
+                                                }
+                                            }
+                                        }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "owning release is idempotent" in {
+            withFileSystem { (fileSystem, path) =>
+                Scope.run {
+                    fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+                        lock.release(lock.ownership).andThen(lock.release(lock.ownership)).andThen {
+                            fileSystem.tryLock(path, Path.LockMode.Exclusive).map(acquired => assert(acquired.isDefined))
+                        }
+                    }
+                }
+            }
+        }
+
+        "concurrent releases both terminate" in {
+            // Release is reachable from two directions at once: the Scope finalizer and an explicit
+            // call. Whichever loses the claim must return rather than wait on the winner, because
+            // the loser can be the finalizer, and a finalizer that does not return is a scope that
+            // never closes. The earlier implementation had the loser loop on an intermediate state
+            // with no yield and no exit condition it could reach on its own.
+            withFileSystem { (fileSystem, path) =>
+                Scope.run {
+                    fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+                        for
+                            gate   <- Latch.init(1)
+                            first  <- Fiber.initUnscoped(gate.await.andThen(lock.release(lock.ownership)))
+                            second <- Fiber.initUnscoped(gate.await.andThen(lock.release(lock.ownership)))
+                            _      <- gate.release
+                            _      <- first.get
+                            _      <- second.get
+                            // The claim is genuinely gone, not merely reported as released.
+                            reacquired <- fileSystem.tryLock(path, Path.LockMode.Exclusive)
+                        yield assert(reacquired.isDefined)
+                        end for
+                    }
+                }
+            }
+        }
+
+        "wrong owner cannot release a claim" in {
+            withFileSystem { (fileSystem, path) =>
+                Scope.run {
+                    fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+                        Abort.run[FileLockException](lock.release(Path.LockOwnership.fresh())).map { result =>
+                            result match
+                                case Result.Failure(_: FileLockOwnershipLostException) => ()
+                                case other => assert(false, s"expected FileLockOwnershipLostException, got $other")
+                            lock.check.andThen(fileSystem.tryLock(path, Path.LockMode.Exclusive)).map { acquired =>
+                                assert(acquired.isEmpty)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "check reports deterministic ownership loss" in {
+            withFileSystem { (fileSystem, path) =>
+                Scope.run {
+                    fileSystem.lock(path, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+                        lock.release(lock.ownership).andThen(Abort.run[FileLockException](lock.check)).map {
+                            case Result.Failure(_: FileLockOwnershipLostException) => assert(true)
+                            case other => assert(false, s"expected FileLockOwnershipLostException, got $other")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+end FileSystemLockTestSuite

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemReadTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemReadTest.scala
@@ -5,9 +5,7 @@ package kyo
   * Implementations provide a fresh backend, a populated file, and its expected UTF-8 value for
   * each assertion.
   */
-abstract class FileSystemReadTestSuite extends kyo.test.Test[Any]:
-
-    private given Frame = Frame.internal
+abstract class FileSystemReadTest extends kyo.test.Test[Any]:
 
     protected def createFileSystem(using
         Frame
@@ -168,4 +166,4 @@ abstract class FileSystemReadTestSuite extends kyo.test.Test[Any]:
         }
     }
 
-end FileSystemReadTestSuite
+end FileSystemReadTest

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemTest.scala
@@ -32,6 +32,7 @@ class FileSystemTest extends kyo.test.Test[Any]:
         export delegate.isRegularFile
         export delegate.isSymbolicLink
         export delegate.list
+        export delegate.lock
         export delegate.mkDir
         export delegate.mkFile
         export delegate.move
@@ -56,6 +57,7 @@ class FileSystemTest extends kyo.test.Test[Any]:
         export delegate.temp
         export delegate.tempDir
         export delegate.truncate
+        export delegate.tryLock
         export delegate.writeBytes
         export delegate.writeChunk
         export delegate.writeLines

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemWriteTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemWriteTest.scala
@@ -1,9 +1,7 @@
 package kyo
 
 /** Reusable behavioral contract for mutable filesystem backends. */
-abstract class FileSystemWriteTestSuite extends kyo.test.Test[Any]:
-
-    private given Frame = Frame.internal
+abstract class FileSystemWriteTest extends kyo.test.Test[Any]:
 
     protected def createFileSystem(using
         Frame
@@ -88,4 +86,4 @@ abstract class FileSystemWriteTestSuite extends kyo.test.Test[Any]:
         }
     }
 
-end FileSystemWriteTestSuite
+end FileSystemWriteTest

--- a/kyo-system/shared/src/test/scala/kyo/PathCapabilityTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathCapabilityTest.scala
@@ -56,7 +56,7 @@ class PathCapabilityTest extends kyo.test.Test[Any]:
             """
             given kyo.Frame = kyo.Frame.internal
             val bad: kyo.Maybe[kyo.Path.Lock] < (kyo.PathRead & kyo.Scope) =
-                kyo.Path.suspendTryLock(kyo.Path("x"), kyo.Path.LockMode.Shared)
+                kyo.Path.suspendTryLock(kyo.Path("x"), kyo.Path.LockMode.Shared, kyo.Path.defaultLockSuffix)
             """
         )
         val lockErrors = typeCheckErrors(
@@ -66,7 +66,8 @@ class PathCapabilityTest extends kyo.test.Test[Any]:
                 kyo.Path.suspendLock(
                     kyo.Path("x"),
                     kyo.Path.LockMode.Exclusive,
-                    kyo.Path.LockWait.UntilAvailable
+                    kyo.Path.LockWait.UntilAvailable,
+                    kyo.Path.defaultLockSuffix
                 )
             """
         )

--- a/kyo-system/shared/src/test/scala/kyo/PathCapabilityTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathCapabilityTest.scala
@@ -19,6 +19,15 @@ class PathCapabilityTest extends kyo.test.Test[Any]:
     val mixed: String < PathWrite                              = somePath.read.map(s => otherPath.write(s).andThen(s))
     val readRuns: String < (Sync & Abort[FileSystemException]) = Path.runReadOnly(readOnly)
     val writeRuns: Unit < (Sync & Abort[FileSystemException])  = Path.run(write)
+    // Async is in tryLock's row deliberately, and this ascription is what states it. It does not
+    // mean tryLock waits for a conflicting holder, which is still lock's job alone: it means the
+    // host backend may have to wait out the span in which a compatible same-process claim is being
+    // taken but is not yet shareable, since answering during it would report a conflict that does
+    // not exist.
+    val tryLockRow: Maybe[Path.Lock] < (PathRead & Sync & Async & Scope) =
+        somePath.tryLock(Path.LockMode.Shared)
+    val lockRow: Path.Lock < (PathRead & Async & Scope) =
+        somePath.lock(Path.LockMode.Exclusive, Path.LockWait.UntilAvailable)
 
     "the read-only runner leaves a write undischarged so its residual does not type-check" in {
         val errors = typeCheckErrors(
@@ -30,6 +39,39 @@ class PathCapabilityTest extends kyo.test.Test[Any]:
         )
         assert(errors.nonEmpty)
         assert(errors.exists(_.message.contains("PathWrite")))
+    }
+
+    "the removed FileLock and Boolean lock APIs do not type-check" in {
+        val fileLockErrors = typeCheckErrors("val lock: kyo.Path.FileLock = ???")
+        val booleanErrors = typeCheckErrors("""
+            given kyo.Frame = kyo.Frame.internal
+            kyo.Path("x").lock(true)
+            """)
+        assert(fileLockErrors.nonEmpty)
+        assert(booleanErrors.nonEmpty)
+    }
+
+    "internal lock suspensions retain their required handlers" in {
+        val tryLockErrors = typeCheckErrors(
+            """
+            given kyo.Frame = kyo.Frame.internal
+            val bad: kyo.Maybe[kyo.Path.Lock] < (kyo.PathRead & kyo.Scope) =
+                kyo.Path.suspendTryLock(kyo.Path("x"), kyo.Path.LockMode.Shared)
+            """
+        )
+        val lockErrors = typeCheckErrors(
+            """
+            given kyo.Frame = kyo.Frame.internal
+            val bad: kyo.Path.Lock < (kyo.PathRead & kyo.Scope) =
+                kyo.Path.suspendLock(
+                    kyo.Path("x"),
+                    kyo.Path.LockMode.Exclusive,
+                    kyo.Path.LockWait.UntilAvailable
+                )
+            """
+        )
+        assert(tryLockErrors.nonEmpty)
+        assert(lockErrors.nonEmpty)
     }
 
     "an explicit backend effect remains in the runner residual" in {

--- a/kyo-system/shared/src/test/scala/kyo/PathLockTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathLockTest.scala
@@ -1,6 +1,6 @@
 package kyo
 
-class HostPathLockTest extends FileSystemLockTestSuite:
+class HostPathLockTest extends FileSystemLockTest:
     protected def withFileSystem(
         use: (FileSystem.Read[Sync], Path) => Unit < (Async & Sync & Scope & Abort[FileSystemException])
     )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =

--- a/kyo-system/shared/src/test/scala/kyo/PathLockTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathLockTest.scala
@@ -123,6 +123,43 @@ class HostPathLockTest extends FileSystemLockTest:
         }
     }
 
+    "claims under different sentinel suffixes are independent" in {
+        // The suffix names the sentinel sibling and is part of the lock's identity: two exclusive
+        // claims on one data path under different suffixes contend on different files, so both are
+        // granted, while a second claim under the same suffix still conflicts.
+        Scope.acquireRelease(FileSystem.host.tempDir("kyo-lock-suffix"))(h => Sync.Unsafe.defer(h.remove())).map { handle =>
+            val target = handle.path / "state.bin"
+            Scope.run {
+                FileSystem.host.lock(target, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { _ =>
+                    FileSystem.host.tryLock(target, Path.LockMode.Exclusive).map { sameSuffix =>
+                        assert(sameSuffix.isEmpty, "a same-suffix claim did not conflict")
+                        FileSystem.host.tryLock(target, Path.LockMode.Exclusive, sentinelSuffix = ".other-lock").map { otherSuffix =>
+                            assert(otherSuffix.isDefined, "a claim under a different suffix was refused")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "an invalid sentinel suffix is refused with a typed failure" in {
+        // Empty would put the claim on the data file itself, resurrecting the POSIX
+        // unlock-on-close hazard; a separator would move the sentinel into another directory.
+        Scope.acquireRelease(FileSystem.host.tempDir("kyo-lock-suffix-invalid"))(h => Sync.Unsafe.defer(h.remove())).map { handle =>
+            val target = handle.path / "state.bin"
+            Abort.run[FileReadException | FileLockException](
+                Scope.run(FileSystem.host.tryLock(target, Path.LockMode.Exclusive, sentinelSuffix = "").unit)
+            ).map { empty =>
+                assert(empty.failure.exists(_.isInstanceOf[FileInvalidPathException]))
+                Abort.run[FileReadException | FileLockException](
+                    Scope.run(FileSystem.host.lock(target, Path.LockMode.Exclusive, Path.LockWait.Immediate, "bad/suffix").unit)
+                ).map { separator =>
+                    assert(separator.failure.exists(_.isInstanceOf[FileInvalidPathException]))
+                }
+            }
+        }
+    }
+
     "failed raw release remains retryable" in {
         AtomicInt.init(0).map { releases =>
             val raw = new Path.RawLock:

--- a/kyo-system/shared/src/test/scala/kyo/PathLockTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathLockTest.scala
@@ -1,0 +1,115 @@
+package kyo
+
+class HostPathLockTest extends FileSystemLockTestSuite:
+    protected def withFileSystem(
+        use: (FileSystem.Read[Sync], Path) => Unit < (Async & Sync & Scope & Abort[FileSystemException])
+    )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
+        Scope.acquireRelease(FileSystem.host.tempDir("kyo-path-lock"))(handle => Sync.Unsafe.defer(handle.remove())).map { handle =>
+            use(FileSystem.host, handle.path / "target.bin")
+        }
+
+    "Path lock operations dispatch through PathRead" in {
+        Scope.acquireRelease(FileSystem.host.tempDir("kyo-path-lock-dispatch"))(handle => Sync.Unsafe.defer(handle.remove())).map {
+            handle =>
+                val path = handle.path / "path-lock-target.bin"
+                Scope.run {
+                    Path.runReadOnlyWith(FileSystem.host) {
+                        path.lock(Path.LockMode.Shared, Path.LockWait.Immediate).map { lock =>
+                            path.tryLock(Path.LockMode.Exclusive).map { conflicting =>
+                                assert(lock.mode == Path.LockMode.Shared)
+                                assert(conflicting.isEmpty)
+                            }
+                        }
+                    }
+                }
+        }
+    }
+
+    "an interrupt delivered once the lock is held still releases it" in {
+        // The acquisition interrupts its own fiber from inside the claim node, via the hook
+        // HostFileSystem exposes for exactly this. The request is made with the OS lock already
+        // held, and delivery happens at the next safepoint, so the interrupt lands after the
+        // acquisition produced the lock rather than before it started. That instant is the whole
+        // defect: with the finalizer registered in a continuation after acquire, nothing capable of
+        // releasing the claim exists yet, and the path stays unacquirable for the life of the
+        // process.
+        //
+        // Mutation-checked rather than assumed: rewriting tryLock as Scope.acquireRelease, with the
+        // hook in the same position inside acquire, fails this case on the retry below. An earlier
+        // version of this test interrupted from outside the fiber and passed under both orderings,
+        // because that interrupt is delivered before the claim is ever made.
+        Scope.acquireRelease(FileSystem.host.tempDir("kyo-lock-window"))(h => Sync.Unsafe.defer(h.remove())).map { handle =>
+            val target = handle.path / "windowed.bin"
+            Scope.ensure(Sync.defer(HostFileSystem.afterClaimHook = () => ())).andThen {
+                Fiber.Promise.init[Fiber[Unit, Any], Any].map { handoff =>
+                    Fiber.initUnscoped {
+                        handoff.get.map { self =>
+                            Sync.defer {
+                                import AllowUnsafe.embrace.danger
+                                HostFileSystem.afterClaimHook = () => discard(self.unsafe.interrupt())
+                            }.andThen {
+                                Abort.run[FileReadException | FileLockException](
+                                    Scope.run(FileSystem.host.tryLock(target, Path.LockMode.Exclusive).unit)
+                                ).unit
+                            }
+                        }
+                    }.map { fiber =>
+                        handoff.complete(Result.succeed(fiber)).andThen(fiber.getResult)
+                    }
+                }.andThen {
+                    Sync.defer(HostFileSystem.afterClaimHook = () => ())
+                }.andThen {
+                    // Retried rather than attempted once. Interrupting a fiber starts its finalizer
+                    // but does not wait for it, so a correct release may still be in flight; that is
+                    // a lock briefly held, not a stranded one. A stranded lock never becomes
+                    // available, so only the retry distinguishes the two.
+                    assertEventually {
+                        Scope.run(FileSystem.host.tryLock(target, Path.LockMode.Exclusive).map(_.isDefined))
+                    }
+                }
+            }
+        }
+    }
+
+    "repeated interrupted acquisitions leave the path acquirable".ignore(
+        "kyo-core can lose a Scope.ensure finalizer when its fiber is interrupted under load, which strands the lock; see #1928"
+    ) in {
+        // Interrupting from outside the fiber, which lands before the claim is made. That is the
+        // opposite end of the acquisition from the case above and is worth holding separately: it
+        // pins that an acquisition abandoned before it claims anything leaves nothing behind, so
+        // repeated attempts cannot accumulate claims.
+        Scope.acquireRelease(FileSystem.host.tempDir("kyo-lock-interrupt"))(h => Sync.Unsafe.defer(h.remove())).map { handle =>
+            val target = handle.path / "contended.bin"
+            Loop.indexed { i =>
+                if i >= 200 then Loop.done
+                else
+                    Fiber.initUnscoped(Scope.run(FileSystem.host.tryLock(target, Path.LockMode.Exclusive).map(_ => ())))
+                        .map(_.interrupt)
+                        .andThen(Loop.continue)
+            }.andThen {
+                assertEventually {
+                    Scope.run(FileSystem.host.tryLock(target, Path.LockMode.Exclusive).map(_.isDefined))
+                }
+            }
+        }
+    }
+
+    "failed raw release remains retryable" in {
+        AtomicInt.init(0).map { releases =>
+            val raw = new Path.RawLock:
+                def isExclusive: Boolean                                               = true
+                def check()(using AllowUnsafe, Frame): Result[FileLockException, Unit] = Result.unit
+                def release()(using AllowUnsafe, Frame): Result[FileLockException, Unit] =
+                    if releases.unsafe.incrementAndGet() == 1 then Result.fail(FileLockOwnershipLostException(Path("retry-lock")))
+                    else Result.unit
+            AtomicInt.init(0).map { state =>
+                val service = new HostFileSystem.HostFileSystem
+                val lock    = service.lockFrom(Path("retry-lock"), raw, Path.LockMode.Exclusive, state)
+                Abort.run[FileLockException](lock.release(lock.ownership)).map { first =>
+                    assert(first.isFailure)
+                    lock.release(lock.ownership).andThen(releases.get.map(count => assert(count == 2)))
+                }
+            }
+        }
+    }
+end HostPathLockTest

--- a/kyo-system/shared/src/test/scala/kyo/PathLockTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathLockTest.scala
@@ -94,6 +94,35 @@ class HostPathLockTest extends FileSystemLockTest:
         }
     }
 
+    "data path I/O while holding the lock does not disturb the claim" in {
+        // The scenario from review: on POSIX, an fcntl lock on the data file itself is released
+        // the moment the same process closes any other handle to that file, so a read of the
+        // locked path would silently destroy cross-process exclusion. The claim lives on a
+        // sentinel sibling that data I/O never opens, so reads and writes of the data path leave
+        // it standing.
+        Scope.acquireRelease(FileSystem.host.tempDir("kyo-lock-sentinel"))(h => Sync.Unsafe.defer(h.remove())).map { handle =>
+            val target = handle.path / "state.bin"
+            Scope.run {
+                FileSystem.host.lock(target, Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
+                    FileSystem.host.write(target, "first", Path.WriteOptions()).andThen {
+                        FileSystem.host.read(target).map { value =>
+                            assert(value == "first")
+                            FileSystem.host.write(target, "second", Path.WriteOptions()).andThen {
+                                lock.check.andThen {
+                                    FileSystem.host.tryLock(target, Path.LockMode.Exclusive).map { conflicting =>
+                                        assert(conflicting.isEmpty, "the claim was lost after data path I/O")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }.andThen {
+                Scope.run(FileSystem.host.tryLock(target, Path.LockMode.Exclusive).map(released => assert(released.isDefined)))
+            }
+        }
+    }
+
     "failed raw release remains retryable" in {
         AtomicInt.init(0).map { releases =>
             val raw = new Path.RawLock:


### PR DESCRIPTION
### What this adds

Advisory file locks. `Path.Lock` is scope-managed: acquiring registers the release with the enclosing `Scope` before anything is claimed, so an interrupt landing between the claim and the finalizer cannot strand the lock. `LockMode` selects shared or exclusive compatibility, and `LockWait` selects whether a contended attempt fails immediately, waits, or waits until a deadline.

```scala
import kyo.*

val guarded = Scope.run {
    Path.runReadOnly {
        Path("state.bin").lock(Path.LockMode.Exclusive, Path.LockWait.Immediate).map(_.check)
    }
}
```

`tryLock` answers `Absent` for a conflicting holder and never waits for one. It still carries `Async`, for a different reason: a backend that merges same-process claims onto one platform lock has a span in which a compatible claim is being taken but is not yet shareable, and answering during that span would report a conflict that does not exist. Waiting it out is bounded and needs no holder to release anything.

There is no public manual release. A lock goes when its `Scope` closes, and `check` reports `FileLockOwnershipLostException` for the backends that can lose a claim underneath the handle.

### What changed

**`Path`** gains `LockMode`, `LockWait`, the public `Lock` trait, and the `lock` and `tryLock` extension methods. The private surface a platform implements is `RawLock` plus `LockAttempt`, which separates "no" from "not yet": only the unsettled answer is worth retrying on its own, since a real conflict clears when the holder releases and that is the waiting caller's concern.

**`FileSystem.Read`** gains `tryLock` and `lock`, so a read-only backend still vends locks. `FileSystem.awaitLock` holds the waiting policy in one place and paces its retries with `Async.sleep` rather than `Clock.sleep`, since the latter hands back the timer fiber instead of suspending on it and would turn the retry into a busy spin against the holder it is waiting on.

**`FileSystemException`** gains the `FileLockException` marker and the `FileLockUnavailableException`, `FileLockTimeoutException` and `FileLockOwnershipLostException` leaves. `FileSystemOperation` gains `Lock`, so an acquisition failure names what it was doing instead of borrowing `Read`.

**JVM and Native** back a lock with `FileChannel.tryLock` behind a process-wide `NioPathLockRegistry`. POSIX advisory locks do not exclude the owning process from reacquiring its own lock, so same-process exclusion is enforced explicitly rather than assumed from the platform call. The registry key is the resolved real path, so two names for one file through a symbolic link share one entry instead of opening two channels the JVM then refuses as overlapping.

**JS and Wasm** implement an `O_EXCL` lockfile protocol. A claim records host, pid and a random token, and an owner whose process is provably gone is reclaimed rather than left blocking the path for good.

**Tests.** `FileSystemLockTest` joins the read, write and channel suites as the fourth cross-backend contract, so every backend added later inherits the same laws. `HostPathLockTest` covers the interrupt window from both ends: an interrupt delivered from inside the claim node with the OS lock already held, and repeated interrupts landing before the claim is made. The repeated-interrupt stress case is currently marked ignored: it reliably exposes #1928, a core defect where an interrupted fiber can lose its `Scope.ensure` finalizers under load, which no backend-side code can compensate for. The claim path additionally records the holder through a tombstone, so a claim that completes after the finalizer has already drained releases the lock in place instead of stranding it.

### Stack

Part of the path-capability stack: process fixes, filesystem vocabulary, abstraction, capability flip, channels, locks, watch, durability, confinement, in-memory, zip, then overlay (#1799). Merge bottom up; GitHub retargets the stack above each merge.

The lower branches (#1856, #1857, #1852, #1854, #1888, #1861, #1862, #1863, #1864, #1865) have landed, so this branch is now a single commit rebased onto `main`. The original incremental development history remains visible in #1799's earlier timeline and in the backup refs recorded in the working notes.
