### PR TITLE
[kyo-schema] canonical Structure.Value nodes for sums and maps, non-throwing discriminator matching

### DIFF
--- a/kyo-jsonrpc/shared/src/main/scala/kyo/internal/codec/JsonRpcEnvelopeSchema.scala
+++ b/kyo-jsonrpc/shared/src/main/scala/kyo/internal/codec/JsonRpcEnvelopeSchema.scala
@@ -111,9 +111,27 @@ private[kyo] object JsonRpcEnvelopeSchema:
                                     )(using Frame.internal)
                                 case None =>
                                     Structure.Value.Record(base ++ extraFields)
+                        case Present(Structure.Value.MapEntries(entries)) if entries.forall {
+                                case (Structure.Value.Str(_), _) => true
+                                case _                           => false
+                            } =>
+                            // A string-keyed map merges losslessly into the envelope object, same as a Record.
+                            val extraFields = entries.map {
+                                case (Structure.Value.Str(k), v) => (k, v)
+                                case _                           => bug("unreachable: guard requires Str keys")
+                            }
+                            extraFields.iterator.map(_._1).find(reservedKeys.contains) match
+                                case Some(key) =>
+                                    throw JsonRpcInvalidRequestError(
+                                        Structure.Value.Str(s"extras key '$key' is reserved"),
+                                        Chunk.empty
+                                    )(using Frame.internal)
+                                case None =>
+                                    Structure.Value.Record(base ++ extraFields)
+                            end match
                         case Present(Structure.Value.VariantCase(_, _)) | Present(Structure.Value.MapEntries(_)) =>
                             throw JsonRpcInvalidRequestError(
-                                Structure.Value.Str("extras must be a Record or Null, not VariantCase/MapEntries"),
+                                Structure.Value.Str("extras must be a Record, string-keyed map, or Null"),
                                 Chunk.empty
                             )(using Frame.internal)
                         case Present(other) =>

--- a/kyo-schema-json/shared/src/test/scala/kyo/ChangesetTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/kyo/ChangesetTest.scala
@@ -157,20 +157,16 @@ class ChangesetTest extends kyo.test.Test[Any]:
         val m2 = MTMapHolder(Map("a" -> 1, "c" -> 3))
         val d  = Changeset(m1, m2)
         assert(!d.isEmpty)
-        // Key "b" removed, key "c" added: changeset should have operations reflecting this
-        val nestedOps = d.operations.collect { case op: Changeset.Patch.Nested => op }
-        assert(nestedOps.size == 1)
-        assert(nestedOps.head.fieldPath == Chunk("data"))
-        val innerOps = nestedOps.head.operations
-        // Should have a RemoveField for "b" and SetField for "c"
-        assert(innerOps.exists {
-            case Changeset.Patch.RemoveField(Seq("b")) => true
-            case _                                     => false
-        })
-        assert(innerOps.exists {
-            case Changeset.Patch.SetField(Seq("c"), _) => true
-            case _                                     => false
-        })
+        // Maps encode as MapEntries, so a map field diffs into the dedicated MapPatch op:
+        // key "b" removed, key "c" added, nothing updated.
+        val mapOps = d.operations.collect { case op: Changeset.Patch.MapPatch => op }
+        assert(mapOps.size == 1)
+        val mapOp = mapOps.head
+        assert(mapOp.fieldPath == Chunk("data"))
+        assert(mapOp.added == Chunk((Structure.Value.Str("c"), Structure.Value.Integer(3L))))
+        assert(mapOp.removed == Chunk(Structure.Value.Str("b")))
+        assert(mapOp.updated.isEmpty)
+        assert(d.applyTo(m1).getOrThrow == m2)
     }
 
     // 17. StringPatch.applyTo inserts/deletes/replaces character range correctly

--- a/kyo-schema-tests/shared/src/test/scala/kyo/CodecTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/CodecTest.scala
@@ -539,6 +539,12 @@ class CodecTest extends kyo.test.Test[Any]:
         assertRenameOrDenyRoundTrip[TransformMapDeny, Bson](transformMapDenyValue)
     }
 
+    private val transformMapRenameAllValue = TransformMapRenameAll("Dave", Map("k1" -> 1, "k2" -> 2))
+
+    "no-op renameAllFields alongside a Map field decodes the Map correctly through JSON" in {
+        assertRenameOrDenyRoundTrip[TransformMapRenameAll, Json](transformMapRenameAllValue)
+    }
+
     // --- Field transform + Map/mixed product regression matrix, extended to every representable
     // codec (Yaml, Ion text, Ion Binary, alongside the JSON/MsgPack/BSON matrix above) and to a
     // richer mixed-field product, so the transform-aware Map guard alignment is proven
@@ -604,6 +610,10 @@ class CodecTest extends kyo.test.Test[Any]:
 
     "schema-level denyUnknownFields alongside a Map field decodes the Map correctly through Yaml" in {
         assertRenameOrDenyRoundTrip[TransformMapDeny, Yaml](transformMapDenyValue)
+    }
+
+    "no-op renameAllFields alongside a Map field decodes the Map correctly through Yaml" in {
+        assertRenameOrDenyRoundTrip[TransformMapRenameAll, Yaml](transformMapRenameAllValue)
     }
 
     "schema-level denyUnknownFields alongside a Map field decodes the Map correctly through Protobuf" in {

--- a/kyo-schema-tests/shared/src/test/scala/kyo/StructureTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/StructureTest.scala
@@ -1048,6 +1048,82 @@ class StructureTest extends kyo.test.Test[Any]:
             }
         }
 
