### PR TITLE
[kyo-core] exit quietly when a signal stops the application

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/KyoAppInterrupts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoAppInterrupts.scala
@@ -5,18 +5,39 @@ import kyo.internal.Platform
 
 /** Signal handling for Kyo application entrypoints. Mixed into `KyoAppRunnerWithInterrupts`. */
 private[kyo] trait KyoAppInterrupts:
+
+    // The exact Interrupted this trait raised for a signal, with the signal's conventional exit code.
+    // The runner recognises the termination by IDENTITY against this value rather than by matching on a
+    // message, which an application's own interrupt could imitate and be mistaken for a clean stop.
+    // Unsafe: a plain cell, written from the signal handler thread and read once at exit.
+    private val signalCause =
+        AtomicRef.Unsafe.init[Maybe[(Interrupted, Int)]](Absent)(using AllowUnsafe.embrace.danger)
+
+    /** Records that `signal` fired and returns the interrupt raised for it. */
+    private[kyo] def recordSignal(signal: String, exitCode: Int)(using AllowUnsafe): Interrupted =
+        val cause = Interrupted(Frame.internal, s"Interrupt Signal: $signal")
+        signalCause.set(Present((cause, exitCode)))
+        cause
+    end recordSignal
+
+    /** The exit code for `e`, when `e` is the interrupt this trait raised for an OS signal. */
+    private[kyo] def signalExitCode(e: Throwable)(using AllowUnsafe): Maybe[Int] =
+        signalCause.get() match
+            case Present((cause, code)) if cause eq e => Present(code)
+            case _                                    => Absent
+
     private val awaitInterrupt =
         given AllowUnsafe = AllowUnsafe.embrace.danger
         val promise       = Promise.Unsafe.init[Nothing, Any]()
 
-        val interrupt = (signal: String) =>
-            () =>
-                promise
-                    .completeDiscard(Result.panic(Interrupted(Frame.internal, s"Interrupt Signal: $signal")))
+        val interrupt = (signal: String, exitCode: Int) =>
+            () => promise.completeDiscard(Result.panic(recordSignal(signal, exitCode)))
 
         if !Platform.isWindows then
-            OsSignal.handle("INT", interrupt("INT"))
-            OsSignal.handle("TERM", interrupt("TERM"))
+            // 128 + the signal number: what a shell reports and a supervisor reads for a signalled stop.
+            OsSignal.handle("INT", interrupt("INT", 130))
+            OsSignal.handle("TERM", interrupt("TERM", 143))
+        end if
 
         promise.mask().safe
     end awaitInterrupt

--- a/kyo-core/shared/src/main/scala/kyo/internal/KyoAppRunner.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/KyoAppRunner.scala
@@ -27,19 +27,40 @@ trait KyoAppRunner:
         for proc <- initCode do proc()
     end runInitCode
 
-    /** Handles the result of a registered effect block. */
+    /** The exit code for a termination the runner treats as normal, when this is one.
+      *
+      * An operator stopping the process is not a fault, so it must not be rendered, must not throw, and
+      * must not exit as a failure would. The default recognises none; [[KyoAppRunnerWithInterrupts]]
+      * recognises the interrupt it raised for a signal.
+      */
+    protected def normalTermination(e: Throwable)(using AllowUnsafe): Maybe[Int] = Absent
+
+    /** Handles the result of a registered effect block.
+      *
+      * A termination [[normalTermination]] recognises is reported by neither channel: it renders nothing
+      * and exits with the code that supplies. An operator stopping the process is not a fault, so
+      * rendering and rethrowing it puts a stack-trace-shaped line on stderr for every ordinary stop.
+      */
     final protected def onResult[E, A](result: Result[E, A])(using Render[Result[E, A]], AllowUnsafe): Unit =
-        if !result.exists(().equals(_)) then println(result.show)
         result match
-            case Error(e: Throwable) => throw e
-            case Error(_)            => exitHook(1)
-            case _                   =>
+            case Error(e: Throwable) if normalTermination(e).nonEmpty =>
+                exitHook(normalTermination(e).getOrElse(0))
+            case _ =>
+                if !result.exists(().equals(_)) then println(result.show)
+                result match
+                    case Error(e: Throwable) => throw e
+                    case Error(_)            => exitHook(1)
+                    case _                   =>
+                end match
         end match
     end onResult
 end KyoAppRunner
 
 /** [[KyoAppRunner]] with SIGINT/SIGTERM handling on non-Windows platforms. */
 trait KyoAppRunnerWithInterrupts extends KyoAppRunner, KyoAppInterrupts:
