### PR TITLE
[kyo-system] watch a path for filesystem changes

### DIFF
--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Node lockfile protocol already used. The lock does not exclude a foreign process
 data file directly through the OS.
 
 Watchers use the independent `PathWatch` capability. Acquisition returns only after backend
-registration is active. Events are normalized as `PathChange`; overflow and root invalidation are
+registration is active. Events are normalized as `Path.Change`; overflow and root invalidation are
 stream values. Invalidation is terminal: emit it exactly once, close the stream, and release the
 registration.
 

--- a/kyo-system/CONTRIBUTING.md
+++ b/kyo-system/CONTRIBUTING.md
@@ -14,10 +14,11 @@ The module owns these capability boundaries:
 |---|---|---|
 | Filesystem reads | `Path`, `FileSystem.Read` | `PathRead` |
 | Filesystem writes | `Path`, `FileSystem.Write` | `PathWrite` |
+| Filesystem observation | `Path.Watcher`, `FileSystem.Watch` | `PathWatch` |
 | Commands and processes | `Command`, `Process` | `Sync`, `Async`, `Scope` |
 | Environment | `System` | `Sync` |
 
-`PathWrite <: PathRead`: write authority includes read authority.
+`PathWrite <: PathRead`: write authority includes read authority. `PathWatch` is independent.
 `Path.runReadOnly` intentionally cannot discharge a `PathWrite` operation. Keep this negative
 capability law visible in return types and compile-time tests.
 
@@ -40,13 +41,14 @@ kyo-system/
 ## Filesystem authority and selection
 
 `FileSystem.Read[S]` contains only inspection and read operations. `FileSystem.Write[S]` extends it
-with mutation, typed write channels, and structure changes.
+with mutation, typed write channels, and structure changes. A backend mixes in
+`FileSystem.Watch[S]` only when it can satisfy the complete watcher contract.
 
 The built-in factories are:
 
 | Factory | Authority | Purpose |
 |---|---|---|
-| `FileSystem.host` | write | Local host filesystem |
+| `FileSystem.host` | write and watch | Local host filesystem |
 
 `FileSystem.let(backend)(program)` changes the backend used by the default Path runners for a
 dynamic scope. Selection uses `Local`, propagates to child fibers, and restores the previous backend
@@ -115,7 +117,7 @@ scope.
 - `Create` opens an existing file or creates it.
 - `CreateNew` fails if any target already exists.
 
-## Locks
+## Locks and watchers
 
 Locks are advisory, scope-managed values. `Path.LockMode` selects shared or exclusive compatibility.
 `Path.LockWait` selects immediate, unbounded, or deadline-bounded acquisition. Fiber waiting must use
@@ -130,6 +132,11 @@ file data I/O never opens, which closes that hole by construction, and it is the
 Node lockfile protocol already used. The lock does not exclude a foreign process that locks the
 data file directly through the OS.
 
+Watchers use the independent `PathWatch` capability. Acquisition returns only after backend
+registration is active. Events are normalized as `PathChange`; overflow and root invalidation are
+stream values. Invalidation is terminal: emit it exactly once, close the stream, and release the
+registration.
+
 ## Error contracts
 
 `FileSystemException` is the umbrella. Concrete exceptions mix in only the marker traits for the
@@ -139,6 +146,7 @@ operations that can raise them:
 - `FileWriteException`
 - `FileStructureException`
 - `FileLockException`
+- `FileWatchException`
 
 Use `FileIOException(path, operation, cause)` only when no more precise leaf describes the failure.
 Preserve `Result.Panic` as a panic. Do not translate interruption, programmer defects, or unexpected
@@ -146,7 +154,7 @@ throwables into expected filesystem failures.
 
 ## Adding an operation
 
-1. Decide whether the operation needs read or write authority.
+1. Decide whether the operation needs read, write, or watch authority.
 2. Add a focused shared test that proves behavior and its precise failure case.
 3. Add the safe Path surface and reified operation when it is a Path capability operation.
 4. Add the narrowest `FileSystem` tier method and precise effect row.
@@ -168,9 +176,10 @@ Use the reusable suites for backend laws:
 - `FileSystemWriteTest`
 - `FileSystemChannelTest`
 - `FileSystemLockTest`
+- `FileSystemWatchTestSuite`
 
 Test capability rows with `typeCheck` and `typeCheckErrors`. Use deterministic `Async` coordination
-for lock tests. Never use sleeps or blocking primitives to make scheduling tests pass.
+for watcher and lock tests. Never use sleeps or blocking primitives to make scheduling tests pass.
 
 Before submission, run the affected module tests on all four platforms and the module doctest. Read
 formatted files again after sbt completes because compilation formats sources.

--- a/kyo-system/README.md
+++ b/kyo-system/README.md
@@ -67,11 +67,12 @@ val positioned =
     }
 ```
 
-### Locks
+### Locks and watchers
 
 Advisory locks are scope-managed. Choose shared or exclusive compatibility and an explicit waiting
 policy. The claim is taken on a sentinel sibling of the path (`state.bin.kyo-lock` here), never on
-the path itself, so reading and writing the locked path while holding the lock is safe:
+the path itself, so reading and writing the locked path while holding the lock is safe. Watchers
+have their own `PathWatch` capability and are registered before acquisition returns:
 
 ```scala
 import kyo.*
@@ -81,6 +82,12 @@ val guarded = Scope.run {
         Path("state.bin").lock(Path.LockMode.Exclusive, Path.LockWait.Immediate).map { lock =>
             Path("state.bin").write("next").andThen(lock.check)
         }
+    }
+}
+
+val changes = Scope.run {
+    Path.runWatch {
+        Path("src").openWatcher().map(_.events.take(1).run)
     }
 }
 ```
@@ -217,7 +224,7 @@ val processed: Unit < (Sync & Scope & Abort[FileSystemException]) =
 
 `readStream(charset, bufferSize)` and `readBytesStream(bufferSize)` expose the buffer-size parameter for tuning. `walk` is a Scope-managed stream of directory entries (covered under Directory operations).
 
-`tail` polls for new content appended to a file. It seeks to EOF, then sleeps for the configured `pollDelay` (default 100ms) and reads any new bytes. When the file size decreases it resets to position 0, handling log rotation and truncation. The stream carries `Async` because of the poll sleep. `tail` is a poll loop; it does not use a kernel file-event API (inotify or kqueue):
+`tail` polls for new content appended to a file. It seeks to EOF, then sleeps for the configured `pollDelay` (default 100ms) and reads any new bytes. When the file size decreases it resets to position 0, handling log rotation and truncation. The stream carries `Async` because of the poll sleep. `tail` is a poll loop, not a kernel watch API (inotify or kqueue):
 
 ```scala
 import kyo.*
@@ -333,6 +340,7 @@ val deleted: Boolean < (Sync & Abort[FileSystemException]) =
 | `FileWriteException` | Content mutation and synchronization |
 | `FileStructureException` | Creation, removal, copying, and movement |
 | `FileLockException` | Advisory lock acquisition and ownership |
+| `FileWatchException` | Watch registration and delivery |
 
 Each concrete exception implements only the marker traits that apply to it. After `Path.runReadOnly`, the runner folds the markers into `Abort[FileSystemException]`:
 

--- a/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -73,6 +73,7 @@ trait NodeStats extends js.Object:
     def isSymbolicLink(): Boolean = js.native
     def size: Double              = js.native
     def mtimeMs: Double           = js.native
+    def birthtimeMs: Double       = js.native
     def dev: Double               = js.native
     def ino: Double               = js.native
 end NodeStats
@@ -649,8 +650,12 @@ final private[kyo] class NodePathUnsafe(raw: String) extends Path.Unsafe:
 
     private[kyo] def stableIdentity()(using AllowUnsafe, Frame): Result[FileReadException, Maybe[String]] =
         catchRead {
-            val s = NodeFs.statSync(pathStr)
-            Present(s"${s.dev.toString}:${s.ino.toString}")
+            val s         = NodeFs.statSync(pathStr)
+            val birthtime = s.birthtimeMs
+            // An inode can be reused as soon as an entry is deleted. Its birth time distinguishes
+            // that replacement from a rename, which preserves both values.
+            if birthtime.isNaN || birthtime <= 0 then Absent
+            else Present(s"${s.dev.toString}:${s.ino.toString}:${birthtime.toString}")
         }
 
     // --- Write ---

--- a/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -647,6 +647,12 @@ final private[kyo] class NodePathUnsafe(raw: String) extends Path.Unsafe:
             kyo.Path.PathStat(math.round(s.mtimeMs), s.size.toLong)
         }
 
+    private[kyo] def stableIdentity()(using AllowUnsafe, Frame): Result[FileReadException, Maybe[String]] =
+        catchRead {
+            val s = NodeFs.statSync(pathStr)
+            Present(s"${s.dev.toString}:${s.ino.toString}")
+        }
+
     // --- Write ---
 
     def write(value: String, options: Path.WriteOptions)(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -139,9 +139,12 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
             val key        = attrs.fileKey
             val birthNanos = attrs.creationTime.to(TimeUnit.NANOSECONDS)
             // An inode can be reused as soon as an entry is deleted. Its birth time distinguishes
-            // that replacement from a rename, which preserves both values.
-            if key == null || birthNanos == 0L then Absent
-            else Present(s"${key.toString}:$birthNanos")
+            // that replacement from a rename, which preserves both values. OpenJDK reports a null
+            // file key on Windows, where creation time is the stable identity available through
+            // BasicFileAttributes.
+            if birthNanos == 0L then Absent
+            else if key == null then Present(s"birth:$birthNanos")
+            else Present(s"key:${key.toString}:$birthNanos")
         }
 
     // --- Write ---

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -132,6 +132,12 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
             kyo.Path.PathStat(attrs.lastModifiedTime.toMillis, attrs.size)
         }
 
+    private[kyo] def stableIdentity()(using AllowUnsafe, Frame): Result[FileReadException, Maybe[String]] =
+        catchRead {
+            val key = Files.readAttributes(jpath, classOf[BasicFileAttributes]).fileKey
+            if key == null then Absent else Present(key.toString)
+        }
+
     // --- Write ---
 
     def write(value: String, options: Path.WriteOptions)(using AllowUnsafe, Frame): Result[FileWriteException, Unit] =

--- a/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-system/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -21,6 +21,7 @@ import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.TimeUnit
 import kyo.*
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.*
@@ -134,8 +135,13 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
 
     private[kyo] def stableIdentity()(using AllowUnsafe, Frame): Result[FileReadException, Maybe[String]] =
         catchRead {
-            val key = Files.readAttributes(jpath, classOf[BasicFileAttributes]).fileKey
-            if key == null then Absent else Present(key.toString)
+            val attrs      = Files.readAttributes(jpath, classOf[BasicFileAttributes])
+            val key        = attrs.fileKey
+            val birthNanos = attrs.creationTime.to(TimeUnit.NANOSECONDS)
+            // An inode can be reused as soon as an entry is deleted. Its birth time distinguishes
+            // that replacement from a rename, which preserves both values.
+            if key == null || birthNanos == 0L then Absent
+            else Present(s"${key.toString}:$birthNanos")
         }
 
     // --- Write ---