+        // Structure.encode must emit Value.MapEntries for maps, matching the Value ADT's documented
+        // intent, so map entries stay distinguishable from product fields and pair lists.
+        "Structure.encode map encoding" - {
+
+            "Map[String, V] encodes as MapEntries with Str keys" in {
+                val encoded = Structure.encode(Map("a" -> 1, "b" -> 2))
+                assert(encoded == Structure.Value.MapEntries(Chunk(
+                    (Structure.Value.Str("a"), Structure.Value.Integer(1L)),
+                    (Structure.Value.Str("b"), Structure.Value.Integer(2L))
+                )))
+            }
+
+            "Map[Int, V] encodes as MapEntries with Integer keys" in {
+                val encoded = Structure.encode(Map(1 -> "x", 2 -> "y"))
+                assert(encoded == Structure.Value.MapEntries(Chunk(
+                    (Structure.Value.Integer(1L), Structure.Value.Str("x")),
+                    (Structure.Value.Integer(2L), Structure.Value.Str("y"))
+                )))
+            }
+
+            "Dict[String, V] encodes as MapEntries with Str keys" in {
+                val encoded = Structure.encode(Dict("a" -> 1, "b" -> 2))
+                assert(encoded == Structure.Value.MapEntries(Chunk(
+                    (Structure.Value.Str("a"), Structure.Value.Integer(1L)),
+                    (Structure.Value.Str("b"), Structure.Value.Integer(2L))
+                )))
+            }
+
+            "PathSegment.Field navigates a Str-keyed MapEntries entry" in {
+                val encoded = Structure.encode(Map("a" -> 1, "b" -> 2))
+                assert(Structure.Path.field("b").get(encoded) == Result.succeed(Chunk(Structure.Value.Integer(2L))))
+            }
+
+            "PathSegment.Field sets a Str-keyed MapEntries entry preserving order" in {
+                val encoded = Structure.encode(Map("a" -> 1, "b" -> 2))
+                val updated = Structure.Path.field("a").set(encoded, Structure.Value.Integer(10L))
+                assert(updated == Result.succeed(Structure.Value.MapEntries(Chunk(
+                    (Structure.Value.Str("a"), Structure.Value.Integer(10L)),
+                    (Structure.Value.Str("b"), Structure.Value.Integer(2L))
+                ))))
+            }
+
+            "PathSegment.Each walks MapEntries values" in {
+                val encoded = Structure.encode(Map("a" -> 1, "b" -> 2))
+                val path    = Structure.Path.root / Structure.PathSegment.Each
+                assert(path.get(encoded) == Result.succeed(Chunk(Structure.Value.Integer(1L), Structure.Value.Integer(2L))))
+            }
+
+            "Structure.decode round-trips a string-keyed map" in {
+                val m = Map("a" -> 1, "b" -> 2, "c" -> 3)
+                assert(Structure.decode[Map[String, Int]](Structure.encode(m)) == Result.succeed(m))
+            }
+
+            "Structure.decode round-trips an int-keyed map" in {
+                val m = Map(1 -> "x", 2 -> "y")
+                assert(Structure.decode[Map[Int, String]](Structure.encode(m)) == Result.succeed(m))
+            }
+
+            "Structure.decode round-trips maps nested in a product with a renamed sibling schema" in {
+                // The #1741 shape: a Map field under a schema carrying a field transform.
+                val m                  = Map("tierA" -> 1, "tierB" -> 2)
+                given Schema[MTPerson] = Schema[MTPerson].rename("name", "full_name")
+                val encoded            = Structure.encode(m)
+                assert(Structure.decode[Map[String, Int]](encoded) == Result.succeed(m))
+            }
+
+            "Structure.decode accepts the legacy Record spelling for a string-keyed map" in {
+                // Trees built before MapEntries production (or hand-built) still decode.
+                val legacy = Structure.Value.Record(Chunk(
+                    ("a", Structure.Value.Integer(1L)),
+                    ("b", Structure.Value.Integer(2L))
+                ))
+                assert(Structure.decode[Map[String, Int]](legacy) == Result.succeed(Map("a" -> 1, "b" -> 2)))
+            }
+        }
+
         "Structure.Path variant" - {
 
             "variant get" in {

--- a/kyo-schema-tests/shared/src/test/scala/kyo/StructureTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/StructureTest.scala
@@ -594,21 +594,20 @@ class StructureTest extends kyo.test.Test[Any]:
             }
 
             "sealed trait toStructure" in {
+                // Sums encode as VariantCase, not as the wire wrapper record (#1860).
                 val schema: Schema[MTShape] = summon[Schema[MTShape]]
                 val circle: MTShape         = MTCircle(5.0)
                 val dv                      = toStructure(schema, circle)
                 dv match
-                    case Structure.Value.Record(fields) =>
-                        assert(fields.size == 1)
-                        val (variantName, variantValue) = fields.head
+                    case Structure.Value.VariantCase(variantName, variantValue) =>
                         assert(variantName == "MTCircle")
                         variantValue match
                             case Structure.Value.Record(innerFields) =>
                                 val fm = innerFields.toMap
                                 assert(fm("radius") == Structure.Value.primitive(5.0))
-                            case other => fail(s"Expected Record for variant, got $other")
+                            case other => fail(s"Expected Record for variant payload, got $other")
                         end match
-                    case other => fail(s"Expected Record wrapper, got $other")
+                    case other => fail(s"Expected VariantCase, got $other")
                 end match
             }
 
@@ -995,6 +994,58 @@ class StructureTest extends kyo.test.Test[Any]:
 
             val pathWithVariant = Structure.Path.root / Structure.PathSegment.Variant("Circle")
             assert(pathWithVariant.toString == "<Circle>")
+        }
+
+        // Structure.encode must emit Value.VariantCase for sums, matching the Value ADT's documented
+        // intent, so PathSegment.Variant can navigate the encoder's own output (issue #1860).
+        "Structure.encode sum encoding" - {
+
+            "sealed trait case class variant encodes as VariantCase" in {
+                val encoded = Structure.encode[MTShape](MTCircle(5.0))
+                encoded match
+                    case Structure.Value.VariantCase(name, Structure.Value.Record(fields)) =>
+                        assert(name == "MTCircle")
+                        assert(fields.toMap.apply("radius") == Structure.Value.primitive(5.0))
+                    case other => fail(s"Expected VariantCase, got $other")
+                end match
+            }
+
+            "enum case class variant encodes as VariantCase" in {
+                val encoded = Structure.encode[MixedArityEnum](MixedArityEnum.Alpha(7))
+                encoded match
+                    case Structure.Value.VariantCase(name, Structure.Value.Record(fields)) =>
+                        assert(name == "Alpha")
+                        assert(fields.toMap.apply("x") == Structure.Value.primitive(7))
+                    case other => fail(s"Expected VariantCase, got $other")
+                end match
+            }
+
+            "no-arg enum variant encodes as VariantCase with empty Record" in {
+                val encoded = Structure.encode[AllNoArgEnumA](AllNoArgEnumA.Second)
+                assert(encoded == Structure.Value.VariantCase("Second", Structure.Value.Record(Chunk.empty)))
+            }
+
+            "PathSegment.Variant navigates Structure.encode output" in {
+                val encoded = Structure.encode[MTShape](MTCircle(5.0))
+                val result  = Structure.Path.variant("MTCircle").get(encoded)
+                result match
+                    case Result.Success(values) =>
+                        assert(values.size == 1)
+                        values.head match
+                            case Structure.Value.Record(fields) =>
+                                assert(fields.toMap.apply("radius") == Structure.Value.primitive(5.0))
+                            case other => fail(s"Expected Record payload, got $other")
+                        end match
+                    case other => fail(s"Expected Success, got $other")
+                end match
+            }
+
+            "Structure.decode round-trips the VariantCase encoding" in {
+                val circle: MTShape = MTCircle(5.0)
+                val rect: MTShape   = MTRectangle(3.0, 4.0)
+                assert(Structure.decode[MTShape](Structure.encode[MTShape](circle)) == Result.succeed(circle))
+                assert(Structure.decode[MTShape](Structure.encode[MTShape](rect)) == Result.succeed(rect))
+            }
         }
 
         "Structure.Path variant" - {

--- a/kyo-schema/shared/src/main/scala/kyo/Codec.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Codec.scala
@@ -303,6 +303,19 @@ object Codec:
         def nil(): Unit
         def mapStart(size: Int): Unit
         def mapEnd(): Unit
+
+        /** Starts the active variant of a sum type; the variant payload is written next, followed by [[variantEnd]].
+          *
+          * The default writes the wrapper-object envelope (`{variantName: payload}`), so wire codecs represent sums exactly as before. A
+          * writer that models sums natively (StructureValueWriter) overrides both hooks to keep the variant identity instead.
+          */
+        def variantStart(name: String, variantName: String, variantNameBytes: Array[Byte], variantFieldId: Int): Unit =
+            objectStart(name, 1)
+            fieldBytes(variantNameBytes, variantFieldId)
+        end variantStart
+
+        /** Ends the variant started by [[variantStart]]. */
+        def variantEnd(): Unit = objectEnd()
         def bytes(value: Span[Byte]): Unit
         def bigInt(value: BigInt): Unit
         def bigDecimal(value: BigDecimal): Unit

--- a/kyo-schema/shared/src/main/scala/kyo/Codec.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Codec.scala
@@ -304,6 +304,30 @@ object Codec:
         def mapStart(size: Int): Unit
         def mapEnd(): Unit
 
+        /** Starts a map whose keys are not plain strings; each entry is written via [[mapEntryStart]], the key value, [[mapEntryValue]],
+          * the value, and [[mapEntryEnd]], followed by [[mapEntriesEnd]].
+          *
+          * The defaults write the array-of-`{key, value}`-records envelope, so wire codecs represent non-string maps exactly as before. A
+          * writer that models maps natively (StructureValueWriter) overrides these hooks to keep the map identity instead. String-keyed
+          * maps use [[mapStart]]/[[mapEnd]] with each key written as a field.
+          */
+        def mapEntriesStart(size: Int): Unit = arrayStart(size)
+
+        /** Starts one entry of a non-string map; the key value is written next. */
+        def mapEntryStart(): Unit =
+            objectStart("", 2)
+            field("key", 1)
+        end mapEntryStart
+
+        /** Marks the key-to-value transition inside a map entry; the entry's value is written next. */
+        def mapEntryValue(): Unit = field("value", 2)
+
+        /** Ends the entry started by [[mapEntryStart]]. */
+        def mapEntryEnd(): Unit = objectEnd()
+
+        /** Ends the map started by [[mapEntriesStart]]. */
+        def mapEntriesEnd(): Unit = arrayEnd()
+
         /** Starts the active variant of a sum type; the variant payload is written next, followed by [[variantEnd]].
           *
           * The default writes the wrapper-object envelope (`{variantName: payload}`), so wire codecs represent sums exactly as before. A

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -1596,6 +1596,16 @@ object Schema:
         override def variantEnd(): Unit =
             delegate.variantEnd()
 
+        override def mapEntriesStart(size: Int): Unit =
+            beforeValue()
+            delegate.mapEntriesStart(size)
+        end mapEntriesStart
+
+        override def mapEntryStart(): Unit = delegate.mapEntryStart()
+        override def mapEntryValue(): Unit = delegate.mapEntryValue()
+        override def mapEntryEnd(): Unit   = delegate.mapEntryEnd()
+        override def mapEntriesEnd(): Unit = delegate.mapEntriesEnd()
+
         def arrayStart(size: Int): Unit =
             beforeValue()
             delegate.arrayStart(size)
@@ -3013,16 +3023,15 @@ object Schema:
         lazy val vSchema = vSchema0
         Schema.init[Map[K, V]](
             writeFn = (value, writer) =>
-                writer.arrayStart(value.size)
+                writer.mapEntriesStart(value.size)
                 value.foreach { (k, v) =>
-                    writer.objectStart("", 2)
-                    writer.field("key", 1)
+                    writer.mapEntryStart()
                     kSchema.serializeWrite(k, writer)
-                    writer.field("value", 2)
+                    writer.mapEntryValue()
                     vSchema.serializeWrite(v, writer)
-                    writer.objectEnd()
+                    writer.mapEntryEnd()
                 }
-                writer.arrayEnd()
+                writer.mapEntriesEnd()
             ,
             readFn = reader =>
                 discard(reader.arrayStart())
@@ -3254,16 +3263,15 @@ object Schema:
         lazy val vSchema = vSchema0
         Schema.init[Dict[K, V]](
             writeFn = (value, writer) =>
-                writer.arrayStart(value.size)
+                writer.mapEntriesStart(value.size)
                 value.foreach { (k, v) =>
-                    writer.objectStart("", 2)
-                    writer.field("key", 1)
+                    writer.mapEntryStart()
                     kSchema.serializeWrite(k, writer)
-                    writer.field("value", 2)
+                    writer.mapEntryValue()
                     vSchema.serializeWrite(v, writer)
-                    writer.objectEnd()
+                    writer.mapEntryEnd()
                 }
-                writer.arrayEnd()
+                writer.mapEntriesEnd()
             ,
             readFn = reader =>
                 discard(reader.arrayStart())
@@ -3365,16 +3373,15 @@ object Schema:
         lazy val vSchema = vSchema0
         Schema.init[OrderedDict[K, V]](
             writeFn = (value, writer) =>
-                writer.arrayStart(value.size)
+                writer.mapEntriesStart(value.size)
                 value.foreach { (k, v) =>
-                    writer.objectStart("", 2)
-                    writer.field("key", 1)
+                    writer.mapEntryStart()
                     kSchema.serializeWrite(k, writer)
-                    writer.field("value", 2)
+                    writer.mapEntryValue()
                     vSchema.serializeWrite(v, writer)
-                    writer.objectEnd()
+                    writer.mapEntryEnd()
                 }
-                writer.arrayEnd()
+                writer.mapEntriesEnd()
             ,
             readFn = reader =>
                 discard(reader.arrayStart())

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -1588,6 +1588,14 @@ object Schema:
         def objectEnd(): Unit =
             delegate.objectEnd()
 
+        override def variantStart(name: String, variantName: String, variantNameBytes: Array[Byte], variantFieldId: Int): Unit =
+            beforeValue()
+            delegate.variantStart(name, variantName, variantNameBytes, variantFieldId)
+        end variantStart
+
+        override def variantEnd(): Unit =
+            delegate.variantEnd()
+
         def arrayStart(size: Int): Unit =
             beforeValue()
             delegate.arrayStart(size)

--- a/kyo-schema/shared/src/main/scala/kyo/Structure.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Structure.scala
@@ -852,7 +852,12 @@ object Structure:
         /** Elements of a collection in original order. */
         case Sequence(elements: Chunk[Value])
 
-        /** Key-value pairs of a map in original iteration order. */
+        /** Key-value pairs of a map in original iteration order.
+          *
+          * Produced by `Structure.encode` for Map, Dict, and OrderedDict values with any key type. Wire codecs write a string-keyed map as
+          * an object and any other map as an array of `{key, value}` records, so a Value round-tripped through a wire format reads back as
+          * the equivalent Record or Sequence.
+          */
         case MapEntries(entries: Chunk[(Value, Value)])
 
         /** A string scalar. */
@@ -1097,6 +1102,8 @@ object Structure:
                     v match
                         case Value.Record(fields) =>
                             fields.collect { case (n, fv) if n == name => fv }
+                        case Value.MapEntries(entries) =>
+                            entries.collect { case (Value.Str(k), ev) if k == name => ev }
                         case _ => Chunk.empty
                 case PathSegment.Variant(name) =>
                     v match
@@ -1110,8 +1117,9 @@ object Structure:
                         case _ => Chunk.empty
                 case PathSegment.Each =>
                     v match
-                        case Value.Sequence(elements) => elements
-                        case _                        => Chunk.empty
+                        case Value.Sequence(elements)  => elements
+                        case Value.MapEntries(entries) => entries.map(_._2)
+                        case _                         => Chunk.empty
         end stepGet
 
         private def setAt(v: Value, remaining: List[PathSegment], newValue: Value)(using Frame): Result[NavigationException, Value] =
@@ -1131,6 +1139,18 @@ object Structure:
                                             else (acc :+ (n, fv), found)
                                     }
                                     if found then Result.succeed(Value.Record(updated))
