### PR TITLE
[kyo-ffi, kyo-ai] fix the Windows build and Claude CLI integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,61 @@ You can also add these lines to your `.bashrc` or `.zshrc` file for persistent s
 
 ### How to Build Locally
 
+#### Windows toolchains
+
+Builds that reach a kyo-ffi module need a C compiler. The FFI plugin reads the
+`CC` environment variable and otherwise invokes `cc`. If GCC is installed on
+Windows as `gcc.exe` but no `cc.exe` alias exists, set `CC` before starting sbt:
+
+```powershell
+$env:CC = "gcc"
+```
+
+Some modules also use MSVC. Install the Visual Studio Build Tools C++ workload,
+then run the build from a shell initialized by `VsDevCmd.bat` so `cl.exe`,
+`link.exe`, `INCLUDE`, and `LIB` are available. For an x86_64 build:
+
+```powershell
+cmd.exe /k '"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=amd64'
+```
+
+This opens an initialized Command Prompt. Run `powershell` inside it if the
+commands below are being entered in PowerShell.
+
+Confirm the initialized shell sees both tools with `where.exe cl` and
+`where.exe link`. See [kyo-aeron's contributor guide](kyo-aeron/CONTRIBUTING.md#staging-libaeron)
+for that module's required Windows staging step.
+
+On Windows ARM64, install the native ARM64 Podman package explicitly. Scoop can
+otherwise select a package for a different architecture:
+
+```powershell
+scoop install -a arm64 podman
+podman machine init
+podman machine start
+podman info
+```
+
+Run `podman machine init` only when creating the machine. Start an existing
+machine with `podman machine start`.
+
+#### Local build runner
+
+On native Windows, invoke POSIX build scripts through Git Bash. Use the direct
+environment for diff-selected verification:
+
+```powershell
+& $env:SHELL -lc 'scripts/build.sh --env direct testDiff JVM JS'
+```
+
+Do not use `--env podman testDiff`. The container receives a clean source
+archive without `.git`, so the diff selector cannot discover the changed
+modules. Use `--env podman test` when a full Linux container run is needed:
+
+```powershell
+& $env:SHELL -lc 'scripts/build.sh --env podman test JVM JS Native'
+```
+
 Run the following commands to build and test the project locally:
 ```sh
 sbt '+kyoJVM/test' # Runs JVM tests

--- a/kyo-aeron/CONTRIBUTING.md
+++ b/kyo-aeron/CONTRIBUTING.md
@@ -165,7 +165,31 @@ sbt 'kyo-aeronJS/test'
 
 ### Staging libaeron
 
-`kyo-aeron/scripts/build-aeron.sh <os-arch>` clones Aeron at the pinned 1.50.2 tag, builds the static archives with CMake, and stages them under `kyo-aeron/build/aeron/staged/<os-arch>/` (e.g. `darwin-aarch64`, `linux-x86_64`, `linux-aarch64`). The staged tree is gitignored: the archives are build artifacts, never committed binary blobs, so they must be produced on every machine and every CI runner before the compile step. The CI "Prepare libaeron" step runs `kyo-aeron/scripts/build-aeron.sh` per arch on the JVM, Native, JS, and Wasm legs (cmake is preinstalled or installed on demand). Run the script locally once per os-arch before a Native, JS, or Wasm build.
+`kyo-aeron/scripts/build-aeron.sh <os-arch>` clones Aeron at the pinned 1.50.2 tag, builds the static archives with CMake, and stages them under `kyo-aeron/build/aeron/staged/<os-arch>/` (e.g. `darwin-aarch64`, `linux-x86_64`, `linux-aarch64`, `windows-x86_64`). The staged tree is gitignored: the archives are build artifacts, never committed binary blobs, so they must be produced on every machine and every CI runner before the compile step. The CI "Prepare libaeron" step runs `kyo-aeron/scripts/build-aeron.sh` per arch on the JVM, Native, JS, and Wasm legs (cmake is preinstalled or installed on demand). Run the script locally once per os-arch before any build whose dependency graph reaches kyo-aeron, including a JVM build, because shared FFI generation resolves the staged headers and archive.
+
+On Windows, Aeron supports MSVC rather than MinGW. Install CMake and the Visual
+Studio Build Tools C++ workload. Initialize the build shell with
+`VsDevCmd.bat` so `cl.exe`, `link.exe`, `INCLUDE`, and `LIB` are available to
+the later FFI compile. Then stage the x86_64 archive before running sbt:
+
+```powershell
+cmd.exe /k '"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=amd64'
+```
+
+The command opens an initialized Command Prompt. Run `powershell` inside it,
+then launch Git Bash for the staging script. Use a
+Windows-style temporary directory because an MSYS-style `/tmp` path can be
+passed through to native CMake tools without the required path conversion:
+
+```powershell
+New-Item -ItemType Directory -Force C:\Temp | Out-Null
+& $env:SHELL -lc 'export TMPDIR=C:/Temp; kyo-aeron/scripts/build-aeron.sh windows-x86_64'
+```
+
+The generic kyo-ffi compiler defaults to `cc`. If a separate FFI dependency
+uses MinGW GCC and only `gcc.exe` exists, set `$env:CC = "gcc"` before running
+sbt. Keep the MSVC environment initialized because kyo-aeron selects `cl.exe`
+for its Windows shim.
 
 ### The link is driver-only
 

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
@@ -39,7 +39,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
     private case class McpServerConfig(`type`: String, url: String, timeout: Int, alwaysLoad: Boolean) derives Schema
     private case class McpConfig(mcpServers: Map[String, McpServerConfig]) derives Schema
     private case class McpBridge(
-        config: String,
+        configPath: Path,
         allowedTools: Chunk[String],
         executedTools: AtomicRef[Chunk[ExecutedTool]],
         resultCapture: AtomicRef[Maybe[String]],
@@ -90,7 +90,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                     withResultBridge(config, resultTool, resultSchema) { bridge =>
                         runClaudeCommand(
                             config,
-                            claudeCommand(config, commandArgs(config, context, bridge.config, bridge.allowedTools))
+                            claudeCommand(config, commandArgs(config, context, bridge.configPath.toString, bridge.allowedTools))
                                 .stdin(input + "\n"),
                             config.timeout,
                             bridge
@@ -127,7 +127,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                     )
                     raw <- runClaudeCommand(
                         config,
-                        claudeCommand(config, commandArgs(config, context, bridge.config, bridge.allowedTools))
+                        claudeCommand(config, commandArgs(config, context, bridge.configPath.toString, bridge.allowedTools))
                             .stdin(input + "\n"),
                         config.timeout,
                         bridge
@@ -246,9 +246,9 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                 // The --max-turns 2 cap (see ClaudeCodeWire.baseCliArgs) ends a resultless invocation with
                 // error_max_turns and a non-zero exit: this backend's normal turn boundary, not a failure, so
                 // the transcript flows to readMessages and the eval loop replays and iterates (how the forced
-                // turn stays reachable). Every other non-zero exit classifies from the terminal result event's
-                // structured api_error_status (via failureStatus), never by regexing stdout. No structured
-                // status (a hard crash with no result event) -> Absent -> AIHarnessException.
+                // turn stays reachable). Every other non-zero exit classifies from the event's structured
+                // authentication error or api_error_status, never by regexing stdout. No structured signal
+                // (a hard crash with no result event) -> Absent -> AIHarnessException.
                 endedAtTurnCap(out).map {
                     case true  => Kyo.lift[String, Any](out)
                     case false =>
@@ -263,9 +263,16 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                                     Present(config.effectiveMaxOutputTokens)
                                 ))
                             case false =>
-                                failureStatus(out).map(status =>
-                                    Abort.fail(commandFailure(status, s"exited with ${code.toInt}: $out$err"))
-                                )
+                                authenticationFailed(out).map {
+                                    case true =>
+                                        Abort.fail[AIGenException](
+                                            AIProviderAuthException("Claude Code", "CLI OAuth session is not authenticated")
+                                        )
+                                    case false =>
+                                        failureStatus(out).map(status =>
+                                            Abort.fail(commandFailure(status, s"exited with ${code.toInt}: $out$err"))
+                                        )
+                                }
                         }
                 }
             case Result.Success(CliResult.TimedOut) =>
@@ -283,6 +290,26 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
       */
     private[completion] def userToolInfos(tools: Chunk[Tool.internal.Info[?, ?, LLM]]): Chunk[Tool.internal.Info[?, ?, LLM]] =
         tools.filterNot(_.name == Completion.resultToolName)
+
+    /** Writes the MCP configuration to a scoped file for the Claude CLI.
+      *
+      * Passing inline JSON is not portable on Windows: executable shims can consume the JSON's quotes while reconstructing the native
+      * command line, after which Claude treats the malformed value as a file path. A file path contains no JSON quoting and also avoids
+      * platform command-line length limits.
+      */
+    private[completion] def mcpConfigFile(config: String)(using Frame): Path < (Sync & Scope & Abort[AIGenException]) =
+        Abort.run[FileFsException | FileWriteException] {
+            for
+                path <- Path.tempScoped("kyo-ai-claude-mcp-", ".json")
+                _    <- path.write(config)
+            yield path
+        }.map {
+            case Result.Success(path) => path
+            case Result.Failure(ex) =>
+                Abort.fail(AIProviderUnavailableException("Claude Code", s"failed to write the MCP bridge config: ${ex.getMessage}"))
+            case Result.Panic(ex) => Abort.panic(ex)
+        }
+    end mcpConfigFile
 
     /** The in-process MCP server exposing kyo's tools to the CLI, the result tool included.
       *
@@ -336,8 +363,11 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
             }
             url     = s"ws://127.0.0.1:${server.port}/mcp"
             timeout = math.min(Int.MaxValue.toLong, math.max(1000L, config.timeout.toMillis)).toInt
+            configPath <- mcpConfigFile(
+                Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true))))
+            )
             bridge = McpBridge(
-                Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true)))),
+                configPath,
                 userTools.map(_.name).append(Completion.resultToolName).map(name => s"$mcpToolPrefix$name"),
                 executed,
                 resultCapture,
@@ -396,8 +426,11 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
             }
             url     = s"ws://127.0.0.1:${server.port}/mcp"
             timeout = math.min(Int.MaxValue.toLong, math.max(1000L, config.timeout.toMillis)).toInt
+            configPath <- mcpConfigFile(
+                Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true))))
+            )
             bridge = McpBridge(
-                Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true)))),
+                configPath,
                 Chunk(s"$mcpToolPrefix${Completion.resultToolName}"),
                 executed,
                 resultCapture,

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeWire.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeWire.scala
@@ -80,6 +80,14 @@ private[completion] object ClaudeCodeWire:
     private[completion] def stoppedAtOutputLimit(out: String)(using Frame): Boolean < Abort[AIGenException] =
         readEvents(out, lenient = true).map(_.exists(_.error.contains("max_output_tokens")))
 
+    /** True when the CLI emitted its structured authentication failure code.
+      *
+      * This deliberately ignores prose and terminal result text. Only the decoded `error` field can classify a failed command as an
+      * authentication problem, preserving the same no-text-scraping rule used for provider status codes and output limits.
+      */
+    private[completion] def authenticationFailed(out: String)(using Frame): Boolean < Abort[AIGenException] =
+        readEvents(out, lenient = true).map(_.exists(_.error.contains("authentication_failed")))
+
     case class ExecutedTool(name: String, arguments: Structure.Value, output: String)
 
     val mcpServerName = "kyo"

--- a/kyo-ai/shared/src/test/scala/kyo/BaseAITest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/BaseAITest.scala
@@ -251,7 +251,16 @@ abstract class BaseAITest extends kyo.test.Test[Any]:
             config <- Config.credentialed(backend.entry)
             _ <- backend.cli match
                 case Present(command) =>
-                    commandAvailable(command).map(available => assume(available, s"$command CLI is not available"))
+                    for
+                        available <- commandAvailable(command)
+                        _         <- Kyo.lift(assume(available, s"$command CLI is not available"))
+                        _ <-
+                            if command != "claude" then Kyo.unit
+                            else
+                                claudeAuthenticationAvailable.map(authenticated =>
+                                    assume(authenticated, "claude CLI is not authenticated")
+                                )
+                    yield ()
                 case Absent =>
                     Kyo.lift(assume(config.apiKey.isDefined, s"${backend.provider.keyName} is not available")).andThen(
                         apiBackendAvailable(backend, config)
@@ -339,6 +348,26 @@ abstract class BaseAITest extends kyo.test.Test[Any]:
             case _                         => false
         }
     end commandAvailable
+
+    private[kyo] def claudeAuthenticationAvailable(using Frame): Boolean < Async =
+        Abort.run[CommandException] {
+            Command("claude", "auth", "status").textWithExitCode
+        }.map {
+            case Result.Success((output, code)) => code.isSuccess && claudeAuthenticated(output)
+            case _                              => false
+        }
+    end claudeAuthenticationAvailable
+
+    private[kyo] def claudeAuthenticated(output: String): Boolean =
+        Json.decode[Structure.Value](output).toMaybe.exists {
+            case Structure.Value.Record(fields) =>
+                fields.exists {
+                    case ("loggedIn", Structure.Value.Bool(value)) => value
+                    case _                                         => false
+                }
+            case _ => false
+        }
+    end claudeAuthenticated
 
     private[kyo] def providerUnavailable(ex: Throwable): Boolean =
         val renderedUnavailable = unavailableText(ex.getMessage) || unavailableText(ex.toString)

--- a/kyo-ai/shared/src/test/scala/kyo/BaseAITestSelectionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/BaseAITestSelectionTest.scala
@@ -34,4 +34,19 @@ class BaseAITestSelectionTest extends BaseAITest:
         }
     }
 
+    "claudeAuthenticated" - {
+        "accepts an authenticated status response" in {
+            assert(claudeAuthenticated("""{"loggedIn":true,"authMethod":"oauth"}"""))
+        }
+
+        "rejects a logged-out status response" in {
+            assert(!claudeAuthenticated("""{"loggedIn":false,"authMethod":"none"}"""))
+        }
+
+        "rejects malformed and incomplete responses" in {
+            assert(!claudeAuthenticated("not json"))
+            assert(!claudeAuthenticated("""{"authMethod":"oauth"}"""))
+        }
+    }
+
 end BaseAITestSelectionTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeCompletionTest.scala
@@ -5,6 +5,15 @@ import kyo.ai.Config
 
 class ClaudeCodeCompletionTest extends kyo.test.Test[Any]:
 
+    "mcpConfigFile writes the exact config to a scoped JSON file" in Scope.run {
+        val config = """{"mcpServers":{"kyo":{"type":"ws","url":"ws://127.0.0.1:1234/mcp"}}}"""
+        ClaudeCodeCompletion.mcpConfigFile(config).map { path =>
+            path.read.map { contents =>
+                assert(contents == config, s"the CLI must read the exact MCP config from disk: $contents")
+            }
+        }
+    }
+
     "strippedEnvVars is exactly the three ambient API credential vars (subscription-guarantee isolation)" in {
         // The base URL is deliberately NOT in the set: it is routing, not a credential. Stripping it
         // made Config.apiUrl silently inert on this backend alone while the native path honored it.

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeWireTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeWireTest.scala
@@ -375,6 +375,23 @@ class ClaudeCodeWireTest extends kyo.test.Test[Any]:
         end for
     }
 
+    "authenticationFailed reads only the structured authentication error" in {
+        val authFailure =
+            """{"type":"assistant","error":"authentication_failed","message":{"role":"assistant","content":[]}}"""
+        val proseOnly =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"authentication_failed"}]}}"""
+
+        for
+            auth  <- Abort.run[AIGenException](ClaudeCodeWire.authenticationFailed(authFailure))
+            prose <- Abort.run[AIGenException](ClaudeCodeWire.authenticationFailed(proseOnly))
+            empty <- Abort.run[AIGenException](ClaudeCodeWire.authenticationFailed(""))
+        yield
+            assert(auth == Result.Success(true), s"the structured auth error must be recognized: $auth")
+            assert(prose == Result.Success(false), s"prose must never be classified as an auth error: $prose")
+            assert(empty == Result.Success(false), s"empty output has no auth error: $empty")
+        end for
+    }
+
     "turnUsage prefers the terminal result event's aggregate" in {
         // The result event sums the invocation's internal iterations (verified live), so it wins over
         // the per-message assistant events, whose output counts are message-start snapshots.

--- a/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/CCompiler.scala
+++ b/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/CCompiler.scala
@@ -21,7 +21,7 @@ import sys.process._
   *
   * For MSVC the flag shape is:
   * {{{
-  *   cl.exe /LD /O2 /W3 /I<dir> <sources> /Fe:<outFile> <linkFlags> <lib>.lib
+  *   cl.exe /LD /O2 /W3 /I<dir> <sources> /Fo:<objectDir> /Fe:<outFile> <linkFlags> <lib>.lib
   * }}}
   *
   * When `staticLink` is true the named `linkLibs` are folded statically into the produced
@@ -186,14 +186,16 @@ private[sbt] object CCompiler {
             val staticFlag      = if (staticLink) Seq("/MT") else Nil
             val libDirFlags     = libDirs.map(d => "/LIBPATH:" + d.getAbsolutePath)
             val libFlags        = linkLibs.map(l => l + ".lib")
-            // cl.exe builds a DLL with /LD; /Fe: sets output exe/dll name. `/LIBPATH:` is a linker
-            // option: cl silently ignores it on the compiler command line, so the search dirs and the
-            // named import libs must follow `/link`, otherwise the linker cannot find a vendored .lib
-            // (LNK1181). The libs found via the LIB env (winsock, the CRT) resolve either way.
+            val objectDirFlag   = "/Fo:" + outFile.getAbsoluteFile.getParentFile.getAbsolutePath + File.separator
+            // cl.exe builds a DLL with /LD; /Fo: keeps intermediate objects beside the target DLL and
+            // /Fe: sets its name. `/LIBPATH:` is a linker option: cl silently ignores it on the compiler
+            // command line, so the search dirs and the named import libs must follow `/link`, otherwise
+            // the linker cannot find a vendored .lib (LNK1181). The libs found via the LIB env (winsock,
+            // the CRT) resolve either way.
             val linkerArgs = linkFlags ++ libDirFlags ++ libFlags
             splitCc(cc) ++ Seq("/LD") ++ translatedFlags ++ staticFlag ++ includeFlags ++
                 sources.map(_.getAbsolutePath) ++
-                Seq("/Fe:" + outFile.getAbsolutePath) ++
+                Seq(objectDirFlag, "/Fe:" + outFile.getAbsolutePath) ++
                 (if (linkerArgs.nonEmpty) Seq("/link") ++ linkerArgs else Nil)
         case _ =>
             val includeFlags = includes.flatMap(d => Seq("-I", d.getAbsolutePath))

--- a/kyo-ffi/plugin/src/test/scala/kyo/ffi/sbt/CCompilerTest.scala
+++ b/kyo-ffi/plugin/src/test/scala/kyo/ffi/sbt/CCompilerTest.scala
@@ -207,6 +207,7 @@ class CCompilerTest extends AnyFunSuite with Matchers {
         cmd should contain("/O2")
         cmd should contain("/W3")
         cmd should contain("/I" + inc.getAbsolutePath)
+        cmd should contain("/Fo:" + out.getAbsoluteFile.getParentFile.getAbsolutePath + File.separator)
         cmd should contain("/Fe:" + out.getAbsolutePath)
         cmd should contain("ws2_32.lib")
         // -fPIC is dropped on Windows (PIC is default for DLLs):


### PR DESCRIPTION
## Summary

Cross-platform verification on Windows surfaced three independent problems. They were originally carried on the #1854 branch, which is about `ByteSize` in JSONL; they have nothing to do with that change, so they move here.

- **`kyo-ffi`, MSVC object placement.** `cl.exe` writes intermediate `.obj` files to the current working directory unless told otherwise, so an sbt build left them beside the build definition instead of under `target`. The command now passes `/Fo:<target dir>\`, which keeps the objects next to the DLL that `/Fe:` names.
- **`kyo-ai`, Claude CLI MCP configuration.** The MCP bridge configuration was passed to the CLI as inline JSON. Windows executable shims rebuild the native command line and can consume the JSON quoting, after which the CLI reads the malformed value as a file path. The configuration is now written to a `Scope`-managed temporary file and the path is passed instead, which carries no quoting and also stays clear of command-line length limits.
- **`kyo-ai`, logged-out CLI environments.** A CLI that is installed but not authenticated failed with an unclassified command error. The failure is now classified from the CLI's structured `authentication_failed` event into `AIProviderAuthException`, following the same rule already used for provider status codes and output limits: read the decoded `error` field, never scrape prose. `BaseAITest` skips the CLI-backed suites when `claude auth status` reports a logged-out session.
- **Docs.** `CONTRIBUTING.md` and `kyo-aeron/CONTRIBUTING.md` record the Windows toolchains the build was exercised against.

## Verification

`sbt kyo-ffi-plugin/test` passes: 107 tests, 6 suites.
`sbt 'kyo-aiJVM/testOnly kyo.ai.completion.ClaudeCodeCompletionTest kyo.ai.completion.ClaudeCodeWireTest kyo.BaseAITestSelectionTest'` passes: 36 tests.

New tests cover each behavior change: `mcpConfigFile` writes the exact configuration to a scoped file, `authenticationFailed` reads only the structured error and never the prose around it, `claudeAuthenticated` accepts an authenticated status response and rejects logged-out and malformed ones, and the MSVC command carries `/Fo:`.
