### PR TITLE
[kyo-jsonrpc, kyo-mcp] make a failing MCP server say what actually failed

### DIFF
--- a/kyo-jsonrpc/shared/src/main/scala/kyo/JsonRpcError.scala
+++ b/kyo-jsonrpc/shared/src/main/scala/kyo/JsonRpcError.scala
@@ -394,7 +394,10 @@ case class JsonRpcImplementationError private (
 )(using Frame)
     extends JsonRpcError(
         code0 = code,
-        message = s"Server error ($code): $label",
+        // The code is already the wire's own `code` field, and `fromWire` rebuilds this error from the
+        // `message` it receives: folding the code in here would re-apply on every hop, so a message
+        // relayed through a proxy or a reverse call would accumulate one prefix per hop.
+        message = label,
         data0 = data
     ) with JsonRpcExecutionFailure
 
@@ -451,4 +454,6 @@ case class JsonRpcCustomError(
     label: String,
     override val data: Maybe[Structure.Value] = Absent
 )(using Frame)
-    extends JsonRpcApplicationError(code, s"Application error ($code): $label", data)
+// As with JsonRpcImplementationError, the code is NOT folded into the message: `fromWire` re-enters
+// this constructor with whatever arrived, so any prefix added here is re-applied on every hop.
+    extends JsonRpcApplicationError(code, label, data)

--- a/kyo-jsonrpc/shared/src/main/scala/kyo/JsonRpcTransport.scala
+++ b/kyo-jsonrpc/shared/src/main/scala/kyo/JsonRpcTransport.scala
@@ -71,6 +71,61 @@ object JsonRpcTransport:
             fromWire(wire, framer, codec)
         }
 