+                                    else Result.panic(PathNotFoundException(Seq.empty, name))
+                                case Value.MapEntries(entries) =>
+                                    val (updated, found) = entries.foldLeft((Chunk.empty[(Value, Value)], false)) {
+                                        case ((acc, found), (k, ev)) =>
+                                            k match
+                                                case Value.Str(s) if s == name =>
+                                                    setAt(ev, rest, newValue) match
+                                                        case Result.Success(nv) => (acc :+ (k, nv), true)
+                                                        case _                  => (acc :+ (k, ev), true)
+                                                case _ => (acc :+ (k, ev), found)
+                                    }
+                                    if found then Result.succeed(Value.MapEntries(updated))
                                     else Result.panic(PathNotFoundException(Seq.empty, name))
                                 case _ =>
                                     Result.panic(TypeMismatchException(Seq.empty, "Record", v.toString))
@@ -1162,6 +1182,13 @@ object Structure:
                                             case _                  => el
                                     )
                                     Result.succeed(Value.Sequence(updated))
+                                case Value.MapEntries(entries) =>
+                                    val updated = entries.map { (k, ev) =>
+                                        setAt(ev, rest, newValue) match
+                                            case Result.Success(nv) => (k, nv)
+                                            case _                  => (k, ev)
+                                    }
+                                    Result.succeed(Value.MapEntries(updated))
                                 case _ =>
                                     Result.panic(TypeMismatchException(Seq.empty, "Sequence", v.toString))
             end match

