### PR TITLE
[ci] survive the new runner images: use the image podman, smoke-probe the stack at setup

### DIFF
--- a/.github/actions/release-setup/action.yml
+++ b/.github/actions/release-setup/action.yml
@@ -23,8 +23,7 @@ runs:
     - name: Prepare BoringSSL
       shell: bash
       run: |
-        command -v cmake >/dev/null 2>&1 || bash scripts/apt-install.sh cmake
-        command -v go >/dev/null 2>&1 || bash scripts/apt-install.sh golang-go
+        bash scripts/apt-install.sh --if-missing cmake go:golang-go
         bash kyo-net/build/boringssl/build-boringssl.sh linux-x86_64
 
     # The staged libaeron tree is gitignored, so anything that compiles kyo-aeron's C shim has to
@@ -32,10 +31,9 @@ runs:
     - name: Prepare libaeron
       shell: bash
       run: |
-        command -v cmake >/dev/null 2>&1 || bash scripts/apt-install.sh cmake
         # The Aeron driver links -luuid on Linux and the package providing the libuuid.so link
         # target is not preinstalled.
-        dpkg -s uuid-dev >/dev/null 2>&1 || bash scripts/apt-install.sh uuid-dev
+        bash scripts/apt-install.sh --if-missing cmake uuid-dev
         bash kyo-aeron/scripts/build-aeron.sh linux-x86_64
 
     - uses: coursier/setup-action@v3.0.0

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -107,7 +107,27 @@ runs:
       if: ${{ contains(inputs.os, 'linux') }}
       shell: bash
       run: |
-        bash scripts/apt-install.sh podman uidmap
+        # Use the podman the runner image ships when there is one. Since image 20260810.x the
+        # runners carry podman under /usr/local with matching helpers (conmon, netavark) in
+        # /usr/local/lib/podman, and installing Ubuntu's podman package ON TOP of that breaks
+        # every container start: the package's containers.conf selects the journald log driver,
+        # the image's conmon is built without journald support, conmon exits 1, the container
+        # never leaves the "created" state, and each exec then fails with HTTP 500 "container
+        # state improper" across the kyo-pod suites. See #1881. The apt stack is only coherent
+        # on its own, so install it only when the image provides no podman at all.
+        bash scripts/apt-install.sh uidmap
+        if command -v podman >/dev/null 2>&1; then
+          echo "using the runner image's podman at $(command -v podman): $(podman --version)"
+        else
+          bash scripts/apt-install.sh podman
+          # Force the runc OCI runtime for the apt stack. The crun shipped on the pre-20260810
+          # runner images fails to start containers with "crun: unknown version specified" (an
+          # OCI config version it rejects), which fails every kyo-pod container integration
+          # test. runc accepts the config podman writes. The image podman above needs no pin:
+          # its own crun matches it (verified by the #1881 probe on both architectures).
+          mkdir -p "$HOME/.config/containers"
+          printf '[engine]\nruntime = "runc"\n' > "$HOME/.config/containers/containers.conf"
+        fi
         # Install runc separately, and only when the runner has none. Ubuntu's runc package Conflicts
         # with Docker's containerd.io, so `apt-get install runc` resolves the conflict by REMOVING
         # containerd.io and docker-ce. That leaves no Docker daemon, which fails the `docker version`
@@ -135,12 +155,6 @@ runs:
           exit 1
         fi
         export XDG_RUNTIME_DIR="/run/user/$uid"
-        # Force the runc OCI runtime. The crun shipped on the runners fails to start containers with
-        # "crun: unknown version specified" (an OCI config version it rejects), which fails every
-        # kyo-pod container integration test. runc accepts the config podman writes, so the service and
-        # every container it starts use runc instead.
-        mkdir -p "$HOME/.config/containers"
-        printf '[engine]\nruntime = "runc"\n' > "$HOME/.config/containers/containers.conf"
         mkdir -p "$XDG_RUNTIME_DIR/podman"
         sock="$XDG_RUNTIME_DIR/podman/podman.sock"
         # The rootless podman API socket can take well over 10s to appear on a loaded runner. Retry the
