### PR TITLE
[kyo-data] a tag's hash is computed once per tag, not once per comparison

### DIFF
--- a/kyo-data/js-wasm/src/main/scala/kyo/internal/TagHash.scala
+++ b/kyo-data/js-wasm/src/main/scala/kyo/internal/TagHash.scala
@@ -1,0 +1,41 @@
+package kyo.internal
+
+import scala.scalajs.js
+
+/** The raw `Map` members. `js.Map`'s own `Raw` facade is `private[js]`, and the public Scala view
+  * returns an `Option`, which would allocate on every dispatch. `js.Map.apply` casts the same way.
+  */
+@js.native
+private trait RawTagMemo extends js.Object:
+    def get(key: String): js.UndefOr[Int]  = js.native
+    def set(key: String, value: Int): Unit = js.native
+end RawTagMemo
+
+/** A `Tag`'s hash code, memoized for the encoded `String` form.
+  *
+  * Scala.js compiles `String.hashCode` to a loop over the characters and nothing memoizes the result:
+  * a JS string has nowhere to keep one, unlike the JVM's `String.hash` field. `Tag`'s dispatch path
+  * asks for it up to four times per comparison that misses the identity check, twice in the fast path
+  * and twice more to build the subtype cache's key, over encoded types that run to a few hundred
+  * characters. Hashing was the largest single cost of effect dispatch on JS because of it.
+  *
+  * Keys are the statically derived tag strings, a set the program fixes at compile time, so this grows
+  * no further than the decode cache it sits beside. Dynamic tags carry their own `hashCode` and pass
+  * straight through.
+  */
+private[kyo] object TagHash:
+
+    private val memo = js.Map.empty[String, Int].asInstanceOf[RawTagMemo]
+
+    def of(tag: Any): Int =
+        tag match
+            case tag: String =>
+                val cached = memo.get(tag)
+                if cached.isDefined then cached.get
+                else
+                    val hash = tag.hashCode
+                    memo.set(tag, hash)
+                    hash
+                end if
+            case tag => tag.hashCode
+end TagHash

--- a/kyo-data/jvm-native/src/main/scala/kyo/internal/TagHash.scala
+++ b/kyo-data/jvm-native/src/main/scala/kyo/internal/TagHash.scala
@@ -1,0 +1,9 @@
+package kyo.internal
+
+/** A `Tag`'s hash code. `String.hashCode` is already memoized in the `String` itself here, so this
+  * inlines away to the call it replaces and the dispatch path is unchanged. The JS twin exists because
+  * that platform has no such memoization.
+  */
+private[kyo] object TagHash:
+    inline def of(tag: Any): Int = tag.hashCode
+end TagHash

--- a/kyo-data/shared/src/main/scala/kyo/Tag.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Tag.scala
@@ -3,6 +3,7 @@ package kyo
 import java.util.concurrent.ConcurrentHashMap
 import kyo.Tag.internal.Type.Entry.*
 import kyo.internal.Platform
+import kyo.internal.TagHash
 import kyo.internal.TagMacro
 import kyo.internal.XXHash
 import scala.annotation.tailrec
@@ -167,8 +168,9 @@ object Tag:
           * extremely unlikely. This method checks for these common cases before falling back to the more expensive full type-based checking
           * if any of the tags are dynamic.
           *
-          * This method runs on the kernel's per-operation dispatch path, so it relies on the memoized `String.hashCode` and must not
-          * recompute a content hash per call. Content-stable cross-process hashing is `hash`'s job, not this method's.
+          * This method runs on the kernel's per-operation dispatch path, so it goes through `TagHash` and must not recompute a content hash
+          * per call. `TagHash` is the JVM's memoized `String.hashCode` here and a memo table on JS, which has none. Content-stable
+          * cross-process hashing is `hash`'s job, not this method's.
           */
         private def fastPathEqual[B](that: Tag[B]): Boolean =
             (self eq that) || {
@@ -176,7 +178,7 @@ object Tag:
                     case self: String =>
                         that match
                             case that: String =>
-                                self.hashCode == that.hashCode
+                                TagHash.of(self) == TagHash.of(that)
                             case _ =>
                                 false
                     case _ =>
@@ -378,9 +380,9 @@ object Tag:
           *   true if a is a subtype of b, false otherwise
           */
         def checkTypes[A, B](a: Tag[A], b: Tag[B], mode: Mode): Boolean =
-            // Cache key from memoized hashCodes: this is a per-call in-process key, so it must not
-            // recompute a content hash (the memoization constraint on fastPathEqual applies here too).
-            var hash = (a.hashCode.toLong << 32) | (b.hashCode & 0xffffffffL)
+            // Cache key from memoized hashCodes: this is a per-call in-process key, so it goes through
+            // `TagHash` and must not recompute a content hash (the constraint on fastPathEqual applies here too).
+            var hash = (TagHash.of(a).toLong << 32) | (TagHash.of(b) & 0xffffffffL)
             hash += mode.factor
             hash ^= (hash >>> 30)
             hash *= 0xbf58476d1ce4e5b9L

--- a/kyo-data/shared/src/test/scala/kyo/TagTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TagTest.scala
@@ -3,6 +3,7 @@ package kyo
 import izumi.reflect.Tag as ITag
 import kyo.*
 import kyo.internal.RegisterFunction
+import kyo.internal.TagHash
 import kyo.internal.TagTestMacro.test
 import scala.annotation.nowarn
 
@@ -1257,6 +1258,35 @@ class TagTest extends kyo.test.Test[Any]:
         "is pinned to its content-derived constant (process-independent determinism)" in {
             assert(Tag[Int].hash == -1492440803, s"Tag[Int].hash = ${Tag[Int].hash}")
             assert(Tag[String].hash == -59591402, s"Tag[String].hash = ${Tag[String].hash}")
+        }
+    }
+
+    // `TagHash` is the dispatch hash, not the content-stable `Tag.hash` above: it memoizes on the
+    // platforms whose `String.hashCode` does not. What has to hold is that memoizing changes nothing,
+    // so each case reads a tag twice, once filling the memo and once through it.
+    "dispatch hash memoization" - {
+
+        "agrees with hashCode, before and after the memo is filled" in {
+            trait MA
+            val tag    = Tag[MA]
+            val direct = tag.hashCode
+            assert(TagHash.of(tag) == direct)
+            assert(TagHash.of(tag) == direct)
+        }
+
+        "distinct types keep distinct dispatch hashes" in {
+            assert(TagHash.of(Tag[Int]) != TagHash.of(Tag[String]))
+        }
+
+        "repeated comparisons hold their verdict once the memo is warm" in {
+            trait MB
+            trait MC extends MB
+            val sub    = (1 to 10).map(_ => Tag[MC] <:< Tag[MB])
+            val notSub = (1 to 10).map(_ => Tag[MB] <:< Tag[MC])
+            val notEq  = (1 to 10).map(_ => Tag[MB] =:= Tag[MC])
+            assert(sub.distinct.size == 1 && sub.head)
+            assert(notSub.distinct.size == 1 && !notSub.head)
+            assert(notEq.distinct.size == 1 && !notEq.head)
         }
     }
 