+    /** [[stdio]] with the process's own streams protected for the duration of `f`.
+      *
+      * On this transport stdin and stdout ARE the protocol channel, so an application write to either
+      * corrupts it. `Console.printLine` is the idiomatic way to print in kyo and does exactly that: one
+      * line of application output lands between two envelopes and the peer sees a parse error or drops
+      * the connection, which is the worst place to debug it from, since the server side looks fine.
+      *
+      * Inside `f`, `Console` is rebound so `print` and `printLine` go to stderr along with `printErr`,
+      * and `readLine` fails rather than consuming bytes the protocol is waiting for. Handlers therefore
+      * print safely by construction and no author has to know the rule. Nothing else changes: the
+      * transport is the one [[stdio]] returns, and the binding is dynamically scoped, so the dispatch
+      * loop and every handler forked inside `f` inherit it.
+      *
+      * {{{
+      * JsonRpcTransport.stdioWith() { transport =>
+      *     McpServer.init(transport, handlers*).andThen(Async.never)
+      * }
+      * }}}
+      *
+      * Prefer this over [[stdio]] for any server that runs on the process's own streams.
+      *
+      * @param framer byte-stream framing strategy; defaults to [[JsonRpcFramer.lineDelimited]]
+      * @param codec  envelope serialisation; defaults to the strict `Schema[JsonRpcEnvelope]`
+      * @param f      the body, run with the transport and with `Console` diverted away from the channel
+      */
+    def stdioWith[A, S](
+        framer: JsonRpcFramer = JsonRpcFramer.lineDelimited,
+        codec: Schema[JsonRpcEnvelope] = summon[Schema[JsonRpcEnvelope]]
+    )(f: JsonRpcTransport => A < S)(using Frame): A < (S & Async & Scope) =
+        stdio(framer, codec).map { transport =>
+            Console.use(ambient => Console.let(divertedConsole(ambient))(f(transport)))
+        }
+
+    /** The ambient console with its stdout side diverted to stderr and its input closed.
+      *
+      * Derived from the ambient console rather than from `Console.live`, so an enclosing binding (a test
+      * capturing output, a custom sink) still sees the writes, on the side they were diverted to.
+      */
+    private def divertedConsole(ambient: Console): Console =
+        val under = ambient.unsafe
+        Console(
+            new Console.Unsafe:
+                def readLine()(using AllowUnsafe): Result[java.io.IOException, String] =
+                    Result.fail(new java.io.IOException(
+                        "stdin is the JSON-RPC protocol channel on this transport; reading it would consume protocol bytes"
+                    ))
+                def print(s: String)(using AllowUnsafe): Unit        = under.printErr(s)
+                def printErr(s: String)(using AllowUnsafe): Unit     = under.printErr(s)
+                def printLine(s: String)(using AllowUnsafe): Unit    = under.printLineErr(s)
+                def printLineErr(s: String)(using AllowUnsafe): Unit = under.printLineErr(s)
+                def checkErrors(using AllowUnsafe): Boolean          = under.checkErrors
+                def flush()(using AllowUnsafe): Unit                 = under.flush()
+        )
+    end divertedConsole
+
     /** Unix domain socket transport, served over the platform kyo-net transport.
       *
       * Binds a Unix-domain listener on `sockPath` and serves a single client: the first accepted connection becomes the

--- a/kyo-jsonrpc/shared/src/test/scala/kyo/JsonRpcErrorTest.scala
+++ b/kyo-jsonrpc/shared/src/test/scala/kyo/JsonRpcErrorTest.scala
@@ -109,4 +109,42 @@ class JsonRpcErrorTest extends JsonRpcTest:
         assert(decoded.data == Present(Structure.Value.Str("details")))
     }
 
+    "the wire message is the registered message, with the code only in `code`" - {
+
+        "an application error does not fold its code into its message" in {
+            val err = JsonRpcCustomError(-40001, "read-only-violation")
+            assert(err.code == -40001)
+            assert(
+                err.message == "read-only-violation",
+                s"JSON-RPC carries `code` as its own field; repeating it in `message` is duplication: ${err.message}"
+            )
+        }
+
+        "an implementation error does not fold its code into its message" in {
+            val err = JsonRpcImplementationError(-32050, "backend unavailable", Absent)
+            assert(err.code == -32050)
+            assert(err.message == "backend unavailable", s"got: ${err.message}")
+        }
+
+        "a wire round trip is idempotent for an application error" in {
+            // `fromWire` re-enters the same constructor with whatever `message` arrived. Any prefix the
+            // constructor adds is therefore re-applied on every hop, so a message that survives one round
+            // trip unchanged is the only shape that survives a proxy or a reverse call.
+            val original = JsonRpcCustomError(-40001, "read-only-violation")
+            val once     = JsonRpcError.fromWire(original.code, original.message, original.data)
+            val twice    = JsonRpcError.fromWire(once.code, once.message, once.data)
+            assert(once.message == "read-only-violation", s"after one hop: ${once.message}")
+            assert(twice.message == "read-only-violation", s"after two hops: ${twice.message}")
+            assert(twice.code == -40001)
+        }
+
+        "a wire round trip is idempotent for an implementation error" in {
+            val original = JsonRpcImplementationError(-32050, "backend unavailable", Absent)
+            val once     = JsonRpcError.fromWire(original.code, original.message, original.data)
+            val twice    = JsonRpcError.fromWire(once.code, once.message, once.data)
+            assert(once.message == "backend unavailable", s"after one hop: ${once.message}")
+            assert(twice.message == "backend unavailable", s"after two hops: ${twice.message}")
+        }
+    }
+
 end JsonRpcErrorTest

--- a/kyo-jsonrpc/shared/src/test/scala/kyo/JsonRpcTransportTest.scala
+++ b/kyo-jsonrpc/shared/src/test/scala/kyo/JsonRpcTransportTest.scala
@@ -166,4 +166,67 @@ class JsonRpcTransportTest extends JsonRpcTest:
         }
     }
 
+    "stdioWith keeps application output off the protocol channel" - {
+
+        "Console.printLine from inside the body goes to stderr, not stdout" in {
+            // stdout IS the protocol channel here, so one application line between two envelopes makes
+            // the peer see a parse error. `Console.printLine` is the idiomatic way to print in kyo, so
+            // the transport that owns the channel is what has to make it safe.
+            Console.withOut {
+                Scope.run {
+                    JsonRpcTransport.stdioWith() { _ =>
+                        Console.printLine("this line must not reach the protocol channel")
+                    }
+                }
+            }.map { (out, _) =>
+                assert(out.stdOut.isEmpty, s"nothing may reach stdout; got: ${out.stdOut}")
+                assert(
+                    out.stdErr.contains("this line must not reach the protocol channel"),
+                    s"the line must still be printed, on stderr; got: ${out.stdErr}"
+                )
+            }
+        }
+
+        "Console.print from inside the body goes to stderr too" in {
+            Console.withOut {
+                Scope.run {
+                    JsonRpcTransport.stdioWith()(_ => Console.print("partial"))
+                }
+            }.map { (out, _) =>
+                assert(out.stdOut.isEmpty, s"nothing may reach stdout; got: ${out.stdOut}")
+                assert(out.stdErr.contains("partial"), s"got: ${out.stdErr}")
+            }
+        }
+
+        "Console.printErr still reaches stderr" in {
+            Console.withOut {
+                Scope.run {
+                    JsonRpcTransport.stdioWith()(_ => Console.printLineErr("diagnostic"))
+                }
+            }.map { (out, _) =>
+                assert(out.stdErr.contains("diagnostic"), s"got: ${out.stdErr}")
+            }
+        }
+
+        "reading stdin fails rather than consuming protocol bytes" in {
+            // The other half of the same channel. A handler that reads a line would steal bytes the
+            // dispatch loop is waiting for, which corrupts the stream in the harder-to-see direction.
+            Scope.run {
+                Abort.run[java.io.IOException] {
+                    JsonRpcTransport.stdioWith()(_ => Console.readLine)
+                }
+            }.map { result =>
+                assert(result.isFailure, s"reading stdin must fail on this transport; got: $result")
+            }
+        }
+
+        "the binding is scoped to the body and does not leak out" in {
+            Scope.run(JsonRpcTransport.stdioWith()(_ => ())).andThen {
+                Console.withOut(Console.printLine("after")).map { (out, _) =>
+                    assert(out.stdOut.contains("after"), s"stdout must work again outside the body; got: $out")
+                }
+            }
+        }
+    }
+
 end JsonRpcTransportTest

--- a/kyo-mcp/README.md
+++ b/kyo-mcp/README.md
@@ -11,7 +11,11 @@ case class Confirm(approved: Boolean) derives Schema, CanEqual
 def lookupForecast(city: String): Forecast < Sync = Forecast(city, "clear", 21)
 def renderChartPng(f: Forecast): String           = "iVBORw0KGgo="
 def externalTempReading(city: String): String     = "21"
-val png: McpMimeType                              = McpMimeType("image/png")
+
+case class WeatherApi(endpoint: String)
+def lookupForecastVia(city: String): Forecast < (Env[WeatherApi] & Sync) =
+    Env.use[WeatherApi](_ => lookupForecast(city))
+val png: McpMimeType = McpMimeType("image/png")
 
 val weather = McpHandler.tool[WeatherIn]("weather", "Current conditions for a city") { in =>
     lookupForecast(in.city)
@@ -78,12 +82,14 @@ object WeatherServer extends KyoApp:
             McpHandler.tool[WeatherIn]("weather", "Current conditions for a city") { in =>
                 Forecast(in.city, "clear", 21)
             }
-        JsonRpcTransport.stdio().map { transport =>
+        JsonRpcTransport.stdioWith() { transport =>
             McpServer.initWith(transport, weather)(_ => Async.never)
         }
     }
 end WeatherServer
 ```
+
+`stdioWith` rather than `stdio`: on this transport stdin and stdout ARE the protocol channel, so an application write to either corrupts it, and `Console.printLine` is the natural way to write one. Inside the body `Console`'s stdout side is diverted to stderr and `readLine` fails, so a handler prints safely without its author having to know the rule. Use plain `stdio()` only when you own the process's streams yourself.
 
 `Async.never` parks the main fiber forever: the inbound stdio dispatch fiber drives all the work, so the main fiber only has to hold the scope open until the host stops the process. For a server that should shut itself down, replace `Async.never` with a `Fiber.Promise[Unit, Sync]` that a handler completes when it is time to exit.
 
@@ -94,6 +100,30 @@ end WeatherServer
 Every server endpoint is an `McpHandler` value built by a role-tagged factory on the `McpHandler` companion, where the role names what the MCP host can do with it: a tool is a function the model may call, a resource is read-only data the host can fetch, a prompt is a parameterised message template, a completion is IDE-style argument autocomplete, and a custom method is a vendor extension. The factories share one shape: you annotate `[In]` at the call site and the compiler infers `[Out]` from your handler's return type through clause interleaving, so the only type you ever write is the request type.
 
 The per-request context (who is calling, the cancellation signal, the progress channel, the live peer for reverse calls) is not a handler parameter. It is reached through the `Mcp.*` accessors covered in [Inside a handler](#inside-a-handler-the-per-request-context). That keeps every handler signature down to `In => Out`.
+
+### The handler row is closed
+
+A handler body's effect row is fixed at `Async & Abort[JsonRpcResponse.Halt | E]`, where `E` is what you declare with [`.error[E]`](#typed-domain-errors). Nothing else crosses it. That is deliberate, since the engine calls handlers itself and has nothing to supply an ambient effect with, but it means a body cannot run in `Env`, `DB`, or any other effect the rest of your program is written in.
+
+Discharge those where the handler is *built*, so each handler closes over what its body needs:
+
+```scala
+def weatherHandlers(api: WeatherApi): Seq[McpHandler[?, ?, ?]] =
+    Seq(
+        McpHandler.tool[WeatherIn]("weather", "Current conditions for a city") { in =>
+            Env.run(api)(lookupForecastVia(in.city))
+        }
+    )
+```
+
+Handlers become a function of their dependencies, and `McpServer.init(transport, weatherHandlers(api)*)` supplies them once at startup. Wrapping the whole server in `Env.run(api) { ... }` instead does not work and is worth naming, because it is the shape most kyo modules teach: the body's row is what the factory checks, not the row the surrounding program happens to be in.
+
+An undischarged effect is a compile error at the handler body whose first line names the offending effect exactly:
+
+```
+Found:    Forecast < (kyo.Env[WeatherApi] & kyo.Sync)
+Required: Any < (kyo.Async & kyo.Abort[kyo.JsonRpcResponse.Halt | Any])
+```
 
 ### Tools
 
@@ -574,7 +604,7 @@ val drainThenClose: Unit < (Async & Abort[McpException]) =
 
 ## Transports and cross-platform behaviour
 
-kyo-mcp ships no transports of its own; it uses the `JsonRpcTransport` factories from `kyo-jsonrpc`. `stdio()` is the line-delimited stdin/stdout transport for a CLI server a host launches as a subprocess. `inMemory` returns a cross-wired pair, ideal for wiring a client and a server in one process (every example in this README that uses `inMemory` does exactly that). `fromWire(...)` lifts a byte-stream transport plus framer plus codec into the envelope seam for a custom wire.
+kyo-mcp ships no transports of its own; it uses the `JsonRpcTransport` factories from `kyo-jsonrpc`. `stdio()` is the line-delimited stdin/stdout transport for a CLI server a host launches as a subprocess, and `stdioWith(...) { transport => ... }` is the form to reach for: because that transport owns stdin and stdout, application output written to them corrupts the protocol, so the body it runs has `Console`'s stdout side diverted to stderr and `readLine` failing. A single `Console.printLine` in a handler is otherwise enough to make the host report a parse error, which is the worst place to debug it from, since the server side looks healthy. `inMemory` returns a cross-wired pair, ideal for wiring a client and a server in one process (every example in this README that uses `inMemory` does exactly that). `fromWire(...)` lifts a byte-stream transport plus framer plus codec into the envelope seam for a custom wire.
 
 The full surface compiles and runs on JVM, JavaScript, and Scala Native, with no platform restriction: `JsonRpcTransport.unixDomain(path)` works everywhere, running over the platform kyo-net transport (JVM posix/NIO, Native posix, JS/Wasm Node's `net` module). On JS/Wasm it needs a Node.js runtime, since a browser has no sockets.
 

--- a/kyo-mcp/shared/src/main/scala/kyo/McpClientHandler.scala
+++ b/kyo-mcp/shared/src/main/scala/kyo/McpClientHandler.scala
@@ -22,7 +22,7 @@ package kyo
 sealed trait McpClientHandler[In, Out, +E]:
     def method: String
     def direction: McpHandler.Direction
-    private[kyo] def toRoute(serverRef: AtomicRef[Maybe[McpServer.Unsafe]])(using Frame): JsonRpcRoute[?, ?, ?]
+    private[kyo] def toRoute(serverRef: Fiber.Promise[McpServer.Unsafe, Any])(using Frame): JsonRpcRoute[?, ?, ?]
     private[kyo] def requiredCapability: Maybe[McpCapabilities.Name]
 end McpClientHandler
 
@@ -36,7 +36,7 @@ object McpClientHandler:
         val handler: In => Out < (Async & Abort[JsonRpcResponse.Halt | E])
     ) extends McpClientHandler[In, Out, E]:
         def direction: McpHandler.Direction = McpHandler.Direction.ClientHandled
-        private[kyo] def toRoute(serverRef: AtomicRef[Maybe[McpServer.Unsafe]])(using Frame): JsonRpcRoute[?, ?, ?] =
+        private[kyo] def toRoute(serverRef: Fiber.Promise[McpServer.Unsafe, Any])(using Frame): JsonRpcRoute[?, ?, ?] =
             internal.mcp.McpClientHandlerLift.liftRequest(this, serverRef)
     end RequestCarrier
 
@@ -47,7 +47,7 @@ object McpClientHandler:
     ) extends McpClientHandler[In, Unit, E]:
         def direction: McpHandler.Direction                 = McpHandler.Direction.ClientHandled
         def requiredCapability: Maybe[McpCapabilities.Name] = Absent
-        private[kyo] def toRoute(serverRef: AtomicRef[Maybe[McpServer.Unsafe]])(using Frame): JsonRpcRoute[?, ?, ?] =
+        private[kyo] def toRoute(serverRef: Fiber.Promise[McpServer.Unsafe, Any])(using Frame): JsonRpcRoute[?, ?, ?] =
             internal.mcp.McpClientHandlerLift.liftNotification(this, serverRef)
     end NotificationCarrier
 

--- a/kyo-mcp/shared/src/main/scala/kyo/McpHandler.scala
+++ b/kyo-mcp/shared/src/main/scala/kyo/McpHandler.scala
@@ -37,6 +37,17 @@ sealed trait McpHandler[In, Out, +E]:
     /** Per-handler error mappings registered via `.error[E2]`. */
     private[kyo] def errorMappings: Chunk[McpHandler.ErrorMapping[?]]
 