@@ -165,10 +179,31 @@ runs:
         echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
         podman info | grep -iE 'cgroup|rootless' || true
         podman version
-        # Which OCI runtime podman resolved. Printed rather than asserted on: containers.conf above
-        # pins runc, and a silent fall back to crun shows up downstream as "crun: unknown version
-        # specified" on every kyo-pod container test, which this line attributes.
-        podman info | grep -iE 'ociRuntime|runc|crun' || true
+        # Which OCI runtime and conmon podman resolved. Printed rather than asserted on: the smoke
+        # probe below is the real gate; these lines attribute a probe failure to the component.
+        podman info | grep -iE 'ociRuntime|runc|crun|conmon|path:' || true
+        # Smoke-probe the container runtime end to end (create, start, exec) so a broken podman
+        # stack fails this step with a named cause instead of surfacing two hours later as
+        # HTTP 500 "container state improper" across the kyo-pod suites. This is exactly the
+        # cycle that the 20260810.x runner image regression broke. See #1881.
+        probe_ok=""
+        if podman pull -q docker.io/library/alpine:3 \
+          && podman create --name setup-probe docker.io/library/alpine:3 sleep 60 >/dev/null \
+          && podman start setup-probe >/dev/null \
+          && [ "$(podman inspect --format '{{.State.Status}}' setup-probe)" = "running" ] \
+          && [ "$(podman exec setup-probe echo probe-exec-ok)" = "probe-exec-ok" ]; then
+          probe_ok=1
+        fi
+        if [ -z "$probe_ok" ]; then
+          echo "podman smoke probe failed: a freshly started container is not running or not" >&2
+          echo "exec-able. Every kyo-pod podman case would fail the same way. Container state:" >&2
+          podman inspect --format '{{.State.Status}} exit={{.State.ExitCode}} err={{.State.Error}}' setup-probe >&2 || true
+          echo "service log:" >&2
+          cat /tmp/podman.log >&2 || true
+          exit 1
+        fi
+        podman rm -f setup-probe >/dev/null
+        echo "podman smoke probe passed (create + start + exec)"
         # docker is load-bearing too, and it has been removed out from under this step before, so name
         # what broke rather than letting `set -e` end the step on a bare exit code.
         if ! docker version; then

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -107,38 +107,22 @@ runs:
       if: ${{ contains(inputs.os, 'linux') }}
       shell: bash
       run: |
-        # Use the podman the runner image ships when there is one. Since image 20260810.x the
-        # runners carry podman under /usr/local with matching helpers (conmon, netavark) in
+        # --if-missing keeps the runner image's podman when it ships one. Since image 20260810.x
+        # the runners carry podman under /usr/local with matching helpers (conmon, netavark) in
         # /usr/local/lib/podman, and installing Ubuntu's podman package ON TOP of that breaks
         # every container start: the package's containers.conf selects the journald log driver,
         # the image's conmon is built without journald support, conmon exits 1, the container
         # never leaves the "created" state, and each exec then fails with HTTP 500 "container
         # state improper" across the kyo-pod suites. See #1881. The apt stack is only coherent