+    final override protected def normalTermination(e: Throwable)(using AllowUnsafe): Maybe[Int] =
+        signalExitCode(e)
+
     final override protected def handle[A](v: A < (Async & Scope & Abort[Any]))(using Frame): A < (Async & Abort[Throwable]) =
         handleWithInterrupts(KyoApp.abortAnyToThrowable(Scope.run(v)))
     end handle

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppInterruptsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppInterruptsTest.scala
@@ -1,0 +1,109 @@
+package kyo
+
+import java.io.ByteArrayOutputStream
+import kyo.internal.KyoAppRunner
+import kyo.internal.KyoAppRunnerWithInterrupts
+
+/** How a signalled stop is reported.
+  *
+  * A host stops a stdio server by sending SIGTERM, so this is the ordinary end of a long-running kyo
+  * application, not a fault. It used to end by rethrowing the interrupt, which printed
+  * `Exception in thread "main" kyo.Interrupted: Fiber interrupted ... by Interrupt Signal: TERM` and
+  * exited non-zero. A supervisor that surfaces a subprocess's stderr then shows a stack-trace-shaped line
+  * on every normal stop, which teaches an operator to ignore that stream.
+  */
+class KyoAppInterruptsTest extends kyo.test.Test[Any]:
+
+    given AllowUnsafe = AllowUnsafe.embrace.danger
+
+    /** A runner that records what it would have done to the process. */
+    private class Recording extends KyoAppRunner:
+        var exited: Maybe[Int]                                     = Absent
+        protected def exitHook(code: Int)(using AllowUnsafe): Unit = exited = Present(code)
+        protected def handle[A](v: A < (Async & Scope & Abort[Any]))(using Frame): A < (Async & Abort[Throwable]) =
+            throw new UnsupportedOperationException("not used by these tests")
+
+        /** Exposes the entrypoint's result handling, which is `protected` on the runner. */
+        def report[E, A](result: Result[E, A])(using Render[Result[E, A]], AllowUnsafe): Unit =
+            onResult(result)
+    end Recording
+
+    /** The same, with the real signal wiring mixed in. */
+    private class RecordingWithInterrupts extends Recording, KyoAppRunnerWithInterrupts
+
+    /** Runs `f` with stdout and stderr captured. */
+    private def captured(f: => Unit): (String, String) =
+        val out = new ByteArrayOutputStream
+        val err = new ByteArrayOutputStream
+        scala.Console.withOut(out)(scala.Console.withErr(err)(f))
+        (out.toString, err.toString)
+    end captured
+
+    "a signalled stop" - {
+
+        "ends quietly with the signal's conventional exit code" in {
+            val runner = new RecordingWithInterrupts
+            val cause  = runner.recordSignal("TERM", 143)
+            val (out, err) = captured {
+                runner.report(Result.panic(cause))
+            }
+            assert(runner.exited == Present(143), s"SIGTERM must exit 143; got: ${runner.exited}")
+            assert(out.isEmpty, s"a normal stop must print nothing to stdout; got: $out")
+            assert(err.isEmpty, s"a normal stop must print nothing to stderr; got: $err")
+        }
+
+        "reports 130 for SIGINT" in {
+            val runner = new RecordingWithInterrupts
+            val cause  = runner.recordSignal("INT", 130)
+            captured(runner.report(Result.panic(cause)))
+            assert(runner.exited == Present(130), s"SIGINT must exit 130; got: ${runner.exited}")
+        }
+
+        "is recognised by identity, so an application's own interrupt is still a failure" in {
+            // The message alone would not distinguish them: an application can raise an interrupt whose
+            // text says the same thing, and that is a real failure the operator must see.
+            val runner    = new RecordingWithInterrupts
+            val _         = runner.recordSignal("TERM", 143)
+            val lookalike = Interrupted(Frame.internal, "Interrupt Signal: TERM")
+            val thrown =
+                try
+                    captured(runner.report(Result.panic(lookalike)))
+                    Absent
+                catch case e: Throwable => Present(e)
+            assert(thrown == Present(lookalike), s"an unrelated interrupt must still propagate; got: $thrown")
+            assert(runner.exited == Absent, s"and must not report a clean exit; got: ${runner.exited}")
+        }
+    }
+
+    "a value still reaches the caller's output" in {
+        // The signalled-stop branch added above sits in front of the reporting, so it must not swallow
+        // the ordinary cases. Which STREAM each outcome lands on is a separate concern and is not
+        // asserted here.
+        val runner     = new Recording
+        val (out, err) = captured(runner.report(Result.succeed(42)))
+        assert((out + err).contains("42"), s"a returned value must still be reported; got out=$out err=$err")
+        assert(runner.exited == Absent)
+    }
+
+    "an ordinary failure still propagates" in {
+        // The throw is caught INSIDE the captured block on purpose: catching it outside would let it
+        // escape before the captured streams were read.
+        val runner                   = new Recording
+        val failure                  = new RuntimeException("boom")
+        var thrown: Maybe[Throwable] = Absent
+        val (out, err) = captured {
+            try runner.report(Result.panic(failure))
+            catch case e: Throwable => thrown = Present(e)
+        }
+        assert(thrown == Present(failure), s"a real failure must still be thrown; got: $thrown")
+        assert((out + err).contains("boom"), s"the failure must still be reported; got out=$out err=$err")
+    }
+
+    "a successful unit result prints nothing and does not exit" in {
+        val runner     = new Recording
+        val (out, err) = captured(runner.report(Result.succeed(())))
+        assert(out.isEmpty && err.isEmpty, s"a quiet success must stay quiet; out=$out err=$err")
+        assert(runner.exited == Absent)
+    }
+
+end KyoAppInterruptsTest


### PR DESCRIPTION
### Problem

An MCP host stops a stdio server with SIGTERM, and a supervisor stops a daemon the same way. `KyoApp` treated that ordinary shutdown as a failure: the interrupt escaped as an uncaught `kyo.Interrupted`, so every normal stop printed a stack trace and exited non-zero.

A supervisor that surfaces a subprocess's stderr then shows a fault every time it stops something, which teaches operators to ignore the one stream carrying real diagnostics, and an orchestrator reading exit codes cannot tell a clean stop from a crash.

### Solution

The signal handler records the exact `Interrupted` it raises, and the runner recognises that value by identity, exiting with the signal's conventional code (130 for INT, 143 for TERM) without rendering or rethrowing it. Identity rather than message text, because an application can raise an interrupt that reads identically and that one is a real failure an operator must see.

Cancellation is unchanged: the race already interrupted the loser and ran its finalizers, this changes only how the outcome is reported.

### Notes

The guard sits in front of the reporting rather than inside it, so it composes with the separate change routing failures to stderr: a signalled stop is reported on neither stream, because it is not a diagnostic.

Tested on JVM, JS and Native. The signalled-stop tests go red without the fix, and companion tests pin that ordinary values and failures are still reported and still propagate.