+    /** The abort type this handler's body declared, as a runtime tag, when a factory captured one.
+      *
+      * `.error[E2]` records a mapping but cannot say which leaves of the body's `E` were meant to be
+      * mapped, so a leaf with no mapping stayed invisible until it aborted at dispatch and reached the
+      * peer as an opaque internal error carrying the exception's `toString`. The engine reads this at
+      * startup and refuses such a handler, the way it already refuses a reserved-range error code.
+      *
+      * `Absent` for a handler constructed directly rather than through a factory.
+      */
+    private[kyo] def declaredErrorTag: Maybe[ConcreteTag[Any]]
+
     /** Adds a typed-error mapping. When the handler aborts with a value of type `E2`, the engine
       * emits a JSON-RPC error with the supplied `code` and `message`. Mirrors `JsonRpcRoute.error[E2]`.
       */
@@ -430,6 +441,45 @@ object McpHandler:
     private inline def resourceAnnotationsMaybe(a: ResourceAnnotations): Maybe[ResourceAnnotations] =
         if a == ResourceAnnotations.empty then Absent else Present(a)
 
+    /** Evidence that a handler's output type was actually inferred.
+      *
+      * A handler body whose effect row does not fit does not stop the factory from typechecking: `Out`
+      * degrades to `Any`, and the search for `Schema[Any]` then matches several primitive instances at
+      * once, so the author is shown an ambiguity between two instances their code never mentions
+      * (`durationSchema` and `intSchema`, say) instead of the effect their body actually carries. For
+      * some bodies that phantom is the only error reported and the real one is suppressed entirely.
+      *
+      * Requiring this evidence BEFORE the schema turns that into a named failure. It also rejects a
+      * handler that genuinely returns `Any`, which is correct: `Any` has no schema to advertise.
+      *
+      * This is evidence, never written by hand.
+      */
+    @scala.annotation.implicitNotFound(
+        "This handler's output type could not be inferred (it came out as Any).\n" +
+            "If another error names an effect the handler body carries, that is the cause: a handler " +
+            "body's row is closed at Async & Abort[JsonRpcResponse.Halt | E], and a body that does not " +
+            "fit leaves the output type uninferred here. Fix that error first.\n" +
+            "If the handler really does return Any, give it a concrete return type instead: Any has no " +
+            "schema to advertise."
+    )
+    final class OutInferred[Out]
+
+    object OutInferred:
+        private val instance                                                          = new OutInferred[Any]
+        given inferred[Out](using scala.util.NotGiven[Out =:= Any]): OutInferred[Out] = instance.asInstanceOf[OutInferred[Out]]
+
+    /** Wraps a factory-captured abort tag for the carrier, dropping the `Nothing` case.
+      *
+      * A body that aborts nothing has `E = Nothing`, which carries no leaf to map and must not be
+      * mistaken for one that was left unmapped.
+      */
+    private def declaredError[E](tag: ConcreteTag[E]): Maybe[ConcreteTag[Any]] =
+        val widened = tag.asInstanceOf[ConcreteTag[Any]]
+        widened match
+            case ConcreteTag.NothingTag => Absent
+            case _                      => Present(widened)
+    end declaredError
+
     // --- Factories ------------------------------------------------------------
 
     inline def tool[In](
@@ -440,12 +490,17 @@ object McpHandler:
         inSchema: Schema[In]
     )[Out, E](
         handler: In => Out < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using outSchema: Schema[Out], frame: Frame): McpHandler[In, Out, E] =
+    )(using errorTag: ConcreteTag[E], outInferred: OutInferred[Out], outSchema: Schema[Out], frame: Frame): McpHandler[In, Out, E] =
         // `inline` so `Json.jsonSchema[In]`/`Json.jsonSchema[Out]` expand at the call site where
         // `In`/`Out` are concrete; against an abstract type parameter they yield an empty Product.
         // The advertised `outputSchema` is derived from `Out`; the lift encodes the one returned
         // value into `structuredContent` and a text mirror, so the three coupled fields agree by
         // construction.
+        //
+        // `OutInferred` is required BEFORE the output schema so a body that left `Out` uninferred is
+        // reported as that, rather than as an ambiguity between two primitive schemas the author never
+        // mentioned. See its docs.
+        val _ = outInferred
         val meta = ToolMeta(
             name = name,
             description = if description.isEmpty then Absent else Present(description),
@@ -453,7 +508,7 @@ object McpHandler:
             outputSchema = Present(Json.jsonSchema[Out]),
             annotations = toolAnnotationsMaybe(annotations)
         )
-        new ToolHandler[In, Out, E](meta, inSchema, outSchema, handler, Chunk.empty)
+        new ToolHandler[In, Out, E](meta, inSchema, outSchema, handler, Chunk.empty, declaredError(errorTag))
     end tool
 
     /** Constructs a tool handler returning a full [[ToolOutcome]] for total control
@@ -466,7 +521,7 @@ object McpHandler:
         annotations: ToolAnnotations = ToolAnnotations.empty
     )[E](
         handler: In => ToolOutcome < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using inSchema: Schema[In], frame: Frame): McpHandler[In, ToolOutcome, E] =
+    )(using errorTag: ConcreteTag[E], inSchema: Schema[In], frame: Frame): McpHandler[In, ToolOutcome, E] =
         // `inline` so `Json.jsonSchema[In]` resolves against the concrete `In` at the call site.
         val meta = ToolMeta(
             name = name,
@@ -475,7 +530,7 @@ object McpHandler:
             outputSchema = Absent,
             annotations = toolAnnotationsMaybe(annotations)
         )
-        new ToolMultiHandler[In, E](meta, inSchema, handler, Chunk.empty)
+        new ToolMultiHandler[In, E](meta, inSchema, handler, Chunk.empty, declaredError(errorTag))
     end toolRaw
 
     /** Constructs a fixed-URI resource handler.
@@ -499,7 +554,7 @@ object McpHandler:
         subscribe: Boolean = false
     )[E](
         handler: => Chunk[ResourceBody] < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using frame: Frame): McpHandler[Unit, Chunk[ResourceBody], E] =
+    )(using errorTag: ConcreteTag[E], frame: Frame): McpHandler[Unit, Chunk[ResourceBody], E] =
         val meta = ResourceMeta(
             uri = uri,
             name = name,
@@ -507,7 +562,7 @@ object McpHandler:
             mimeType = mimeType,
             annotations = resourceAnnotationsMaybe(annotations)
         )
-        new ResourceHandler[E](meta, subscribe, () => handler, Chunk.empty)
+        new ResourceHandler[E](meta, subscribe, () => handler, Chunk.empty, declaredError(errorTag))
     end resource
 
     /** Constructs a URI-template resource handler. The closure receives a [[ResourceMatch]]
@@ -521,7 +576,7 @@ object McpHandler:
         annotations: ResourceAnnotations = ResourceAnnotations.empty
     )[E](
         handler: ResourceMatch => Chunk[ResourceBody] < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using frame: Frame): McpHandler[ResourceMatch, Chunk[ResourceBody], E] =
+    )(using errorTag: ConcreteTag[E], frame: Frame): McpHandler[ResourceMatch, Chunk[ResourceBody], E] =
         val meta = ResourceTemplateMeta(
             uriTemplate = uriTemplate,
             name = name,
@@ -529,7 +584,7 @@ object McpHandler:
             mimeType = mimeType,
             annotations = resourceAnnotationsMaybe(annotations)
         )
-        new ResourceTemplateHandler[E](meta, handler, Chunk.empty)
+        new ResourceTemplateHandler[E](meta, handler, Chunk.empty, declaredError(errorTag))
     end resourceTemplate
 
     /** Constructs a typed prompt handler.
@@ -546,13 +601,13 @@ object McpHandler:
         inSchema: Schema[In]
     )[E](
         handler: In => PromptOutcome < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using frame: Frame): McpHandler[In, PromptOutcome, E] =
+    )(using errorTag: ConcreteTag[E], frame: Frame): McpHandler[In, PromptOutcome, E] =
         val meta = PromptMeta(
             name = name,
             description = if description.isEmpty then Absent else Present(description),
             arguments = internal.mcp.McpPromptArguments.fromSchema[In]
         )
-        new TypedPromptHandler[In, E](meta, inSchema, handler, Chunk.empty)
+        new TypedPromptHandler[In, E](meta, inSchema, handler, Chunk.empty, declaredError(errorTag))
     end prompt
 
     /** Constructs a prompt handler over the raw inbound `Map[String, String]` (the escape
@@ -564,13 +619,13 @@ object McpHandler:
         arguments: Chunk[PromptArgument]
     )[E](
         handler: Map[String, String] => PromptOutcome < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using frame: Frame): McpHandler[Map[String, String], PromptOutcome, E] =
+    )(using errorTag: ConcreteTag[E], frame: Frame): McpHandler[Map[String, String], PromptOutcome, E] =
         val meta = PromptMeta(
             name = name,
             description = if description.isEmpty then Absent else Present(description),
             arguments = arguments
         )
-        new PromptHandler[E](meta, handler, Chunk.empty)
+        new PromptHandler[E](meta, handler, Chunk.empty, declaredError(errorTag))
     end prompt
 
     /** Constructs a 1-arg completion handler (just the [[CompletionArg]]). The previously-filled
@@ -580,15 +635,15 @@ object McpHandler:
       */
     def completion(ref: CompletionRef)[E](
         handler: CompletionArg => CompletionOutcome < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using frame: Frame): McpHandler[CompletionArg, CompletionOutcome, E] =
-        new CompletionHandler[E](ref, (arg, _) => handler(arg), Chunk.empty)
+    )(using errorTag: ConcreteTag[E], frame: Frame): McpHandler[CompletionArg, CompletionOutcome, E] =
+        new CompletionHandler[E](ref, (arg, _) => handler(arg), Chunk.empty, declaredError(errorTag))
 
     /** Constructs a completion handler whose ref is read off a registered prompt handler value,
       * removing the third restatement of a prompt name.
       */
     def completion[In](promptHandler: McpHandler[In, PromptOutcome, ?])[E](
         handler: CompletionArg => CompletionOutcome < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using frame: Frame): McpHandler[CompletionArg, CompletionOutcome, E] =