-        # on its own, so install it only when the image provides no podman at all.
-        bash scripts/apt-install.sh uidmap
-        if command -v podman >/dev/null 2>&1; then
-          echo "using the runner image's podman at $(command -v podman): $(podman --version)"
-        else
-          bash scripts/apt-install.sh podman
-          # Force the runc OCI runtime for the apt stack. The crun shipped on the pre-20260810
-          # runner images fails to start containers with "crun: unknown version specified" (an
-          # OCI config version it rejects), which fails every kyo-pod container integration
-          # test. runc accepts the config podman writes. The image podman above needs no pin:
-          # its own crun matches it (verified by the #1881 probe on both architectures).
-          mkdir -p "$HOME/.config/containers"
-          printf '[engine]\nruntime = "runc"\n' > "$HOME/.config/containers/containers.conf"
-        fi
-        # Install runc separately, and only when the runner has none. Ubuntu's runc package Conflicts
-        # with Docker's containerd.io, so `apt-get install runc` resolves the conflict by REMOVING
-        # containerd.io and docker-ce. That leaves no Docker daemon, which fails the `docker version`
-        # probe below and costs the kyo-pod suite the half of its container cases that run against
-        # docker. The runners already carry a runc binary alongside containerd.io, so this normally
-        # installs nothing.
-        if command -v runc >/dev/null 2>&1; then
-          echo "runc already present at $(command -v runc)"
-        else
-          bash scripts/apt-install.sh runc
-        fi
+        # on its own, so it is installed only when the image provides no podman at all.
+        bash scripts/apt-install.sh --if-missing podman uidmap
+        # runc goes in a separate call because Ubuntu's runc package Conflicts with Docker's
+        # containerd.io: a plain `apt-get install runc` resolves the conflict by REMOVING
+        # containerd.io and docker-ce, which leaves no Docker daemon, fails the `docker version`
+        # probe below, and costs the kyo-pod suite the half of its container cases that run
+        # against docker. The runners already carry a runc binary alongside containerd.io, so
+        # --if-missing normally installs nothing.
+        bash scripts/apt-install.sh --if-missing runc
 
     - name: Start podman (Linux)
       if: ${{ contains(inputs.os, 'linux') }}
@@ -155,6 +139,13 @@ runs:
           exit 1
         fi
         export XDG_RUNTIME_DIR="/run/user/$uid"
+        # Force the runc OCI runtime. The crun shipped on the pre-20260810 runner images fails to
+        # start containers with "crun: unknown version specified" (an OCI config version it
+        # rejects), which fails every kyo-pod container integration test; runc accepts the config
+        # podman writes. The image podman on the 20260810.x images works with runc too (verified
+        # by the #1881 probe on both architectures), so the pin is safe in both worlds.
+        mkdir -p "$HOME/.config/containers"
+        printf '[engine]\nruntime = "runc"\n' > "$HOME/.config/containers/containers.conf"
         mkdir -p "$XDG_RUNTIME_DIR/podman"
         sock="$XDG_RUNTIME_DIR/podman/podman.sock"
         # The rootless podman API socket can take well over 10s to appear on a loaded runner. Retry the
@@ -332,10 +323,9 @@ runs:
           *) echo "libaeron not staged for ${{ inputs.os }} (unsupported os-arch); skipping" && exit 0 ;;
         esac
         if [[ "${{ inputs.os }}" == linux-* ]]; then
-          command -v cmake >/dev/null 2>&1 || bash scripts/apt-install.sh cmake
           # The Aeron driver links -luuid on Linux, and the package providing the libuuid.so link
           # target is not preinstalled. macOS gets uuid from libSystem.
-          dpkg -s uuid-dev >/dev/null 2>&1 || bash scripts/apt-install.sh uuid-dev
+          bash scripts/apt-install.sh --if-missing cmake uuid-dev
         elif [[ "${{ inputs.os }}" == windows-* ]]; then
           # cmake and MSVC are preinstalled on the Windows runner; build-aeron.sh selects the
           # Visual Studio generator for this os-arch (aeron supports Windows only under MSVC).

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -168,41 +168,11 @@ runs:
           exit 1
         fi
         echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