--- a/kyo-schema/shared/src/main/scala/kyo/Structure.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Structure.scala
@@ -842,7 +842,11 @@ object Structure:
         /** Named fields of a product/case class, ordered by declaration. */
         case Record(fields: Chunk[(String, Value)])
 
-        /** Active variant of a sum type, carrying the variant name and its payload. */
+        /** Active variant of a sum type, carrying the variant name and its payload.
+          *
+          * Produced by `Structure.encode` for sealed traits, enums, and unions. Wire codecs write it as a single-field wrapper object
+          * (`{name: payload}`), so a Value round-tripped through a wire format reads back as the equivalent single-field Record.
+          */
         case VariantCase(name: String, value: Value)
 
         /** Elements of a collection in original order. */

--- a/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
@@ -1452,10 +1452,9 @@ import scala.quoted.*
                 val mName    = Expr(memberNames(idx))
                 val mFieldId = Expr(kyo.internal.CodecMacro.fieldId(memberNames(idx)))
                 val arm = '{
-                    $w.objectStart($mName, 1)
-                    $w.fieldBytes(${ Ref(nameByteSyms(idx)).asExprOf[Array[Byte]] }, $mFieldId)
+                    $w.variantStart($mName, $mName, ${ Ref(nameByteSyms(idx)).asExprOf[Array[Byte]] }, $mFieldId)
                     ${ Ref(variantSyms(idx)).asExprOf[Schema[Any]] }.serializeWrite($v, $w)
-                    $w.objectEnd()
+                    $w.variantEnd()
                 }.asTerm
                 If(cond, arm, elseTerm)
             }
@@ -2214,10 +2213,14 @@ import scala.quoted.*
             ) { (idx, elseTerm) =>
                 val cond = variantCheck(idx, v).asTerm
                 val arm = '{
-                    $w.objectStart(${ Expr(typeName) }, 1)
-                    $w.fieldBytes(${ Ref(nameByteSyms(idx)).asExprOf[Array[Byte]] }, ${ Expr(CodecMacro.fieldId(childNames(idx))) })
+                    $w.variantStart(
+                        ${ Expr(typeName) },
+                        ${ Expr(childNames(idx)) },
+                        ${ Ref(nameByteSyms(idx)).asExprOf[Array[Byte]] },
+                        ${ Expr(CodecMacro.fieldId(childNames(idx))) }
+                    )
                     ${ Ref(variantSyms(idx)).asExprOf[Schema[Any]] }.serializeWrite($v, $w)
-                    $w.objectEnd()
+                    $w.variantEnd()
                 }.asTerm
                 If(cond, arm, elseTerm)
             }

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -409,9 +409,9 @@ private[kyo] object SchemaSerializer:
         end if
     end readWithDiscriminatorField
 
-    /** Transforms a wrapper-format sealed trait value into flat discriminator format.
+    /** Transforms a materialized sealed trait value into flat discriminator format.
       *
-      * Wrapper format: `Record([("MTCircle", Record([("radius", 5.0)]))])` Flat format:
+      * Materialized form: `VariantCase("MTCircle", Record([("radius", 5.0)]))` Flat format:
       * `Record([("type", Str("MTCircle")), ("radius", 5.0)])`
       *
       * For case objects (variant value is an empty Record), produces: `Record([("type", Str("Active"))])`
@@ -422,10 +422,8 @@ private[kyo] object SchemaSerializer:
         resolveWire: String => String
     ): Structure.Value =
         value match
-            // Wrapper format: single-field Record where field name is variant name
-            case Structure.Value.Record(fields) if fields.size == 1 =>
-                val (variantName, innerValue) = fields.head
-                val wireName                  = resolveWire(variantName)
+            case Structure.Value.VariantCase(variantName, innerValue) =>
+                val wireName = resolveWire(variantName)
                 innerValue match
                     case Structure.Value.Record(innerFields) =>
                         // Flatten: discriminator field + variant's fields at same level
@@ -437,7 +435,7 @@ private[kyo] object SchemaSerializer:
                         Structure.Value.Record(Chunk(discEntry))
                 end match
             case other =>
-                // Not a wrapper format, pass through unchanged
+                // Not a variant, pass through unchanged
                 other
     end flattenWithDiscriminator
 
@@ -450,7 +448,7 @@ private[kyo] object SchemaSerializer:
             throw RepresentationUnsupportedException(writer.codecName, representation)
     end requireTopLevelCapable
 
-    /** Adjacent: rewrite the single-field wrapper into a two-field object
+    /** Adjacent: rewrite the materialized VariantCase into a two-field object
       * `{tagKey: wireName, contentKey: payload}`. The payload passes through unchanged, so a
       * non-object payload (scalar/array/null) survives as the content value; an empty-payload variant
       * yields `{contentKey: {}}` (the precedent-consistent empty object).
@@ -462,9 +460,8 @@ private[kyo] object SchemaSerializer:
         resolveWire: String => String
     ): Structure.Value =
         value match
-            case Structure.Value.Record(fields) if fields.size == 1 =>
-                val (variantName, payload) = fields.head
-                val wireName               = resolveWire(variantName)
+            case Structure.Value.VariantCase(variantName, payload) =>
+                val wireName = resolveWire(variantName)
                 Structure.Value.Record(Chunk(
                     (tagKey, Structure.Value.Str(wireName)),
                     (contentKey, payload)
@@ -472,7 +469,7 @@ private[kyo] object SchemaSerializer:
             case other => other
     end adjacentEncode
 
-    /** Tuple: rewrite the single-field wrapper into the two-element positional array
+    /** Tuple: rewrite the materialized VariantCase into the two-element positional array
       * `[wireName, payload]`. A non-object payload rides through as the second element.
       */
     private def tupleEncode(
@@ -480,14 +477,13 @@ private[kyo] object SchemaSerializer:
         resolveWire: String => String
     ): Structure.Value =
         value match
