### PR TITLE
[kyo-sql] prepare the SQL modules for Scala 3.9

### DIFF
--- a/kyo-sql-mysql/shared/src/test/scala/kyo/internal/mysql/MysqlEncoderShortTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/internal/mysql/MysqlEncoderShortTest.scala
@@ -201,7 +201,7 @@ class MysqlEncoderShortTest extends Test:
         case class Row(n: Short) derives CanEqual
 
         val schema = summon[SqlSchema[Row]]
-        val rows   = List(Row(Short.MaxValue), Row(Short.MinValue), Row(-1.toShort), Row(0.toShort), Row(12345.toShort))
+        val rows   = List(Row(Short.MaxValue), Row(Short.MinValue), Row((-1).toShort), Row(0.toShort), Row(12345.toShort))
 
         kyo.Kyo.foreach(rows) { row =>
             val params = rowParams(schema, row)

--- a/kyo-sql-tests/shared/src/test/scala/kyo/SqlStaticMacroMultiDialectTest.scala
+++ b/kyo-sql-tests/shared/src/test/scala/kyo/SqlStaticMacroMultiDialectTest.scala
@@ -74,6 +74,20 @@ class SqlStaticMacroMultiDialectTest extends Test:
         val total = SqlStaticProbe.render(Sql.from[Person]("p").sum(_.p.age))
         assert(total.sqlFor(Idiom.Id("postgres")).get == """SELECT SUM("p"."age") FROM "person" "p"""")
         assert(total.sqlFor(Idiom.Id("mysql")).get == "SELECT SUM(`p`.`age`) FROM `person` `p`")
+        // MIN and AVG state their result type the same way SUM does, through an `AsMaybe` given, so the
+        // inliner adapts each construction to a path-dependent `n.Out` and the lift has to see through that
+        // adaptation. COUNT does not: it is the one node whose result type is fixed, so it would still fold
+        // if the others stopped. Asserting all three keeps the whole family covered rather than the one
+        // member that happens to be shaped most simply.
+        val smallest = SqlStaticProbe.render(Sql.from[Person]("p").min(_.p.age))
+        assert(smallest.sqlFor(Idiom.Id("postgres")).get == """SELECT MIN("p"."age") FROM "person" "p"""")
+        assert(smallest.sqlFor(Idiom.Id("mysql")).get == "SELECT MIN(`p`.`age`) FROM `person` `p`")
+        val mean = SqlStaticProbe.render(Sql.from[Person]("p").avg(_.p.age))
+        assert(mean.sqlFor(Idiom.Id("postgres")).get == """SELECT AVG("p"."age") FROM "person" "p"""")
+        assert(mean.sqlFor(Idiom.Id("mysql")).get == "SELECT AVG(`p`.`age`) FROM `person` `p`")
+        val tally = SqlStaticProbe.render(Sql.from[Person]("p").count(_.p.age))
+        assert(tally.sqlFor(Idiom.Id("postgres")).get == """SELECT COUNT("p"."age") FROM "person" "p"""")
+        assert(tally.sqlFor(Idiom.Id("mysql")).get == "SELECT COUNT(`p`.`age`) FROM `person` `p`")
         val rolledUp = SqlStaticProbe.render(
             Sql.from[Person]("p").groupByRollup(c => c.p.deptId).select(v => (v.deptId, v.age.sum))
         )

--- a/kyo-sql/shared/src/main/scala/kyo/SqlConfig.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/SqlConfig.scala
@@ -506,19 +506,19 @@ object SqlConfig:
                     // while an `@` with nothing before it named an empty user and is Present("").
                     // The LAST `@` ends the userinfo (RFC 3986), so a password containing `@` parses whole instead
                     // of silently truncating and misreading the host.
-                    val (userInfo, hostPart): (Maybe[String], String) = authority.lastIndexOf('@') match
-                        case -1  => (Absent, authority)
+                    val (userInfo, hostPart) = authority.lastIndexOf('@') match
+                        case -1  => (Maybe.empty[String], authority)
                         case idx => (Present(authority.substring(0, idx)), authority.substring(idx + 1))
 
                     // Within a declared userinfo the colon does the same job: no colon means no password field at all,
                     // and a colon makes whatever follows it a declared credential, including the empty string, so
                     // `user:@host` said "empty password" and is Present("").
-                    val (user, password): (Maybe[String], Maybe[String]) =
+                    val (user, password) =
                         userInfo match
-                            case Absent => (Absent, Absent)
+                            case Absent => (Maybe.empty[String], Maybe.empty[String])
                             case Present(info) =>
                                 info.indexOf(':') match
-                                    case -1  => (Present(info), Absent)
+                                    case -1  => (Present(info), Maybe.empty[String])
                                     case idx => (Present(info.substring(0, idx)), Present(info.substring(idx + 1)))
 
                     hostPart.indexOf('/') match

--- a/kyo-sql/shared/src/main/scala/kyo/internal/FromExprDerived.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/FromExprDerived.scala
@@ -483,6 +483,15 @@ object FromExprDerived:
                     // identity coercion, strip it so field matchers see the wrapped term directly.
                     case Apply(TypeApply(Select(_, "substituteCo" | "substituteContra"), _), List(inner)) =>
                         transformTerm(inner)(owner)
+                    // A cast the inliner inserted to adapt an inlined body to its declared result type. A DSL
+                    // entry point whose result type is path-dependent on a `using` parameter
+                    // (`sum(...)(using n: AsMaybe[S]): Query[n.Out]`) expands to the construction adapted to
+                    // `n.Out`, which the inliner spells as `AggregateQuery.apply(...).$asInstanceOf$[Query[n.Out]]`.
+                    // The cast restates a static type and never touches the value, so it is stripped for the same
+                    // reason `substituteCo` is: leaving it in place puts a `Select(_, "$asInstanceOf$")` where the
+                    // field matchers expect the constructor head, and the whole statement silently fails to fold.
+                    case TypeApply(Select(inner, "asInstanceOf" | "$asInstanceOf$"), _) =>
+                        transformTerm(inner)(owner)
                     case sel @ Select(receiver, fieldName) =>
                         val resolvedReceiver = transformTerm(receiver)(owner)
                         // Peel `Inlined` / `Block` / `Typed` wrappers off the resolved receiver before


### PR DESCRIPTION
## Problem

Scala 3.9 is the next LTS release. Validating kyo against 3.9.0-RC6 surfaced three issues in the SQL modules, all addressed here on 3.8.4 so the eventual bump is a two-line `build.sbt` change.

Two are straightforward `-Werror` failures, self-evident in the diff.

The third is silent: whole-table aggregates stop folding at compile time, because 3.9 wraps the inlined construction in a cast the fold does not see through. `.runStatic` fails the compile, so we caught it, but `.run` would have degraded to runtime rendering unnoticed.

## Solution

Strip the cast in `resolveBindings`, beside the `substituteCo` arm already there for the same reason. Every `FromExpr` entry point runs `resolveBindings` first, so one arm covers all nesting levels, where patching the individual `peel` and `unwrap` sites would cover only the shapes we anticipated.

## Notes

The cast strip is not 3.9-only: it also fires on `asInstanceOf` nodes present in 3.8 trees, so it changes behaviour on the current compiler. The SQL suites pass on 3.8.4 and 3.9.0-RC6 is green across JVM, JS, Native and Wasm.