### PR DESCRIPTION
`Tag`'s dispatch path reads `String.hashCode` up to four times per comparison that misses the
identity check: twice in `fastPathEqual`, twice more in `checkTypes` to build the subtype cache's
key. Both places document that they lean on a memoized hash, and on the JVM they do, because
`String` keeps it in a field.

Scala.js has no such field. It compiles `String.hashCode` to a loop over the characters:

```js
function $f_T__hashCode__I($thiz) {
  var n = $thiz.length, h = 0, i = 0;
  while (i !== n) { h = ((h << 5) - h | 0) + $thiz.charCodeAt(i) | 0; i = 1 + i | 0; }
  return h;
}
```

So every one of those reads walks the whole encoded type. Those run to a few hundred characters, and the
longest in the bundles inspected here is 708, which puts a single non-matching comparison at roughly
2800 character steps before anything else happens.
`ArrowEffect.handle` decides each suspension with `effectTag <:< kyo.tag`. A handler that matches
settles it; one that does not passes it outward, having paid for the comparison. In a stack of
several effects the non-matching comparison is therefore both the common case and the expensive one.

This is the part of #1752 that does not carry to JS. That PR moved the dispatch path off `XXHash`
and onto `String.hashCode` precisely to get a constant-time hash. On the JVM it does. On JS it
exchanged one linear hash for another.

## The change

`TagHash` restores the assumption per platform, and `Tag` goes through it in the three places that
hash on the dispatch path.

- `jvm-native` inlines to the `hashCode` call it replaces, so that path is byte for byte what it was.
- `js-wasm` memoizes into a `js.Map`, cast to a raw facade so a lookup allocates nothing.

The memo needs no eviction, and not as a judgement call. Its keys are the statically derived tag
strings, a set the program fixes at compile time: nothing turns a runtime string into a `Tag`, only
`derive` and `internal.dynamic` produce one and both are macros. `decodeCache` already leans on that
exact bound, on the same keys, and stores a decoded `Type` per entry where this stores an `Int`.
Entries are rarer still than that, because `fastPathEqual` reaches the hash only after `self eq that`
has failed, so a tag that always hits the identity check never gets one.

The tags that ARE allocated at runtime are `Dynamic`, and they neither enter the memo nor need to:

```scala
final case class Dynamic(tag: String, map: Map[Entry.Id, Any]):
    override val hashCode = dynamicHashCode(tag, map)
```

A `val`, so a dynamic tag hashes itself once, when it is built. Which leaves exactly one of the three
representations with nowhere to keep its hash: a `String` on JS. The JVM has `String.hash` for it and
`Dynamic` has the field above; this gives the third case the same thing.

## Measured

A Scala.js program that does nothing but suspend, on `fullLinkJS` with minification, Node 22. The
operations run on the OUTERMOST handled effect, so each suspension walks past `depth` handlers that
cannot match it before reaching the one that can. `Var[V]` is an `ArrowEffect` per value type, so
`Var[Int]`, `Var[String]`, `Var[Double]` and `Var[Boolean]` supply the mismatches:

```scala
def loop(i: Int, n: Int): Unit < Var[Long] =
    if i >= n then () else Var.updateDiscard[Long](_ + 1L).map(_ => loop(i + 1, n))

// depth = 2
Var.runTuple(0L)(Var.run(0)(Var.run("")(loop(0, 100000)))).eval
```

100k operations, 10 warmup runs, median of 25, the two builds alternated over 5 rounds so drift
cancels. Both print the same checksum:

| depth | before | after | |
|---:|---:|---:|---|
| 0 | 5.1 ms | 5.0 ms | -2.5%, 23 of 25 pairwise |
| 1 | 95.6 ms | **9.1 ms** | -90.5%, 25 of 25 |
| 2 | 214.3 ms | **13.8 ms** | -93.5%, 25 of 25 |
| 4 | 395.0 ms | **21.5 ms** | -94.5%, 25 of 25 |

`depth = 0` is the control and the one that should not move: with no handler to miss there is no
repeated hash to save, and it does not move. Every layer above it costs about 100ms per 100k
suspensions before and about 4ms after.

## Scope

Three files, 58 lines added, 6 changed. `TagTest` and `ConcreteTagTest` pass on JS and JVM, 836
tests. The JVM and Native paths compile to what they did before, so the change is confined to the
platforms whose `String.hashCode` is not memoized.