-            case Structure.Value.Record(fields) if fields.size == 1 =>
-                val (variantName, payload) = fields.head
-                val wireName               = resolveWire(variantName)
+            case Structure.Value.VariantCase(variantName, payload) =>
+                val wireName = resolveWire(variantName)
                 Structure.Value.Sequence(Chunk(Structure.Value.Str(wireName), payload))
             case other => other
     end tupleEncode
 
-    /** TupleFlat: rewrite the single-field wrapper into the positional-flattened array
+    /** TupleFlat: rewrite the materialized VariantCase into the positional-flattened array
       * `[wireName, field0Value, field1Value, ...]`. The payload Record's field Chunk is in
       * declaration order, so each field value becomes its own element in that order; field names are
       * dropped. A field that is itself a record passes through as one nested element (not
@@ -498,9 +494,8 @@ private[kyo] object SchemaSerializer:
         resolveWire: String => String
     ): Structure.Value =
         value match
-            case Structure.Value.Record(fields) if fields.size == 1 =>
-                val (variantName, payload) = fields.head
-                val wireName               = resolveWire(variantName)
+            case Structure.Value.VariantCase(variantName, payload) =>
+                val wireName = resolveWire(variantName)
                 val fieldValues = payload match
                     case Structure.Value.Record(payloadFields) => payloadFields.map(_._2)
                     case _                                     => Chunk.empty
@@ -508,14 +503,13 @@ private[kyo] object SchemaSerializer:
             case other => other
     end tupleFlatEncode
 
-    /** Untagged: drop the wrapper entirely and emit the bare payload. The tag resolver is not
+    /** Untagged: drop the variant tag entirely and emit the bare payload. The tag resolver is not
       * consulted (there is no tag).
       */
     private def untaggedEncode(value: Structure.Value): Structure.Value =
         value match
-            case Structure.Value.Record(fields) if fields.size == 1 =>
-                fields.head._2
-            case other => other
+            case Structure.Value.VariantCase(_, payload) => payload
+            case other                                   => other
     end untaggedEncode
 
     /** Builds the variant forward resolver: explicit pair wins, then the renameAll
@@ -946,14 +940,13 @@ private[kyo] object SchemaSerializer:
                     writer.arrayEnd()
                 end if
             case Structure.Value.VariantCase(name, v) =>
-                // Shape-aware VariantCase: single-field object whose key is the variant name. Symmetric with reading a
-                // single-field object as a Record(name, value); the universal Structure.Value tree treats VariantCase
-                // and Record(<single field>) as the same wire shape; round-trips through the shape-aware identity
-                // Schema therefore canonicalize to Record on read.
-                writer.objectStart(name, 1)
-                writer.fieldBytes(name.getBytes(java.nio.charset.StandardCharsets.UTF_8), 0)
+                // Shape-aware VariantCase: on wire codecs the variantStart default writes the single-field object
+                // whose key is the variant name, symmetric with reading a single-field object as a Record(name, value).
+                // Wire round-trips through the shape-aware identity Schema therefore canonicalize to Record on read;
+                // a StructureValueWriter target keeps the VariantCase identity.
+                writer.variantStart(name, name, name.getBytes(java.nio.charset.StandardCharsets.UTF_8), 0)
                 writeStructureValue(writer, v)
-                writer.objectEnd()
+                writer.variantEnd()
             case Structure.Value.Str(s) => writer.string(s)
             case Structure.Value.Integer(l) =>
                 if l >= Int.MinValue && l <= Int.MaxValue then writer.int(l.toInt)

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -38,8 +38,9 @@ private[kyo] object SchemaSerializer:
       * are ever field ids come from `CodecMacro.fieldId(name).toString` or a Protobuf numeric tag, both
       * always ASCII decimal. Any other token, including a unicode name or a name made of unicode digits
       * (Arabic-Indic, fullwidth, ...), is a field NAME and must return -1 so it stays classified as a
-      * name. Accepting unicode digits here would misclassify such a name as an id. This is the same
-      * numeric-tag classification `matchField` does via `parsed.toInt`, without the throw on a non-id.
+      * name. Accepting unicode digits here would misclassify such a name as an id.
+      * `DiscriminatorReader.matchField` uses this for its numeric-tag fallback for the same reason:
+      * a plain field name must classify as a name without constructing a `NumberFormatException`.
       */
     private def wireFieldId(token: String): Int =
         if token.isEmpty then -1
@@ -1608,9 +1609,9 @@ private[kyo] object SchemaSerializer:
                     // Wire-format-agnostic fallback: when the underlying inner reader is wire-format-tagged
                     // (e.g. Protobuf, which reports fields by their numeric tag id), the buffered "name" is a
                     // numeric string. Match it against CodecMacro.fieldId(expected) to align with the way