-        podman info | grep -iE 'cgroup|rootless' || true
-        podman version
-        # Which OCI runtime and conmon podman resolved. Printed rather than asserted on: the smoke
-        # probe below is the real gate; these lines attribute a probe failure to the component.
-        podman info | grep -iE 'ociRuntime|runc|crun|conmon|path:' || true
-        # Smoke-probe the container runtime end to end (create, start, exec) so a broken podman
-        # stack fails this step with a named cause instead of surfacing two hours later as
-        # HTTP 500 "container state improper" across the kyo-pod suites. This is exactly the
-        # cycle that the 20260810.x runner image regression broke. See #1881.
-        probe_ok=""
-        if podman pull -q docker.io/library/alpine:3 \
-          && podman create --name setup-probe docker.io/library/alpine:3 sleep 60 >/dev/null \
-          && podman start setup-probe >/dev/null \
-          && [ "$(podman inspect --format '{{.State.Status}}' setup-probe)" = "running" ] \
-          && [ "$(podman exec setup-probe echo probe-exec-ok)" = "probe-exec-ok" ]; then
-          probe_ok=1
-        fi
-        if [ -z "$probe_ok" ]; then
-          echo "podman smoke probe failed: a freshly started container is not running or not" >&2
-          echo "exec-able. Every kyo-pod podman case would fail the same way. Container state:" >&2
-          podman inspect --format '{{.State.Status}} exit={{.State.ExitCode}} err={{.State.Error}}' setup-probe >&2 || true
-          echo "service log:" >&2
-          cat /tmp/podman.log >&2 || true
-          exit 1
-        fi
-        podman rm -f setup-probe >/dev/null
-        echo "podman smoke probe passed (create + start + exec)"
-        # docker is load-bearing too, and it has been removed out from under this step before, so name
-        # what broke rather than letting `set -e` end the step on a bare exit code.
-        if ! docker version; then
-          echo "docker daemon unreachable. The kyo-pod suite runs its container cases against docker as" >&2
-          echo "well as podman, so this is fatal. Check the apt output in the podman install step: the" >&2
-          echo "ubuntu runc package Conflicts with containerd.io, and installing it removes docker-ce." >&2
-          exit 1
-        fi
+        # Health gate: exercises the full podman cycle (create, start, exec) and the docker
+        # daemon, with per-component diagnostics, so a broken container stack fails here with a
+        # named cause instead of surfacing two hours later across the kyo-pod suites (#1881).
+        # Pass --warn-only to degrade the gate to a loud warning annotation.
+        bash scripts/container-check.sh
 
     - name: Configure build environment (Windows)
       if: ${{ contains(inputs.os, 'windows') }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -54,8 +54,7 @@ jobs:
       - name: Prepare BoringSSL
         shell: bash
         run: |
-          command -v cmake >/dev/null 2>&1 || bash scripts/apt-install.sh cmake
-          command -v go >/dev/null 2>&1 || bash scripts/apt-install.sh golang-go
+          bash scripts/apt-install.sh --if-missing cmake go:golang-go
           bash kyo-net/build/boringssl/build-boringssl.sh linux-x86_64
       - name: Link the browser bundle (fullLinkJS)
         run: sbt 'kyo-website-bundleJS/Compile/fullLinkJS'

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -35,9 +35,8 @@ jobs:
       - name: Prepare libaeron
         shell: bash
         run: |
-          command -v cmake >/dev/null 2>&1 || bash scripts/apt-install.sh cmake
           # The Aeron driver links -luuid on Linux, and the package providing the libuuid.so link
           # target is not preinstalled.
-          dpkg -s uuid-dev >/dev/null 2>&1 || bash scripts/apt-install.sh uuid-dev
+          bash scripts/apt-install.sh --if-missing cmake uuid-dev
           bash kyo-aeron/scripts/build-aeron.sh linux-x86_64
       - run: sbt doctest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,9 +105,7 @@ jobs:
       - name: Install BoringSSL + posix build dependencies
         shell: bash
         run: |
-          command -v cmake >/dev/null 2>&1 || bash scripts/apt-install.sh cmake
-          command -v go >/dev/null 2>&1 || bash scripts/apt-install.sh golang-go
-          dpkg -s liburing-dev >/dev/null 2>&1 || bash scripts/apt-install.sh liburing-dev
+          bash scripts/apt-install.sh --if-missing cmake go:golang-go liburing-dev
       - name: Build linux-x86_64 (glibc) natives
         shell: bash
         run: |
@@ -171,9 +169,7 @@ jobs:
       - name: Install BoringSSL + posix build dependencies
         shell: bash
         run: |
-          command -v cmake >/dev/null 2>&1 || bash scripts/apt-install.sh cmake
-          command -v go >/dev/null 2>&1 || bash scripts/apt-install.sh golang-go
-          dpkg -s liburing-dev >/dev/null 2>&1 || bash scripts/apt-install.sh liburing-dev
+          bash scripts/apt-install.sh --if-missing cmake go:golang-go liburing-dev
       - name: Build linux-aarch64 (glibc) natives
         shell: bash
         run: |

--- a/kyo-pod/shared/src/main/scala/kyo/internal/HttpContainerBackend.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/internal/HttpContainerBackend.scala
@@ -340,7 +340,7 @@ final private[kyo] class HttpContainerBackend(
     end create
 
     /** Build the HostConfig portion of a create request from configuration values resolved by the caller. */
-    private def buildHostConfig(
+    private[internal] def buildHostConfig(
         config: Config,
         binds: Chunk[String],
         portBindings: Map[String, Seq[PortBindingEntry]],
@@ -358,7 +358,7 @@ final private[kyo] class HttpContainerBackend(
             MemorySwap = config.memorySwap.getOrElse(0L),
             NanoCPUs = config.cpuLimit.map(c => (c * 1e9).toLong).getOrElse(0L),
             CpusetCpus = config.cpuAffinity.getOrElse(""),
-            PidsLimit = config.maxProcesses.getOrElse(0L),
+            PidsLimit = config.maxProcesses,
             Privileged = config.privileged,
             CapAdd = config.addCapabilities.toSeq.map(_.cliName),
             CapDrop = config.dropCapabilities.toSeq.map(_.cliName),
@@ -1200,7 +1200,7 @@ final private[kyo] class HttpContainerBackend(
             MemorySwap = memorySwap.getOrElse(0L),
             NanoCPUs = cpuLimit.map(c => (c * 1e9).toLong).getOrElse(0L),
             CpusetCpus = cpuAffinity.getOrElse(""),
-            PidsLimit = maxProcesses.getOrElse(0L),
+            PidsLimit = maxProcesses,
             RestartPolicy = restartPol.getOrElse(RestartPolicyEntry("", 0))
         )
         val jsonBody = Json.encode(body)
@@ -2231,7 +2231,7 @@ final private[kyo] class HttpContainerBackend(
         Aliases: Seq[String] = Seq.empty
     ) derives Schema
 
-    final private case class HostConfig(
+    final private[internal] case class HostConfig(
         Binds: Seq[String] = Seq.empty,
         PortBindings: Map[String, Seq[PortBindingEntry]] = Map.empty,
         NetworkMode: String = "",
@@ -2241,7 +2241,7 @@ final private[kyo] class HttpContainerBackend(
         MemorySwap: Long = 0,
         NanoCPUs: Long = 0,
         CpusetCpus: String = "",
-        PidsLimit: Long = 0,
+        PidsLimit: Maybe[Long] = Absent,
         Privileged: Boolean = false,
         CapAdd: Seq[String] = Seq.empty,
         CapDrop: Seq[String] = Seq.empty,
@@ -2252,17 +2252,17 @@ final private[kyo] class HttpContainerBackend(
         Tmpfs: Map[String, String] = Map.empty
     ) derives Schema
 
-    final private case class PortBindingEntry(
+    final private[internal] case class PortBindingEntry(
         HostIp: String = "",
         HostPort: String = ""
     ) derives Schema
 
-    final private case class RestartPolicyEntry(
+    final private[internal] case class RestartPolicyEntry(
         Name: String = "",
         MaximumRetryCount: Int = 0
     ) derives Schema
 
-    final private case class MountEntry(
+    final private[internal] case class MountEntry(
         Type: String = "",
         Source: String = "",
         Target: String = ""
@@ -2277,12 +2277,12 @@ final private[kyo] class HttpContainerBackend(
         StatusCode: Int = 0
     ) derives Schema
 
-    final private case class UpdateRequest(
+    final private[internal] case class UpdateRequest(
         Memory: Long = 0,
         MemorySwap: Long = 0,
         NanoCPUs: Long = 0,
         CpusetCpus: String = "",
-        PidsLimit: Long = 0,
+        PidsLimit: Maybe[Long] = Absent,
         RestartPolicy: RestartPolicyEntry = RestartPolicyEntry()
     ) derives Schema
 

--- a/kyo-pod/shared/src/test/scala/kyo/internal/HttpContainerBackendTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/internal/HttpContainerBackendTest.scala
@@ -44,6 +44,46 @@ class HttpContainerBackendTest extends BasePodTest:
         }
     end claimLegacyFixture
 
+    "create payload" - {
+        // Regression guard for the podman 5.x compat API: docker and podman 4.x treat
+        // PidsLimit 0 as "no limit configured", but podman 5.8.4 applies it as a literal
+        // pids.max=0, so every container created through the HTTP backend died at start
+        // (exit 2, sh unable to fork). The limit must be absent from the JSON unless the
+        // caller configured one.
+        def hostConfigJson(config: Container.Config): String < Sync =
+            Sync.defer {
+                val backend = new HttpContainerBackend("/unused.sock")
+                Json.encode(backend.buildHostConfig(
+                    config,
+                    binds = Chunk.empty,
+                    portBindings = Map.empty,
+                    networkModeStr = "bridge",
+                    tmpfs = Map.empty,
+                    restartPol = backend.RestartPolicyEntry("no", 0)
+                ))
+            }
+
+        "omits PidsLimit when maxProcesses is unset" in {
+            hostConfigJson(Container.Config(ContainerImage("alpine"))).map { json =>
+                assert(!json.contains("PidsLimit"), s"PidsLimit must be absent when unconfigured: $json")
+            }
+        }
+
+        "carries PidsLimit when maxProcesses is set" in {
+            hostConfigJson(Container.Config(ContainerImage("alpine")).maxProcesses(64)).map { json =>
+                assert(json.contains("\"PidsLimit\":64"), s"configured limit must be encoded: $json")
+            }
+        }
+    }
+
+    "update payload" - {
+        "omits PidsLimit when maxProcesses is unset" in {
+            val backend = new HttpContainerBackend("/unused.sock")
+            val json    = Json.encode(backend.UpdateRequest(Memory = 1024L))
+            assert(!json.contains("PidsLimit"), s"PidsLimit must be absent when unconfigured: $json")
+        }
+    }
+
     "copyTo" - {
         "scoped UUID temp directories do not overwrite or delete the exact legacy staging path" in {
             claimLegacyFixture.map { (uuid, foreignPath, missingSource) =>

--- a/scripts/apt-install.sh
+++ b/scripts/apt-install.sh
@@ -3,7 +3,14 @@ set -uo pipefail
 #
 # apt-install.sh - install apt packages with bounded retries that survive mirror hangs.
 #
-# Usage: apt-install.sh <package>...
+# Usage: apt-install.sh [--if-missing] <package>...
+#
+# With --if-missing, each argument may be "pkg" or "cmd:pkg". A package is skipped when dpkg
+# already has it installed, or when the command (the part before ":", defaulting to the package
+# name) is already on PATH. The PATH check covers tools the runner image ships outside dpkg, such
+# as the /usr/local podman on the 20260810.x images (#1881) or the tarball-installed go, where a
+# plain apt install would break or duplicate the image's stack. When nothing is missing the
+# script exits 0 without touching apt.
 #
 # Each attempt runs apt-get update + install under `sudo timeout`: timeout must run as root so it
 # can signal the root-owned apt-get when the deadline expires. Wrapping `sudo apt-get` in a
@@ -11,7 +18,33 @@ set -uo pipefail
 # runner user cannot signal a root process, turning an apt mirror hang into a hard job failure.
 # apt-level Acquire::Retries covers transient fetch errors within an attempt.
 
-[ $# -ge 1 ] || { echo "usage: $0 <package>..." >&2; exit 2; }
+if_missing=""
+if [ "${1:-}" = "--if-missing" ]; then
+    if_missing=1
+    shift
+fi
+
+[ $# -ge 1 ] || { echo "usage: $0 [--if-missing] <package>..." >&2; exit 2; }
+
+if [ -n "$if_missing" ]; then
+    missing=()
+    for arg in "$@"; do
+        cmd="${arg%%:*}"
+        pkg="${arg#*:}"
+        if dpkg -s "$pkg" >/dev/null 2>&1; then
+            echo "$pkg already installed (dpkg)"
+        elif command -v "$cmd" >/dev/null 2>&1; then
+            echo "$pkg already present: $cmd at $(command -v "$cmd")"
+        else
+            missing+=("$pkg")
+        fi
+    done
+    if [ ${#missing[@]} -eq 0 ]; then
+        echo "nothing to install"
+        exit 0
+    fi
+    set -- "${missing[@]}"
+fi
 
 for attempt in 1 2 3; do
     if sudo timeout -k 30 300 apt-get update &&

--- a/scripts/container-check.sh
+++ b/scripts/container-check.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -uo pipefail
+#
+# container-check.sh - health gate for the container runtimes the kyo-pod suites depend on.
+#
+# Usage: container-check.sh [--warn-only]
+#
+# Runs two checks and prints component diagnostics for each:
+#   1. podman: create + start + exec a real container. This is the exact cycle the 20260810.x
+#      runner image regression broke (conmon without journald support exited 1 on every start,
+#      and each exec then failed with HTTP 500 "container state improper"; see #1881). The
+#      resolved OCI runtime and conmon paths are printed first, so a failure names the
+#      component instead of a bare exit code.
+#   2. docker: the daemon answers `docker version`. Ubuntu's runc package Conflicts with
+#      containerd.io, and an apt resolution that removes docker-ce has taken the daemon out
+#      from under CI before; the kyo-pod suites run half of their container cases against it.
+#
+# Both checks always run, so one broken runtime does not hide the state of the other. By
+# default any failed check fails the job. With --warn-only the same checks and diagnostics run,
+# but the script emits a GitHub warning annotation and exits 0: the switch for maintainers who
+# later decide the gate should be loud instead of fatal, without restructuring the workflow.
+#
+# Expects a running rootless podman API service and XDG_RUNTIME_DIR pointing at its runtime
+# dir (the "Start podman" step provides both). If the service wrote a log to /tmp/podman.log,
+# a podman failure appends it to the diagnostics.
+
+warn_only=""
+if [ "${1:-}" = "--warn-only" ]; then
+    warn_only=1
+    shift
+fi
+[ $# -eq 0 ] || { echo "usage: $0 [--warn-only]" >&2; exit 2; }
+
+failed=""
+
+check_podman() {
+    podman version
+    # Which OCI runtime and conmon podman resolved. Printed rather than asserted on: the probe
+    # below is the real gate; these lines attribute a probe failure to the component.
+    podman info | grep -iE 'ociRuntime|runc|crun|conmon|rootless|cgroup|path:' || true
+    if podman pull -q docker.io/library/alpine:3 \
+        && podman create --name setup-probe docker.io/library/alpine:3 sleep 60 >/dev/null \
+        && podman start setup-probe >/dev/null \
+        && [ "$(podman inspect --format '{{.State.Status}}' setup-probe)" = "running" ] \
+        && [ "$(podman exec setup-probe echo probe-exec-ok)" = "probe-exec-ok" ]; then
+        echo "podman check passed (create + start + exec)"
+    else
+        echo "podman check failed: a freshly started container is not running or not exec-able." >&2
+        echo "Every kyo-pod podman case would fail the same way. Container state:" >&2
+        podman inspect --format '{{.State.Status}} exit={{.State.ExitCode}} err={{.State.Error}}' setup-probe >&2 || true
+        if [ -f /tmp/podman.log ]; then
+            echo "service log:" >&2
+            cat /tmp/podman.log >&2
+        fi
+        failed=1
+    fi
+    podman rm -f setup-probe >/dev/null 2>&1 || true
+}
+
+check_docker() {
+    if docker version; then
+        echo "docker check passed"
+    else
+        echo "docker daemon unreachable. The kyo-pod suite runs its container cases against docker" >&2
+        echo "as well as podman. Check the apt output in the podman install step: the ubuntu runc" >&2
+        echo "package Conflicts with containerd.io, and installing it removes docker-ce." >&2
+        failed=1
+    fi
+}
+
+check_podman
+check_docker
+
+if [ -n "$failed" ]; then
+    if [ -n "$warn_only" ]; then
+        echo "::warning title=container runtime check failed::podman or docker is broken on this runner; the kyo-pod container suites will fail. See the 'Start podman' step log. Running in --warn-only mode, so the job continues."
+        exit 0
+    fi
+    exit 1
+fi


### PR DESCRIPTION
Fixes the linux CI failures tracked in #1881.

## What broke

The 20260810.x runner images (rolled out gradually from Aug 12) ship podman 5.8.4 under `/usr/local` with matching helpers (conmon, netavark) in `/usr/local/lib/podman`. Our setup action still apt-installed Ubuntu's podman 4.9.3 on top of it. The package's `containers.conf` selects the journald log driver, the image's conmon is built without journald support, so conmon exits 1 on every container start. The container never leaves the `created` state and each exec fails with HTTP 500 `container state improper`, which took down all `[podman]` cases of the kyo-pod suites on JVM, JS, Native, and Wasm, on both x64 and arm64.

A probe matrix on the new images (see #1881) confirmed: the image's own podman stack passes a create + start + exec cycle with crun, runc, and the default runtime on both architectures, while any mix with the apt package fails with the exact CI error.

## The fix

- Use the podman the runner image ships when there is one, and apt-install podman only when the image provides none, so each stack stays coherent on its own.
- Add a health gate right after the podman API service comes up. A broken container stack now fails the setup step with a named cause instead of surfacing two hours later inside the kyo-pod suites.
- The runc pin stays where it was and stays unconditional: the probe verified the image podman works pinned to runc on both architectures, so there is no need to branch on where podman came from.

## Approach: logic in scripts, workflows stay declarative

The first version of this branch put both the install conditionals and the health checks inline in the setup action, which hurt the readability of the workflow. Both now live in scripts, and each script carries a flag that changes policy without restructuring the workflow.

**`scripts/apt-install.sh --if-missing`** expresses "install unless present". The callers read as plain one-liners:

```sh
bash scripts/apt-install.sh --if-missing podman uidmap
bash scripts/apt-install.sh --if-missing cmake go:golang-go liburing-dev
```

It skips a package when dpkg reports it installed, or when a binary with its name is already on PATH. The PATH check is the piece that matters for #1881: it is what keeps the image's `/usr/local` podman in place instead of layering the apt package on top of it. When the command name differs from the package name, a `cmd:pkg` token maps one to the other (`go:golang-go`: the runners ship go as a tarball, so neither dpkg nor a `golang-go` lookup would find it). When nothing is missing the script exits without touching apt, which also saves the `apt-get update` round-trip. The same flag replaces every inline `command -v X || apt-install` and `dpkg -s X || apt-install` guard that had accumulated across `release.yml`, `deploy-site.yml`, `readme.yml`, `release-setup/action.yml`, and the libaeron step of the setup action, so the repo now has one idiom for "install unless present" instead of three.

**`scripts/container-check.sh`** is the health gate. It verifies both runtimes the kyo-pod suites depend on: the full podman cycle (create, start, exec a real container, after printing the resolved OCI runtime and conmon so a failure names the component) and the docker daemon. Both checks always run, so one broken runtime does not hide the state of the other. The workflow calls it as a single line:

```sh
bash scripts/container-check.sh
```

By default a failed check fails the job. `--warn-only` runs the same checks and diagnostics but emits a GitHub warning annotation and exits 0: the switch for maintainers who later decide the gate should be loud instead of fatal, one flag in the workflow instead of a rewrite of the step.