--- a/kyo-system/jvm/src/test/scala/kyo/PathWatchJvmTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/PathWatchJvmTest.scala
@@ -1,0 +1,75 @@
+package kyo
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class PathWatchJvmTest extends kyo.test.Test[Any]:
+
+    "host recursive watching follows symbolic links only when requested" in {
+        val fileSystem = FileSystem.host
+        Clock.withTimeControl { clock =>
+            Scope.acquireRelease(fileSystem.tempDir("kyo-watch-root"))(handle => Sync.Unsafe.defer(handle.remove())).map { rootHandle =>
+                Scope.acquireRelease(fileSystem.tempDir("kyo-watch-outside"))(handle => Sync.Unsafe.defer(handle.remove())).map {
+                    outsideHandle =>
+                        val root       = rootHandle.path
+                        val outside    = outsideHandle.path
+                        val link       = root / "linked"
+                        val linkedFile = link / "created.txt"
+                        val directFile = root / "direct.txt"
+                        Sync.defer(Files.createSymbolicLink(Paths.get(link.toString), Paths.get(outside.toString))).andThen {
+                            fileSystem.openWatcher(
+                                root,
+                                WatchOptions(depth = WatchDepth.Recursive, followLinks = false)
+                            ).map { noFollow =>
+                                fileSystem.openWatcher(
+                                    root,
+                                    WatchOptions(depth = WatchDepth.Recursive, followLinks = true)
+                                ).map { follow =>
+                                    fileSystem.write(outside / "created.txt", "linked", Path.WriteOptions()).andThen {
+                                        clock.advance(Duration.Zero, 10.millis).andThen(clock.advance(10.millis, 10.millis)).andThen {
+                                            fileSystem.write(directFile, "direct", Path.WriteOptions()).andThen {
+                                                clock.advance(10.millis, 10.millis).andThen {
+                                                    Scope.run(follow.events.take(1).run).map { followed =>
+                                                        Scope.run(noFollow.events.take(1).run).map { notFollowed =>
+                                                            assert(followed == Chunk(PathChange.Created(linkedFile)))
+                                                            assert(notFollowed == Chunk(PathChange.Created(directFile)))
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                }
+            }
+        }
+    }
+
+    "host recursive watching terminates traversal at a symbolic-link cycle" in {
+        val fileSystem = FileSystem.host
+        Scope.acquireRelease(fileSystem.tempDir("kyo-watch-cycle"))(handle => Sync.Unsafe.defer(handle.remove())).map { rootHandle =>
+            val root   = rootHandle.path
+            val nested = root / "nested"
+            val back   = nested / "back"
+            val file   = root / "created.txt"
+            fileSystem.mkDir(nested).andThen {
+                Sync.defer(Files.createSymbolicLink(Paths.get(back.toString), Paths.get(root.toString))).andThen {
+                    Clock.withTimeControl { clock =>
+                        fileSystem.openWatcher(root, WatchOptions(depth = WatchDepth.Recursive, followLinks = true)).map { watcher =>
+                            fileSystem.write(file, "created", Path.WriteOptions()).andThen {
+                                Fiber.initUnscoped(Scope.run(watcher.events.take(1).run)).map { fiber =>
+                                    clock.advance(10.millis).andThen(fiber.get).map { events =>
+                                        assert(events == Chunk(PathChange.Created(file)))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+end PathWatchJvmTest

--- a/kyo-system/jvm/src/test/scala/kyo/PathWatchJvmTest.scala
+++ b/kyo-system/jvm/src/test/scala/kyo/PathWatchJvmTest.scala
@@ -2,6 +2,9 @@ package kyo
 
 import java.nio.file.Files
 import java.nio.file.Paths
+import kyo.Path.Change as PathChange
+import kyo.Path.WatchDepth
+import kyo.Path.WatchOptions
 
 class PathWatchJvmTest extends kyo.test.Test[Any]:
 

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -154,10 +154,10 @@ object FileSystem:
       * This tier is independent of [[Read]] and [[Write]]. A filesystem
       * advertises it only when it can provide the complete watch contract.
       */
-    trait Watch[S]:
+    trait Watch:
         def openWatcher(path: Path, options: WatchOptions)(using
             Frame
-        ): Path.Watcher < (S & Async & Scope & Abort[FileWatchException])
+        ): Path.Watcher < (Async & Scope & Abort[FileWatchException])
     end Watch
 
     abstract class Write[S] extends Read[S]:
@@ -238,8 +238,8 @@ object FileSystem:
         FileSystem.host.asInstanceOf[FileSystem.Read[Any]]
     )
 
-    private val watchLocal = Local.init[FileSystem.Watch[Any]](
-        FileSystem.host.asInstanceOf[FileSystem.Watch[Any]]
+    private val watchLocal = Local.init[FileSystem.Watch](
+        FileSystem.host
     )
 
     /** Runs `value` with `fileSystem` selected as the backend used by [[Path.run]] and
@@ -255,12 +255,12 @@ object FileSystem:
 
     /** Runs `value` with a coherent read, write, and watch backend selection. */
     @scala.annotation.targetName("letWatchable")
-    def let[A, S, FS](fileSystem: FileSystem.Write[FS] & FileSystem.Watch[FS])(value: A < S)(using
+    def let[A, S, FS](fileSystem: FileSystem.Write[FS] & FileSystem.Watch)(value: A < S)(using
         Frame
     ): A < (FS & S) =
         local.let(fileSystem.asInstanceOf[FileSystem.Write[Any]])(
             readLocal.let(fileSystem.asInstanceOf[FileSystem.Read[Any]])(
-                watchLocal.let(fileSystem.asInstanceOf[FileSystem.Watch[Any]])(value)
+                watchLocal.let(fileSystem)(value)
             )
         )
 
@@ -270,7 +270,7 @@ object FileSystem:
     private[kyo] def useReadErased[A, S](f: FileSystem.Read[Any] => A < S)(using Frame): A < S =
         readLocal.use(f)
 
-    private[kyo] def useWatchErased[A, S](f: FileSystem.Watch[Any] => A < S)(using Frame): A < S =
+    private[kyo] def useWatchErased[A, S](f: FileSystem.Watch => A < S)(using Frame): A < S =
         watchLocal.use(f)
 
     private[kyo] def letErased[A, S, FS](fileSystem: FileSystem.Write[FS])(value: A < S)(using Frame): A < S =
@@ -301,6 +301,6 @@ object FileSystem:
       * `Result[File*Exception, A]` into `Abort[FileSystemException]`, so it preserves current
       * `Path` behavior exactly.
       */
-    def host: FileSystem.Write[Sync] & FileSystem.Watch[Sync] = HostFileSystem()
+    def host: FileSystem.Write[Sync] & FileSystem.Watch = HostFileSystem()
 
 end FileSystem

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -1,6 +1,7 @@
 package kyo
 
 import java.nio.charset.Charset
+import kyo.Path.WatchOptions
 
 /** Filesystem backend capabilities, effect-polymorphic in the backend effect `S`. [[Read]] exposes
   * inspection, content reads, channels, and locks. [[Write]] extends it with mutation and structure

--- a/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystem.scala
@@ -99,6 +99,7 @@ object FileSystem:
         def readLines(path: Path, charset: Charset)(using Frame): Chunk[String] < (S & Abort[FileReadException])
         def size(path: Path)(using Frame): Long < (S & Abort[FileReadException])
         def stat(path: Path)(using Frame): Path.PathStat < (S & Abort[FileReadException])
+        private[kyo] def stableIdentity(path: Path)(using Frame): Maybe[String] < (S & Abort[FileReadException]) = Absent
 
         // read handles (internal handle types; back the streaming reads and walk)
         def openRead(path: Path)(using Frame): Path.ReadHandle < (S & Abort[FileReadException])
@@ -142,6 +143,22 @@ object FileSystem:
             Frame
         ): (Path.ReadChannel[S], () => Unit < (Sync & S)) < (S & Abort[FileReadException])
     end Read
+
+    /** Optional filesystem tier for scoped change observation.
+      *
+      * Implementations register observation before returning a watcher,
+      * so mutations made immediately after acquisition remain visible.
+      * The returned watcher and its asynchronous stream are owned by the
+      * surrounding [[Scope]]. Closing that scope releases backend resources.
+      *
+      * This tier is independent of [[Read]] and [[Write]]. A filesystem
+      * advertises it only when it can provide the complete watch contract.
+      */
+    trait Watch[S]:
+        def openWatcher(path: Path, options: WatchOptions)(using
+            Frame
+        ): Path.Watcher < (S & Async & Scope & Abort[FileWatchException])
+    end Watch
 
     abstract class Write[S] extends Read[S]:
 
@@ -221,6 +238,10 @@ object FileSystem:
         FileSystem.host.asInstanceOf[FileSystem.Read[Any]]
     )
 
+    private val watchLocal = Local.init[FileSystem.Watch[Any]](
+        FileSystem.host.asInstanceOf[FileSystem.Watch[Any]]
+    )
+
     /** Runs `value` with `fileSystem` selected as the backend used by [[Path.run]] and
       * [[Path.runReadOnly]]. The selection is inherited by child fibers and restored when the
       * dynamic scope exits.
@@ -232,11 +253,25 @@ object FileSystem:
             readLocal.let(fileSystem.asInstanceOf[FileSystem.Read[Any]])(value)
         )
 
+    /** Runs `value` with a coherent read, write, and watch backend selection. */
+    @scala.annotation.targetName("letWatchable")
+    def let[A, S, FS](fileSystem: FileSystem.Write[FS] & FileSystem.Watch[FS])(value: A < S)(using
+        Frame
+    ): A < (FS & S) =
+        local.let(fileSystem.asInstanceOf[FileSystem.Write[Any]])(
+            readLocal.let(fileSystem.asInstanceOf[FileSystem.Read[Any]])(
+                watchLocal.let(fileSystem.asInstanceOf[FileSystem.Watch[Any]])(value)
+            )
+        )
+
     private[kyo] def useErased[A, S](f: FileSystem.Write[Any] => A < S)(using Frame): A < S =
         local.use(f)
 
     private[kyo] def useReadErased[A, S](f: FileSystem.Read[Any] => A < S)(using Frame): A < S =
         readLocal.use(f)
+
+    private[kyo] def useWatchErased[A, S](f: FileSystem.Watch[Any] => A < S)(using Frame): A < S =
+        watchLocal.use(f)
 
     private[kyo] def letErased[A, S, FS](fileSystem: FileSystem.Write[FS])(value: A < S)(using Frame): A < S =
         local.let(fileSystem.asInstanceOf[FileSystem.Write[Any]])(
@@ -266,6 +301,6 @@ object FileSystem:
       * `Result[File*Exception, A]` into `Abort[FileSystemException]`, so it preserves current
       * `Path` behavior exactly.
       */
-    def host: FileSystem.Write[Sync] = HostFileSystem()
+    def host: FileSystem.Write[Sync] & FileSystem.Watch[Sync] = HostFileSystem()
 
 end FileSystem

--- a/kyo-system/shared/src/main/scala/kyo/FileSystemException.scala
+++ b/kyo-system/shared/src/main/scala/kyo/FileSystemException.scala
@@ -2,7 +2,7 @@ package kyo
 
 /** Operations recorded by generic filesystem failures. */
 enum FileSystemOperation derives CanEqual:
-    case Exists, Inspect, RealPath, Read, Write, List, Walk, Create, Move, Copy, Remove, Channel, Sync, Lock
+    case Exists, Inspect, RealPath, Read, Write, List, Walk, Create, Move, Copy, Remove, Channel, Sync, Lock, Watch
 
 /** Base type for failures reported by filesystem capabilities. */
 sealed abstract class FileSystemException(message: String, cause: Throwable | String = "")(using Frame)
@@ -12,6 +12,7 @@ sealed trait FileReadException      extends FileSystemException
 sealed trait FileWriteException     extends FileSystemException
 sealed trait FileStructureException extends FileSystemException
 sealed trait FileLockException      extends FileSystemException
+sealed trait FileWatchException     extends FileSystemException
 
 case class FileNotFoundException(path: Path)(using Frame)
     extends FileSystemException(s"File or directory not found: $path")
@@ -19,7 +20,7 @@ case class FileNotFoundException(path: Path)(using Frame)
 
 case class FileAccessDeniedException(path: Path)(using Frame)
     extends FileSystemException(s"Permission denied: $path")
-    with FileReadException with FileWriteException with FileStructureException with FileLockException
+    with FileReadException with FileWriteException with FileStructureException with FileLockException with FileWatchException
     derives CanEqual
 
 case class FileIsADirectoryException(path: Path)(using Frame)
@@ -40,12 +41,12 @@ case class FileDirectoryNotEmptyException(path: Path)(using Frame)
 
 case class FileInvalidPathException(input: String, operation: FileSystemOperation)(using Frame)
     extends FileSystemException(s"Invalid path for $operation: $input")
-    with FileReadException with FileWriteException with FileStructureException with FileLockException
+    with FileReadException with FileWriteException with FileStructureException with FileLockException with FileWatchException
     derives CanEqual
 
 case class FileIOException(path: Path, operation: FileSystemOperation, diagnosticCause: Throwable)(using Frame)
     extends FileSystemException(s"I/O error during $operation on $path", diagnosticCause)
-    with FileReadException with FileWriteException with FileStructureException with FileLockException
+    with FileReadException with FileWriteException with FileStructureException with FileLockException with FileWatchException
     derives CanEqual
 
 case class FileAtomicMoveUnsupportedException(source: Path, target: Path)(using Frame)
@@ -71,6 +72,10 @@ private[kyo] case class FileLockCleanupException(
 )(using Frame)
     extends FileSystemException(s"Multiple lock cleanup failures on $path: ${primary.getMessage}; ${cleanup.getMessage}", primary)
     with FileLockException derives CanEqual
+
+case class FileWatchInvalidatedException(path: Path)(using Frame)
+    extends FileSystemException(s"Watch invalidated for $path")
+    with FileWatchException derives CanEqual
 
 object FileSystemException:
     given Render[FileSystemException] with

--- a/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
@@ -6,7 +6,7 @@ import kyo.internal.Platform
 
 private[kyo] object HostFileSystem:
 
-    def apply(): FileSystem.Write[Sync] = new HostFileSystem
+    def apply(): FileSystem.Write[Sync] & FileSystem.Watch[Sync] = new HostFileSystem
 
     // Fires inside the claim node in tryLock, once the OS lock is held and recorded and before
     // tryLock returns. Default no-op; private[kyo] so tests in this package can reach it, and
@@ -40,7 +40,7 @@ private[kyo] object HostFileSystem:
       *
       * The two are not the same question. macOS default volumes are case-insensitive while the
       * platform is not Windows, so inferring from the operating system reports the wrong policy on
-      * every such machine, and the value feeds `list(path, glob)`.
+      * every such machine, and the value feeds `list(path, glob)` and every watcher's glob.
       *
       * Probed against the filesystem's own temporary directory, so a host instance answers for its
       * own volume rather than for the process temp volume. The result is cached per instance: it is
@@ -69,7 +69,7 @@ private[kyo] object HostFileSystem:
         }
     end probeCaseSensitivity
 
-    final class HostFileSystem extends FileSystem.Write[Sync]:
+    final class HostFileSystem extends FileSystem.Write[Sync], FileSystem.Watch[Sync]:
 
         // Memo cell for the one-off volume probe below. A plain atomic rather than Kyo's: the cell
         // has to exist at construction, outside any Sync context, and it carries no effect of its
@@ -132,6 +132,9 @@ private[kyo] object HostFileSystem:
         def stat(path: Path)(using Frame): Path.PathStat < (Sync & Abort[FileReadException]) =
             // Unsafe: bridges Path.Unsafe.stat into the safe tier
             Sync.Unsafe.defer(Abort.get(path.unsafe.stat()))
+        override private[kyo] def stableIdentity(path: Path)(using Frame): Maybe[String] < (Sync & Abort[FileReadException]) =
+            // Unsafe: bridges the platform file identity used only for polling move correlation
+            Sync.Unsafe.defer(Abort.get(path.unsafe.stableIdentity()))
         def openRead(path: Path)(using Frame): Path.ReadHandle < (Sync & Abort[FileReadException]) =
             // Unsafe: bridges Path.Unsafe.openRead into the safe tier
             Sync.Unsafe.defer(Abort.get(path.unsafe.openRead()))
@@ -430,5 +433,10 @@ private[kyo] object HostFileSystem:
             Frame
         ): Path.Lock < (Sync & Async & Scope & Abort[FileReadException | FileLockException]) =
             FileSystem.awaitLock(path, wait)(tryLock(path, mode, sentinelSuffix))
+
+        def openWatcher(path: Path, options: WatchOptions)(using
+            Frame
+        ): Path.Watcher < (Sync & Async & Scope & Abort[FileWatchException]) =
+            PathWatch.polling(this, path, options)
     end HostFileSystem
 end HostFileSystem

--- a/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
@@ -2,6 +2,7 @@ package kyo
 
 import java.io.IOException
 import java.nio.charset.Charset
+import kyo.Path.WatchOptions
 import kyo.internal.Platform
 
 private[kyo] object HostFileSystem:

--- a/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
+++ b/kyo-system/shared/src/main/scala/kyo/HostFileSystem.scala
@@ -6,7 +6,7 @@ import kyo.internal.Platform
 
 private[kyo] object HostFileSystem:
 
-    def apply(): FileSystem.Write[Sync] & FileSystem.Watch[Sync] = new HostFileSystem
+    def apply(): FileSystem.Write[Sync] & FileSystem.Watch = new HostFileSystem
 
     // Fires inside the claim node in tryLock, once the OS lock is held and recorded and before
     // tryLock returns. Default no-op; private[kyo] so tests in this package can reach it, and
@@ -69,7 +69,7 @@ private[kyo] object HostFileSystem:
         }
     end probeCaseSensitivity
 
-    final class HostFileSystem extends FileSystem.Write[Sync], FileSystem.Watch[Sync]:
+    final class HostFileSystem extends FileSystem.Write[Sync], FileSystem.Watch:
 
         // Memo cell for the one-off volume probe below. A plain atomic rather than Kyo's: the cell
         // has to exist at construction, outside any Sync context, and it carries no effect of its

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -333,10 +333,10 @@ object Path extends PathPlatformSpecific:
         }
 
     /** Runs `program` against an explicit watch-capable filesystem, discharging [[PathWatch]]. */
-    def runWatchWith[A, S, FS](fileSystem: FileSystem.Watch[FS])(program: A < (PathWatch & S))(using
+    def runWatchWith[A, S](fileSystem: FileSystem.Watch)(program: A < (PathWatch & S))(using
         Frame
-    ): A < (FS & Async & Scope & Abort[FileWatchException] & S) =
-        ArrowEffect.handle[[A] =>> WatchOp[A], Id, PathWatch, A, S, FS & Async & Scope & Abort[FileWatchException]](
+    ): A < (Async & Scope & Abort[FileWatchException] & S) =
+        ArrowEffect.handle[[A] =>> WatchOp[A], Id, PathWatch, A, S, Async & Scope & Abort[FileWatchException]](
             Tag[PathWatch],
             program
         )(
@@ -409,7 +409,7 @@ object Path extends PathPlatformSpecific:
 
     /** Stateless isolation for watch operations. See [[isolateRead]]. */
     given isolateWatch: Isolate[PathWatch, Async, PathWatch] with
-        type State        = FileSystem.Watch[Any]
+        type State        = FileSystem.Watch
         type Transform[A] = Result[FileWatchException, A]
 
         def capture[A, S](f: State => A < S)(using Frame): A < (PathWatch & Async & S) =

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -91,6 +91,70 @@ object Path extends PathPlatformSpecific:
       */
     final case class PathStat(lastModifiedMs: Long, sizeBytes: Long) derives CanEqual
 
+    /** Selects how deeply a watcher observes a directory.
+      *
+      * [[Immediate]] observes only direct children of the watched root. [[Recursive]] also observes
+      * descendants at every depth. The watched root itself is not passed through the glob filter.
+      * Its disappearance is instead reported as [[Change.Invalidated]].
+      *
+      * Depth is applied before glob matching, and paths emitted by either mode retain their complete
+      * backend path.
+      */
+    enum WatchDepth derives CanEqual:
+        case Immediate
+        case Recursive
+    end WatchDepth
+
+    /** Selects the case policy used when matching a watch glob.
+      *
+      * [[FileSystemDefault]] delegates to the backend's native policy. [[Sensitive]] compares every
+      * glob component case sensitively. [[Insensitive]] compares every glob component without case.
+      *
+      * This setting changes only event selection. It does not rewrite the paths contained in emitted
+      * [[Change]] values.
+      */
+    enum MatchCase derives CanEqual:
+        case FileSystemDefault
+        case Sensitive
+        case Insensitive
+    end MatchCase
+
+    /** A normalized filesystem change emitted by a [[Watcher]].
+      *
+      * Creation, modification, and removal events identify one path. A move identifies both its former
+      * and current paths. Moves crossing a watch filter boundary are normalized to removal or creation.
+      * [[Overflow]] reports that bounded event delivery lost detail, while [[Invalidated]] reports that
+      * the watched root is no longer usable.
+      *
+      * Paths use the namespace of the filesystem that acquired the watcher.
+      */
+    enum Change derives CanEqual:
+        case Created(path: Path)
+        case Modified(path: Path)
+        case Removed(path: Path)
+        case Moved(from: Path, to: Path)
+        case Overflow(root: Path)
+        case Invalidated(root: Path)
+    end Change
+
+    /** Configures filesystem watching and event selection.
+      *
+      * `depth` controls traversal below the watched root. `glob` is matched against paths relative to
+      * that root using `caseSensitivity`. `capacity` bounds pending changes and must be positive. When
+      * it is exceeded, queued detail is replaced by [[Change.Overflow]]. `followLinks` controls whether
+      * linked directories and their targets participate in observation.
+      *
+      * The defaults observe direct children, match all names using the backend's case policy, retain 256
+      * pending changes, and do not follow links.
+      */
+    final case class WatchOptions(
+        depth: WatchDepth = WatchDepth.Immediate,
+        glob: Glob = Glob.all,
+        caseSensitivity: MatchCase = MatchCase.FileSystemDefault,
+        capacity: Int = 256,
+        followLinks: Boolean = false
+    ) derives CanEqual
+
     /** Where a byte-level read begins.
       *
       * `Start` reads the file from its first byte, so a follower replays existing content before emitting new content. `End` skips whatever
@@ -1211,10 +1275,10 @@ object Path extends PathPlatformSpecific:
       *
       * Backend failures are reported through [[FileWatchException]]. Event
       * loss and watched-root loss are values in the stream instead, represented
-      * by [[PathChange.Overflow]] and [[PathChange.Invalidated]].
+      * by [[Change.Overflow]] and [[Change.Invalidated]].
       */
     trait Watcher:
-        def events: Stream[PathChange, Async & Scope & Abort[FileWatchException]]
+        def events: Stream[Change, Async & Scope & Abort[FileWatchException]]
     end Watcher
 
     // --- System directories ---

--- a/kyo-system/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-system/shared/src/main/scala/kyo/Path.scala
@@ -269,6 +269,11 @@ object Path extends PathPlatformSpecific:
         case WriteString(handle: Path.WriteHandle, value: String, charset: Charset) extends Op[Unit]
     end Op
 
+    private[kyo] enum WatchOp[A]:
+        case Open(path: Path, options: WatchOptions)        extends WatchOp[Watcher]
+        case Raise(error: Result.Error[FileWatchException]) extends WatchOp[Nothing]
+    end WatchOp
+
     // --- Runners ---
 
     /** Runs `program`, discharging both write and read capabilities against the Local-selected
@@ -327,6 +332,37 @@ object Path extends PathPlatformSpecific:
             )
         }
 
+    /** Runs `program` against an explicit watch-capable filesystem, discharging [[PathWatch]]. */
+    def runWatchWith[A, S, FS](fileSystem: FileSystem.Watch[FS])(program: A < (PathWatch & S))(using
+        Frame
+    ): A < (FS & Async & Scope & Abort[FileWatchException] & S) =
+        ArrowEffect.handle[[A] =>> WatchOp[A], Id, PathWatch, A, S, FS & Async & Scope & Abort[FileWatchException]](
+            Tag[PathWatch],
+            program
+        )(
+            [C] =>
+                (op, cont) =>
+                    op match
+                        case WatchOp.Open(path, options) => fileSystem.openWatcher(path, options).map(cont)
+                        case WatchOp.Raise(error)        => Abort.error(error)
+        )
+
+    /** Runs `program`, discharging [[PathWatch]] against the Local-selected watch backend. */
+    def runWatch[A, S](program: A < (PathWatch & S))(using
+        Frame
+    ): A < (Async & Scope & Abort[FileWatchException] & S) =
+        ArrowEffect.handle[[A] =>> WatchOp[A], Id, PathWatch, A, S, Async & Scope & Abort[FileWatchException]](
+            Tag[PathWatch],
+            program
+        )(
+            [C] =>
+                (op, cont) =>
+                    op match
+                        case WatchOp.Open(path, options) =>
+                            FileSystem.useWatchErased(_.openWatcher(path, options)).map(cont)
+                        case WatchOp.Raise(error) => Abort.error(error)
+        )
+
     /** Stateless isolation for read operations. Each child captures the Local-selected backend and
       * installs an independent Path handler around its computation.
       */
@@ -370,6 +406,27 @@ object Path extends PathPlatformSpecific:
                     ArrowEffect.suspend(Tag[PathWrite], Op.Raise(panic))
             }
     end isolateWrite
+
+    /** Stateless isolation for watch operations. See [[isolateRead]]. */
+    given isolateWatch: Isolate[PathWatch, Async, PathWatch] with
+        type State        = FileSystem.Watch[Any]
+        type Transform[A] = Result[FileWatchException, A]
+
+        def capture[A, S](f: State => A < S)(using Frame): A < (PathWatch & Async & S) =
+            FileSystem.useWatchErased(f)
+
+        def isolate[A, S](state: State, value: A < (S & PathWatch))(using Frame): Result[FileWatchException, A] < (Async & S) =
+            Abort.run[FileWatchException](Scope.run(runWatchWith(state)(value)))
+
+        def restore[A, S](value: Result[FileWatchException, A] < S)(using Frame): A < (PathWatch & S) =
+            value.map {
+                case Result.Success(result) => result
+                case Result.Failure(error) =>
+                    ArrowEffect.suspend(Tag[PathWatch], WatchOp.Raise(Result.Failure(error)))
+                case panic: Result.Panic =>
+                    ArrowEffect.suspend(Tag[PathWatch], WatchOp.Raise(panic))
+            }
+    end isolateWatch
 
     private def dispatch[S, C](service: FileSystem.Write[S], op: Op[C])(using Frame): C < (S & Abort[FileSystemException]) =
         op match
@@ -1136,10 +1193,29 @@ object Path extends PathPlatformSpecific:
         inline def removeAll(using inline frame: Frame): Unit < PathWrite =
             ArrowEffect.suspend(Tag[PathWrite], Path.Op.RemoveAll(self))
 
+        /** Acquires a watcher after its backend registration is active. */
+        def openWatcher(options: WatchOptions = WatchOptions())(using Frame): Watcher < PathWatch =
+            ArrowEffect.suspend(Tag[PathWatch], Path.WatchOp.Open(self, options))
+
         /** Returns the underlying `Unsafe` implementation for direct use in unsafe code. */
         def unsafe: Path.Unsafe = self
 
     end extension
+
+    /** A scope-managed source of normalized filesystem changes.
+      *
+      * Watchers are acquired with [[Path.openWatcher]] only after their
+      * backend registration is active. Their event stream remains valid
+      * for the lifetime of the acquisition scope and suspends asynchronously
+      * while waiting for changes.
+      *
+      * Backend failures are reported through [[FileWatchException]]. Event
+      * loss and watched-root loss are values in the stream instead, represented
+      * by [[PathChange.Overflow]] and [[PathChange.Invalidated]].
+      */
+    trait Watcher:
+        def events: Stream[PathChange, Async & Scope & Abort[FileWatchException]]
+    end Watcher
 
     // --- System directories ---
 
@@ -1444,6 +1520,7 @@ object Path extends PathPlatformSpecific:
         def openReadLines(charset: Charset)(using AllowUnsafe, Frame): Result[FileReadException, Path.LineReadHandle]
         def size()(using AllowUnsafe, Frame): Result[FileReadException, Long]
         def stat()(using AllowUnsafe, Frame): Result[FileReadException, PathStat]
+        private[kyo] def stableIdentity()(using AllowUnsafe, Frame): Result[FileReadException, Maybe[String]]
 
         // --- Write ---
 

--- a/kyo-system/shared/src/main/scala/kyo/PathWatch.scala
+++ b/kyo-system/shared/src/main/scala/kyo/PathWatch.scala
@@ -1,0 +1,389 @@
+package kyo
+
+import kyo.kernel.ArrowEffect
+
+/** Capability required to acquire filesystem watchers.
+  *
+  * A program suspends this capability through [[Path.openWatcher]].
+  * [[Path.runWatchWith]] interprets it with an explicit watch backend,
+  * while [[Path.runWatch]] uses the backend selected in [[Local]].
+  * Watchers are scope managed and emit their changes asynchronously.
+  *
+  * This capability is separate from [[PathRead]] and [[PathWrite]] so
+  * backends can expose observation independently of reading and writing.
+  */
+sealed trait PathWatch extends ArrowEffect[[A] =>> Path.WatchOp[A], Id]
+
+/** Selects how deeply a watcher observes a directory.
+  *
+  * [[Immediate]] observes only direct children of the watched root.
+  * [[Recursive]] also observes descendants at every depth.
+  * The watched root itself is not passed through the glob filter.
+  * Its disappearance is instead reported as [[PathChange.Invalidated]].
+  *
+  * Depth is applied before glob matching, and paths emitted by either
+  * mode retain their complete backend path.
+  */
+enum WatchDepth derives CanEqual:
+    case Immediate
+    case Recursive
+end WatchDepth
+
+/** Selects the case policy used when matching a watch glob.
+  *
+  * [[FileSystemDefault]] delegates to the backend's native policy.
+  * [[Sensitive]] compares every glob component case sensitively.
+  * [[Insensitive]] compares every glob component without case.
+  *
+  * This setting changes only event selection. It does not rewrite
+  * the paths contained in emitted [[PathChange]] values.
+  */
+enum MatchCase derives CanEqual:
+    case FileSystemDefault
+    case Sensitive
+    case Insensitive
+end MatchCase
+
+/** A normalized filesystem change emitted by a [[Path.Watcher]].
+  *
+  * Creation, modification, and removal events identify one path.
+  * A move identifies both its former and current paths. Moves crossing
+  * a watch filter boundary are normalized to removal or creation.
+  * [[Overflow]] reports that bounded event delivery lost detail, while
+  * [[Invalidated]] reports that the watched root is no longer usable.
+  *
+  * Paths use the namespace of the filesystem that acquired the watcher.
+  */
+enum PathChange derives CanEqual:
+    case Created(path: Path)
+    case Modified(path: Path)
+    case Removed(path: Path)
+    case Moved(from: Path, to: Path)
+    case Overflow(root: Path)
+    case Invalidated(root: Path)
+end PathChange
+
+/** Configures filesystem watching and event selection.
+  *
+  * `depth` controls traversal below the watched root. `glob` is matched
+  * against paths relative to that root using `caseSensitivity`.
+  * `capacity` bounds pending changes and must be positive. When it is
+  * exceeded, queued detail is replaced by [[PathChange.Overflow]].
+  * `followLinks` controls whether linked directories and their targets
+  * participate in observation.
+  *
+  * The defaults observe direct children, match all names using the
+  * backend's case policy, retain 256 pending changes, and do not follow links.
+  */
+final case class WatchOptions(
+    depth: WatchDepth = WatchDepth.Immediate,
+    glob: Glob = Glob.all,
+    caseSensitivity: MatchCase = MatchCase.FileSystemDefault,
+    capacity: Int = 256,
+    followLinks: Boolean = false
+) derives CanEqual
+
+private[kyo] object PathWatch:
+
+    private val pollInterval = 5.millis
+
+    final private case class Snapshot(directory: Boolean, stat: Path.PathStat, contentHash: Int, identity: Maybe[String])
+        derives CanEqual
+    final private case class ScanPanic(error: Throwable)
+
+    private def watchFailure(root: Path, error: FileSystemException)(using Frame): FileWatchException =
+        error match
+            case watch: FileWatchException => watch
+            case other                     => FileIOException(root, FileSystemOperation.Watch, other)
+
+    private def scan[S](service: FileSystem.Read[S], root: Path, options: WatchOptions)(using
+        Frame
+    ): Result[FileWatchException, Map[Path, Snapshot]] < S =
+        def hash(bytes: Span[Byte]): Int =
+            var value = 1
+            var index = 0
+            while index < bytes.size do
+                value = 31 * value + bytes(index)
+                index += 1
+            value
+        end hash
+
+        def entry(path: Path): Snapshot < (S & Abort[FileReadException]) =
+            service.isSymbolicLink(path).map { symbolic =>
+                if symbolic && !options.followLinks then Snapshot(false, Path.PathStat(0L, 0L), 0, Absent)
+                else
+                    service.isDirectory(path).map { directory =>
+                        service.stat(path).map { stat =>
+                            service.stableIdentity(path).map { identity =>
+                                if directory then Snapshot(true, stat, 0, identity)
+                                else service.readBytes(path).map(bytes => Snapshot(false, stat, hash(bytes), identity))
+                            }
+                        }
+                    }
+            }
+
+        def children(path: Path, recursive: Boolean, visited: Set[Path]): Map[Path, Snapshot] <
+            (S & Abort[FileReadException | FileStructureException | ScanPanic]) =
+            service.list(path).map { listed =>
+                Kyo.foldLeft(listed)(Map.empty[Path, Snapshot]) { (acc, child) =>
+                    val observe = entry(child).map { childSnapshot =>
+                        val next = acc.updated(child, childSnapshot)
+                        if recursive && childSnapshot.directory then
+                            service.isSymbolicLink(child).map { symbolic =>
+                                if symbolic && !options.followLinks then next
+                                else if options.followLinks then
+                                    service.realPath(child).map { real =>
+                                        if visited.contains(real) then next
+                                        else children(child, recursive, visited + real).map(next ++ _)
+                                    }
+                                else children(child, recursive, visited).map(next ++ _)
+                            }
+                        else next
+                        end if
+                    }
+                    Abort.run[FileReadException | FileStructureException | ScanPanic](observe).map {
+                        case Result.Success(next) => next
+                        case Result.Failure(error) =>
+                            Abort.run[FileReadException](service.exists(child, options.followLinks)).map {
+                                case Result.Success(false)      => acc
+                                case Result.Success(true)       => Abort.fail(error)
+                                case Result.Failure(checkError) => Abort.fail(checkError)
+                                case Result.Panic(checkError)   => Abort.fail(ScanPanic(checkError))
+                            }
+                        case Result.Panic(error) => Abort.fail(ScanPanic(error))
+                    }
+                }
+            }
+
+        val read = service.exists(root, options.followLinks).map {
+            case false => Abort.fail[FileWatchException](FileWatchInvalidatedException(root))
+            case true =>
+                service.isDirectory(root).map {
+                    case false =>
+                        Abort.fail[FileReadException](
+                            FileIOException(root, FileSystemOperation.Watch, new java.io.IOException("watched path is not a directory"))
+                        )
+                    case true =>
+                        if options.followLinks then
+                            service.realPath(root).map(real => children(root, options.depth == WatchDepth.Recursive, Set(real)))
+                        else children(root, options.depth == WatchDepth.Recursive, Set.empty)
+                }
+        }
+        Abort.run[FileReadException | FileStructureException | FileWatchException | ScanPanic](read).map {
+            case Result.Success(snapshot)                   => Result.Success(snapshot)
+            case Result.Failure(scanPanic: ScanPanic)       => Result.Panic(scanPanic.error)
+            case Result.Failure(error: FileSystemException) => Result.Failure(watchFailure(root, error))
+            case Result.Panic(error)                        => Result.Panic(error)
+        }
+    end scan
+
+    private def changes(before: Map[Path, Snapshot], after: Map[Path, Snapshot]): Chunk[PathChange] =
+        val removed = scala.collection.mutable.ArrayBuffer.from(before.keySet.diff(after.keySet).toSeq.sortBy(_.toString))
+        val created = scala.collection.mutable.ArrayBuffer.from(after.keySet.diff(before.keySet).toSeq.sortBy(_.toString))
+        val moved   = scala.collection.mutable.ArrayBuffer.empty[(Path, Path)]
+        var old     = 0
+        while old < removed.size do
+            val from     = removed(old)
+            val identity = before(from).identity
+            val candidates = identity.fold(Seq.empty[(Path, Int)])(id =>
+                created.zipWithIndex.filter((to, _) => after(to).identity.contains(id))
+            )
+            val oldMatches = identity.fold(0)(id => removed.count(candidate => before(candidate).identity.contains(id)))
+            if identity.isDefined && candidates.size == 1 && oldMatches == 1 then
+                val (to, newIndex) = candidates.head
+                moved += ((from, to))
+                val _ = created.remove(newIndex)
+                val _ = removed.remove(old)
+            else old += 1
+            end if
+        end while
+        val modified = before.keySet
+            .intersect(after.keySet)
+            .toSeq
+            .sortBy(_.toString)
+            .filter(path => !before(path).directory && before(path) != after(path))
+        Chunk.from(moved.map(PathChange.Moved.apply)) ++
+            Chunk.from(removed.map(PathChange.Removed.apply)) ++
+            Chunk.from(created.map(PathChange.Created.apply)) ++
+            Chunk.from(modified.map(PathChange.Modified.apply))
+    end changes
+
+    private def relative(root: Path, path: Path): Maybe[Chunk[String]] =
+        val rootParts = root.parts
+        val parts     = path.parts
+        if parts.size < rootParts.size || parts.take(rootParts.size) != rootParts then Absent
+        else Present(parts.drop(rootParts.size))
+    end relative
+
+    private def matches(root: Path, options: WatchOptions, caseSensitivity: Glob.CaseSensitivity, path: Path): Boolean =
+        relative(root, path).exists { parts =>
+            parts.nonEmpty &&
+            (options.depth == WatchDepth.Recursive || parts.size == 1) &&
+            options.glob.matches(parts, caseSensitivity)
+        }
+
+    private def select(
+        root: Path,
+        options: WatchOptions,
+        caseSensitivity: Glob.CaseSensitivity,
+        change: PathChange
+    ): Maybe[PathChange] =
+        def selected(path: Path): Boolean = matches(root, options, caseSensitivity, path)
+        change match
+            case PathChange.Created(path)  => if selected(path) then Present(change) else Absent
+            case PathChange.Modified(path) => if selected(path) then Present(change) else Absent
+            case PathChange.Removed(path)  => if selected(path) then Present(change) else Absent
+            case PathChange.Moved(from, to) =>
+                (selected(from), selected(to)) match
+                    case (true, true)  => Present(change)
+                    case (true, false) => Present(PathChange.Removed(from))
+                    case (false, true) => Present(PathChange.Created(to))
+                    case _             => Absent
+            case PathChange.Overflow(_)    => Present(PathChange.Overflow(root))
+            case PathChange.Invalidated(_) => Present(PathChange.Invalidated(root))
+        end match
+    end select
+
+    def polling[S, S2](service: FileSystem.Read[S & Sync], root: Path, options: WatchOptions)(using
+        Frame,
+        Isolate[S, Sync, S2]
+    ): Path.Watcher < (S & Sync & Async & Scope & Abort[FileWatchException]) =
+        if options.capacity <= 0 then
+            Abort.fail(FileIOException(root, FileSystemOperation.Watch, new IllegalArgumentException("watch capacity must be positive")))
+        else
+            service.defaultCaseSensitivity.map { defaultCase =>
+                val caseSensitivity = options.caseSensitivity match
+                    case MatchCase.FileSystemDefault => defaultCase
+                    case MatchCase.Sensitive         => Glob.CaseSensitivity.Sensitive
+                    case MatchCase.Insensitive       => Glob.CaseSensitivity.Insensitive
+                scan(service, root, options).map {
+                    case Result.Failure(error) => Abort.fail(error)
+                    case Result.Panic(error)   => Abort.panic[FileWatchException](error)
+                    case Result.Success(initial) =>
+                        Channel.init[Result[FileWatchException, PathChange]](options.capacity).map { channel =>
+                            AtomicInt.init(0).map { pending =>
+                                AtomicBoolean.init(false).map { overflowed =>
+                                    def overflow: Unit < Sync =
+                                        overflowed.compareAndSet(false, true).map {
+                                            case false => ()
+                                            case true =>
+                                                Abort.run[Closed](channel.drain).andThen {
+                                                    pending.set(1).andThen {
+                                                        Abort.run[Closed](channel.offer(Result.Success(PathChange.Overflow(root)))).map {
+                                                            case Result.Success(true) => ()
+                                                            case _                    => pending.set(0).andThen(overflowed.set(false))
+                                                        }
+                                                    }
+                                                }
+                                        }
+                                    def offer(event: PathChange): Unit < Sync =
+                                        overflowed.get.map {
+                                            case true => ()
+                                            case false =>
+                                                pending.incrementAndGet.map { count =>
+                                                    if count > options.capacity then overflow
+                                                    else
+                                                        Abort.run[Closed](channel.offer(Result.Success(event))).map {
+                                                            case Result.Success(true)  => ()
+                                                            case Result.Success(false) => overflow
+                                                            case _                     => pending.decrementAndGet.unit
+                                                        }
+                                                }
+                                        }
+                                    def publish(events: Chunk[PathChange]): Unit < Sync =
+                                        val selected = events.flatMap(change =>
+                                            select(root, options, caseSensitivity, change).fold(Chunk.empty[PathChange])(Chunk(_))
+                                        )
+                                        Kyo.foreachDiscard(selected)(offer)
+                                    end publish
+                                    def fail(error: FileWatchException): Unit < Sync =
+                                        Abort.run[Closed](channel.drain).andThen {
+                                            pending.set(1).andThen {
+                                                Abort.run[Closed](channel.offer(Result.Failure(error))).unit
+                                            }
+                                        }
+                                    def panic(error: Throwable): Unit < Sync =
+                                        Abort.run[Closed](channel.drain).andThen {
+                                            pending.set(1).andThen {
+                                                Abort.run[Closed](channel.offer(Result.Panic(error))).unit
+                                            }
+                                        }
+                                    def invalidate: Unit < Sync =
+                                        Abort.run[Closed](channel.drain).andThen {
+                                            pending.set(1).andThen {
+                                                Abort.run[Closed](channel.offer(Result.Success(PathChange.Invalidated(root)))).unit
+                                            }
+                                        }
+                                    def terminate(error: FileWatchException): Unit < (S & Sync) =
+                                        Abort.run[FileReadException](service.exists(root, options.followLinks)).map {
+                                            case Result.Success(false) => invalidate
+                                            case Result.Success(true) =>
+                                                Abort.run[FileReadException](service.isDirectory(root)).map {
+                                                    case Result.Success(false)      => invalidate
+                                                    case Result.Success(true)       => fail(error)
+                                                    case Result.Failure(checkError) => fail(watchFailure(root, checkError))
+                                                    case Result.Panic(checkError)   => Abort.panic(checkError)
+                                                }
+                                            case Result.Failure(checkError) => fail(watchFailure(root, checkError))
+                                            case Result.Panic(checkError)   => Abort.panic(checkError)
+                                        }
+                                    def poll(previous: Map[Path, Snapshot], deferredRemoval: Boolean): Unit < (S & Async) =
+                                        scan(service, root, options).map {
+                                            case Result.Success(current) =>
+                                                val detected = changes(previous, current)
+                                                val removalOnly = detected.nonEmpty && detected.forall {
+                                                    case PathChange.Removed(_) => true
+                                                    case _                     => false
+                                                }
+                                                if removalOnly && !deferredRemoval then loop(previous, true)
+                                                else publish(detected).andThen(loop(current, false))
+                                            case Result.Failure(error) => terminate(error)
+                                            case Result.Panic(error)   => panic(error)
+                                        }
+                                    // Async.sleep, not Clock.sleep: the latter hands back the timer Fiber rather than
+                                    // suspending on it, so discarding it would leave this loop free-running.
+                                    def loop(previous: Map[Path, Snapshot], deferredRemoval: Boolean): Unit < (S & Async) =
+                                        Async.sleep(pollInterval).andThen(poll(previous, deferredRemoval))
+                                    // The first interval is armed here, in the acquiring fiber, rather than inside the
+                                    // poll fiber. Clock.sleep is the Fiber-returning form on purpose: registering the
+                                    // timer before openWatcher returns is what makes the first tick deterministic. A
+                                    // timer armed inside the poll fiber would race the caller, and under a controlled
+                                    // Clock an advance that lands before the fiber reaches its first sleep would set a
+                                    // deadline that never fires.
+                                    Clock.sleep(pollInterval).map { firstTick =>
+                                        Fiber.init(firstTick.get.andThen(poll(initial, false)))
+                                    }.map { _ =>
+                                        new Path.Watcher:
+                                            def events: Stream[PathChange, Async & Scope & Abort[FileWatchException]] =
+                                                Stream:
+                                                    def pull: Unit < (Emit[Chunk[PathChange]] & Async & Abort[FileWatchException]) =
+                                                        Abort.run[Closed](channel.take).map {
+                                                            case Result.Failure(_)   => ()
+                                                            case Result.Panic(error) => Abort.panic[FileWatchException](error)
+                                                            case Result.Success(result) =>
+                                                                pending.decrementAndGet.andThen {
+                                                                    result match
+                                                                        case Result.Success(event) =>
+                                                                            event match
+                                                                                case PathChange.Overflow(_) =>
+                                                                                    overflowed.set(
+                                                                                        false
+                                                                                    ).andThen(Emit.value(Chunk(event))).andThen(pull)
+                                                                                case PathChange.Invalidated(_) =>
+                                                                                    channel.close.andThen(Emit.value(Chunk(event)))
+                                                                                case _ => Emit.value(Chunk(event)).andThen(pull)
+                                                                        case Result.Failure(error) =>
+                                                                            channel.close.andThen(Abort.fail(error))
+                                                                        case Result.Panic(error) =>
+                                                                            channel.close.andThen(Abort.panic[FileWatchException](error))
+                                                                }
+                                                        }
+                                                    pull
+                                    }
+                                }
+                            }
+                        }
+                }
+            }
+    end polling
+end PathWatch

--- a/kyo-system/shared/src/main/scala/kyo/PathWatch.scala
+++ b/kyo-system/shared/src/main/scala/kyo/PathWatch.scala
@@ -1,5 +1,9 @@
 package kyo
 
+import kyo.Path.Change as PathChange
+import kyo.Path.MatchCase
+import kyo.Path.WatchDepth
+import kyo.Path.WatchOptions
 import kyo.kernel.ArrowEffect
 
 /** Capability required to acquire filesystem watchers.
@@ -13,75 +17,6 @@ import kyo.kernel.ArrowEffect
   * backends can expose observation independently of reading and writing.
   */
 sealed trait PathWatch extends ArrowEffect[[A] =>> Path.WatchOp[A], Id]
-
-/** Selects how deeply a watcher observes a directory.
-  *
-  * [[Immediate]] observes only direct children of the watched root.
-  * [[Recursive]] also observes descendants at every depth.
-  * The watched root itself is not passed through the glob filter.
-  * Its disappearance is instead reported as [[PathChange.Invalidated]].
-  *
-  * Depth is applied before glob matching, and paths emitted by either
-  * mode retain their complete backend path.
-  */
-enum WatchDepth derives CanEqual:
-    case Immediate
-    case Recursive
-end WatchDepth
-
-/** Selects the case policy used when matching a watch glob.
-  *
-  * [[FileSystemDefault]] delegates to the backend's native policy.
-  * [[Sensitive]] compares every glob component case sensitively.
-  * [[Insensitive]] compares every glob component without case.
-  *
-  * This setting changes only event selection. It does not rewrite
-  * the paths contained in emitted [[PathChange]] values.
-  */
-enum MatchCase derives CanEqual:
-    case FileSystemDefault
-    case Sensitive
-    case Insensitive
-end MatchCase
-
-/** A normalized filesystem change emitted by a [[Path.Watcher]].
-  *
-  * Creation, modification, and removal events identify one path.
-  * A move identifies both its former and current paths. Moves crossing
-  * a watch filter boundary are normalized to removal or creation.
-  * [[Overflow]] reports that bounded event delivery lost detail, while
-  * [[Invalidated]] reports that the watched root is no longer usable.
-  *
-  * Paths use the namespace of the filesystem that acquired the watcher.
-  */
-enum PathChange derives CanEqual:
-    case Created(path: Path)
-    case Modified(path: Path)
-    case Removed(path: Path)
-    case Moved(from: Path, to: Path)
-    case Overflow(root: Path)
-    case Invalidated(root: Path)
-end PathChange
-
-/** Configures filesystem watching and event selection.
-  *
-  * `depth` controls traversal below the watched root. `glob` is matched
-  * against paths relative to that root using `caseSensitivity`.
-  * `capacity` bounds pending changes and must be positive. When it is
-  * exceeded, queued detail is replaced by [[PathChange.Overflow]].
-  * `followLinks` controls whether linked directories and their targets
-  * participate in observation.
-  *
-  * The defaults observe direct children, match all names using the
-  * backend's case policy, retain 256 pending changes, and do not follow links.
-  */
-final case class WatchOptions(
-    depth: WatchDepth = WatchDepth.Immediate,
-    glob: Glob = Glob.all,
-    caseSensitivity: MatchCase = MatchCase.FileSystemDefault,
-    capacity: Int = 256,
-    followLinks: Boolean = false
-) derives CanEqual
 
 private[kyo] object PathWatch:
 

--- a/kyo-system/shared/src/test/resources/kyo/path/watch-trace.snap
+++ b/kyo-system/shared/src/test/resources/kyo/path/watch-trace.snap
@@ -1,0 +1,3 @@
+Created(root/a.txt)
+Modified(root/a.txt)
+Removed(root/a.txt)

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceDeclarationTest.scala
@@ -10,9 +10,10 @@ class FileSystemConformanceDeclarationTest extends kyo.test.Test[Any]:
             classOf[FileSystemReadTest],
             classOf[FileSystemWriteTest],
             classOf[FileSystemChannelTest],
-            classOf[FileSystemLockTest]
+            classOf[FileSystemLockTest],
+            classOf[FileSystemWatchTestSuite]
         )
-        assert(suites.size == 4)
+        assert(suites.size == 5)
     }
 
     "a read-only fixture cannot select write members" in {

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
@@ -4,7 +4,7 @@ private object FileSystemConformanceFixtures:
 
     def host(prefix: String)(using
         Frame
-    ): (FileSystem.Write[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
+    ): (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
         Scope.acquireRelease(FileSystem.host.tempDir(prefix))(handle => Sync.Unsafe.defer(handle.remove())).map { handle =>
             (FileSystem.host, handle.path)
         }

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemConformanceTest.scala
@@ -4,7 +4,7 @@ private object FileSystemConformanceFixtures:
 
     def host(prefix: String)(using
         Frame
-    ): (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path) < (Sync & Scope & Abort[FileSystemException]) =
+    ): (FileSystem.Write[Sync] & FileSystem.Watch, Path) < (Sync & Scope & Abort[FileSystemException]) =
         Scope.acquireRelease(FileSystem.host.tempDir(prefix))(handle => Sync.Unsafe.defer(handle.remove())).map { handle =>
             (FileSystem.host, handle.path)
         }

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemExceptionTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemExceptionTest.scala
@@ -19,9 +19,10 @@ class FileSystemExceptionTest extends kyo.test.Test[Any]:
             FileAtomicMoveUnsupportedException(p, target),
             FileLockUnavailableException(p),
             FileLockTimeoutException(p, 10.millis),
-            FileLockOwnershipLostException(p)
+            FileLockOwnershipLostException(p),
+            FileWatchInvalidatedException(p)
         )
-        assert(values.size == 11)
+        assert(values.size == 12)
         assert(values(5).asInstanceOf[FileInvalidPathException].input == "nul")
         assert(values(6).asInstanceOf[FileIOException].operation == FileSystemOperation.Read)
         assert(values(6).getCause eq cause)
@@ -35,6 +36,8 @@ class FileSystemExceptionTest extends kyo.test.Test[Any]:
         assert(FileAtomicMoveUnsupportedException(p, Path("to")).isInstanceOf[FileStructureException])
         assert(FileLockTimeoutException(p, 1.millis).isInstanceOf[FileLockException])
         assert(FileLockOwnershipLostException(p).isInstanceOf[FileLockException])
+        assert(FileWatchInvalidatedException(p).isInstanceOf[FileWatchException])
+        assert(!FileWatchInvalidatedException(p).isInstanceOf[FileReadException])
     }
 
     "FileIsADirectoryException is FileReadException and FileWriteException but not FileStructureException" in {

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemSnapshotTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemSnapshotTest.scala
@@ -13,6 +13,13 @@ class FileSystemSnapshotTest extends kyo.test.Test[Any]:
             case Result.Success(value) => value
             case other                 => throw AssertionError(s"invalid fixture glob: $other")
 
+    private def take(clock: Clock.TimeControl, watcher: Path.Watcher)(using
+        Frame
+    ): Chunk[PathChange] < (Async & Abort[FileWatchException]) =
+        Fiber.initUnscoped(Scope.run(watcher.events.take(1).run)).map { fiber =>
+            clock.advance(10.millis).andThen(clock.advance(10.millis)).andThen(fiber.get)
+        }
+
     "glob matrix snapshot represents matcher behavior" in {
         val rows = Chunk(
             s"*.txt|alpha.txt=${glob("*.txt").matches("alpha.txt", Glob.CaseSensitivity.Sensitive)}|nested/alpha.txt=${glob("*.txt").matches("nested/alpha.txt", Glob.CaseSensitivity.Sensitive)}",
@@ -45,6 +52,30 @@ class FileSystemSnapshotTest extends kyo.test.Test[Any]:
         }
     }
 
+    "watch trace snapshot represents ordered changes" in {
+        Clock.withTimeControl { clock =>
+            hostTempDir("kyo-snapshot-watch").map { dir =>
+                val fileSystem = FileSystem.host
+                val root       = dir / "root"
+                val file       = root / "a.txt"
+                fileSystem.mkDir(root).andThen {
+                    fileSystem.openWatcher(root, WatchOptions()).map { watcher =>
+                        fileSystem.write(file, "a", Path.WriteOptions()).andThen(take(clock, watcher)).map { created =>
+                            fileSystem.write(file, "changed", Path.WriteOptions()).andThen(take(clock, watcher)).map { modified =>
+                                fileSystem.removeExisting(file).andThen(take(clock, watcher)).map { removed =>
+                                    val trace = created ++ modified ++ removed
+                                    assert(trace == Chunk(PathChange.Created(file), PathChange.Modified(file), PathChange.Removed(file)))
+                                    val normalized = trace.map(_.toString.replace(s"${dir.toString}/", ""))
+                                    assert(normalized.mkString("\n") == FileSystemSnapshotValues.watchTrace)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     "normalized error snapshot represents typed failures" in {
         val rows = Chunk(
             "Read|root/missing.txt|FileNotFoundException",
@@ -62,6 +93,7 @@ private[kyo] object FileSystemSnapshotValues:
     val globMatrix: String =
         "*.txt|alpha.txt=true|nested/alpha.txt=false\n**/*.txt|alpha.txt=true|nested/alpha.txt=true\n*.TXT|alpha.txt=false|ALPHA.TXT=true"
     val normalizedTree: String = "root/\nroot/a.txt=a\nroot/nested/\nroot/nested/b.txt=b"
+    val watchTrace: String     = "Created(root/a.txt)\nModified(root/a.txt)\nRemoved(root/a.txt)"
     val normalizedErrors: String =
         "Read|root/missing.txt|FileNotFoundException\nWrite|root/missing/value.txt|FileNotFoundException\nCreate|root/a.txt|FileAlreadyExistsException"
 end FileSystemSnapshotValues

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemSnapshotTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemSnapshotTest.scala
@@ -1,5 +1,8 @@
 package kyo
 
+import kyo.Path.Change as PathChange
+import kyo.Path.WatchOptions
+
 /** Cross-platform behavioral assertions represented by the stable filesystem snapshots. */
 class FileSystemSnapshotTest extends kyo.test.Test[Any]:
 

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemWatchTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemWatchTestSuite.scala
@@ -6,12 +6,12 @@ abstract class FileSystemWatchTestSuite extends kyo.test.Test[Any]:
     private given Frame = Frame.internal
 
     protected def withFileSystem(
-        use: (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path) => Unit <
+        use: (FileSystem.Write[Sync] & FileSystem.Watch, Path) => Unit <
             (Async & Sync & Scope & Abort[FileSystemException])
     )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException])
 
     private def withControlledClock(
-        use: (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path, Clock.TimeControl) => Unit <
+        use: (FileSystem.Write[Sync] & FileSystem.Watch, Path, Clock.TimeControl) => Unit <
             (Async & Sync & Scope & Abort[FileSystemException])
     )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
         Clock.withTimeControl(clock => withFileSystem((fileSystem, root) => use(fileSystem, root, clock)))
@@ -199,7 +199,7 @@ end FileSystemWatchTestSuite
 
 class HostPathWatchTest extends FileSystemWatchTestSuite:
     protected def withFileSystem(
-        use: (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path) => Unit <
+        use: (FileSystem.Write[Sync] & FileSystem.Watch, Path) => Unit <
             (Async & Sync & Scope & Abort[FileSystemException])
     )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
         val fileSystem = FileSystem.host

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemWatchTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemWatchTestSuite.scala
@@ -26,8 +26,8 @@ abstract class FileSystemWatchTestSuite extends kyo.test.Test[Any]:
     private def takeQueued(clock: Clock.TimeControl, watcher: Path.Watcher, count: Int)(using
         Frame
     ): Chunk[PathChange] < (Async & Abort[FileWatchException]) =
-        clock.advance(Duration.Zero, 10.millis).andThen {
-            clock.advance(10.millis, 10.millis).andThen(Scope.run(watcher.events.take(count).run))
+        clock.advance(10.millis).andThen {
+            clock.awaitPendingSleepers(1).andThen(Scope.run(watcher.events.take(count).run))
         }
 
     private def glob(value: String): Glob =

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemWatchTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemWatchTestSuite.scala
@@ -1,0 +1,210 @@
+package kyo
+
+/** Shared watch contract for mutable filesystem backends. */
+abstract class FileSystemWatchTestSuite extends kyo.test.Test[Any]:
+
+    private given Frame = Frame.internal
+
+    protected def withFileSystem(
+        use: (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path) => Unit <
+            (Async & Sync & Scope & Abort[FileSystemException])
+    )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException])
+
+    private def withControlledClock(
+        use: (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path, Clock.TimeControl) => Unit <
+            (Async & Sync & Scope & Abort[FileSystemException])
+    )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
+        Clock.withTimeControl(clock => withFileSystem((fileSystem, root) => use(fileSystem, root, clock)))
+
+    private def take(clock: Clock.TimeControl, watcher: Path.Watcher, count: Int)(using
+        Frame
+    ): Chunk[PathChange] < (Async & Abort[FileWatchException]) =
+        Fiber.initUnscoped(Scope.run(watcher.events.take(count).run)).map { fiber =>
+            clock.advance(10.millis).andThen(clock.advance(10.millis)).andThen(fiber.get)
+        }
+
+    private def takeQueued(clock: Clock.TimeControl, watcher: Path.Watcher, count: Int)(using
+        Frame
+    ): Chunk[PathChange] < (Async & Abort[FileWatchException]) =
+        clock.advance(Duration.Zero, 10.millis).andThen {
+            clock.advance(10.millis, 10.millis).andThen(Scope.run(watcher.events.take(count).run))
+        }
+
+    private def glob(value: String): Glob =
+        Glob.parse(value) match
+            case Result.Success(glob) => glob
+            case Result.Failure(error) =>
+                throw new AssertionError(s"invalid test glob at ${error.offset}: ${error.reason}")
+            case Result.Panic(error) => throw error
+
+    "watch suite emits Created after registration" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            val file = root / "created.txt"
+            fileSystem.openWatcher(root, WatchOptions()).map { watcher =>
+                fileSystem.write(file, "created", Path.WriteOptions()).andThen {
+                    take(clock, watcher, 1).map(events => assert(events == Chunk(PathChange.Created(file))))
+                }
+            }
+        }
+    }
+
+    "watch suite emits Modified" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            val file = root / "modified.txt"
+            fileSystem.write(file, "before", Path.WriteOptions()).andThen {
+                fileSystem.openWatcher(root, WatchOptions()).map { watcher =>
+                    fileSystem.write(file, "after-value", Path.WriteOptions()).andThen {
+                        take(clock, watcher, 1).map(events => assert(events == Chunk(PathChange.Modified(file))))
+                    }
+                }
+            }
+        }
+    }
+
+    "watch suite emits Removed" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            val file = root / "removed.txt"
+            fileSystem.write(file, "before", Path.WriteOptions()).andThen {
+                fileSystem.openWatcher(root, WatchOptions()).map { watcher =>
+                    fileSystem.removeExisting(file).andThen {
+                        take(clock, watcher, 1).map(events => assert(events == Chunk(PathChange.Removed(file))))
+                    }
+                }
+            }
+        }
+    }
+
+    "watch suite emits Moved within the selected view" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            val from = root / "from.txt"
+            val to   = root / "to.txt"
+            fileSystem.write(from, "before", Path.WriteOptions()).andThen {
+                fileSystem.openWatcher(root, WatchOptions()).map { watcher =>
+                    fileSystem.move(from, to, Path.MoveOptions()).andThen {
+                        take(clock, watcher, 1).map(events => assert(events == Chunk(PathChange.Moved(from, to))))
+                    }
+                }
+            }
+        }
+    }
+
+    "watch suite honors immediate and recursive depth" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            val nested    = root / "nested"
+            val deep      = nested / "deep.txt"
+            val direct    = root / "direct.txt"
+            val recursive = nested / "recursive.txt"
+            fileSystem.mkDir(nested).andThen {
+                fileSystem.openWatcher(root, WatchOptions()).map { immediate =>
+                    fileSystem.openWatcher(root, WatchOptions(depth = WatchDepth.Recursive)).map { recursiveWatcher =>
+                        fileSystem.write(deep, "deep", Path.WriteOptions()).andThen {
+                            fileSystem.write(direct, "direct", Path.WriteOptions()).andThen {
+                                take(clock, immediate, 1).map { immediateEvents =>
+                                    take(clock, recursiveWatcher, 2).map { recursiveEvents =>
+                                        assert(immediateEvents == Chunk(PathChange.Created(direct)))
+                                        assert(recursiveEvents.contains(PathChange.Created(deep)))
+                                        assert(recursiveEvents.contains(PathChange.Created(direct)))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watch suite applies a root-relative glob and move normalization" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            val outside = root / "value.bin"
+            val inside  = root / "value.txt"
+            val left    = root / "left.bin"
+            fileSystem.write(outside, "value", Path.WriteOptions()).andThen {
+                fileSystem.openWatcher(root, WatchOptions(glob = glob("*.txt"))).map { watcher =>
+                    fileSystem.move(outside, inside, Path.MoveOptions()).andThen {
+                        take(clock, watcher, 1).map { entered =>
+                            fileSystem.move(inside, left, Path.MoveOptions()).andThen {
+                                take(clock, watcher, 1).map { exited =>
+                                    assert(entered == Chunk(PathChange.Created(inside)))
+                                    assert(exited == Chunk(PathChange.Removed(inside)))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watch suite enforces the exact logical capacity" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            fileSystem.openWatcher(root, WatchOptions(capacity = 3)).map { watcher =>
+                Kyo.foreachDiscard(0 until 4)(index =>
+                    fileSystem.write(root / s"capacity-$index.txt", index.toString, Path.WriteOptions())
+                ).andThen {
+                    takeQueued(clock, watcher, 1).map { events =>
+                        val resumed = root / "capacity-resumed.txt"
+                        fileSystem.write(resumed, "resumed", Path.WriteOptions()).andThen {
+                            take(clock, watcher, 1).map { resumedEvents =>
+                                assert(events == Chunk(PathChange.Overflow(root)))
+                                assert(resumedEvents == Chunk(PathChange.Created(resumed)))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watch suite emits Invalidated when the watched root is removed" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            fileSystem.openWatcher(root, WatchOptions()).map { watcher =>
+                fileSystem.removeAll(root).andThen {
+                    take(clock, watcher, 1).map(events => assert(events == Chunk(PathChange.Invalidated(root))))
+                }
+            }
+        }
+    }
+
+    "watch suite uses the backend case policy for FileSystemDefault" in {
+        withControlledClock { (fileSystem, root, clock) =>
+            val upper = root / "UPPER.TXT"
+            val lower = root / "lower.txt"
+            fileSystem.defaultCaseSensitivity.map { caseSensitivity =>
+                fileSystem.openWatcher(root, WatchOptions(glob = glob("*.txt"))).map { watcher =>
+                    fileSystem.write(upper, "upper", Path.WriteOptions()).andThen {
+                        val finish: Unit < (Sync & Abort[FileWriteException]) = caseSensitivity match
+                            case Glob.CaseSensitivity.Sensitive   => fileSystem.write(lower, "lower", Path.WriteOptions())
+                            case Glob.CaseSensitivity.Insensitive => ()
+                        finish.andThen {
+                            val expected = caseSensitivity match
+                                case Glob.CaseSensitivity.Sensitive   => lower
+                                case Glob.CaseSensitivity.Insensitive => upper
+                            take(clock, watcher, 1).map(events => assert(events == Chunk(PathChange.Created(expected))))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watch suite releases resources with the acquisition scope" in {
+        withControlledClock { (fileSystem, root, _) =>
+            Scope.run(fileSystem.openWatcher(root, WatchOptions())).map { watcher =>
+                Scope.run(watcher.events.run).map(events => assert(events.isEmpty))
+            }
+        }
+    }
+end FileSystemWatchTestSuite
+
+class HostPathWatchTest extends FileSystemWatchTestSuite:
+    protected def withFileSystem(
+        use: (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path) => Unit <
+            (Async & Sync & Scope & Abort[FileSystemException])
+    )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
+        val fileSystem = FileSystem.host
+        Scope.acquireRelease(fileSystem.tempDir("kyo-path-watch"))(handle => Sync.Unsafe.defer(handle.remove())).map { handle =>
+            use(fileSystem, handle.path)
+        }
+    end withFileSystem
+end HostPathWatchTest

--- a/kyo-system/shared/src/test/scala/kyo/FileSystemWatchTestSuite.scala
+++ b/kyo-system/shared/src/test/scala/kyo/FileSystemWatchTestSuite.scala
@@ -1,5 +1,9 @@
 package kyo
 
+import kyo.Path.Change as PathChange
+import kyo.Path.WatchDepth
+import kyo.Path.WatchOptions
+
 /** Shared watch contract for mutable filesystem backends. */
 abstract class FileSystemWatchTestSuite extends kyo.test.Test[Any]:
 

--- a/kyo-system/shared/src/test/scala/kyo/PathWatchTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathWatchTest.scala
@@ -10,7 +10,7 @@ class PathWatchTest extends FileSystemWatchTestSuite:
     final private class CountingRead(
         delegate: FileSystem.Write[Sync],
         scans: AtomicInt
-    ) extends FileSystem.Read[Sync], FileSystem.Watch[Sync]:
+    ) extends FileSystem.Read[Sync], FileSystem.Watch:
         export delegate.{list as _, *}
 
         override def list(path: Path)(using Frame): Chunk[Path] < (Sync & Abort[FileReadException | FileStructureException]) =
@@ -31,7 +31,7 @@ class PathWatchTest extends FileSystemWatchTestSuite:
         delegate: FileSystem.Write[Sync],
         failList: AtomicBoolean,
         rootIsDirectory: AtomicBoolean
-    ) extends FileSystem.Read[Sync], FileSystem.Watch[Sync]:
+    ) extends FileSystem.Read[Sync], FileSystem.Watch:
         export delegate.{isDirectory as _, list as _, *}
 
         override def isDirectory(path: Path)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
@@ -71,7 +71,7 @@ class PathWatchTest extends FileSystemWatchTestSuite:
         faults: AtomicBoolean,
         panicCheck: java.util.concurrent.atomic.AtomicBoolean,
         panic: Throwable
-    ) extends FileSystem.Read[Sync], FileSystem.Watch[Sync]:
+    ) extends FileSystem.Read[Sync], FileSystem.Watch:
         export delegate.{exists as _, stat as _, *}
 
         override def stat(path: Path)(using Frame): Path.PathStat < (Sync & Abort[FileReadException]) =
@@ -105,7 +105,7 @@ class PathWatchTest extends FileSystemWatchTestSuite:
     end RecoveryFaultRead
 
     protected def withFileSystem(
-        use: (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path) => Unit <
+        use: (FileSystem.Write[Sync] & FileSystem.Watch, Path) => Unit <
             (Async & Sync & Scope & Abort[FileSystemException])
     )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
         val fileSystem = FileSystem.host

--- a/kyo-system/shared/src/test/scala/kyo/PathWatchTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathWatchTest.scala
@@ -1,5 +1,9 @@
 package kyo
 
+import kyo.Path.Change as PathChange
+import kyo.Path.MatchCase
+import kyo.Path.WatchDepth
+import kyo.Path.WatchOptions
 import scala.compiletime.testing.typeCheckErrors
 
 class PathWatchTest extends FileSystemWatchTestSuite:

--- a/kyo-system/shared/src/test/scala/kyo/PathWatchTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathWatchTest.scala
@@ -379,11 +379,9 @@ class PathWatchTest extends FileSystemWatchTestSuite:
 
     "watcher emits Overflow when its bounded queue loses changes" in {
         // Both writes land before the scan, so the one poll pass that follows sees both new files at
-        // once and folds them into a single Overflow. The read is issued only after the wall-clock-
-        // waiting advances settle that whole pass, deliberately not forked ahead of it: a reader
-        // already parked on take(1) can claim the batch's first successful offer (the plain Created)
-        // before the same pass reaches the offer that trips overflow, which is a real race against
-        // the scan, not an artifact of an uncontrolled clock.
+        // once and folds them into a single Overflow. The polling loop rearms its sleeper only after
+        // that scan publishes the whole batch, so waiting for the rearm proves the Overflow is queued
+        // before the read begins.
         Clock.withTimeControl { clock =>
             hostRoot("kyo-path-watch-overflow").map { dir =>
                 val fileSystem = FileSystem.host
@@ -396,8 +394,8 @@ class PathWatchTest extends FileSystemWatchTestSuite:
                                 watcher <- root.openWatcher(WatchOptions(capacity = 1))
                                 _       <- (root / "first").write("first")
                                 _       <- (root / "second").write("second")
-                                _       <- clock.advance(Duration.Zero, 10.millis)
-                                _       <- clock.advance(10.millis, 10.millis)
+                                _       <- clock.advance(10.millis)
+                                _       <- clock.awaitPendingSleepers(1)
                                 events  <- watcher.events.take(1).run
                             yield assert(events == Chunk(PathChange.Overflow(root)))
                         }
@@ -408,9 +406,8 @@ class PathWatchTest extends FileSystemWatchTestSuite:
     }
 
     "watch capacity is an exact logical bound" in {
-        // Same reasoning as the Overflow case above: the read is issued only after the scan settles,
-        // never forked ahead of it, so it cannot claim one of the batch's earlier successful offers
-        // before the same pass reaches the one that overflows.
+        // Same reasoning as the Overflow case above: waiting for the polling loop to rearm proves the
+        // scan has published the complete batch before the read begins.
         Clock.withTimeControl { clock =>
             hostRoot("kyo-path-watch-capacity").map { dir =>
                 val fileSystem = FileSystem.host
@@ -422,8 +419,8 @@ class PathWatchTest extends FileSystemWatchTestSuite:
                                 _       <- root.mkDir
                                 watcher <- root.openWatcher(WatchOptions(capacity = 3))
                                 _       <- Kyo.foreachDiscard(0 until 4)(index => (root / s"$index.txt").write(index.toString))
-                                _       <- clock.advance(Duration.Zero, 10.millis)
-                                _       <- clock.advance(10.millis, 10.millis)
+                                _       <- clock.advance(10.millis)
+                                _       <- clock.awaitPendingSleepers(1)
                                 events  <- watcher.events.take(1).run
                             yield assert(events == Chunk(PathChange.Overflow(root)))
                         }

--- a/kyo-system/shared/src/test/scala/kyo/PathWatchTest.scala
+++ b/kyo-system/shared/src/test/scala/kyo/PathWatchTest.scala
@@ -1,0 +1,882 @@
+package kyo
+
+import scala.compiletime.testing.typeCheckErrors
+
+class PathWatchTest extends FileSystemWatchTestSuite:
+
+    /** Counts the scans the polling watcher performs, so its pacing can be asserted rather than
+      * assumed.
+      */
+    final private class CountingRead(
+        delegate: FileSystem.Write[Sync],
+        scans: AtomicInt
+    ) extends FileSystem.Read[Sync], FileSystem.Watch[Sync]:
+        export delegate.{list as _, *}
+
+        override def list(path: Path)(using Frame): Chunk[Path] < (Sync & Abort[FileReadException | FileStructureException]) =
+            scans.incrementAndGet.andThen(delegate.list(path))
+
+        def list(path: Path, glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using
+            Frame
+        ): Chunk[Path] < (Sync & Abort[FileReadException | FileStructureException]) =
+            delegate.list(path, glob, caseSensitivity)
+
+        def openWatcher(path: Path, options: WatchOptions)(using
+            Frame
+        ): Path.Watcher < (Sync & Async & Scope & Abort[FileWatchException]) =
+            PathWatch.polling(this, path, options)
+    end CountingRead
+
+    final private class FaultRead(
+        delegate: FileSystem.Write[Sync],
+        failList: AtomicBoolean,
+        rootIsDirectory: AtomicBoolean
+    ) extends FileSystem.Read[Sync], FileSystem.Watch[Sync]:
+        export delegate.{isDirectory as _, list as _, *}
+
+        override def isDirectory(path: Path)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
+            rootIsDirectory.get.map {
+                case false => false
+                case true  => delegate.isDirectory(path)
+            }
+
+        override def list(path: Path)(using Frame): Chunk[Path] < (Sync & Abort[FileReadException | FileStructureException]) =
+            failList.get.map {
+                case false => delegate.list(path)
+                case true  => Abort.fail(FileIOException(path, FileSystemOperation.List, new java.io.IOException("watch list failed")))
+            }
+
+        def list(path: Path, glob: Glob, caseSensitivity: Glob.CaseSensitivity)(using
+            Frame
+        ): Chunk[Path] < (Sync & Abort[FileReadException | FileStructureException]) =
+            delegate.list(path, glob, caseSensitivity)
+
+        def openWatcher(path: Path, options: WatchOptions)(using
+            Frame
+        ): Path.Watcher < (Sync & Async & Scope & Abort[FileWatchException]) =
+            PathWatch.polling(this, path, options)
+    end FaultRead
+
+    /** One flag arms both faults, deliberately.
+      *
+      * The observation fault and the existence-check fault were separate flags, set as two effects
+      * with the watcher already open. A poll landing between them saw the pair half-applied: `stat`
+      * failing while `exists` still succeeded takes a different recovery path than the one the test
+      * asserts on. They are only ever armed together, so one flag removes the intermediate state
+      * rather than relying on nothing observing it.
+      */
+    final private class RecoveryFaultRead(
+        delegate: FileSystem.Write[Sync],
+        child: Path,
+        faults: AtomicBoolean,
+        panicCheck: java.util.concurrent.atomic.AtomicBoolean,
+        panic: Throwable
+    ) extends FileSystem.Read[Sync], FileSystem.Watch[Sync]:
+        export delegate.{exists as _, stat as _, *}
+
+        override def stat(path: Path)(using Frame): Path.PathStat < (Sync & Abort[FileReadException]) =
+            if panicCheck.get() && path == child then
+                Abort.fail(FileIOException(path, FileSystemOperation.Inspect, new java.io.IOException("observation failed")))
+            else
+                faults.get.map {
+                    case true if path == child =>
+                        Abort.fail(FileIOException(path, FileSystemOperation.Inspect, new java.io.IOException("observation failed")))
+                    case _ => delegate.stat(path)
+                }
+
+        override def exists(path: Path)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
+            exists(path, false)
+
+        override def exists(path: Path, followLinks: Boolean)(using Frame): Boolean < (Sync & Abort[FileReadException]) =
+            if path != child then delegate.exists(path, followLinks)
+            else
+                if panicCheck.get() then
+                    Abort.panic[FileReadException](panic)
+                else
+                    faults.get.map {
+                        case true  => Abort.fail(FileIOException(path, FileSystemOperation.Exists, new java.io.IOException("check failed")))
+                        case false => delegate.exists(path, followLinks)
+                    }
+
+        def openWatcher(path: Path, options: WatchOptions)(using
+            Frame
+        ): Path.Watcher < (Sync & Async & Scope & Abort[FileWatchException]) =
+            PathWatch.polling(this, path, options)
+    end RecoveryFaultRead
+
+    protected def withFileSystem(
+        use: (FileSystem.Write[Sync] & FileSystem.Watch[Sync], Path) => Unit <
+            (Async & Sync & Scope & Abort[FileSystemException])
+    )(using Frame): Unit < (Async & Sync & Scope & Abort[FileSystemException]) =
+        val fileSystem = FileSystem.host
+        Scope.acquireRelease(fileSystem.tempDir("kyo-path-watch-test"))(handle => Sync.Unsafe.defer(handle.remove())).map { handle =>
+            use(fileSystem, handle.path)
+        }
+    end withFileSystem
+
+    private def hostRoot(prefix: String)(using Frame): Path < (Sync & Scope & Abort[FileSystemException]) =
+        Scope.acquireRelease(FileSystem.host.tempDir(prefix))(handle => Sync.Unsafe.defer(handle.remove())).map(_.path)
+
+    private def glob(value: String): Glob =
+        Glob.parse(value) match
+            case Result.Success(glob) => glob
+            case Result.Failure(error) =>
+                throw new AssertionError(s"invalid test glob at ${error.offset}: ${error.reason}")
+            case Result.Panic(error) => throw error
+
+    "watcher emits Created after registration" in {
+        hostRoot("kyo-path-watch-created").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "watched"
+            val file       = root / "created.txt"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- root.mkDir
+                            watcher <- root.openWatcher()
+                            _       <- file.write("created")
+                            events  <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Created(file)))
+                    }
+                }
+            }
+        }
+    }
+
+    "mutation during an initial walk is queued by the already-open watcher" in {
+        hostRoot("kyo-path-watch-walk-race").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "walk-race-root"
+            val created    = root / "during-walk.txt"
+            Latch.init(1).map { walkStarted =>
+                Latch.init(1).map { finishWalk =>
+                    Scope.run {
+                        Path.runWatchWith(fileSystem) {
+                            Path.runWith(fileSystem) {
+                                for
+                                    _       <- (root / "seed.txt").write("seed")
+                                    watcher <- root.openWatcher()
+                                    walk <- Fiber.initUnscoped(
+                                        Scope.run(
+                                            Path.runReadOnlyWith(fileSystem)(
+                                                root.walk
+                                                    .map(path => walkStarted.release.andThen(finishWalk.await).map(_ => path))
+                                                    .run
+                                            )
+                                        )
+                                    )
+                                    _      <- walkStarted.await
+                                    _      <- created.write("created")
+                                    _      <- finishWalk.release
+                                    _      <- walk.get
+                                    events <- watcher.events.take(1).run
+                                yield assert(events == Chunk(PathChange.Created(created)))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher emits Modified for an existing file" in {
+        hostRoot("kyo-path-watch-modified").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "modified-root"
+            val file       = root / "modified.txt"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- file.write("before")
+                            watcher <- root.openWatcher()
+                            _       <- file.write("after")
+                            events  <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Modified(file)))
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher emits Removed for a removed child" in {
+        hostRoot("kyo-path-watch-removed").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "removed-root"
+            val file       = root / "removed.txt"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- file.write("before")
+                            watcher <- root.openWatcher()
+                            _       <- file.removeExisting
+                            events  <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Removed(file)))
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher emits Moved for a rename within the selected view" in {
+        hostRoot("kyo-path-watch-moved").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "moved-root"
+            val from       = root / "from.txt"
+            val to         = root / "to.txt"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- from.write("before")
+                            watcher <- root.openWatcher()
+                            _       <- from.move(to)
+                            events  <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Moved(from, to)))
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher emits Invalidated when its root is removed" in {
+        hostRoot("kyo-path-watch-invalidated").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "invalidated-root"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- root.mkDir
+                            watcher <- root.openWatcher()
+                            _       <- root.removeAll
+                            events  <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Invalidated(root)))
+                    }
+                }
+            }
+        }
+    }
+
+    "invalidation is terminal and cannot resume after root recreation" in {
+        // On the clock-driven poll loop, removeAll and the recreation below both land between two
+        // scans unless the removal's own scan is forced through first: the advance after removeAll
+        // is what lets the loop observe the root missing and close the stream before recreation ever
+        // happens, rather than folding straight from "existed" to "exists again" and never noticing.
+        Clock.withTimeControl { clock =>
+            hostRoot("kyo-path-watch-terminal").map { dir =>
+                val fileSystem = FileSystem.host
+                val root       = dir / "terminal-root"
+                val later      = root / "later.txt"
+                Scope.run {
+                    fileSystem.mkDir(root).andThen {
+                        fileSystem.openWatcher(root, WatchOptions()).map { watcher =>
+                            Fiber.initUnscoped(Scope.run(watcher.events.run)).map { fiber =>
+                                fileSystem.removeAll(root).andThen {
+                                    clock.advance(10.millis).andThen {
+                                        fileSystem.mkDir(root).andThen {
+                                            fileSystem.write(later, "later", Path.WriteOptions()).andThen {
+                                                clock.advance(10.millis).andThen {
+                                                    fiber.get.map(events => assert(events == Chunk(PathChange.Invalidated(root))))
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher does not invent moves for equal files or directories" in {
+        hostRoot("kyo-path-watch-identity").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "identity-root"
+            val oldFile    = root / "old.txt"
+            val newFile    = root / "new.txt"
+            val oldDir     = root / "old-dir"
+            val newDir     = root / "new-dir"
+            Scope.run {
+                fileSystem.write(oldFile, "same", Path.WriteOptions()).andThen(fileSystem.mkDir(oldDir)).andThen {
+                    fileSystem.openWatcher(root, WatchOptions()).map { watcher =>
+                        fileSystem.removeExisting(oldFile).andThen(fileSystem.write(newFile, "same", Path.WriteOptions())).andThen {
+                            fileSystem.removeAll(oldDir).andThen(fileSystem.mkDir(newDir)).andThen {
+                                watcher.events.take(4).run.map { events =>
+                                    assert(!events.exists { case PathChange.Moved(_, _) => true; case _ => false })
+                                    assert(events.toSet == Set(
+                                        PathChange.Removed(oldFile),
+                                        PathChange.Created(newFile),
+                                        PathChange.Removed(oldDir),
+                                        PathChange.Created(newDir)
+                                    ))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher invalidates when its root is moved away" in {
+        hostRoot("kyo-path-watch-moved-away").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "moved-watch-root"
+            Scope.run {
+                fileSystem.mkDir(root).andThen {
+                    fileSystem.openWatcher(root, WatchOptions(capacity = 1)).map { watcher =>
+                        fileSystem.move(root, dir / "moved-watch-target", Path.MoveOptions()).andThen {
+                            watcher.events.take(1).run.map(events => assert(events == Chunk(PathChange.Invalidated(root))))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher invalidates when an ancestor is moved away" in {
+        hostRoot("kyo-path-watch-ancestor-moved").map { dir =>
+            val fileSystem = FileSystem.host
+            val ancestor   = dir / "moved-watch-ancestor"
+            val root       = ancestor / "root"
+            Scope.run {
+                fileSystem.mkDir(root).andThen {
+                    fileSystem.openWatcher(root, WatchOptions(capacity = 1)).map { watcher =>
+                        fileSystem.move(ancestor, dir / "moved-ancestor-target", Path.MoveOptions()).andThen {
+                            watcher.events.take(1).run.map(events => assert(events == Chunk(PathChange.Invalidated(root))))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "multi-event traces are stably path sorted" in {
+        hostRoot("kyo-path-watch-sorted").map { tempRoot =>
+            val fileSystem = FileSystem.host
+            val root       = tempRoot / "sorted-watch-root"
+            val dir        = root / "dir"
+            val a          = dir / "a.txt"
+            val b          = dir / "b.txt"
+            fileSystem.write(a, "a", Path.WriteOptions()).andThen(fileSystem.write(b, "b", Path.WriteOptions())).andThen {
+                Scope.run {
+                    fileSystem.openWatcher(root, WatchOptions(depth = WatchDepth.Recursive)).map { watcher =>
+                        fileSystem.removeAll(dir).andThen {
+                            watcher.events.take(3).run.map { events =>
+                                assert(events == Chunk(PathChange.Removed(dir), PathChange.Removed(a), PathChange.Removed(b)))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher emits Overflow when its bounded queue loses changes" in {
+        // Both writes land before the scan, so the one poll pass that follows sees both new files at
+        // once and folds them into a single Overflow. The read is issued only after the wall-clock-
+        // waiting advances settle that whole pass, deliberately not forked ahead of it: a reader
+        // already parked on take(1) can claim the batch's first successful offer (the plain Created)
+        // before the same pass reaches the offer that trips overflow, which is a real race against
+        // the scan, not an artifact of an uncontrolled clock.
+        Clock.withTimeControl { clock =>
+            hostRoot("kyo-path-watch-overflow").map { dir =>
+                val fileSystem = FileSystem.host
+                val root       = dir / "overflow-root"
+                Scope.run {
+                    Path.runWatchWith(fileSystem) {
+                        Path.runWith(fileSystem) {
+                            for
+                                _       <- root.mkDir
+                                watcher <- root.openWatcher(WatchOptions(capacity = 1))
+                                _       <- (root / "first").write("first")
+                                _       <- (root / "second").write("second")
+                                _       <- clock.advance(Duration.Zero, 10.millis)
+                                _       <- clock.advance(10.millis, 10.millis)
+                                events  <- watcher.events.take(1).run
+                            yield assert(events == Chunk(PathChange.Overflow(root)))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "watch capacity is an exact logical bound" in {
+        // Same reasoning as the Overflow case above: the read is issued only after the scan settles,
+        // never forked ahead of it, so it cannot claim one of the batch's earlier successful offers
+        // before the same pass reaches the one that overflows.
+        Clock.withTimeControl { clock =>
+            hostRoot("kyo-path-watch-capacity").map { dir =>
+                val fileSystem = FileSystem.host
+                val root       = dir / "capacity-root"
+                Scope.run {
+                    Path.runWatchWith(fileSystem) {
+                        Path.runWith(fileSystem) {
+                            for
+                                _       <- root.mkDir
+                                watcher <- root.openWatcher(WatchOptions(capacity = 3))
+                                _       <- Kyo.foreachDiscard(0 until 4)(index => (root / s"$index.txt").write(index.toString))
+                                _       <- clock.advance(Duration.Zero, 10.millis)
+                                _       <- clock.advance(10.millis, 10.millis)
+                                events  <- watcher.events.take(1).run
+                            yield assert(events == Chunk(PathChange.Overflow(root)))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "immediate depth excludes descendants below direct children" in {
+        hostRoot("kyo-path-watch-immediate").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "immediate-root"
+            val nested     = root / "nested"
+            val direct     = root / "direct.txt"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- nested.mkDir
+                            watcher <- root.openWatcher()
+                            _       <- (nested / "ignored.txt").write("ignored")
+                            _       <- direct.write("selected")
+                            events  <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Created(direct)))
+                    }
+                }
+            }
+        }
+    }
+
+    "recursive depth includes descendants" in {
+        hostRoot("kyo-path-watch-recursive").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "recursive-root"
+            val nested     = root / "nested"
+            val file       = nested / "selected.txt"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- nested.mkDir
+                            watcher <- root.openWatcher(WatchOptions(depth = WatchDepth.Recursive))
+                            _       <- file.write("selected")
+                            events  <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Created(file)))
+                    }
+                }
+            }
+        }
+    }
+
+    "glob matching is root relative and observes explicit case policy" in {
+        hostRoot("kyo-path-watch-glob").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "glob-root"
+            val ignored    = root / "other" / "FILE.TXT"
+            val selected   = root / "selected" / "FILE.TXT"
+            val options = WatchOptions(
+                depth = WatchDepth.Recursive,
+                glob = glob("selected/*.txt"),
+                caseSensitivity = MatchCase.Insensitive
+            )
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- root.mkDir
+                            watcher <- root.openWatcher(options)
+                            _       <- ignored.write("ignored")
+                            _       <- selected.write("selected")
+                            events  <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Created(selected)))
+                    }
+                }
+            }
+        }
+    }
+
+    "FileSystemDefault uses the backend case policy" in {
+        // Which file the glob selects depends on the host volume's own case policy, so the write
+        // order and the expected event both branch on it rather than assuming Sensitive: on an
+        // insensitive volume "IGNORED.TXT" matches "*.txt" too, so writing it first would make it
+        // the first captured event instead of "selected.txt".
+        hostRoot("kyo-path-watch-default-case").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "default-case-root"
+            val upper      = root / "IGNORED.TXT"
+            val lower      = root / "selected.txt"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _               <- root.mkDir
+                            watcher         <- root.openWatcher(WatchOptions(glob = glob("*.txt")))
+                            caseSensitivity <- fileSystem.defaultCaseSensitivity
+                            _ <- caseSensitivity match
+                                case Glob.CaseSensitivity.Sensitive   => upper.write("ignored").andThen(lower.write("selected"))
+                                case Glob.CaseSensitivity.Insensitive => upper.write("selected")
+                            expected = caseSensitivity match
+                                case Glob.CaseSensitivity.Sensitive   => lower
+                                case Glob.CaseSensitivity.Insensitive => upper
+                            events <- watcher.events.take(1).run
+                        yield assert(events == Chunk(PathChange.Created(expected)))
+                    }
+                }
+            }
+        }
+    }
+
+    "glob-filtered moves normalize entering and leaving the selected view" in {
+        hostRoot("kyo-path-watch-move-filter").map { dir =>
+            val fileSystem   = FileSystem.host
+            val root         = dir / "move-filter-root"
+            val outside      = root / "value.bin"
+            val inside       = root / "value.txt"
+            val outsideAgain = root / "renamed.bin"
+            Scope.run {
+                Path.runWatchWith(fileSystem) {
+                    Path.runWith(fileSystem) {
+                        for
+                            _       <- outside.write("value")
+                            watcher <- root.openWatcher(WatchOptions(glob = glob("*.txt")))
+                            _       <- outside.move(inside)
+                            entered <- watcher.events.take(1).run
+                            _       <- inside.move(outsideAgain)
+                            left    <- watcher.events.take(1).run
+                        yield
+                            assert(entered == Chunk(PathChange.Created(inside)))
+                            assert(left == Chunk(PathChange.Removed(inside)))
+                    }
+                }
+            }
+        }
+    }
+
+    "watcher resources are released with their acquisition scope" in {
+        hostRoot("kyo-path-watch-scope").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "scope-root"
+            Path.runWith(fileSystem)(root.mkDir).andThen {
+                Scope.run(fileSystem.openWatcher(root, WatchOptions())).map { watcher =>
+                    Scope.run(watcher.events.run).map(events => assert(events.isEmpty))
+                }
+            }
+        }
+    }
+
+    "PathWatch runner uses the Local-selected watch backend" in {
+        hostRoot("kyo-path-watch-local").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "local-watch-root"
+            val file       = root / "created.txt"
+            FileSystem.let(fileSystem) {
+                Scope.run {
+                    Path.runWatch {
+                        Path.run {
+                            for
+                                _       <- root.mkDir
+                                watcher <- root.openWatcher()
+                                _       <- file.write("created")
+                                events  <- watcher.events.take(1).run
+                            yield assert(events == Chunk(PathChange.Created(file)))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "polling watcher surfaces a terminal typed scan failure" in {
+        Clock.withTimeControl { clock =>
+            hostRoot("kyo-path-watch-fault").map { dir =>
+                val delegate = FileSystem.host
+                AtomicBoolean.init(false).map { failList =>
+                    AtomicBoolean.init(true).map { rootIsDirectory =>
+                        val root = dir / "fault-watch-root"
+                        val fs   = new FaultRead(delegate, failList, rootIsDirectory)
+                        delegate.mkDir(root).andThen {
+                            fs.openWatcher(root, WatchOptions()).map { watcher =>
+                                failList.set(true).andThen {
+                                    Fiber.initUnscoped(Abort.run[FileWatchException](Scope.run(watcher.events.run))).map { fiber =>
+                                        clock.advance(10.millis).andThen(fiber.get).map {
+                                            case Result.Failure(error: FileIOException) =>
+                                                assert(error.path == root)
+                                                assert(error.operation == FileSystemOperation.List)
+                                            case other => fail(s"expected terminal watch failure, found $other")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "polling watcher invalidates when its root becomes a file" in {
+        Clock.withTimeControl { clock =>
+            hostRoot("kyo-path-watch-root-file").map { dir =>
+                val delegate = FileSystem.host
+                AtomicBoolean.init(false).map { failList =>
+                    AtomicBoolean.init(true).map { rootIsDirectory =>
+                        val root = dir / "file-watch-root"
+                        val fs   = new FaultRead(delegate, failList, rootIsDirectory)
+                        delegate.mkDir(root).andThen {
+                            fs.openWatcher(root, WatchOptions()).map { watcher =>
+                                rootIsDirectory.set(false).andThen {
+                                    Fiber.initUnscoped(Scope.run(watcher.events.take(1).run)).map { fiber =>
+                                        clock.advance(10.millis).andThen(fiber.get).map { events =>
+                                            assert(events == Chunk(PathChange.Invalidated(root)))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "polling invalidation is terminal and cannot resume after root recreation" in {
+        Clock.withTimeControl { clock =>
+            hostRoot("kyo-path-watch-terminal-polling").map { dir =>
+                val delegate = FileSystem.host
+                AtomicBoolean.init(false).map { failList =>
+                    AtomicBoolean.init(true).map { rootIsDirectory =>
+                        val root = dir / "terminal-polling-root"
+                        val fs   = new FaultRead(delegate, failList, rootIsDirectory)
+                        delegate.mkDir(root).andThen {
+                            fs.openWatcher(root, WatchOptions()).map { watcher =>
+                                Fiber.initUnscoped(Scope.run(watcher.events.run)).map { fiber =>
+                                    rootIsDirectory.set(false).andThen(clock.advance(10.millis)).andThen {
+                                        rootIsDirectory.set(true).andThen(delegate.write(
+                                            root / "later",
+                                            "later",
+                                            Path.WriteOptions()
+                                        )).andThen {
+                                            clock.advance(10.millis).andThen(fiber.get).map(events =>
+                                                assert(events == Chunk(PathChange.Invalidated(root)))
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "polling paces its scans by the poll interval rather than spinning" in {
+        // Deliberately on the live clock: the pacing under test is the loop awaiting its own sleep,
+        // and a controlled clock would make the loop's progress a property of the test instead.
+        //
+        // The bound is one-sided, which is what keeps this from becoming another timing-sensitive
+        // test: a slower or busier machine completes fewer scans, never more, so load can only move
+        // the result away from the failure. At a 5ms interval a paced loop performs roughly 40 scans
+        // in 200ms; the bound sits far above that and orders of magnitude below a free-running loop.
+        hostRoot("kyo-path-watch-pacing").map { dir =>
+            val delegate = FileSystem.host
+            val root     = dir / "poll-pacing-root"
+            AtomicInt.init(0).map { scans =>
+                val fs = new CountingRead(delegate, scans)
+                delegate.mkDir(root).andThen {
+                    Scope.run {
+                        fs.openWatcher(root, WatchOptions()).map { watcher =>
+                            Fiber.initUnscoped(Scope.run(watcher.events.run)).map { _ =>
+                                Async.sleep(200.millis).andThen {
+                                    scans.get.map { count =>
+                                        assert(
+                                            count <= 500,
+                                            s"polling performed $count scans in 200ms at a 5ms interval; the loop is not awaiting its sleep"
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "polling recovery preserves the precise existence-check failure" in {
+        Clock.withTimeControl { clock =>
+            hostRoot("kyo-path-watch-recovery-failure").map { dir =>
+                val delegate = FileSystem.host
+                val root     = dir / "recovery-failure-root"
+                val child    = root / "child.txt"
+                AtomicBoolean.init(false).map { faults =>
+                    val panicCheck = new java.util.concurrent.atomic.AtomicBoolean(false)
+                    Kyo.unit.map { _ =>
+                        Kyo.unit.map { _ =>
+                            val fs = new RecoveryFaultRead(delegate, child, faults, panicCheck, new RuntimeException)
+                            delegate.write(child, "value", Path.WriteOptions()).andThen {
+                                fs.openWatcher(root, WatchOptions()).map { watcher =>
+                                    // Armed in one step, after the watcher's clean initial snapshot.
+                                    faults.set(true).andThen {
+                                        Fiber.initUnscoped(Scope.run(Abort.run[FileWatchException](watcher.events.run))).map { fiber =>
+                                            clock.advance(10.millis).andThen(fiber.get).map {
+                                                case Result.Failure(error: FileIOException) =>
+                                                    assert(error.path == child)
+                                                    assert(error.operation == FileSystemOperation.Exists)
+                                                case other => fail(s"expected precise existence failure, found $other")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "polling recovery preserves existence-check panics".timeout(5.seconds) in {
+        hostRoot("kyo-path-watch-recovery-panic").map { dir =>
+            val delegate   = FileSystem.host
+            val root       = dir / "recovery-panic-root"
+            val child      = root / "child.txt"
+            val marker     = new RuntimeException("check panic")
+            val panicCheck = new java.util.concurrent.atomic.AtomicBoolean(true)
+            AtomicBoolean.init(false).map { faults =>
+                Kyo.unit.map { _ =>
+                    val fs = new RecoveryFaultRead(delegate, child, faults, panicCheck, marker)
+                    delegate.write(child, "value", Path.WriteOptions()).andThen {
+                        Abort.run[FileWatchException](fs.openWatcher(root, WatchOptions())).map {
+                            case Result.Panic(error) => assert(error eq marker)
+                            case other               => fail(s"expected existence-check panic, found $other")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "terminal panic channel mapping preserves the exact panic" in {
+        val marker = new RuntimeException("terminal panic")
+        Channel.init[Result[FileWatchException, PathChange]](1).map { channel =>
+            val events = Stream:
+                Abort.run[Closed](channel.take).map {
+                    case Result.Success(Result.Success(event)) => Emit.value(Chunk(event))
+                    case Result.Success(Result.Failure(error)) => Abort.fail(error)
+                    case Result.Success(Result.Panic(error))   => Abort.panic[FileWatchException](error)
+                    case Result.Failure(_)                     => ()
+                    case Result.Panic(error)                   => Abort.panic[FileWatchException](error)
+                }
+            Abort.run[Closed](channel.offer(Result.Panic(marker))).map { offered =>
+                assert(offered == Result.Success(true))
+            }.andThen(Abort.run[FileWatchException](events.run)).map {
+                case Result.Panic(error) => assert(error eq marker)
+                case other               => fail(s"expected terminal panic, found $other")
+            }
+        }
+    }
+
+    "FileSystem.let coherently selects the watch backend" in {
+        hostRoot("kyo-path-watch-coherent-local").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "coherent-local-watch"
+            val file       = root / "created.txt"
+            FileSystem.let(fileSystem) {
+                Scope.run {
+                    Path.runWatch {
+                        Path.run {
+                            for
+                                _       <- root.mkDir
+                                watcher <- root.openWatcher()
+                                _       <- file.write("created")
+                                events  <- watcher.events.take(1).run
+                            yield assert(events == Chunk(PathChange.Created(file)))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "PathWatch is isolatable across concurrent child fibers" in {
+        val errors = typeCheckErrors("""
+            given Frame = Frame.internal
+            val root = Path("isolated-watch")
+            val program: Chunk[Path.Watcher] < (PathWatch & Async) =
+                Async.foreach(0 until 2, 2)(_ => root.openWatcher())
+        """)
+        assert(errors.isEmpty)
+    }
+
+    "PathWatch runs watchers in concurrent child fibers" in {
+        hostRoot("kyo-path-watch-concurrent-fibers").map { dir =>
+            val fileSystem = FileSystem.host
+            val roots      = Chunk(dir / "isolated-watch-one", dir / "isolated-watch-two")
+            FileSystem.let(fileSystem) {
+                Scope.run {
+                    Path.runWatch {
+                        Path.run {
+                            Kyo.foreachDiscard(roots)(_.mkDir).andThen {
+                                Async.foreach(roots, 2) { root =>
+                                    val file = root / "created.txt"
+                                    for
+                                        watcher <- root.openWatcher()
+                                        _       <- file.write("created")
+                                        events  <- watcher.events.take(1).run
+                                    yield events
+                                    end for
+                                }.map { events =>
+                                    assert(events == roots.map(root => Chunk(PathChange.Created(root / "created.txt"))))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "interrupting a PathWatch child releases its watchers" in {
+        hostRoot("kyo-path-watch-interrupted").map { dir =>
+            val fileSystem = FileSystem.host
+            val root       = dir / "interrupted-watch"
+            fileSystem.mkDir(root).andThen {
+                AtomicRef.init[Maybe[Path.Watcher]](Absent).map { acquired =>
+                    Latch.init(1).map { ready =>
+                        Latch.init(1).map { hold =>
+                            Scope.run {
+                                for
+                                    fiber <- Fiber.initUnscoped {
+                                        Scope.run {
+                                            Path.runWatchWith(fileSystem) {
+                                                for
+                                                    watcher <- root.openWatcher()
+                                                    _       <- acquired.set(Present(watcher))
+                                                    _       <- ready.release
+                                                    _       <- hold.await
+                                                yield ()
+                                            }
+                                        }
+                                    }
+                                    _           <- ready.await
+                                    interrupted <- fiber.interrupt
+                                    watcher     <- acquired.get.map(_.get)
+                                    events      <- Scope.run(watcher.events.run)
+                                yield assert(interrupted && events.isEmpty)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+end PathWatchTest


### PR DESCRIPTION
### What this adds

Filesystem watching as its own capability. `PathWatch` is separate from `PathRead`, discharged by `Path.runWatch` and `Path.runWatchWith`, so a program that only observes changes says so in its type. `FileSystem.Watch` supplies the backend; the host watcher polls through `PathWatch.polling` rather than binding a native notification API.

### Stack

Part of the path-capability stack on #1859: process fixes, filesystem vocabulary, abstraction, capability flip, channels, locks, watch, durability, confinement, in-memory, zip, then overlay (#1799). Merge bottom up; GitHub retargets the stack above each merge.

Each branch carries one synthesized commit whose diff is exactly this pull request. The original incremental development history remains visible in #1799's earlier timeline and in the backup refs recorded in the working notes.