-                    // the macro-generated case-class read body matches fields downstream.
-                    try parsed.toInt == CodecMacro.fieldId(expected)
-                    catch case _: NumberFormatException => false
+                    // the macro-generated case-class read body matches fields downstream. wireFieldId returns
+                    // -1 for a non-id token and fieldId is always positive, so a plain name never matches.
+                    wireFieldId(parsed) == CodecMacro.fieldId(expected)
                 end if
         end matchField
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -856,18 +856,17 @@ private[kyo] object SchemaSerializer:
     /** Writes a Structure.Value tree to a Writer. Reverse of StructureValueWriter.
       *
       * `shape` is an optional type hint carried down from the originating Schema's structure. It
-      * exists to break a genuine ambiguity in `Structure.Value`: `StructureValueWriter` materializes
-      * both a product and a string-keyed map as `Record` (`mapStart`/`mapEnd` build the same
-      * `ObjectFrame` as `objectStart`/`objectEnd`), so replaying a `Record` with no further
-      * information cannot tell the two apart. That is harmless for a self-describing codec, where an
-      * object and a map write identically, but Protobuf's wire encoding of the two is NOT
-      * interchangeable: an object is one nested sub-message under the field's own number, while a map
-      * is a REPEATED MapEntry sub-message per entry (key at field 1, value at field 2) under that
-      * same number. Replaying a map with object framing corrupts the wire (each entry key becomes a
-      * bogus hash-derived field number instead of a MapEntry key). When `shape` resolves to
-      * `Mapping`, the `Record` writes as a map; otherwise (no hint, or a genuine `Product`) it writes
-      * as an object, matching the shape-free behavior every caller other than `writeWithTransforms`
-      * still relies on.
+      * exists to break an ambiguity for `Record` trees that spell a map: a wire-decoded or hand-built
+      * tree carries a string-keyed map as `Record` (only `Structure.encode` produces `MapEntries`),
+      * so replaying such a `Record` with no further information cannot tell it from a product. That
+      * is harmless for a self-describing codec, where an object and a map write identically, but
+      * Protobuf's wire encoding of the two is NOT interchangeable: an object is one nested
+      * sub-message under the field's own number, while a map is a REPEATED MapEntry sub-message per
+      * entry (key at field 1, value at field 2) under that same number. Replaying a map with object
+      * framing corrupts the wire (each entry key becomes a bogus hash-derived field number instead of
+      * a MapEntry key). When `shape` resolves to `Mapping`, the `Record` writes as a map; otherwise
+      * (no hint, or a genuine `Product`) it writes as an object, matching the shape-free behavior
+      * every caller other than `writeWithTransforms` still relies on.
       */
     def writeStructureValue(writer: Writer, value: Structure.Value, shape: Maybe[Structure.Type] = Maybe.empty): Unit =
         value match
@@ -906,9 +905,11 @@ private[kyo] object SchemaSerializer:
                 elements.foreach(e => writeStructureValue(writer, e, elemShape))
                 writer.arrayEnd()
             case Structure.Value.MapEntries(entries) =>
-                // Shape-aware MapEntries:
-                //   * all-String keys -> JSON object with each key as a field; round-trips through the universal Record shape.
-                //   * mixed/non-String keys -> array-of-pairs; non-String keys are inexpressible as JSON field names.
+                // Shape-aware MapEntries, matching the typed map schemas' wire spelling exactly so the
+                // transform-replay path is byte-identical with the raw write path:
+                //   * all-String keys -> map framing with each key as a field (a JSON object).
+                //   * mixed/non-String keys -> the mapEntriesStart envelope (array of {key, value}
+                //     records on wire codecs); non-String keys are inexpressible as JSON field names.
                 val (keyShape, valueShape) = shape.map(unwrapOptionalShape) match
                     case Maybe.Present(Structure.Type.Mapping(_, _, k, v)) =>
                         (Maybe(unwrapOptionalShape(k)), Maybe(unwrapOptionalShape(v)))
@@ -930,14 +931,15 @@ private[kyo] object SchemaSerializer:
                     }
                     writer.mapEnd()
                 else
-                    writer.arrayStart(entries.size)
+                    writer.mapEntriesStart(entries.size)
                     entries.foreach { (k, v) =>
-                        writer.arrayStart(2)
+                        writer.mapEntryStart()
                         writeStructureValue(writer, k, keyShape)
+                        writer.mapEntryValue()
                         writeStructureValue(writer, v, valueShape)
-                        writer.arrayEnd()
+                        writer.mapEntryEnd()
                     }
-                    writer.arrayEnd()
+                    writer.mapEntriesEnd()
                 end if
             case Structure.Value.VariantCase(name, v) =>
                 // Shape-aware VariantCase: on wire codecs the variantStart default writes the single-field object

--- a/kyo-schema/shared/src/main/scala/kyo/internal/StructureValueReader.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/StructureValueReader.scala
@@ -9,8 +9,8 @@ import kyo.Codec.Reader
   * Provides the deserialization counterpart to [[StructureValueWriter]]: given a Structure.Value tree, this reader exposes it through the
   * standard Reader protocol so that Schema-derived codecs can reconstruct a typed Scala value from the universal representation.
   *
-  *   - Navigates [[kyo.Structure.Value.Record]], [[kyo.Structure.Value.Sequence]], typed primitive nodes (Str, Bool, Integer, Decimal,
-  *     BigNum, Bytes, Instant, Duration), and [[kyo.Structure.Value.VariantCase]] nodes
+  *   - Navigates [[kyo.Structure.Value.Record]], [[kyo.Structure.Value.Sequence]], [[kyo.Structure.Value.MapEntries]], typed primitive
+  *     nodes (Str, Bool, Integer, Decimal, BigNum, Bytes, Instant, Duration), and [[kyo.Structure.Value.VariantCase]] nodes
   *   - Maintains a stack of frames matching the nesting depth of the value tree
   *   - Supports `captureValue()` for deferred sub-tree reading (used by sum type codecs)
   *
@@ -66,6 +66,14 @@ final class StructureValueReader(root: Structure.Value)(using _frame: Frame) ext
             case Structure.Value.Sequence(elements) =>
                 stack = ArrayFrame(elements.iterator) :: stack
                 elements.size
+            case Structure.Value.MapEntries(entries) =>
+                // A map read through the array protocol (the non-string-keyed map readFn) is
+                // presented as the array-of-{key, value}-records envelope the wire uses.
+                val asRecords = entries.iterator.map { (k, v) =>
+                    Structure.Value.Record(Chunk(("key", k), ("value", v))): Structure.Value
+                }
+                stack = ArrayFrame(asRecords) :: stack
+                entries.size
             case other =>
                 throw TypeMismatchException(Seq.empty, "Sequence", other.toString)
     end arrayStart
@@ -205,7 +213,21 @@ final class StructureValueReader(root: Structure.Value)(using _frame: Frame) ext
 
     def readStructure(): Structure.Value = currentValue
 
-    def mapStart(): Int         = objectStart()
+    def mapStart(): Int =
+        currentValue match
+            case Structure.Value.MapEntries(entries) =>
+                // A map read through the string-map protocol requires Str keys; the entries are
+                // presented as object fields. A Record (the legacy spelling and every wire-decoded
+                // tree) falls through to the object presentation.
+                val asFields = entries.iterator.map {
+                    case (Structure.Value.Str(k), v) => (k, v)
+                    case (k, _)                      => throw TypeMismatchException(Seq.empty, "String map key", k.toString)
+                }
+                stack = ObjectFrame(asFields, Maybe.empty) :: stack
+                entries.size
+            case _ =>
+                objectStart()
+    end mapStart
     def mapEnd(): Unit          = objectEnd()
     def hasNextEntry(): Boolean = hasNextField()
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/StructureValueWriter.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/StructureValueWriter.scala
@@ -8,8 +8,8 @@ import kyo.Codec.Writer
   * Used by the structure subsystem to convert a typed Scala value into the universal Structure.Value representation via the standard Writer
   * protocol. The resulting tree can then be inspected, diffed, or transformed without knowledge of the original type.
   *
