### PR TITLE
[kyo-ui] reconnect WebSocket on connection drop with exponential backoff

### DIFF
--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -1159,6 +1159,7 @@ private[kyo] object HtmlRenderer:
         s"""(function(){
            |var base="$basePath";
            |var __q=[];
+           |var __ws;
            |// Mirrors DomBackend.setSelection: the one place that knows the two ways a caret move can be a no-op.
            |// Elements outside input and textarea (select, contenteditable) have no setSelectionRange at all, and
            |// on input types without a text selection (email, number) it throws InvalidStateError; in both cases
@@ -1166,12 +1167,13 @@ private[kyo] object HtmlRenderer:
            |function kyoSetCaret(t,s,e){if(typeof t.setSelectionRange!=="function")return;
            |  try{t.setSelectionRange(s,e);}catch(er){if(er.name!=="InvalidStateError")throw er;}}
            |$reactiveRangesJs
+           |(function connect(retries){
            |var ws=new WebSocket((location.protocol===\"https:\"?\"wss:\":\"ws:\")+"//"+location.host+base+"/_kyo/ws");
+           |__ws=ws;Object.defineProperty(window,"__kyoWs",{get:function(){return ws;},configurable:true});
            |ws.onopen=function(){__q.forEach(function(m){ws.send(m);});__q=[];};
            |${DragClientJs.script(basePath)}
            |var __dragRt=installDragRuntime(function(m){post(m);},{onClose:function(c){__dragCleanup=c;}});
            |var __dragCleanup=__dragRt.cleanup;
-           |ws.onclose=function(){if(__dragCleanup){__dragCleanup();__dragCleanup=null;}};
            |ws.onmessage=function(e){
            |  var op=JSON.parse(e.data);
            |  if(op.ResolveDrag){
@@ -1220,6 +1222,12 @@ private[kyo] object HtmlRenderer:
            |    });
            |  }
            |};
+           |ws.onclose=function(){
+           |  if(__dragCleanup){__dragCleanup();__dragCleanup=null;}
+           |  var d=Math.min(500*Math.pow(2,retries),30000);
+           |  setTimeout(function(){connect(retries+1);},d*(0.5+Math.random()*0.5));
+           |};
+           |})(0);
            |function fp(el){
            |  while(el&&el!==document.body){
            |    if(el.hasAttribute("data-kyo-path"))return el;
@@ -1243,7 +1251,7 @@ private[kyo] object HtmlRenderer:
            |// buffered in __q and flushed on ws.onopen.
            |function post(b){
            |  var m=JSON.stringify(b);
-           |  if(ws.readyState===1)ws.send(m);
+           |  if(__ws&&__ws.readyState===1)__ws.send(m);
            |  else __q.push(m);
            |}
            |function pa(el){

--- a/kyo-ui/shared/src/test/scala/kyo/UIServerTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIServerTest.scala
@@ -60,4 +60,21 @@ class UIServerTest extends UITest:
         end for
     }
 
+    "WebSocket reconnects and reactive updates resume after connection drop" in {
+        val app: UI < Async =
+            for ref <- Signal.initRef("before")
+            yield UI.div(
+                UI.button("update").id("btn").onClick(ref.set("after")),
+                ref.map(v => UI.span(v).id("val"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("val"), "before")
+                _ <- Browser.eval("window.__kyoWs.close()")
+                _ <- Browser.click(Selector.id("btn"))
+                _ <- Browser.assertText(Selector.id("val"), "after")
+            yield ()
+        }
+    }
+
 end UIServerTest


### PR DESCRIPTION
Fixes #1877.

## Problem

The SSR client WebSocket had no `onclose` handler. Any connection drop (load-balancer idle timeout, server rolling restart, device sleep, mobile network transition) left the page dead with no recovery, causing random UI hangs.

## Solution

Wrap the WebSocket setup in a named IIFE `(function connect(retries){...})(0)` so definition and initial call are coupled. On `onclose`, schedule a reconnect with exponential backoff capped at 30 s and 50-100% jitter to avoid thundering herd:

```js
ws.onclose = function() {
  var d = Math.min(500 * Math.pow(2, retries), 30000);
  setTimeout(function() { connect(retries + 1); }, d * (0.5 + Math.random() * 0.5));
};
```

Events fired while the socket is down are buffered in the existing `__q` queue and flushed on the new socket's `onopen`, so no user interactions are lost.

`__ws` is a private runtime reference used by `post()`. `window.__kyoWs` is a read-only (getter-only via `Object.defineProperty`) test hook, updated on each reconnect.

## Test

Browser-based test in `UIServerTest`: closes the socket via `window.__kyoWs.close()`, clicks while the socket is down (event is buffered), then asserts the DOM updates once the client reconnects and flushes the queue.

## References

- https://websocket.org/guides/reconnection/#reconnection-is-not-an-edge-case
- #1877