+    )(using errorTag: ConcreteTag[E], frame: Frame): McpHandler[CompletionArg, CompletionOutcome, E] =
         completion(CompletionRef.Prompt(promptHandler.name))[E](handler)
 
     /** Constructs a 2-arg completion handler receiving `(arg, contextOpt)`. The `ref` argument
@@ -601,8 +656,8 @@ object McpHandler:
             CompletionArg,
             Maybe[CompletionArg.Context]
         ) => CompletionOutcome < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using frame: Frame): McpHandler[CompletionArg, CompletionOutcome, E] =
-        new CompletionHandler[E](ref, handler, Chunk.empty)
+    )(using errorTag: ConcreteTag[E], frame: Frame): McpHandler[CompletionArg, CompletionOutcome, E] =
+        new CompletionHandler[E](ref, handler, Chunk.empty, declaredError(errorTag))
 
     /** Constructs an arbitrary JSON-RPC method handler.
       *
@@ -613,8 +668,10 @@ object McpHandler:
         inSchema: Schema[In]
     )[Out, E](
         handler: In => Out < (Async & Abort[JsonRpcResponse.Halt | E])
-    )(using outSchema: Schema[Out], frame: Frame): McpHandler[In, Out, E] =
-        new CustomHandler[In, Out, E](method, inSchema, outSchema, handler, Chunk.empty)
+    )(using errorTag: ConcreteTag[E], outInferred: OutInferred[Out], outSchema: Schema[Out], frame: Frame): McpHandler[In, Out, E] =
+        val _ = outInferred
+        new CustomHandler[In, Out, E](method, inSchema, outSchema, handler, Chunk.empty, declaredError(errorTag))
+    end custom
 
     // --- Concrete handler carriers (internal) ---------------------------------
 
@@ -623,7 +680,8 @@ object McpHandler:
         val inSchema: Schema[In],
         val outSchema: Schema[Out],
         val toolHandler: In => Out < (Async & Abort[JsonRpcResponse.Halt | E]),
-        val errorMappings: Chunk[ErrorMapping[?]]
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val declaredErrorTag: Maybe[ConcreteTag[Any]] = Absent
     ) extends McpHandler[In, Out, E]:
         def name: String = toolMeta.name
         def kind: Kind   = Kind.Tool
@@ -634,7 +692,8 @@ object McpHandler:
                 inSchema,
                 outSchema,
                 toolHandler,
-                errorMappings.append(new ErrorMapping[E2](code, message))
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                declaredErrorTag
             )
 
         def error[E2](using ec: McpErrorCode[E2], schema: Schema[E2], tag: ConcreteTag[E2]): McpHandler[In, Out, E | E2] =
@@ -645,7 +704,8 @@ object McpHandler:
         val toolMeta: ToolMeta,
         val inSchema: Schema[In],
         val toolHandler: In => ToolOutcome < (Async & Abort[JsonRpcResponse.Halt | E]),
-        val errorMappings: Chunk[ErrorMapping[?]]
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val declaredErrorTag: Maybe[ConcreteTag[Any]] = Absent
     ) extends McpHandler[In, ToolOutcome, E]:
         def name: String = toolMeta.name
         def kind: Kind   = Kind.Tool
@@ -654,7 +714,13 @@ object McpHandler:
             schema: Schema[E2],
             tag: ConcreteTag[E2]
         )(code: Int, message: String): McpHandler[In, ToolOutcome, E | E2] =
-            new ToolMultiHandler[In, E | E2](toolMeta, inSchema, toolHandler, errorMappings.append(new ErrorMapping[E2](code, message)))
+            new ToolMultiHandler[In, E | E2](
+                toolMeta,
+                inSchema,
+                toolHandler,
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                declaredErrorTag
+            )
 
         def error[E2](using ec: McpErrorCode[E2], schema: Schema[E2], tag: ConcreteTag[E2]): McpHandler[In, ToolOutcome, E | E2] =
             error[E2](using schema, tag)(ec.code, ec.message)
@@ -664,7 +730,8 @@ object McpHandler:
         val resourceMeta: ResourceMeta,
         val subscribable: Boolean,
         val resourceHandler: () => Chunk[ResourceBody] < (Async & Abort[JsonRpcResponse.Halt | E]),
-        val errorMappings: Chunk[ErrorMapping[?]]
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val declaredErrorTag: Maybe[ConcreteTag[Any]] = Absent
     ) extends McpHandler[Unit, Chunk[ResourceBody], E]:
         def name: String = resourceMeta.name
         def kind: Kind   = Kind.Resource
@@ -677,7 +744,8 @@ object McpHandler:
                 resourceMeta,
                 subscribable,
                 resourceHandler,
-                errorMappings.append(new ErrorMapping[E2](code, message))
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                declaredErrorTag
             )
 
         def error[E2](using ec: McpErrorCode[E2], schema: Schema[E2], tag: ConcreteTag[E2]): McpHandler[Unit, Chunk[ResourceBody], E | E2] =
@@ -689,7 +757,8 @@ object McpHandler:
         val resourceTemplateHandler: ResourceMatch => Chunk[
             ResourceBody
         ] < (Async & Abort[JsonRpcResponse.Halt | E]),
-        val errorMappings: Chunk[ErrorMapping[?]]
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val declaredErrorTag: Maybe[ConcreteTag[Any]] = Absent
     ) extends McpHandler[ResourceMatch, Chunk[ResourceBody], E]:
         def name: String = resourceTemplateMeta.name
         def kind: Kind   = Kind.ResourceTemplate
@@ -701,7 +770,8 @@ object McpHandler:
             new ResourceTemplateHandler[E | E2](
                 resourceTemplateMeta,
                 resourceTemplateHandler,
-                errorMappings.append(new ErrorMapping[E2](code, message))
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                declaredErrorTag
             )
 
         def error[E2](using
@@ -715,7 +785,8 @@ object McpHandler:
     final private[kyo] class PromptHandler[+E] private[kyo] (
         val promptMeta: PromptMeta,
         val promptHandler: Map[String, String] => PromptOutcome < (Async & Abort[JsonRpcResponse.Halt | E]),
-        val errorMappings: Chunk[ErrorMapping[?]]
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val declaredErrorTag: Maybe[ConcreteTag[Any]] = Absent
     ) extends McpHandler[Map[String, String], PromptOutcome, E]:
         def name: String = promptMeta.name
         def kind: Kind   = Kind.Prompt
@@ -724,7 +795,12 @@ object McpHandler:
             schema: Schema[E2],
             tag: ConcreteTag[E2]
         )(code: Int, message: String): McpHandler[Map[String, String], PromptOutcome, E | E2] =
-            new PromptHandler[E | E2](promptMeta, promptHandler, errorMappings.append(new ErrorMapping[E2](code, message)))
+            new PromptHandler[E | E2](
+                promptMeta,
+                promptHandler,
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                declaredErrorTag
+            )
 
         def error[E2](using
             ec: McpErrorCode[E2],
@@ -738,7 +814,8 @@ object McpHandler:
         val promptMeta: PromptMeta,
         val inSchema: Schema[In],
         val typedPromptHandler: In => PromptOutcome < (Async & Abort[JsonRpcResponse.Halt | E]),
-        val errorMappings: Chunk[ErrorMapping[?]]
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val declaredErrorTag: Maybe[ConcreteTag[Any]] = Absent
     ) extends McpHandler[In, PromptOutcome, E]:
         def name: String = promptMeta.name
         def kind: Kind   = Kind.Prompt
@@ -751,7 +828,8 @@ object McpHandler:
                 promptMeta,
                 inSchema,
                 typedPromptHandler,
-                errorMappings.append(new ErrorMapping[E2](code, message))
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                declaredErrorTag
             )
 
         def error[E2](using ec: McpErrorCode[E2], schema: Schema[E2], tag: ConcreteTag[E2]): McpHandler[In, PromptOutcome, E | E2] =
@@ -764,7 +842,8 @@ object McpHandler:
             CompletionArg,
             Maybe[CompletionArg.Context]
         ) => CompletionOutcome < (Async & Abort[JsonRpcResponse.Halt | E]),
-        val errorMappings: Chunk[ErrorMapping[?]]
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val declaredErrorTag: Maybe[ConcreteTag[Any]] = Absent
     ) extends McpHandler[CompletionArg, CompletionOutcome, E]:
         def name: String = ref match
             case CompletionRef.Prompt(n)   => s"completion/prompt/$n"
@@ -775,7 +854,12 @@ object McpHandler:
             schema: Schema[E2],
             tag: ConcreteTag[E2]
         )(code: Int, message: String): McpHandler[CompletionArg, CompletionOutcome, E | E2] =
-            new CompletionHandler[E | E2](ref, completionHandler, errorMappings.append(new ErrorMapping[E2](code, message)))
+            new CompletionHandler[E | E2](
+                ref,
+                completionHandler,
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                declaredErrorTag
+            )
 
         def error[E2](using
             ec: McpErrorCode[E2],
@@ -790,7 +874,8 @@ object McpHandler:
         val inSchema: Schema[In],
         val outSchema: Schema[Out],
         val customHandler: In => Out < (Async & Abort[JsonRpcResponse.Halt | E]),
-        val errorMappings: Chunk[ErrorMapping[?]]
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val declaredErrorTag: Maybe[ConcreteTag[Any]] = Absent
     ) extends McpHandler[In, Out, E]:
         def name: String = method
         def kind: Kind   = Kind.Custom
@@ -801,7 +886,8 @@ object McpHandler:
                 inSchema,
                 outSchema,
                 customHandler,
-                errorMappings.append(new ErrorMapping[E2](code, message))
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                declaredErrorTag
             )
 
         def error[E2](using ec: McpErrorCode[E2], schema: Schema[E2], tag: ConcreteTag[E2]): McpHandler[In, Out, E | E2] =

--- a/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpBuiltInRoutes.scala
+++ b/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpBuiltInRoutes.scala
@@ -70,18 +70,16 @@ private[kyo] object McpBuiltInRoutes:
     // Wire shape for resources/subscribe and resources/unsubscribe.
     final private case class ResourceSubscribeParams(uri: String) derives Schema
 
-    // Reads the live server from the forward reference for binding into Mcp.local.
+    // Waits for the live server before binding it into Mcp.local. See McpHandlerLift.withCtx: reading a
+    // slot that the dispatch loop can outrun is what produced a -32603 "handler panicked" for a request
+    // that merely arrived early.
     private def withCtx[A, S](
         jrCtx: JsonRpcRoute.Context,
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]],
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any],
         method: String
-    )(body: => A < S)(using Frame): A < S =
-        // Unsafe: synchronous read of forward server reference.
-        serverRef.unsafe.get()(using AllowUnsafe.embrace.danger) match
-            case Present(srv) =>
-                Mcp.local.let(Present(Mcp.RequestContext(jrCtx, srv.safe)))(body)
-            case Absent =>
-                throw new IllegalStateException(s"McpServer not initialised for '$method'")
+    )(body: => A < S)(using Frame): A < (S & Async) =
+        val _ = method
+        serverRef.get.map(srv => Mcp.local.let(Present(Mcp.RequestContext(jrCtx, srv.safe)))(body))
     end withCtx
 
     def toolsList(catalog: McpCatalog)(using Frame): JsonRpcRoute[?, ?, ?] =
@@ -91,7 +89,7 @@ private[kyo] object McpBuiltInRoutes:
             ToolsListResult(page, next)
         }
 
-    def toolsCall(catalog: McpCatalog, serverRef: AtomicRef[Maybe[McpServer.Unsafe]])(using Frame): JsonRpcRoute[?, ?, ?] =
+    def toolsCall(catalog: McpCatalog, serverRef: Fiber.Promise[McpServer.Unsafe, Any])(using Frame): JsonRpcRoute[?, ?, ?] =
         JsonRpcRoute.request[ToolCallParams, McpHandler.ToolOutcome]("tools/call") { (params, jrCtx) =>
             val matchedTool = catalog.toolHandlers.collectFirst {
                 case c: McpHandler.ToolHandler[?, ?, ?] if c.name == params.name =>
@@ -152,7 +150,7 @@ private[kyo] object McpBuiltInRoutes:
             ResourcesListResult(page, next)
         }
 
-    def resourcesRead(catalog: McpCatalog, serverRef: AtomicRef[Maybe[McpServer.Unsafe]])(using Frame): JsonRpcRoute[?, ?, ?] =
+    def resourcesRead(catalog: McpCatalog, serverRef: Fiber.Promise[McpServer.Unsafe, Any])(using Frame): JsonRpcRoute[?, ?, ?] =
         JsonRpcRoute.request[ResourceReadParams, ResourceReadResponse]("resources/read") { (params, jrCtx) =>
             val parsedUri = McpResourceUri.parse(params.uri)
             parsedUri match
@@ -222,7 +220,7 @@ private[kyo] object McpBuiltInRoutes:
             PromptsListResult(page, next)
         }
 
-    def promptsGet(catalog: McpCatalog, serverRef: AtomicRef[Maybe[McpServer.Unsafe]])(using Frame): JsonRpcRoute[?, ?, ?] =
+    def promptsGet(catalog: McpCatalog, serverRef: Fiber.Promise[McpServer.Unsafe, Any])(using Frame): JsonRpcRoute[?, ?, ?] =
         JsonRpcRoute.request[PromptGetParams, McpHandler.PromptOutcome]("prompts/get") { (params, jrCtx) =>
             val matchedRaw = catalog.promptHandlers.collectFirst {
                 case c: McpHandler.PromptHandler[?] if c.name == params.name => c
@@ -283,7 +281,7 @@ private[kyo] object McpBuiltInRoutes:
                     subs.getAndUpdate(_ - uri).andThen(SetLogLevelResult())
         }
 
-    def completionComplete(catalog: McpCatalog, serverRef: AtomicRef[Maybe[McpServer.Unsafe]])(using Frame): JsonRpcRoute[?, ?, ?] =
+    def completionComplete(catalog: McpCatalog, serverRef: Fiber.Promise[McpServer.Unsafe, Any])(using Frame): JsonRpcRoute[?, ?, ?] =
         JsonRpcRoute.request[CompleteParams, CompleteResult]("completion/complete") { (params, jrCtx) =>
             // Look up a registered completion handler matching params.ref; fall back to empty (non-fatal per spec).
             val matched = catalog.completionHandlers.collectFirst {

--- a/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpClientEngine.scala
+++ b/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpClientEngine.scala
@@ -85,9 +85,13 @@ private[kyo] object McpClientEngine:
         val serverCapabilitiesRef = AtomicRef.Unsafe.init[Maybe[McpCapabilities.Server]](Absent)(using AllowUnsafe.embrace.danger).safe
         val serverInfoRef         = AtomicRef.Unsafe.init[Maybe[McpInfo]](Absent)(using AllowUnsafe.embrace.danger).safe
         val negotiatedVersionRef  = AtomicRef.Unsafe.init[Maybe[McpConfig.ProtocolVersion]](Absent)(using AllowUnsafe.embrace.danger).safe
-        // Unsafe: forward reference holding the sentinel "server" used to bind into Mcp.local
-        // during client-side reverse-direction dispatch.
-        val serverRef = AtomicRef.Unsafe.init[Maybe[McpServer.Unsafe]](Absent)(using AllowUnsafe.embrace.danger).safe
+        // Forward reference holding the sentinel "server" used to bind into Mcp.local during
+        // client-side reverse-direction dispatch. A promise for the same reason as the server engine's:
+        // it is completed after the handler is built, by which time dispatch is already running, so an
+        // early reverse request must wait rather than find it missing. Unsafe: constructed outside an
+        // effect, like the sibling ref above.
+        val serverRef =
+            Fiber.Promise.Unsafe.init[McpServer.Unsafe, Any]()(using AllowUnsafe.embrace.danger).safe
 
         val reverseRoutes = McpReverseDispatch.buildRoutes(handlers, capabilities, serverRef)
 
@@ -125,7 +129,7 @@ private[kyo] object McpClientEngine:
                 // reverse-direction handlers can still bind a context into Mcp.local without panic.
                 // Unsafe: synchronous write of forward reference immediately after construction.
                 val sentinelServer = buildClientSentinelServer(handler)
-                serverRef.unsafe.set(Present(sentinelServer))(using AllowUnsafe.embrace.danger)
+                serverRef.unsafe.completeDiscard(Result.succeed(sentinelServer))(using AllowUnsafe.embrace.danger)
                 unsafe
         )
     end initClient
@@ -137,7 +141,7 @@ private[kyo] object McpClientEngine:
       * peer in client mode), so we provide a sentinel that aborts with a clear error if a handler
       * accidentally reaches into `Mcp.server` for a reverse-direction call.
       * The handler itself must not call `ctx.server`; this sentinel exists solely to satisfy the
-      * carrier's serverRef requirement and avoid IllegalStateException during dispatch.
+      * carrier's serverRef requirement so reverse dispatch has something to bind.
       */
     private def buildClientSentinelServer(handler: JsonRpcHandler): McpServer.Unsafe =
         new McpServer.Unsafe:

--- a/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpClientHandlerLift.scala
+++ b/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpClientHandlerLift.scala
@@ -13,7 +13,7 @@ private[kyo] object McpClientHandlerLift:
 
     def liftRequest[In, Out, E](
         c: McpClientHandler.RequestCarrier[In, Out, E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         if c.method == "roots/list" then
             // onRoots returns Chunk[Root]; wrap in the wire envelope the route decodes.
@@ -33,7 +33,7 @@ private[kyo] object McpClientHandlerLift:
 
     def liftNotification[In, E](
         c: McpClientHandler.NotificationCarrier[In, E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         given Schema[In] = c.inSchema
         JsonRpcRoute.notification[In](c.method) { (in, jrCtx) =>

--- a/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpEngine.scala
+++ b/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpEngine.scala
@@ -35,9 +35,13 @@ private[kyo] object McpEngine:
         val logLevelRef = AtomicRef.Unsafe.init[McpServer.LogLevel](McpServer.LogLevel.Info)(using AllowUnsafe.embrace.danger).safe
         // Unsafe: AtomicRef for resource subscription set; initialized to empty per §3.4.
         val subscriptionsRef = AtomicRef.Unsafe.init[Set[McpResourceUri]](Set.empty)(using AllowUnsafe.embrace.danger).safe
-        // Unsafe: forward reference holding the live McpServer.Unsafe so each dispatch can
-        // bind it into Mcp.local. Populated synchronously after JsonRpcHandler.initUnscoped completes.
-        val serverRef = AtomicRef.Unsafe.init[Maybe[McpServer.Unsafe]](Absent)(using AllowUnsafe.embrace.danger).safe
+        // Forward reference holding the live McpServer.Unsafe so each dispatch can bind it into
+        // Mcp.local. A promise rather than a slot: it is completed right after JsonRpcHandler.initUnscoped
+        // returns, but that call has already started the dispatch loop, so a request arriving in between
+        // must WAIT for the server rather than find it missing. Unsafe: constructed outside an effect,
+        // like the sibling refs above.
+        val serverRef =
+            Fiber.Promise.Unsafe.init[McpServer.Unsafe, Any]()(using AllowUnsafe.embrace.danger).safe
 
         val catalog = McpCatalog(userHandlers)
 
@@ -52,6 +56,32 @@ private[kyo] object McpEngine:
                         s"handler '${h.name}'.error",
                         s"error code ${m.code} falls in the framework-reserved range [-32003, -32000]; use codes outside that range"
                     )
+            }
+        }
+
+        // A handler whose body aborts a type no `.error[E2]` covers cannot answer that failure: the
+        // engine reaches its unmapped-error path and the peer gets a -32603 carrying the exception's
+        // `toString`, which leaks whatever the exception carries (a query, a connection id) inside a code
+        // the model cannot discriminate. The information to refuse it is available here, so the handler
+        // is rejected before the transport opens, the same class of programmer error as the reserved-code
+        // check above and reported the same way.
+        userHandlers.foreach { h =>
+            h.declaredErrorTag.foreach { declared =>
+                errorLeaves(declared).foreach { leaf =>
+                    // A leaf that is already a JsonRpcError carries its own code and message, and the
+                    // dispatch boundary forwards it as-is rather than taking the unmapped path. Requiring
+                    // a mapping for it would refuse the handlers that abort `McpToolExecutionException`
+                    // and friends, which are exactly the ones that already answer correctly. This mirrors
+                    // the runtime branch in `JsonRpcRoute.applyMappingsAtBoundary`.
+                    val wireShaped = leaf <:< jsonRpcErrorTag
+                    if !wireShaped && !h.errorMappings.exists(m => leaf <:< m.tag.asInstanceOf[ConcreteTag[Any]]) then
+                        throw McpConfigurationError(
+                            s"handler '${h.name}'",
+                            s"the handler body can abort ${leaf.showType}, which no `.error[...]` maps to a wire code; " +
+                                s"register a mapping for it, or handle it inside the body"
+                        )
+                    end if
+                }
             }
         }
 
@@ -324,11 +354,25 @@ private[kyo] object McpEngine:
 
             end unsafe
 
-            // Publish the live server into the forward reference so each dispatch can bind it into
-            // Mcp.local. Unsafe: synchronous write of forward reference immediately after construction.
-            serverRef.unsafe.set(Present(unsafe))(using AllowUnsafe.embrace.danger)
+            // Publish the live server, releasing any dispatch already waiting on it. Unsafe: synchronous
+            // completion of the forward reference immediately after construction.
+            serverRef.unsafe.completeDiscard(Result.succeed(unsafe))(using AllowUnsafe.embrace.danger)
             unsafe
         }
     end initServer
+
+    /** The individual abort types inside a declared error tag.
+      *
+      * `ConcreteTag` models a union structurally, so `A | B` decomposes into its members and anything
+      * else is a single leaf. Nested unions are flattened, since a body row can be built up in stages.
+      */
+    private val jsonRpcErrorTag: ConcreteTag[Any] =
+        summon[ConcreteTag[JsonRpcError]].asInstanceOf[ConcreteTag[Any]]
+
+    private def errorLeaves(tag: ConcreteTag[Any]): Chunk[ConcreteTag[Any]] =
+        tag match
+            case ConcreteTag.Union(elements) => Chunk.from(elements).flatMap(errorLeaves)
+            case ConcreteTag.NothingTag      => Chunk.empty
+            case other                       => Chunk(other)
 
 end McpEngine

--- a/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpHandlerLift.scala
+++ b/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpHandlerLift.scala
@@ -16,7 +16,7 @@ private[kyo] object McpHandlerLift:
 
     def lift(
         handler: McpHandler[?, ?, ?],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         val base: JsonRpcRoute[?, ?, ?] = handler match
             case h: McpHandler.ToolHandler[?, ?, ?]       => liftTool(h, serverRef)
@@ -43,35 +43,28 @@ private[kyo] object McpHandlerLift:
         base.asInstanceOf[JsonRpcRoute[Any, Any, Nothing]].error[E](m.code, m.message)
     end applyOne
 
-    // Reads the live server from the forward reference. Returns Absent before init completes (impossible
-    // during a real dispatch because the engine writes the ref before any handler runs).
-    private def readServer(serverRef: AtomicRef[Maybe[McpServer.Unsafe]]): Maybe[McpServer.Unsafe] =
-        // Unsafe: synchronous read of forward server reference.
-        serverRef.unsafe.get()(using AllowUnsafe.embrace.danger)
-
     // Exposed for the client-side McpClientHandlerLift to reuse the same context binding.
     private[kyo] def bindClientCtx[A, S](
         jrCtx: JsonRpcRoute.Context,
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
-    )(body: => A < S)(using Frame): A < S =
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
+    )(body: => A < S)(using Frame): A < (S & Async) =
         withCtx(jrCtx, serverRef)(body)
 
+    // Waits for the live server rather than reading a slot that may not be filled yet. The engine
+    // completes the forward reference immediately after construction, but the dispatch loop is already
+    // running by then, so a request that arrives in that window used to find the slot empty and was
+    // answered with a -32603 "handler panicked" naming a handler that had not been called. Waiting makes
+    // the window unobservable: the wait is over as soon as the server exists, which is at once.
     private def withCtx[A, S](
         jrCtx: JsonRpcRoute.Context,
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
-    )(body: => A < S)(using Frame): A < S =
-        readServer(serverRef) match
-            case Present(srv) =>
-                Mcp.local.let(Present(Mcp.RequestContext(jrCtx, srv.safe)))(body)
-            case Absent =>
-                // The engine populates serverRef synchronously after construction; this can only fire
-                // if a dispatch races initialisation. Surface as a panic so it shows up loudly.
-                throw new IllegalStateException(s"McpServer not initialised for route '${jrCtx.requestId}'")
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
+    )(body: => A < S)(using Frame): A < (S & Async) =
+        serverRef.get.map(srv => Mcp.local.let(Present(Mcp.RequestContext(jrCtx, srv.safe)))(body))
     end withCtx
 
     private def liftTool[In, Out, E](
         h: McpHandler.ToolHandler[In, Out, E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         given Schema[Out] = h.outSchema
         JsonRpcRoute.request[In, McpHandler.ToolOutcome](h.name) { (in, jrCtx) =>
@@ -89,7 +82,7 @@ private[kyo] object McpHandlerLift:
 
     private def liftToolMulti[In, E](
         h: McpHandler.ToolMultiHandler[In, E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         JsonRpcRoute.request[In, McpHandler.ToolOutcome](h.name) { (in, jrCtx) =>
             withCtx(jrCtx, serverRef)(h.toolHandler(in))
@@ -97,7 +90,7 @@ private[kyo] object McpHandlerLift:
 
     private def liftResource[E](
         h: McpHandler.ResourceHandler[E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         val registeredUri  = h.resourceMeta.uri
         val registeredMime = h.resourceMeta.mimeType
@@ -110,7 +103,7 @@ private[kyo] object McpHandlerLift:
 
     private def liftResourceTemplate[E](
         h: McpHandler.ResourceTemplateHandler[E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         val template = h.resourceTemplateMeta.uriTemplate
         val regMime  = h.resourceTemplateMeta.mimeType
@@ -137,7 +130,7 @@ private[kyo] object McpHandlerLift:
 
     private def liftTypedPrompt[In, E](
         h: McpHandler.TypedPromptHandler[In, E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         given Schema[In] = h.inSchema
         JsonRpcRoute.request[Map[String, String], McpHandler.PromptOutcome](h.name) { (args, jrCtx) =>
@@ -152,7 +145,7 @@ private[kyo] object McpHandlerLift:
 
     private def liftPrompt[E](
         h: McpHandler.PromptHandler[E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         JsonRpcRoute.request[Map[String, String], McpHandler.PromptOutcome](h.name) { (args, jrCtx) =>
             withCtx(jrCtx, serverRef)(h.promptHandler(args))
@@ -160,7 +153,7 @@ private[kyo] object McpHandlerLift:
 
     private def liftCompletion[E](
         h: McpHandler.CompletionHandler[E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         JsonRpcRoute.request[(McpHandler.CompletionRef, McpHandler.CompletionArg), McpHandler.CompletionOutcome](h.name) {
             (pair, jrCtx) => withCtx(jrCtx, serverRef)(h.completionHandler(pair._2, Absent))
@@ -168,7 +161,7 @@ private[kyo] object McpHandlerLift:
 
     private def liftCustom[In, Out, E](
         h: McpHandler.CustomHandler[In, Out, E],
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): JsonRpcRoute[?, ?, ?] =
         JsonRpcRoute.request[In, Out](h.method) { (in, jrCtx) =>
             withCtx(jrCtx, serverRef)(h.customHandler(in))

--- a/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpReverseDispatch.scala
+++ b/kyo-mcp/shared/src/main/scala/kyo/internal/mcp/McpReverseDispatch.scala
@@ -34,7 +34,7 @@ private[kyo] object McpReverseDispatch:
     def buildRoutes(
         userHandlers: Seq[McpClientHandler[?, ?, ?]],
         clientCapabilities: McpCapabilities.Client,
-        serverRef: AtomicRef[Maybe[McpServer.Unsafe]]
+        serverRef: Fiber.Promise[McpServer.Unsafe, Any]
     )(using Frame): Seq[JsonRpcRoute[?, ?, ?]] =
         val samplingRoute    = buildSamplingRoute(clientCapabilities)
         val rootsRoute       = buildRootsRoute(clientCapabilities)

--- a/kyo-mcp/shared/src/test/scala/kyo/McpHandlerErrorMessageTest.scala
+++ b/kyo-mcp/shared/src/test/scala/kyo/McpHandlerErrorMessageTest.scala
@@ -1,0 +1,106 @@
+package kyo
+
+import scala.compiletime.testing.typeCheckErrors
+
+/** Pins the compile errors a handler author actually reads.
+  *
+  * A handler body is the one place a user writes an effect row that the factory then closes, so the error
+  * it produces when the row does not fit is this module's most-read diagnostic. It has to name the
+  * offending effect and nothing else. A second, unrelated error sends a cold reader hunting a problem that
+  * does not exist, and readers who work bottom-up start at that one.
+  */
+class McpHandlerErrorMessageTest extends Test:
+
+    case class Query(city: String) derives Schema, CanEqual
+    case class Report(summary: String) derives Schema, CanEqual
+
+    /** True when the errors blame the `Schema[Out]` search, which is the phantom this guards against.
+      *
+      * `Out` degrades to `Any` when the body fails, and an unguarded search then matches several
+      * primitive `Schema` givens at once. The instances named are whichever two the search reached
+      * first, so the check is on the shape of the complaint, not on a particular pair.
+      */
+    private def blamesOutputSchema(errors: List[String]): Boolean =
+        errors.exists(e => e.contains("Ambiguous given instances") && e.contains("Schema[Out]"))
+
+    "a tool body carrying an undischarged Env" - {
+        inline def errors: List[String] =
+            typeCheckErrors(
+                """
+                McpHandler.tool[Query]("weather") { in =>
+                    Env.use[Int](n => Report(s"${in.city}:$n"))
+                }
+                """
+            ).map(_.message)
+
+        "names the effect row that does not fit" in {
+            assert(
+                errors.exists(e => e.contains("kyo.Env") && e.contains("JsonRpcResponse.Halt")),
+                s"the offending effect must be named; errors were:\n${errors.mkString("\n--\n")}"
+            )
+        }
+
+        "does not blame the output schema search" in {
+            assert(!blamesOutputSchema(errors), s"phantom ambiguity reported; errors were:\n${errors.mkString("\n--\n")}")
+        }
+
+        "points the author at the body rather than at a missing instance" in {
+            assert(
+                errors.exists(_.contains("could not be inferred")),
+                s"the author must be told why the output type is unknown; errors were:\n${errors.mkString("\n--\n")}"
+            )
+        }
+    }
+
+    "a tool body carrying an undischarged Var does not blame the output schema search" in {
+        val errors =
+            typeCheckErrors(
+                """
+                McpHandler.tool[Query]("weather") { in =>
+                    Var.use[Int](n => Report(s"${in.city}:$n"))
+                }
+                """
+            ).map(_.message)
+        assert(errors.exists(_.contains("kyo.Var")), s"errors were:\n${errors.mkString("\n--\n")}")
+        assert(!blamesOutputSchema(errors), s"phantom ambiguity reported; errors were:\n${errors.mkString("\n--\n")}")
+    }
+
+    "a tool body referencing an undefined symbol reports that symbol" in {
+        // The worst shape before the guard: the phantom ambiguity was the ONLY error reported, so the
+        // undefined name never reached the author at all.
+        val errors =
+            typeCheckErrors(
+                """
+                McpHandler.tool[Query]("weather") { in =>
+                    noSuchFunction(in)
+                }
+                """
+            ).map(_.message)
+        assert(
+            errors.exists(_.contains("noSuchFunction")),
+            s"the real error must survive; errors were:\n${errors.mkString("\n--\n")}"
+        )
+        assert(!blamesOutputSchema(errors), s"phantom ambiguity reported; errors were:\n${errors.mkString("\n--\n")}")
+    }
+
+    "a custom handler body carrying an undischarged effect does not blame the output schema search" in {
+        val errors =
+            typeCheckErrors(
+                """
+                McpHandler.custom[Query]("weather") { in =>
+                    Env.use[Int](n => Report(s"${in.city}:$n"))
+                }
+                """
+            ).map(_.message)
+        assert(!blamesOutputSchema(errors), s"phantom ambiguity reported; errors were:\n${errors.mkString("\n--\n")}")
+    }
+
+    "a well-formed tool still builds, so the guard costs a correct handler nothing" in {
+        // Compiled normally rather than through `typeCheckErrors`, which cannot derive a `Frame` inside
+        // the kyo package. The rest of this module's suite is the broader positive control: it builds
+        // handlers in around thirty files and would stop compiling if the guard rejected a good one.
+        val handler = McpHandler.tool[Query]("weather", "Current conditions")(in => Report(in.city))
+        assert(handler.name == "weather")
+    }
+
+end McpHandlerErrorMessageTest

--- a/kyo-mcp/shared/src/test/scala/kyo/McpServerErrorMappingTest.scala
+++ b/kyo-mcp/shared/src/test/scala/kyo/McpServerErrorMappingTest.scala
@@ -1,0 +1,133 @@
+package kyo
+
+/** Covers the startup check on `.error[E]` coverage.
+  *
+  * A handler body's abort type is absorbed into `E` whether or not a mapping exists for it, so an
+  * unmapped one used to be invisible: nothing complained at compile time or at `McpServer.init`, and the
+  * gap surfaced a round trip later as a `-32603` carrying the exception's `toString`. That leaks whatever
+  * the exception carries (a query, a connection id) inside a code the caller cannot discriminate from a
+  * genuine server fault. The engine has the information to refuse the handler at startup, so it does.
+  *
+  * The fixtures all return a value on their success path. A body that ONLY aborts leaves `Out`
+  * uninferred, since Scala widens `Nothing` to `Any`, and the output-type guard refuses that with its
+  * own message: such a handler has no output schema to advertise, so it has to name its return type.
+  */
+class McpServerErrorMappingTest extends Test:
+
+    case class Query(sql: String) derives Schema, CanEqual
+    case class Rows(count: Int) derives Schema, CanEqual
+
+    case class QueryFailed(reason: String) derives Schema, CanEqual
+    case class Denied(who: String) derives Schema, CanEqual
+
+    /** A domain failure hierarchy, for the supertype-mapping case. */
+    sealed abstract class StoreFailure(val detail: String)
+    case class StoreOffline(override val detail: String) extends StoreFailure(detail)
+
+    private def startup(handlers: McpHandler[?, ?, ?]*)(using Frame): Result[Throwable, Unit] < (Async & Scope) =
+        JsonRpcTransport.inMemory.map { (serverSide, _) =>
+            Abort.run[Throwable](McpServer.init(serverSide, handlers*).unit)
+        }
+
+    private def refusal(result: Result[Throwable, Unit]): String =
+        result match
+            case Result.Failure(ex) => ex.getMessage
+            case Result.Panic(ex)   => ex.getMessage
+            case Result.Success(_)  => "<accepted>"
+
+    "a handler whose body aborts an unmapped error is refused at init" in {
+        val handler =
+            McpHandler.tool[Query]("run_select", "Run a query") { q =>
+                if q.sql.isEmpty then Abort.fail(QueryFailed("empty query")) else Rows(q.sql.length)
+            }
+        Scope.run(startup(handler)).map { result =>
+            val message = refusal(result)
+            assert(result.isSuccess == false, s"the handler must be refused; got: $message")
+            assert(message.contains("QueryFailed"), s"the refusal must name the unmapped type; got: $message")
+            assert(message.contains("run_select"), s"the refusal must name the handler; got: $message")
+            assert(message.contains("error"), s"the refusal must point at `.error`; got: $message")
+        }
+    }
+
+    "the same handler with the mapping registered starts" in {
+        // The control: the check must not refuse a correct handler.
+        val handler =
+            McpHandler.tool[Query]("run_select", "Run a query") { q =>
+                if q.sql.isEmpty then Abort.fail(QueryFailed("empty query")) else Rows(q.sql.length)
+            }.error[QueryFailed](-40001, "query-failed")
+        Scope.run(startup(handler)).map { result =>
+            assert(result.isSuccess, s"a mapped handler must start; got: ${refusal(result)}")
+        }
+    }
+
+    "a handler that aborts nothing starts" in {
+        val handler = McpHandler.tool[Query]("run_select", "Run a query")(q => Rows(q.sql.length))
+        Scope.run(startup(handler)).map { result =>
+            assert(result.isSuccess, s"a handler with no declared error must start; got: ${refusal(result)}")
+        }
+    }
+
+    "a mapping on a supertype covers a subtype the body aborts" in {
+        val handler =
+            McpHandler.tool[Query]("run_select", "Run a query") { q =>
+                if q.sql.isEmpty then Abort.fail(StoreOffline("no route to host")) else Rows(q.sql.length)
+            }.error[StoreFailure](-40002, "store-failure")
+        Scope.run(startup(handler)).map { result =>
+            assert(result.isSuccess, s"a supertype mapping must cover the leaf; got: ${refusal(result)}")
+        }
+    }
+
+    "a union body error with only one leaf mapped is refused, naming the leaf that is missing" in {
+        val handler =
+            McpHandler.tool[Query]("run_select", "Run a query") { q =>
+                if q.sql.isEmpty then Abort.fail(QueryFailed("empty query"))
+                else if q.sql == "denied" then Abort.fail(Denied("nobody"))
+                else Rows(q.sql.length)
+            }.error[QueryFailed](-40001, "query-failed")
+        Scope.run(startup(handler)).map { result =>
+            val message = refusal(result)
+            assert(result.isSuccess == false, s"the handler must be refused; got: $message")
+            assert(message.contains("Denied"), s"the refusal must name the UNMAPPED leaf; got: $message")
+        }
+    }
+
+    "a union body error with every leaf mapped starts" in {
+        val handler =
+            McpHandler.tool[Query]("run_select", "Run a query") { q =>
+                if q.sql.isEmpty then Abort.fail(QueryFailed("empty query"))
+                else if q.sql == "denied" then Abort.fail(Denied("nobody"))
+                else Rows(q.sql.length)
+            }.error[QueryFailed](-40001, "query-failed")
+                .error[Denied](-40002, "denied")
+        Scope.run(startup(handler)).map { result =>
+            assert(result.isSuccess, s"every leaf is mapped, so it must start; got: ${refusal(result)}")
+        }
+    }
+
+    "a body aborting an McpException needs no mapping" in {
+        // Already wire-shaped: it carries its own code and message, and the dispatch boundary forwards
+        // it rather than taking the unmapped path, so requiring a mapping would refuse exactly the
+        // handlers that already answer correctly.
+        val handler =
+            McpHandler.toolRaw[Query]("run_select") { _ =>
+                Abort.fail(McpToolExecutionException(tool = "run_select", reason = "upstream refused"))
+            }
+        Scope.run(startup(handler)).map { result =>
+            assert(result.isSuccess, s"a wire-shaped error needs no mapping; got: ${refusal(result)}")
+        }
+    }
+
+    "a reserved-range error code is still refused" in {
+        // The sibling check this one is modelled on, pinned here because nothing else covered it.
+        val handler =
+            McpHandler.tool[Query]("run_select", "Run a query") { q =>
+                if q.sql.isEmpty then Abort.fail(QueryFailed("empty query")) else Rows(q.sql.length)
+            }.error[QueryFailed](-32001, "query-failed")
+        Scope.run(startup(handler)).map { result =>
+            val message = refusal(result)
+            assert(result.isSuccess == false, s"a reserved code must be refused; got: $message")
+            assert(message.contains("reserved"), s"the refusal must say why; got: $message")
+        }
+    }
+
+end McpServerErrorMappingTest

--- a/kyo-mcp/shared/src/test/scala/kyo/integration/McpServerEarlyRequestTest.scala
+++ b/kyo-mcp/shared/src/test/scala/kyo/integration/McpServerEarlyRequestTest.scala
@@ -1,0 +1,106 @@
+package kyo.integration
+
+import kyo.*
+
+/** A request that arrives before the server finishes wiring itself must still be served.
+  *
+  * The engine builds the live `McpServer` only after `JsonRpcHandler.initUnscoped` returns, and that call
+  * has already started the dispatch loop. A request arriving in between used to find the forward
+  * reference empty and be answered with `-32603 "Handler 'tools/call' panicked: McpServer not initialised
+  * for 'tools/call'"`, which sends the author hunting a bug in a handler that was never called, and which
+  * a well-behaved client can still provoke by pipelining.
+  *
+  * Every burst here is queued on the transport BEFORE the server is created, so the dispatch loop starts
+  * with work already waiting.
+  *
+  * Read what this suite is and is not. It pins the CONTRACT (a pipelined call is served, and no response
+  * ever blames a handler that was not called), and it is a genuine regression guard for that. It does NOT
+  * reproduce the underlying race: with the pre-fix read restored, these tests still pass, because the
+  * engine publishes the server before the dispatch fiber is scheduled on this runtime. The race was
+  * reported on Native, whose scheduler makes different choices. Widening the window from outside the
+  * engine is not possible, so the evidence for the fix is structural rather than empirical: dispatch now
+  * waits on the reference, and the code that could answer "McpServer not initialised" no longer exists.
+  */
+class McpServerEarlyRequestTest extends Test:
+
+    case class Query(sql: String) derives Schema, CanEqual
+    case class Rows(count: Int) derives Schema, CanEqual
+
+    private val protocolVersion = "2025-06-18"
+
+    private def initializeParams: Structure.Value =
+        Structure.Value.Record(Chunk(
+            "protocolVersion" -> Structure.Value.Str(protocolVersion),
+            "capabilities"    -> Structure.Value.Record(Chunk.empty),
+            "clientInfo" -> Structure.Value.Record(Chunk(
+                "name"    -> Structure.Value.Str("early-client"),
+                "version" -> Structure.Value.Str("0.0.0")
+            ))
+        ))
+
+    private def callParams: Structure.Value =
+        Structure.Value.Record(Chunk(
+            "name" -> Structure.Value.Str("run_select"),
+            "arguments" -> Structure.Value.Record(Chunk(
+                "sql" -> Structure.Value.Str("select 1")
+            ))
+        ))
+
+    private val tool =
+        McpHandler.tool[Query]("run_select", "Run a query")(q => Rows(q.sql.length))
+
+    /** Queues the whole burst, starts the server, and returns the responses it sent back. */
+    private def burst(using Frame): Chunk[JsonRpcResponse] < (Async & Scope & Abort[Closed | McpException]) =
+        JsonRpcTransport.inMemory.flatMap { (serverSide, clientSide) =>
+            for
+                // Pipelined, with no wait for the initialize response: the burst is already sitting on
+                // the transport when the dispatch loop starts.
+                _         <- clientSide.send(JsonRpcRequest(JsonRpcId.Num(1), "initialize", Present(initializeParams), Absent))
+                _         <- clientSide.send(JsonRpcNotification("notifications/initialized", Absent, Absent))
+                _         <- clientSide.send(JsonRpcRequest(JsonRpcId.Num(2), "tools/call", Present(callParams), Absent))
+                _         <- McpServer.init(serverSide, tool)
+                responses <- clientSide.incoming.take(2).run
+            yield responses.collect { case r: JsonRpcResponse => r }
+        }
+
+    "a tools/call pipelined with the handshake is served, not reported as a handler panic" in {
+        Scope.run(burst).map { responses =>
+            val call = responses.find(_.id == JsonRpcId.Num(2))
+            assert(call.isDefined, s"the pipelined call must be answered; got: $responses")
+            val answer = call.get
+            answer.error match
+                case Present(err) =>
+                    fail(s"the pipelined call must not fail; got code ${err.code}: ${err.message}")
+                case Absent =>
+                    assert(answer.result.isDefined, s"the call must carry a result; got: $answer")
+            end match
+        }
+    }
+
+    "no response in the burst blames a handler that was never called" in {
+        // The exact reported symptom, kept as its own assertion so a regression names itself.
+        Scope.run(burst).map { responses =>
+            val faults = responses.flatMap(_.error.toChunk).filter(e =>
+                e.message.contains("panicked") || e.message.contains("not initialised")
+            )
+            assert(faults.isEmpty, s"a startup race must never surface as a handler panic; got: $faults")
+        }
+    }
+
+    "the burst behaves the same way when repeated" in {
+        // One pass proves little about a timing-dependent path, so this exercises a fresh engine each
+        // time. It has never been observed to fail, before or after the fix; see the note on this
+        // suite about what that does and does not establish.
+        Kyo.foreach(Chunk.range(0, 20)) { _ =>
+            Scope.run(burst).map { responses =>
+                responses.flatMap(_.error.toChunk).filter(e =>
+                    e.message.contains("panicked") || e.message.contains("not initialised")
+                )
+            }
+        }.map { faultsPerRun =>
+            val faults = faultsPerRun.flatten
+            assert(faults.isEmpty, s"no run may report a startup race; got: $faults")
+        }
+    }
+
+end McpServerEarlyRequestTest


### PR DESCRIPTION
### Problem

A handler body whose effect row does not fit compiles into an ambiguity between two arbitrary `Schema` instances the author never mentioned, and for some bodies that phantom is the only error reported while the real one is suppressed. A body aborting an error no `.error[...]` covers registers happily and fails a round trip later as a `-32603` carrying the exception's `toString`, which leaked SQL text and a connection id in the reported case. A domain error registered as `read-only-violation` reached the client as `Application error (-40001): Application error (-40001): read-only-violation`. A request arriving before the engine finished wiring itself was answered `Handler 'tools/call' panicked`, naming a handler that was never called. And on the stdio transport, where stdin and stdout ARE the protocol channel, a single `Console.printLine` inside a handler corrupts the stream, with the failure surfacing at the host while the server looks healthy.

### Solution

Two of these move the failure to where the author is standing. An `OutInferred` guard reports an uninferred output type as itself instead of as a schema ambiguity. Handlers now carry their declared abort type as a runtime tag, so the engine refuses an unmapped error leaf at startup, beside the reserved-code check it mirrors.

The prefix doubling was one bug, not two: `JsonRpcCustomError` folds the code into the message and `fromWire` re-enters that same constructor with the already-prefixed text, so it re-applies on every hop. The code now stays in `code`, where JSON-RPC already carries it. Dispatch waits on the live server instead of reading a slot it can outrun.

`JsonRpcTransport.stdioWith` runs a body with `Console`'s stdout side diverted to stderr and `readLine` failing, so handlers print safely by construction. kyo can fix that structurally where the TypeScript SDK cannot, because `Console` here is a scoped service rather than a process global. The READMEs gain the two rules that were previously discoverable only by hitting them: the handler row is closed at `Async & Abort[Halt | E]`, and stdout is unavailable to an application on stdio.

### Notes

A handler body that only aborts now needs its return type named: `Out` widens to `Any`, which has no output schema to advertise, and the new guard refuses it.