-  *   - Produces [[kyo.Structure.Value.Record]], [[kyo.Structure.Value.VariantCase]], [[kyo.Structure.Value.Sequence]], and typed primitive
-  *     nodes (Str, Bool, Integer, Decimal, BigNum, Bytes, Instant, Duration)
+  *   - Produces [[kyo.Structure.Value.Record]], [[kyo.Structure.Value.VariantCase]], [[kyo.Structure.Value.Sequence]],
+  *     [[kyo.Structure.Value.MapEntries]], and typed primitive nodes (Str, Bool, Integer, Decimal, BigNum, Bytes, Instant, Duration)
   *   - Maintains a stack of frames to track nested object/array construction
   *   - `result()` returns `Span.empty`; use `getResult` to obtain the built value tree
   *
@@ -28,6 +28,15 @@ final class StructureValueWriter extends Writer:
     ) extends StackFrame
     private case class ArrayFrame(elements: scala.collection.mutable.ListBuffer[Structure.Value]) extends StackFrame
     private case class VariantFrame(name: String, var value: Structure.Value)                     extends StackFrame
+    private case class MapStringFrame(
+        var currentField: String,
+        entries: scala.collection.mutable.ListBuffer[(Structure.Value, Structure.Value)]
+    ) extends StackFrame
+    private case class MapPairsFrame(
+        var pendingKey: Structure.Value,
+        var inKey: Boolean,
+        entries: scala.collection.mutable.ListBuffer[(Structure.Value, Structure.Value)]
+    ) extends StackFrame
 
     private var stack: List[StackFrame]      = Nil
     private var resultValue: Structure.Value = Structure.Value.Null
@@ -40,6 +49,11 @@ final class StructureValueWriter extends Writer:
                 f.elements += dv
             case (f: VariantFrame) :: _ =>
                 f.value = dv
+            case (f: MapStringFrame) :: _ =>
+                f.entries += ((Structure.Value.Str(f.currentField), dv))
+            case (f: MapPairsFrame) :: _ =>
+                if f.inKey then f.pendingKey = dv
+                else f.entries += ((f.pendingKey, dv))
             case Nil =>
                 resultValue = dv
     end addValue
@@ -72,6 +86,8 @@ final class StructureValueWriter extends Writer:
         stack match
             case (f: ObjectFrame) :: _ =>
                 f.currentField = new String(nameBytes, java.nio.charset.StandardCharsets.UTF_8)
+            case (f: MapStringFrame) :: _ =>
+                f.currentField = new String(nameBytes, java.nio.charset.StandardCharsets.UTF_8)
             case _ =>
                 bug("StructureValueWriter.objectEnd/fieldBytes: no active object frame")
     end fieldBytes
@@ -88,9 +104,40 @@ final class StructureValueWriter extends Writer:
     def nil(): Unit                   = addValue(Structure.Value.Null)
 
     def mapStart(size: Int): Unit =
-        stack = ObjectFrame("", "", scala.collection.mutable.ListBuffer.empty) :: stack
+        stack = MapStringFrame("", scala.collection.mutable.ListBuffer.empty) :: stack
 
-    def mapEnd(): Unit = objectEnd()
+    def mapEnd(): Unit =
+        stack match
+            case (f: MapStringFrame) :: rest =>
+                stack = rest
+                addValue(Structure.Value.MapEntries(Chunk.from(f.entries)))
+            case _ =>
+                bug("StructureValueWriter.mapEnd: no active map frame")
+    end mapEnd
+
+    override def mapEntriesStart(size: Int): Unit =
+        stack = MapPairsFrame(Structure.Value.Null, false, scala.collection.mutable.ListBuffer.empty) :: stack
+
+    override def mapEntryStart(): Unit =
+        stack match
+            case (f: MapPairsFrame) :: _ => f.inKey = true
+            case _                       => bug("StructureValueWriter.mapEntryStart: no active map frame")
+
+    override def mapEntryValue(): Unit =
+        stack match
+            case (f: MapPairsFrame) :: _ => f.inKey = false
+            case _                       => bug("StructureValueWriter.mapEntryValue: no active map frame")
+
+    override def mapEntryEnd(): Unit = ()
+
+    override def mapEntriesEnd(): Unit =
+        stack match
+            case (f: MapPairsFrame) :: rest =>
+                stack = rest
+                addValue(Structure.Value.MapEntries(Chunk.from(f.entries)))
+            case _ =>
+                bug("StructureValueWriter.mapEntriesEnd: no active map frame")
+    end mapEntriesEnd
 
     override def variantStart(name: String, variantName: String, variantNameBytes: Array[Byte], variantFieldId: Int): Unit =
         stack = VariantFrame(variantName, Structure.Value.Null) :: stack

--- a/kyo-schema/shared/src/main/scala/kyo/internal/StructureValueWriter.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/StructureValueWriter.scala
@@ -8,8 +8,8 @@ import kyo.Codec.Writer
   * Used by the structure subsystem to convert a typed Scala value into the universal Structure.Value representation via the standard Writer
   * protocol. The resulting tree can then be inspected, diffed, or transformed without knowledge of the original type.
   *
-  *   - Produces [[kyo.Structure.Value.Record]], [[kyo.Structure.Value.Sequence]], and typed primitive nodes (Str, Bool, Integer, Decimal,
-  *     BigNum, Bytes, Instant, Duration)
+  *   - Produces [[kyo.Structure.Value.Record]], [[kyo.Structure.Value.VariantCase]], [[kyo.Structure.Value.Sequence]], and typed primitive
+  *     nodes (Str, Bool, Integer, Decimal, BigNum, Bytes, Instant, Duration)
   *   - Maintains a stack of frames to track nested object/array construction
   *   - `result()` returns `Span.empty`; use `getResult` to obtain the built value tree
   *
@@ -27,6 +27,7 @@ final class StructureValueWriter extends Writer:
         fields: scala.collection.mutable.ListBuffer[(String, Structure.Value)]
     ) extends StackFrame
     private case class ArrayFrame(elements: scala.collection.mutable.ListBuffer[Structure.Value]) extends StackFrame
+    private case class VariantFrame(name: String, var value: Structure.Value)                     extends StackFrame
 
     private var stack: List[StackFrame]      = Nil
     private var resultValue: Structure.Value = Structure.Value.Null
@@ -37,6 +38,8 @@ final class StructureValueWriter extends Writer:
                 f.fields += ((f.currentField, dv))
             case (f: ArrayFrame) :: _ =>
                 f.elements += dv
+            case (f: VariantFrame) :: _ =>
+                f.value = dv
             case Nil =>
                 resultValue = dv
     end addValue
@@ -88,6 +91,18 @@ final class StructureValueWriter extends Writer:
         stack = ObjectFrame("", "", scala.collection.mutable.ListBuffer.empty) :: stack
 
     def mapEnd(): Unit = objectEnd()
+
+    override def variantStart(name: String, variantName: String, variantNameBytes: Array[Byte], variantFieldId: Int): Unit =
+        stack = VariantFrame(variantName, Structure.Value.Null) :: stack
+
+    override def variantEnd(): Unit =
+        stack match
+            case (f: VariantFrame) :: rest =>
+                stack = rest
+                addValue(Structure.Value.VariantCase(f.name, f.value))
+            case _ =>
+                bug("StructureValueWriter.variantEnd: no active variant frame")
+    end variantEnd
 
     def bytes(value: Span[Byte]): Unit            = addValue(Structure.Value.Bytes(value))
     def bigInt(value: BigInt): Unit               = addValue(Structure.Value.BigNum(BigDecimal(value)))

--- a/kyo-schema/shared/src/test/scala/kyo/CodecTestFixtures.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/CodecTestFixtures.scala
@@ -51,6 +51,13 @@ given transformMapDropSchema: Schema[TransformMapDrop] = Schema[TransformMapDrop
 case class TransformMapDeny(fullName: String, tags: Map[String, Int]) derives CanEqual
 given transformMapDenySchema: Schema[TransformMapDeny] = Schema[TransformMapDeny].denyUnknownFields
 
+// renameAllFields where every field is already camelCase: the rename is a semantic no-op, yet its
+// presence still installs the transform-aware read path. Exact trigger shape of issue #1741, which
+// collapsed the Map to a single entry keyed by the enclosing field name.
+case class TransformMapRenameAll(fullName: String, tags: Map[String, Int]) derives CanEqual
+given transformMapRenameAllSchema: Schema[TransformMapRenameAll] =
+    Schema[TransformMapRenameAll].renameAllFields(Schema.NameCase.CamelCase)(using Frame.internal)
+
 // --- The same field-transform-plus-Map regression, on a richer MIXED product (a scalar, an
 // optional scalar, and a list, alongside the Map field) so the transform-aware guard alignment
 // is proven on a shape closer to a real-world record, not only the minimal two-field case. ---


### PR DESCRIPTION
Four kyo-schema fixes that came out of working through #1879, #1741, and #1860.

## 1. Avoid exception-as-control-flow in `DiscriminatorReader.matchField` (#1879 mitigation)

`matchField`'s numeric-tag fallback threw and caught a `NumberFormatException` for every plain field-name probe:

```scala
try parsed.toInt == CodecMacro.fieldId(expected)
catch case _: NumberFormatException => false
```

On JSON wire input the parsed name is text, so every mismatched candidate threw. Each throw runs `fillInStackTrace`, which on Scala Native calls into libunwind; #1879 identified this as the hottest concurrent stack-capture source behind the kyo-browserNative SIGSEGV/SIGABRT crashes. The fallback now reuses the existing zero-allocation `wireFieldId` digit scan:

```scala
wireFieldId(parsed) == CodecMacro.fieldId(expected)
```

`wireFieldId` returns -1 for any non-ASCII-digit token and `fieldId` is always positive, so a plain name never matches. This removes the exception storm on every platform; the remaining direction in #1879 (tracking the upstream Scala Native concurrent-unwind fix) stays open there.

## 2. Regression coverage for no-op `renameAllFields` alongside a `Map` field (#1741)

#1741 was already fixed in #1742, but the regression matrix never exercised its exact trigger: a `renameAllFields(NameCase.CamelCase)` that renames nothing yet still installs the transform-aware read path that used to corrupt `Map` entry keys.

```scala
case class TransformMapRenameAll(fullName: String, tags: Map[String, Int]) derives CanEqual
given transformMapRenameAllSchema: Schema[TransformMapRenameAll] =
    Schema[TransformMapRenameAll].renameAllFields(Schema.NameCase.CamelCase)
```

JSON and YAML round-trips over that shape now guard the fix. Issue closed after verification.

## 3. `Structure.encode` emits `VariantCase` for sums (#1860)

`Structure.encode` materialized a sum as the wire wrapper record, so `PathSegment.Variant` could never match the encoder's own output:

```scala
Structure.encode[Shape](Shape.Circle(2.5))
// before: Record(Chunk(("Circle", Record(...))))   PathSegment.Variant never matches
// after:  VariantCase("Circle", Record(...))       Path.variant("Circle") navigates
```

The `Writer` protocol gains `variantStart`/`variantEnd` hooks whose defaults write the wrapper-object envelope, so every wire codec's bytes are unchanged:

```scala
def variantStart(name: String, variantName: String, variantNameBytes: Array[Byte], variantFieldId: Int): Unit =
    objectStart(name, 1)
    fieldBytes(variantNameBytes, variantFieldId)

def variantEnd(): Unit = objectEnd()
```

Only `StructureValueWriter` overrides them to keep the variant identity. The representation encoders (discriminator, adjacent, tuple, tupleFlat, untagged) now consume the materialized `VariantCase` instead of pattern-matching a single-field wrapper record, which also removes the fragile "any single-field record is a wrapper" heuristic. One inherent asymmetry is documented on `VariantCase`: a `Value` tree round-tripped through a wire format reads back with the wrapper spelled as a `Record`, because the bytes cannot carry the sum-vs-product distinction.

## 4. `Structure.encode` emits `MapEntries` for maps

Same disease as #1860, second organ: `MapEntries` was declared by the `Value` ADT and documented in the README, but the encoder produced the wire spelling instead (a `Record` for string keys, an array of `{key, value}` records otherwise). `Map[Int, V]` was indistinguishable from a `List` of two-field case classes, and `Changeset`'s `MapPatch` diff op was unreachable dead code.

The `Writer` protocol gains map-entry hooks with byte-identical defaults:

```scala
def mapEntriesStart(size: Int): Unit = arrayStart(size)
def mapEntryStart(): Unit = { objectStart("", 2); field("key", 1) }
def mapEntryValue(): Unit = field("value", 2)
def mapEntryEnd(): Unit = objectEnd()
def mapEntriesEnd(): Unit = arrayEnd()
```

`Map`, `Dict`, and `OrderedDict` (all key types) now materialize as `MapEntries`. `StructureValueReader` presents a `MapEntries` node under both map read protocols and still decodes legacy `Record` trees. `PathSegment.Field` matches `Str`-keyed entries and `PathSegment.Each` walks entry values, so existing paths over string-keyed maps keep working. `Changeset` map diffs now take the dedicated `MapPatch` path, and JSON-RPC `extras` accept a string-keyed map with the same reserved-key validation as a `Record`.

## Verification

- New red-first regression tests: discriminator matching semantics, `renameAllFields` + `Map` matrix rows, `VariantCase` and `MapEntries` production, `Path` navigation over encoder output, decode round-trips (including legacy `Record` map trees), `Changeset` `MapPatch` with an `applyTo` round-trip.
- Full JVM suites green: kyo-schema-tests, json, yaml, msgpack, protobuf, ion, bson, jsonrpc, mcp, lsp, sql, ai.
- Scala.js green: kyo-schema-tests, kyo-schema-json.
- Wire-format guards (wrapper shape, discriminator flat shape, map object shape) all pass unchanged, confirming zero wire-byte drift.

Closes #1860. Related: #1879 (mitigation landed here, upstream tracking stays open), #1741 (fixed in #1742, coverage added here).
