### PR TITLE
[kyo-schema-json, kyo-ai] let an agent use an MCP server's tools

### DIFF
--- a/kyo-ai/README.md
+++ b/kyo-ai/README.md
@@ -152,6 +152,43 @@ val researchTools =
     )
 ```
 
+A tool's type is `Tool[S]`, where `S` is the capability set its run function needs. The input and output types are *existential*: they are held inside the value rather than in its type. That is exactly what lets `aggregate` combine tools of unrelated shapes into one value, and `Tool[S]` is the type to write when a signature needs an explicit annotation.
+
+```scala
+val annotated: Tool[Any] = researchTools
+```
+
+### Tools from an MCP server
+
+The tools above are written in Scala, so their shapes are known when you compile. A tool published by an [MCP](../kyo-mcp/README.md) server is not: the server sends its name, description and input schema over the wire, and a host has no Scala type to name for any of it. `Tool.fromMcp` turns every tool a connected server publishes into a tool this agent can call.
+
+```scala
+def answerWithServerTools(client: McpClient) =
+    Tool.fromMcp(client).map { serverTools =>
+        AI.enable(serverTools)(AI.gen[Answer]("Which country has the most customers?"))
+    }
+```
+
+Nothing there names an input or output type, because none exists to name, so this works against a server whose Scala types are not on your classpath. Each published tool becomes one tool carrying the server's own name, description and schema; a call is forwarded with the model's arguments, and the server's structured result (or its text content when it publishes no output schema) is fed back to the model. A result the server marks as an error becomes a tool failure the model sees and may retry, the same as a locally raised one.
+
+`Tool.initDynamic` is that construction without the client, for a schema you hold as a value rather than as a type.
+
+```scala
+val runSelect =
+    Tool.initDynamic(
+        "run_select",
+        Json.JsonSchema.Obj(
+            properties = List("sql" -> Json.JsonSchema.Str(description = Present("a read-only SELECT"))),
+            required = List("sql")
+        ),
+        "Run a read-only query"
+    ) { args =>
+        Structure.Value.Str(s"rows for $args")
+    }
+```
+
+The declared schema binds. It is advertised to the model verbatim, so a server's own constraints and property descriptions reach the model as published, and the arguments are checked against it before your body runs: a call missing a required field is refused with a message the model can repair from, rather than reaching a body that never agreed to receive it.
+
 The loop handles both failure modes for you, neither of which escapes the generation. If the model sends arguments that fail to decode, the runtime drops the bad call and injects a corrective system message asking the model to match the schema. If your run function throws, the failure is contained, turned into a tool-result message, and fed back so the model can read the error and retry.
 
 > **Note:** a tool whose run function uses effects needs an `Isolate[S, LLM, S]` in scope; a pure run (the common case) infers `S = Any` and needs no import. The instance form `ai.enable(tool)` layers a tool onto one instance only, on top of the scope's tools.
@@ -331,6 +368,19 @@ def streamedAnswers: Chunk[Answer] < (Async & Abort[AIStreamException | AIGenExc
 A fully consumed stream joins the conversation: the turn is recorded once its elements are drained, so a later `gen` or `stream` can read what was streamed, and a stream abandoned part way records nothing. The element row carries `LLM` for that write-back, so a stream is consumed inside `LLM.run`.
 
 The stream's element row also carries `Scope` because the SSE connection is held open until the stream terminates or errors, so running it adds `Scope` to the residual. You write no SSE parsing, no fragment accumulation, no incremental-decode attempt.
+
+### Not every backend streams incrementally
+
+Whether elements arrive *as the model produces them* depends on the backend, and the difference is invisible from the stream itself. The HTTP families stream over SSE, so a chunk arrives per delta. The command harnesses (Claude Code, Codex) report a turn once it is finished, so the whole answer arrives in one piece: the elements and their order are identical and nothing fails, but time-to-first-token equals time-to-last-token, which is the number a chat UI lives on.
+
+Rather than leave that to be discovered in production feel, each backend declares it:
+
+```scala
+def rendersProgressively(config: kyo.ai.Config): Boolean =
+    config.provider.completion.streamsIncrementally
+```
+
+Read it to choose between rendering progressively and showing a pending state. A stream written against either kind is correct; only the pacing differs.
 
 ## Parallel generation
 

--- a/kyo-ai/shared/src/main/scala/kyo/AI.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/AI.scala
@@ -102,6 +102,43 @@ object AI:
     def stream[A: Schema](using Frame, Tag[Emit[Chunk[A]]]): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
         init.map(ai => ai.stream[A])
 
+    /** [[stream]] seeded with an input, the streaming counterpart of `gen(input)`. The input is appended
+      * as a user message before the stream is projected, so `AI.stream[String]("...")` reads the way
+      * `AI.gen[Answer]("...")` does rather than requiring the caller to seed the context by hand.
+      */
+    def stream[A: Schema](using
+        Frame,
+        Tag[Emit[Chunk[A]]]
+    )[B: Schema](input: B): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
+        init.map(ai => ai.stream[A](input))
+
+    def stream[A: Schema](using
+        Frame,
+        Tag[Emit[Chunk[A]]]
+    )[B: Schema, C: Schema](input1: B, input2: C): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
+        stream[A]((input1, input2))
+
+    def stream[A: Schema](using
+        Frame,
+        Tag[Emit[Chunk[A]]]
+    )[B: Schema, C: Schema, D: Schema](
+        input1: B,
+        input2: C,
+        input3: D
+    ): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
+        stream[A]((input1, input2, input3))
+
+    def stream[A: Schema](using
+        Frame,
+        Tag[Emit[Chunk[A]]]
+    )[B: Schema, C: Schema, D: Schema, E: Schema](
+        input1: B,
+        input2: C,
+        input3: D,
+        input4: E
+    ): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
+        stream[A]((input1, input2, input3, input4))
+
     /** Reads the current scope `AIEnv`: the active config plus the scope's enablements (prompt, tools, thoughts, modes, observers). */
     def env(using Frame): AIEnv < LLM = LLM.env
 
@@ -194,6 +231,39 @@ object AI:
 
         def stream[A: Schema](using Frame, Tag[Emit[Chunk[A]]]): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
             LLM.stream(ai, summon[Schema[A]])
+
+        def stream[A: Schema](using
+            Frame,
+            Tag[Emit[Chunk[A]]]
+        )[B: Schema](input: B): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
+            ai.userMessage(Json.encode(input)).andThen(ai.stream[A])
+
+        def stream[A: Schema](using
+            Frame,
+            Tag[Emit[Chunk[A]]]
+        )[B: Schema, C: Schema](input1: B, input2: C): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
+            ai.stream[A]((input1, input2))
+
+        def stream[A: Schema](using
+            Frame,
+            Tag[Emit[Chunk[A]]]
+        )[B: Schema, C: Schema, D: Schema](
+            input1: B,
+            input2: C,
+            input3: D
+        ): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
+            ai.stream[A]((input1, input2, input3))
+
+        def stream[A: Schema](using
+            Frame,
+            Tag[Emit[Chunk[A]]]
+        )[B: Schema, C: Schema, D: Schema, E: Schema](
+            input1: B,
+            input2: C,
+            input3: D,
+            input4: E
+        ): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
+            ai.stream[A]((input1, input2, input3, input4))
 
         def systemMessage(content: String)(using Frame): Unit < LLM =
             LLM.append(ai, SystemMessage(content))

--- a/kyo-ai/shared/src/main/scala/kyo/Tool.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/Tool.scala
@@ -42,6 +42,107 @@ object Tool:
         new Tool[S]:
             def infos = Chunk(Info(name, description, prompt, run, summon[Schema[In]], summon[Schema[Out]], frame))
 
+    /** Builds a tool from a schema known only at runtime.
+      *
+      * `init` needs a `Schema[In]` at compile time, so a tool whose shape is discovered rather than
+      * declared cannot be expressed through it: an MCP server publishes its tools' input schemas over
+      * the wire, and a host has no Scala type to name for any of them. This factory takes that schema as
+      * a value and hands the run the decoded arguments as an open `Structure.Value`.
+      *
+      * The declared schema binds. It is advertised to the model verbatim, and arguments are checked
+      * against it before the body runs, so a call missing a required field is refused with a message the
+      * model can repair from rather than reaching a body that never agreed to receive it. The check runs
+      * inside the tool loop, on the tool-error channel, the same way the result tool enforces its own
+      * open-shape result; that is why the returned row carries `Abort[AIDecodeException]`.
+      *
+      * The check is structural: what `Structure.Type` can carry (shape, required fields, nesting) is
+      * enforced, while JSON Schema's value constraints (`pattern`, numeric bounds) are advisory, since
+      * they reach the model but have no structural carrier. See `Json.JsonSchema.toStructure`.
+      *
+      * @param name
+      *   the tool name the model calls
+      * @param inputSchema
+      *   the JSON Schema for the tool's arguments, as published by whoever owns the tool
+      * @param description
+      *   what the tool does, shown to the model
+      * @param prompt
+      *   a tool-specific prompt, surfaced when the tool is enabled
+      */
+    def initDynamic[S](
+        name: String,
+        inputSchema: Json.JsonSchema,
+        description: String = "",
+        prompt: Prompt[S] = Prompt.empty
+    )(
+        run: Structure.Value => Structure.Value < S
+    )(using frame: Frame): Tool[S & Abort[AIDecodeException]] =
+        val declared  = Json.JsonSchema.toStructure(inputSchema)
+        val openCodec = summon[Schema[Structure.Value]]
+        // The passthrough codec accepts any record, so the declared shape is enforced here rather than
+        // by the decode, exactly as the result tool does for an open-shape result.
+        val checked: Structure.Value => Structure.Value < (S & Abort[AIDecodeException]) =
+            arguments =>
+                Structure.conform(arguments, declared) match
+                    case Present(violation) =>
+                        Abort.fail(AIDecodeException(
+                            s"arguments do not conform to the declared input schema of '$name': $violation"
+                        ))
+                    case Absent => run(arguments)
+        new Tool[S & Abort[AIDecodeException]]:
+            def infos = Chunk(Info(
+                name,
+                description,
+                prompt,
+                checked,
+                openCodec.withStructure(declared),
+                openCodec,
+                frame,
+                Present(inputSchema)
+            ))
+        end new
+    end initDynamic
+
+    /** Bridges every tool an MCP server publishes into tools this agent can call.
+      *
+      * This is the whole point of shipping both an MCP module and an LLM module: a tool set that exists
+      * on the other side of a connection drops into an agent host without anyone writing a wrapper per
+      * tool. Nothing here names an input or output type, so it works against a server whose Scala types
+      * are not on the classpath, which is the case a hand-written wrapper cannot serve at all.
+      *
+      * Each published tool becomes one [[initDynamic]] tool carrying the server's own name, description
+      * and input schema. A call is forwarded with the model's arguments; the tool's structured result is
+      * returned when the server sends one, and its text content otherwise. A result the server marks as
+      * an error becomes a tool failure the model sees and may retry, which is the same contract
+      * `McpHandler.ToolOutcome.error` documents on the server side.
+      *
+      * Pair it with `Tool.aggregate` to combine a server's tools with locally defined ones.
+      */
+    def fromMcp(client: McpClient)(using
+        Frame
+    ): Tool[Async & Abort[McpException] & Abort[AIDecodeException]] < (Async & Abort[McpListFailure]) =
+        client.streamTools.run.map(metas => aggregate(metas.map(fromMcpTool(client, _))*))
+
+    private def fromMcpTool(client: McpClient, meta: McpHandler.ToolMeta)(using
+        Frame
+    ): Tool[Async & Abort[McpException] & Abort[AIDecodeException]] =
+        initDynamic[Async & Abort[McpException]](
+            meta.name,
+            meta.inputSchema,
+            meta.description.getOrElse("")
+        ) { arguments =>
+            client.callToolRaw(meta.name, arguments).map { outcome =>
+                val text = outcome.content.collect { case t: McpContent.Text => t.text }.mkString("\n")
+                if outcome.isError then
+                    Abort.fail(McpToolExecutionException(meta.name, if text.isEmpty then "no detail reported" else text))
+                else
+                    // A server that publishes an output schema sends `structuredContent`; one that does
+                    // not still answers in text, and the model reads either.
+                    outcome.structuredContent.getOrElse(Structure.Value.Str(text))
+                end if
+            }
+        }
+    end fromMcpTool
+
     /** Combines tools into one. */
     def aggregate[S](tools: Tool[S]*): Tool[S] =
         new Tool[S]:
@@ -59,8 +160,20 @@ object Tool:
             run: In => Out < (LLM & S),
             inputSchema: Schema[In],
             outputSchema: Schema[Out],
-            createdAt: Frame
-        )
+            createdAt: Frame,
+            declaredInputSchema: Maybe[Json.JsonSchema] = Absent
+        ):
+            /** The JSON Schema advertised to the model for this tool's input.
+              *
+              * Derived from `inputSchema` for a typed tool. A schema-at-runtime tool carries the schema it
+              * was built from and advertises that instead, so a third-party server's own constraints and
+              * descriptions reach the model as published: re-deriving them through the structural
+              * vocabulary would drop `pattern`, numeric bounds, and any description outside property
+              * position, which is a silent downgrade of someone else's tool contract.
+              */
+            def wireInputSchema: Json.JsonSchema =
+                declaredInputSchema.getOrElse(Json.jsonSchema(using inputSchema))
+        end Info
 
         def infos(using Frame): Chunk[Info[?, ?, LLM]] < LLM =
             // cast: State.tools holds Tool[Any]; re-widen to the LLM-erased Info the eval loop consumes.

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
@@ -107,6 +107,10 @@ private[completion] object AnthropicCompletion extends Completion:
                         )
                 }
 
+    // Streams over SSE: one fragment per delta the endpoint sends, so the stream advances while
+    // the model is still producing.
+    def streamsIncrementally: Boolean = true
+
     def streamFragments(
         config: Config,
         context: Context,
@@ -341,7 +345,7 @@ private[completion] object AnthropicCompletion extends Completion:
                         Present(tools.map { t =>
                             val desc = Maybe.when(t.description.nonEmpty)(t.description)
                             if t.name == Completion.resultToolName then
-                                val raw = resultSchema.getOrElse(Json.jsonSchema(using t.inputSchema))
+                                val raw = resultSchema.getOrElse(t.wireInputSchema)
                                 if config.reasoningEnabled then
                                     // Extended thinking is incompatible with strict grammar-constrained decoding:
                                     // the combination slows a call from ~3s to ~30s+ (the constrained decoder
@@ -357,7 +361,7 @@ private[completion] object AnthropicCompletion extends Completion:
                                         case _                           => ToolDefinition(t.name, desc, Structure.encode(raw))
                                 end if
                             else
-                                ToolDefinition(t.name, desc, Structure.encode(Json.jsonSchema(using t.inputSchema)))
+                                ToolDefinition(t.name, desc, Structure.encode(t.wireInputSchema))
                             end if
                         }.toList)
                 // Reasoning happens before the answer, the native-API analog of the Claude Code full

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
@@ -97,7 +97,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                         ).map { raw =>
                             bridge.resultCapture.get.map {
                                 case Present(envelope) =>
-                                    turnUsage(raw).map { usage =>
+                                    bridge.executedTools.get.map(_.size).map(calls => turnUsage(raw, calls)).map { usage =>
                                         Emit.value(Chunk[Completion.StreamElement](
                                             Completion.StreamElement.Fragment(envelope),
                                             Completion.StreamElement.Usage(usage)
@@ -139,7 +139,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                     // carries duplicate tool_use ids across generations.
                     callIdSeed <- Random.nextStringAlphanumeric(12)
                     messages   <- readMessages(raw, executed, captured, callIdSeed)
-                    usage      <- turnUsage(raw)
+                    usage      <- turnUsage(raw, executed.size)
                 yield (messages, usage)
             }
         }
@@ -498,53 +498,65 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
         meter: Meter,
         tool: Tool.internal.Info[?, ?, LLM]
     )(using Frame): McpHandler[?, ?, ?] =
-        given Schema[Any] = tool.inputSchema.asInstanceOf[Schema[Any]]
-        McpHandler.toolRaw[Any](tool.name, tool.description) { input =>
-            Abort.run[Closed] {
-                meter.run {
-                    stateRef.get.map { state =>
-                        Abort.run[Throwable] {
-                            val run = tool.run.asInstanceOf[Any => Any < LLM](input)
-                            LLM.runWith(state)(run) { (next, out) =>
-                                (next, out)
-                            }
-                        }.map {
-                            case Result.Success((next, out)) =>
-                                val outputSchema = tool.outputSchema.asInstanceOf[Schema[Any]]
-                                val text         = Json.encode[Any](out)(using outputSchema, summon[Frame])
-                                val structured   = Structure.encode[Any](out)(using outputSchema)
-                                val arguments    = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
-                                stateRef.set(next).andThen(executedTools.getAndUpdate(_.append(ExecutedTool(
-                                    tool.name,
-                                    arguments,
-                                    text
-                                ))).unit).andThen(
-                                    McpHandler.ToolOutcome.okWith(
-                                        content = Chunk(McpContent.text(text)),
-                                        structuredContent = Present(structured)
+        // Built directly rather than through `toolRaw` so the advertised `inputSchema` is the tool's own
+        // `wireInputSchema`: for a schema-at-runtime tool that is the schema it was published with, and
+        // `toolRaw` would instead derive one from `In`, which is erased to `Any` here.
+        new McpHandler.ToolMultiHandler[Any, Nothing](
+            McpHandler.ToolMeta(
+                name = tool.name,
+                description = Maybe.when(tool.description.nonEmpty)(tool.description),
+                inputSchema = tool.wireInputSchema,
+                outputSchema = Absent,
+                annotations = Absent
+            ),
+            tool.inputSchema.asInstanceOf[Schema[Any]],
+            input =>
+                Abort.run[Closed] {
+                    meter.run {
+                        stateRef.get.map { state =>
+                            Abort.run[Throwable] {
+                                val run = tool.run.asInstanceOf[Any => Any < LLM](input)
+                                LLM.runWith(state)(run) { (next, out) =>
+                                    (next, out)
+                                }
+                            }.map {
+                                case Result.Success((next, out)) =>
+                                    val outputSchema = tool.outputSchema.asInstanceOf[Schema[Any]]
+                                    val text         = Json.encode[Any](out)(using outputSchema, summon[Frame])
+                                    val structured   = Structure.encode[Any](out)(using outputSchema)
+                                    val arguments    = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
+                                    stateRef.set(next).andThen(executedTools.getAndUpdate(_.append(ExecutedTool(
+                                        tool.name,
+                                        arguments,
+                                        text
+                                    ))).unit).andThen(
+                                        McpHandler.ToolOutcome.okWith(
+                                            content = Chunk(McpContent.text(text)),
+                                            structuredContent = Present(structured)
+                                        )
                                     )
-                                )
-                            case Result.Failure(ex) =>
-                                val text      = toolError(tool.name, ex.toString)
-                                val arguments = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
-                                executedTools.getAndUpdate(_.append(ExecutedTool(tool.name, arguments, text))).unit.andThen(
-                                    McpHandler.ToolOutcome.error(text)
-                                )
-                            case Result.Panic(ex) =>
-                                val text      = toolError(tool.name, ex.toString)
-                                val arguments = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
-                                executedTools.getAndUpdate(_.append(ExecutedTool(tool.name, arguments, text))).unit.andThen(
-                                    McpHandler.ToolOutcome.error(text)
-                                )
+                                case Result.Failure(ex) =>
+                                    val text      = toolError(tool.name, ex.toString)
+                                    val arguments = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
+                                    executedTools.getAndUpdate(_.append(ExecutedTool(tool.name, arguments, text))).unit.andThen(
+                                        McpHandler.ToolOutcome.error(text)
+                                    )
+                                case Result.Panic(ex) =>
+                                    val text      = toolError(tool.name, ex.toString)
+                                    val arguments = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
+                                    executedTools.getAndUpdate(_.append(ExecutedTool(tool.name, arguments, text))).unit.andThen(
+                                        McpHandler.ToolOutcome.error(text)
+                                    )
+                            }
                         }
                     }
-                }
-            }.map {
-                case Result.Success(outcome) => outcome
-                case Result.Failure(ex)      => McpHandler.ToolOutcome.error(toolError(tool.name, ex.toString))
-                case Result.Panic(ex)        => McpHandler.ToolOutcome.error(toolError(tool.name, ex.toString))
-            }
-        }
+                }.map {
+                    case Result.Success(outcome) => outcome
+                    case Result.Failure(ex)      => McpHandler.ToolOutcome.error(toolError(tool.name, ex.toString))
+                    case Result.Panic(ex)        => McpHandler.ToolOutcome.error(toolError(tool.name, ex.toString))
+                },
+            Chunk.empty
+        )
     end mcpToolHandler
 
     private def toolError(name: String, detail: String): String =

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeWire.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeWire.scala
@@ -448,7 +448,14 @@ private[completion] object ClaudeCodeWire:
       * last line. Always reports `turns = 1`: the invocation is one kyo turn whether or not the CLI
       * flushed its numbers.
       */
-    def turnUsage(output: String)(using Frame): AIStats < Abort[AIGenException] =
+    /** The turn's reported spend.
+      *
+      * `toolCalls` is how many tool calls the CLI asked kyo to run during this turn. Like Codex, this
+      * harness runs its own tool loop inside one kyo turn, so counting the replies kyo received reports 1
+      * however much ran. Each call implies the model turn that produced it, plus the turn that answers
+      * with its result, so `calls + 1` is what a reader can reconcile against the calls they saw.
+      */
+    def turnUsage(output: String, toolCalls: Int)(using Frame): AIStats < Abort[AIGenException] =
         readEvents(output, lenient = true).map { events =>
             val resultUsage = events.foldLeft(Maybe.empty[Usage]) { (last, event) =>
                 if event.`type` == "result" then event.usage.orElse(last) else last
@@ -469,7 +476,7 @@ private[completion] object ClaudeCodeWire:
                                 case _ => (byId, anonymous)
                         }
                     (Chunk.from(byId.toMap.values) ++ anonymous).foldLeft(AIStats.empty)((acc, u) => acc.add(usageStats(u)))
-            base.copy(turns = 1)
+            base.copy(turns = math.max(toolCalls + 1, 1))
         }
     end turnUsage
 

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexCompletion.scala
@@ -415,7 +415,11 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
         handler.call[P, A](method, params)
     end requestAs
 
-    private def eventRoutes(events: Channel[RpcEvent])(using Frame): Seq[JsonRpcRoute[?, ?, ?]] =
+    // Every event this backend reads must be routed here. An unrouted notification does not arrive
+    // unhandled, it is DROPPED: the handler runs the default `minimal` unknown-method policy, whose
+    // `onUnknownNotification` is `Drop`, so the consumer downstream simply never runs and reports the
+    // absence as a legitimate zero.
+    private[completion] def eventRoutes(events: Channel[RpcEvent])(using Frame): Seq[JsonRpcRoute[?, ?, ?]] =
         Seq(
             eventRoute(events, "item/started"),
             eventRoute(events, "item/completed"),
@@ -424,6 +428,7 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
             eventRoute(events, "item/agentMessage/delta"),
             eventRoute(events, "turn/completed"),
             eventRoute(events, "thread/status/changed"),
+            eventRoute(events, "thread/tokenUsage/updated"),
             eventRoute(events, "error")
         )
     end eventRoutes
@@ -478,31 +483,39 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
         stderrTail: AtomicRef[String],
         bridge: ToolBridge
     )(using Frame): (Maybe[String], AIStats) < (Async & Abort[AIGenException | Closed]) =
-        Loop((Absent: Maybe[String], "", Maybe.empty[TokenCounts])) { (completed, delta, usage) =>
+        Loop((Absent: Maybe[String], "", Maybe.empty[TokenCounts], 0)) { (completed, delta, usage, requests) =>
             events.take.map { event =>
                 trackFollowUp(bridge, event, threadId, turnId).andThen {
                     bridge.resultCapture.get.map { captured =>
                         bridge.deferred.get.map { deferred =>
                             if captured.isDefined || deferred then
-                                interruptTurn(handler, threadId, turnId)
-                                    .andThen(Loop.done((finalText(completed, delta), turnStats(usage))))
+                                interruptTurn(handler, threadId, turnId).andThen(
+                                    bridge.executed.get.map(calls =>
+                                        Loop.done((finalText(completed, delta), turnStats(usage, requests, calls.size)))
+                                    )
+                                )
                             else if isTurnCompleted(event, threadId, turnId) then
-                                Loop.done((finalText(completed, delta), turnStats(usage)))
+                                bridge.executed.get.map(calls =>
+                                    Loop.done((finalText(completed, delta), turnStats(usage, requests, calls.size)))
+                                )
                             else if event.method == "thread/tokenUsage/updated" then
                                 // Keep the latest total: the ephemeral thread's aggregate IS this turn's
                                 // usage, already summed across the CLI turn's internal provider requests.
                                 // Tracked here rather than in eventText so the interrupt path (capture)
                                 // reports the totals that arrived before the kill.
+                                //
+                                // One notification arrives per provider request, so counting them recovers
+                                // how many model turns actually ran inside this single kyo turn.
                                 decodeEvent[TokenUsageNotification](event).map { notification =>
                                     if notification.threadId == threadId && notification.turnId == turnId then
-                                        Loop.continue((completed, delta, notification.tokenUsage.total.orElse(usage)))
-                                    else Loop.continue((completed, delta, usage))
+                                        Loop.continue((completed, delta, notification.tokenUsage.total.orElse(usage), requests + 1))
+                                    else Loop.continue((completed, delta, usage, requests))
                                 }
                             else
                                 eventText(event, threadId, turnId, stderrTail).map {
-                                    case Present(OutputText.Completed(text)) => Loop.continue((Present(text), delta, usage))
-                                    case Present(OutputText.Delta(text))     => Loop.continue((completed, delta + text, usage))
-                                    case _                                   => Loop.continue((completed, delta, usage))
+                                    case Present(OutputText.Completed(text)) => Loop.continue((Present(text), delta, usage, requests))
+                                    case Present(OutputText.Delta(text))     => Loop.continue((completed, delta + text, usage, requests))
+                                    case _                                   => Loop.continue((completed, delta, usage, requests))
                                 }
                         }
                     }
@@ -511,9 +524,22 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
         }
     end collectTurn
 
-    // A turn that saw no usage notification still ran: one turn, no numbers.
-    private def turnStats(usage: Maybe[TokenCounts]): AIStats =
-        usage.fold(AIStats.empty.copy(turns = 1))(usageStats)
+    /** The turn's reported spend.
+      *
+      * `turns` must agree with the tool calls a reader can see happening. This harness runs its own tool
+      * loop inside one kyo turn, so the count of replies kyo received is 1 no matter how much ran, which
+      * reads as a cheap turn rather than an opaque one.
+      *
+      * Two observations bound it, and the larger is the honest one. The app-server emits one
+      * `thread/tokenUsage/updated` per provider request, but a turn interrupted on a captured result can
+      * end before the last of them arrives, so that count alone under-reports. Every tool call kyo was
+      * asked to run implies a model turn that produced it, plus the turn that answers with its result, so
+      * `calls + 1` is the floor. A turn that saw neither still ran once.
+      */
+    private def turnStats(usage: Maybe[TokenCounts], providerRequests: Int, toolCalls: Int): AIStats =
+        val turns = math.max(math.max(providerRequests, toolCalls + 1), 1)
+        usage.fold(AIStats.empty.copy(turns = turns))(counts => usageStats(counts).copy(turns = turns))
+    end turnStats
 
     private def finalText(completed: Maybe[String], delta: String): Maybe[String] =
         completed match

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexWire.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexWire.scala
@@ -182,7 +182,7 @@ private[completion] object CodexWire:
         tools.map { tool =>
             val schema =
                 if tool.name == Completion.resultToolName then StrictSchema.requireAll(resultSchema)
-                else Json.jsonSchema(using tool.inputSchema.asInstanceOf[Schema[Any]])
+                else tool.wireInputSchema
             DynamicTool("function", tool.name, tool.description, Structure.encode(schema))
         }
     end dynamicToolSpecs

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/Completion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/Completion.scala
@@ -37,6 +37,23 @@ trait Completion:
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
     )(using Frame): Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException])
 
+    /** Whether this backend delivers a stream in pieces as the model produces it.
+      *
+      * `true` where the wire carries incremental deltas, which is every HTTP family (they stream over
+      * SSE). `false` where the backend can only hand back a finished result, which `LLM.stream` then
+      * emits in one go: the elements and their order are exactly the same, and nothing fails, but
+      * time-to-first-token equals time-to-last-token.
+      *
+      * That difference is invisible from the stream itself, and it is the number a chat UI lives on, so
+      * it is declared rather than discovered. Read it to decide whether to render progressively or show a
+      * pending state:
+      *
+      * {{{
+      * val incremental = config.provider.completion.streamsIncrementally
+      * }}}
+      */
+    def streamsIncrementally: Boolean
+
 end Completion
 
 object Completion:

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/HarnessCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/HarnessCompletion.scala
@@ -25,6 +25,11 @@ abstract private[completion] class HarnessCompletion(providerName: String) exten
                     Completion.Reply(messages, Completion.StopReason.Completed, usage)
                 )
 
+    // A command harness reports a turn's result once it is finished: the result the stream is built from
+    // arrives whole, so `streamFragments` emits one fragment and the stream one chunk. The elements are
+    // the same as on an HTTP family; only their arrival is not spread over the generation.
+    final def streamsIncrementally: Boolean = false
+
     protected def run(
         config: Config,
         context: Context,

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/OpenAICompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/OpenAICompletion.scala
@@ -168,6 +168,10 @@ private[completion] object OpenAICompletion extends Completion:
     /** Streams the result-envelope fragments by posting the native SSE request and projecting each line's
       * tool-call argument delta through [[parseDeltaArguments]].
       */
+    // Streams over SSE: one fragment per delta the endpoint sends, so the stream advances while
+    // the model is still producing.
+    def streamsIncrementally: Boolean = true
+
     def streamFragments(
         config: Config,
         context: Context,
@@ -382,8 +386,8 @@ private[completion] object OpenAICompletion extends Completion:
                                 // compelled by tool_choice:"required"), so a required optional field is schema
                                 // pressure, not grammar enforcement.
                                 if p.name == Completion.resultToolName then
-                                    StrictSchema.requireAll(resultSchema.getOrElse(Json.jsonSchema(using p.inputSchema)))
-                                else Json.jsonSchema(using p.inputSchema)
+                                    StrictSchema.requireAll(resultSchema.getOrElse(p.wireInputSchema))
+                                else p.wireInputSchema
                             ToolDef(FunctionDef(p.description, p.name, false, params))
                         }.toList)
                 // A configured temperature reaches the wire only when the entry declares the model accepts it.

--- a/kyo-ai/shared/src/test/scala/kyo/AITest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/AITest.scala
@@ -485,4 +485,67 @@ class AITest extends kyo.test.Test[Any]:
         }
     }
 
+    "stream takes an inline input, the way gen does" - {
+
+        /** Wraps an argument JSON fragment in an OpenAI streaming chunk envelope. */
+        def argDelta(fragment: String): String =
+            val escaped = fragment.replace("\\", "\\\\").replace("\"", "\\\"")
+            s"""{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"$escaped","name":""}}]}}]}"""
+
+        val deltas = Chunk(
+            argDelta("{\"resultValue\":\"The"),
+            argDelta(" sky"),
+            argDelta(" is blue\"}")
+        )
+
+        "the inline form streams the same chunks the seeded form does" in {
+            // `gen` takes its prompt inline, so `stream` reading the same way is the whole point: the
+            // asymmetry cost a compile cycle and a README re-read, and the streaming examples all happen
+            // to show the no-input form, so it is invisible until you hit it.
+            TestCompletionServer.runStreaming { server =>
+                val config = serverConfig(server.baseUrl)
+                server.enqueueStream(deltas).andThen {
+                    LLM.run(config) {
+                        AI.stream[String]("What colour is the sky?").map(_.run.map { collected =>
+                            assert(collected == Chunk("The", " sky", " is blue"), s"got: $collected")
+                        })
+                    }
+                }
+            }
+        }
+
+        "the inline input reaches the model as a user message" in {
+            TestCompletionServer.runStreaming { server =>
+                val config = serverConfig(server.baseUrl)
+                server.enqueueStream(deltas).andThen {
+                    LLM.run(config) {
+                        AI.stream[String]("What colour is the sky?").map(_.run.andThen {
+                            server.captured.map { caps =>
+                                assert(
+                                    caps.head.body.contains("What colour is the sky?"),
+                                    s"the input must be seeded into the request; body: ${caps.head.body}"
+                                )
+                            }
+                        })
+                    }
+                }
+            }
+        }
+
+        "the instance form takes an inline input too" in {
+            TestCompletionServer.runStreaming { server =>
+                val config = serverConfig(server.baseUrl)
+                server.enqueueStream(deltas).andThen {
+                    LLM.run(config) {
+                        AI.initWith { ai =>
+                            ai.stream[String]("What colour is the sky?").map(_.run.map { collected =>
+                                assert(collected.mkString == "The sky is blue", s"got: $collected")
+                            })
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 end AITest

--- a/kyo-ai/shared/src/test/scala/kyo/LLMIntegrationTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/LLMIntegrationTest.scala
@@ -471,4 +471,34 @@ class LLMIntegrationTest extends BaseAITest:
             yield ()
     }
 
+    "report what the turn spent" - runBackends { backend =>
+        // The README promises that every completed model turn reports what it spent, and the budget
+        // guardrail it documents is built on `reply.usage.totalTokens`. A backend that reports zero does
+        // not read as "unsupported", it reads as a free turn: the guardrail adds nothing every turn and
+        // silently never fires, which is worse than having no guardrail. So the assertion is per backend
+        // and it is on the number, not on the field being present.
+        for
+            result <- Abort.run[AIException] {
+                Observe.withStats(AI.gen[String]("Reply with exactly the word: ok"))
+            }
+            statsAndAnswer <- unwrap(backend, result)
+            (stats, _) = statsAndAnswer
+            _ = assert(
+                stats.inputTokens > 0,
+                s"${backend.label} reported no input tokens for a completed turn: $stats"
+            )
+            _ = assert(
+                stats.outputTokens > 0,
+                s"${backend.label} reported no output tokens for a completed turn: $stats"
+            )
+            _ = assert(
+                stats.totalTokens == stats.inputTokens + stats.outputTokens,
+                s"${backend.label} totalTokens must be the sum it documents: $stats"
+            )
+            // A turn that produced a reply is at least one turn. Zero here is the other way the spend
+            // proxy lies when the token counts are missing.
+            _ = assert(stats.turns >= 1, s"${backend.label} reported $stats turns for a completed turn")
+        yield ()
+    }
+
 end LLMIntegrationTest

--- a/kyo-ai/shared/src/test/scala/kyo/LLMStreamIntegrationTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/LLMStreamIntegrationTest.scala
@@ -101,4 +101,37 @@ class LLMStreamIntegrationTest extends BaseAITest:
         end for
     }
 
+    "deliver stream[String] as the declared capability says" - runBackends { backend =>
+        // The defect this guards was silent: `stream[String]` on a harness backend returned the whole
+        // answer as one chunk, with nothing in the API saying so, so a chat UI written against the
+        // documented streaming API showed a blank screen for the whole generation. The fix is that the
+        // capability is declared; this leaf is what keeps the declaration honest, per backend, against a
+        // prompt long enough that one chunk cannot be a coincidence.
+        val ask =
+            "Write a 250-word explanation of B-trees. Reply with the explanation only."
+        for
+            result <- Abort.run[AIException] {
+                Scope.run(AI.stream[String](ask).map(_.run))
+            }
+            chunks <- unwrap(backend, result)
+            _ = assert(chunks.nonEmpty, s"${backend.label} produced no chunks at all")
+            _ = assert(
+                chunks.mkString.length > 400,
+                s"${backend.label} answered too briefly for this leaf to mean anything: ${chunks.mkString.length} chars"
+            )
+            incremental = backend.provider.completion.streamsIncrementally
+            _ = if incremental then
+                assert(
+                    chunks.size > 1,
+                    s"${backend.label} declares incremental streaming but delivered ${chunks.size} chunk(s)"
+                )
+            else
+                assert(
+                    chunks.size >= 1,
+                    s"${backend.label} declares non-incremental streaming; got ${chunks.size} chunk(s)"
+                )
+        yield ()
+        end for
+    }
+
 end LLMStreamIntegrationTest

--- a/kyo-ai/shared/src/test/scala/kyo/ToolIntegrationTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ToolIntegrationTest.scala
@@ -325,4 +325,43 @@ class ToolIntegrationTest extends BaseAITest:
         yield ()
     }
 
+    "count at least one model turn per tool call plus the answer" - runBackends { backend =>
+        // `turns` is the spend proxy a reader reconciles against the tool calls they can see, so it has
+        // to agree with them. A generation that called a tool once saw the model at least twice: once to
+        // produce the call, once to answer with its result. Reporting 1 says the turn was cheap when it
+        // was not, and on a harness backend that runs its own tool loop it said 1 no matter how much ran.
+        //
+        // The assertion is the lower bound, not an exact count: how many turns a model takes for a given
+        // ask is the model's choice, and pinning it would test the sampler.
+        for
+            result <- Abort.run[AIException] {
+                for
+                    calls <- AtomicInt.init(0)
+                    lookup = Tool.init[OrderQuery](
+                        "lookup_order",
+                        "Look up an order by id. Use this tool whenever an order status or ETA is requested."
+                    ) { query =>
+                        calls.incrementAndGet.map(_ => OrderInfo(s"ready_${query.orderId}", 17))
+                    }
+                    statsAndAnswer <- Observe.withStats {
+                        AI.enable(lookup) {
+                            AI.gen[String](
+                                "Call lookup_order with orderId 733, then reply with only the status it returns."
+                            )
+                        }
+                    }
+                    count <- calls.get
+                yield (statsAndAnswer._1, count)
+            }
+            statsAndCalls <- unwrap(backend, result)
+            (stats, calls) = statsAndCalls
+            _              = assert(calls >= 1, s"${backend.label} never called the tool, so this leaf proves nothing")
+            _ = assert(
+                stats.turns >= calls + 1,
+                s"${backend.label} reported ${stats.turns} turns for $calls tool call(s); a call and its " +
+                    s"answer are at least ${calls + 1} model turns: $stats"
+            )
+        yield ()
+    }
+
 end ToolIntegrationTest

--- a/kyo-ai/shared/src/test/scala/kyo/ToolMcpTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ToolMcpTest.scala
@@ -1,0 +1,285 @@
+package kyo
+
+import kyo.Json.JsonSchema
+import kyo.ai.Config
+import kyo.ai.Context.*
+
+/** Covers the schema-at-runtime tool surface: `Tool.initDynamic` and the `Tool.fromMcp` bridge.
+  *
+  * The acceptance property the whole surface exists for is that a tool set is built from what a server
+  * says about itself at runtime, with no `Schema[In]` anywhere in the calling code. Several tests below
+  * therefore drive a server tool that has NO Scala input type at all: its `ToolMeta` is assembled from a
+  * hand-built `JsonSchema` and its handler takes the open `Structure.Value`. That is the in-repo stand-in
+  * for a third-party server whose Scala types are not on the classpath, and it is a stricter one, since
+  * here those types do not exist to be imported.
+  */
+class ToolMcpTest extends kyo.test.Test[Any]:
+
+    private val clientInfo = McpInfo("kyo-ai-bridge-test", "0.0.0")
+    private val clientCaps = McpCapabilities.Client()
+
+    private def withServer[A, S](handlers: McpHandler[?, ?, ?]*)(f: McpClient => A < S)(using
+        Frame
+    ): A < (S & Async & Scope & Abort[McpException]) =
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            McpServer.init(ta, handlers*).flatMap { _ =>
+                McpClient.init(tb, clientInfo, clientCaps).flatMap(f)
+            }
+        }
+
+    /** The schema a third-party server would publish: required and optional properties, descriptions. */
+    private val weatherSchema: JsonSchema =
+        JsonSchema.Obj(
+            properties = List(
+                "city"  -> JsonSchema.Str(description = Present("the city to look up")),
+                "units" -> JsonSchema.Str(description = Present("metric or imperial"))
+            ),
+            required = List("city")
+        )
+
+    /** A server tool with no Scala input type: runtime meta plus an open-valued handler. */
+    private def weatherTool(seen: AtomicRef[Chunk[Structure.Value]])(using Frame): McpHandler[?, ?, ?] =
+        new McpHandler.ToolMultiHandler[Structure.Value, Nothing](
+            McpHandler.ToolMeta(
+                name = "lookup_weather",
+                description = Present("Look up the weather in a city"),
+                inputSchema = weatherSchema,
+                outputSchema = Absent,
+                annotations = Absent
+            ),
+            summon[Schema[Structure.Value]],
+            input =>
+                seen.getAndUpdate(_.append(input)).andThen(
+                    McpHandler.ToolOutcome.okWith(
+                        content = Chunk(McpContent.text("sunny, 21C")),
+                        structuredContent = Present(Structure.Value.Record(Chunk(
+                            "summary" -> Structure.Value.Str("sunny"),
+                            "celsius" -> Structure.Value.Integer(21)
+                        )))
+                    )
+                ),
+            Chunk.empty
+        )
+
+    /** Dispatches one model tool call through the eval loop's own handler and returns the tool message. */
+    private def dispatch(tool: Tool[?], name: String, arguments: String)(using Frame): String < (Async & Abort[AIGenException]) =
+        val callId = CallId("call-1")
+        val call   = Call(callId, name, arguments)
+        val infos  = tool.infos.asInstanceOf[Chunk[Tool.internal.Info[?, ?, LLM]]]
+        LLM.run(
+            AI.init.map { ai =>
+                ai.updateContext(_.assistantMessage("", Chunk(call)))
+                    .andThen(Tool.internal.handle(ai, infos, Chunk(call)))
+                    .andThen(ai.context)
+            }
+        ).map { ctx =>
+            ctx.messages.collect { case ToolMessage(id, content) if id == callId => content }.last
+        }
+    end dispatch
+
+    "initDynamic" - {
+
+        "advertises the supplied schema verbatim, constraints and all" in {
+            // A schema recovered through the structural vocabulary would lose `pattern` and the root
+            // description; the tool must show the model exactly what it was handed.
+            val declared = JsonSchema.Obj(
+                properties = List("sql" -> JsonSchema.Str(pattern = Present("^select"), description = Present("a SELECT"))),
+                required = List("sql"),
+                description = Present("run a query")
+            )
+            val tool = Tool.initDynamic("run_select", declared)(args => args)
+            assert(tool.infos.head.wireInputSchema == declared)
+        }
+
+        "hands the run the decoded arguments" in {
+            AtomicRef.init(Maybe.empty[Structure.Value]).map { captured =>
+                val tool = Tool.initDynamic("echo", weatherSchema) { args =>
+                    captured.set(Present(args)).andThen(Structure.Value.Str("done"))
+                }
+                Scope.run(dispatch(tool, "echo", """{"city":"Paris","units":"metric"}""")).andThen {
+                    captured.get.map { seen =>
+                        assert(seen == Present(Structure.Value.Record(Chunk(
+                            "city"  -> Structure.Value.Str("Paris"),
+                            "units" -> Structure.Value.Str("metric")
+                        ))))
+                    }
+                }
+            }
+        }
+
+        "rejects arguments that do not conform to the declared schema, without running the body" in {
+            AtomicInt.init(0).map { runs =>
+                val tool = Tool.initDynamic("echo", weatherSchema) { _ =>
+                    runs.incrementAndGet.andThen(Structure.Value.Str("done"))
+                }
+                Scope.run(dispatch(tool, "echo", """{"units":"metric"}""")).map { message =>
+                    runs.get.map { count =>
+                        assert(count == 0, "a non-conforming call must not reach the body")
+                        assert(message.contains("do not conform"), s"the model must see why; got: $message")
+                        assert(message.contains("city"), s"the violation must name the field; got: $message")
+                    }
+                }
+            }
+        }
+    }
+
+    "fromMcp" - {
+
+        "builds one tool per server tool, carrying the server's own name, description and schema" in {
+            Scope.run {
+                AtomicRef.init(Chunk.empty[Structure.Value]).map { seen =>
+                    withServer(weatherTool(seen)) { client =>
+                        Tool.fromMcp(client).map { tool =>
+                            val infos = tool.infos
+                            assert(infos.size == 1, s"expected one bridged tool, got ${infos.size}")
+                            val info = infos.head
+                            assert(info.name == "lookup_weather")
+                            assert(info.description == "Look up the weather in a city")
+                            // Verbatim: the model sees what the server published, not a re-derivation.
+                            assert(info.wireInputSchema == weatherSchema)
+                        }
+                    }
+                }
+            }
+        }
+
+        "dispatches the model's arguments to the server and returns its structured result" in {
+            Scope.run {
+                AtomicRef.init(Chunk.empty[Structure.Value]).map { seen =>
+                    withServer(weatherTool(seen)) { client =>
+                        Tool.fromMcp(client).map { tool =>
+                            dispatch(tool, "lookup_weather", """{"city":"Paris"}""").map { message =>
+                                seen.get.map { received =>
+                                    assert(
+                                        received == Chunk(Structure.Value.Record(Chunk("city" -> Structure.Value.Str("Paris")))),
+                                        s"the server must receive the model's arguments; got: $received"
+                                    )
+                                    assert(message.contains("sunny"), s"the tool result must reach the model; got: $message")
+                                    assert(message.contains("21"), s"the structured payload must reach the model; got: $message")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "rejects a non-conforming call against the server's runtime schema before it leaves the process" in {
+            Scope.run {
+                AtomicRef.init(Chunk.empty[Structure.Value]).map { seen =>
+                    withServer(weatherTool(seen)) { client =>
+                        Tool.fromMcp(client).map { tool =>
+                            dispatch(tool, "lookup_weather", """{"units":"metric"}""").map { message =>
+                                seen.get.map { received =>
+                                    assert(received.isEmpty, s"the server must not be called; got: $received")
+                                    assert(message.contains("do not conform"), s"the model must see why; got: $message")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "surfaces a server-side tool failure to the model rather than failing the generation" in {
+            val failing = new McpHandler.ToolMultiHandler[Structure.Value, Nothing](
+                McpHandler.ToolMeta(
+                    name = "always_fails",
+                    description = Present("fails"),
+                    inputSchema = JsonSchema.Obj(List("x" -> JsonSchema.Str()), List("x")),
+                    outputSchema = Absent,
+                    annotations = Absent
+                ),
+                summon[Schema[Structure.Value]],
+                _ => McpHandler.ToolOutcome.error("the upstream said no"),
+                Chunk.empty
+            )
+            Scope.run {
+                withServer(failing) { client =>
+                    Tool.fromMcp(client).map { tool =>
+                        dispatch(tool, "always_fails", """{"x":"y"}""").map { message =>
+                            assert(message.contains("the upstream said no"), s"got: $message")
+                        }
+                    }
+                }
+            }
+        }
+
+        "bridges every tool the server publishes" in {
+            Scope.run {
+                AtomicRef.init(Chunk.empty[Structure.Value]).map { seen =>
+                    val second = new McpHandler.ToolMultiHandler[Structure.Value, Nothing](
+                        McpHandler.ToolMeta(
+                            name = "list_cities",
+                            description = Present("list known cities"),
+                            inputSchema = JsonSchema.Obj(List.empty, List.empty),
+                            outputSchema = Absent,
+                            annotations = Absent
+                        ),
+                        summon[Schema[Structure.Value]],
+                        _ => McpHandler.ToolOutcome.ok(McpContent.text("Paris, Berlin")),
+                        Chunk.empty
+                    )
+                    withServer(weatherTool(seen), second) { client =>
+                        Tool.fromMcp(client).map { tool =>
+                            assert(tool.infos.map(_.name).toSet == Set("lookup_weather", "list_cities"))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "an agent completes a generation that calls a bridged tool it has no Scala types for" in {
+        // The end-to-end acceptance check: the model is offered the server's tool, calls it, and the
+        // result feeds the final answer. Nothing in this block names an input or output type for
+        // `lookup_weather`, because none exists.
+        TestCompletionServer.run { server =>
+            val config = Config.OpenAI.default
+                .apiKey("test")
+                .model(
+                    Config.OpenAI,
+                    "gpt-4o",
+                    128000,
+                    Config.OutputMaximum.Verified(16384),
+                    Config.ReasoningEncoding.Unavailable,
+                    true,
+                    true
+                )
+                .apiUrl(server.baseUrl)
+            AtomicRef.init(Chunk.empty[Structure.Value]).map { seen =>
+                withServer(weatherTool(seen)) { client =>
+                    Tool.fromMcp(client).map { tools =>
+                        val toolCall =
+                            """{"choices":[{"message":{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"lookup_weather","arguments":"{\"city\":\"Paris\"}"}}]}}]}"""
+                        val answer =
+                            """{"choices":[{"message":{"role":"assistant","content":null,"tool_calls":[{"id":"r1","type":"function","function":{"name":"result_tool","arguments":"{\"resultValue\":\"sunny in Paris\"}"}}]}}]}"""
+                        server.enqueueBody(toolCall).andThen(server.enqueueBody(answer)).andThen {
+                            LLM.run(config)(AI.enable(tools)(AI.gen[String])).map { answer =>
+                                seen.get.map { received =>
+                                    assert(answer == "sunny in Paris", s"got: $answer")
+                                    assert(
+                                        received == Chunk(Structure.Value.Record(Chunk("city" -> Structure.Value.Str("Paris")))),
+                                        s"the bridged tool must have run against the server; got: $received"
+                                    )
+                                    server.captured.map { caps =>
+                                        val firstRequest = caps.head.body
+                                        assert(
+                                            firstRequest.contains("lookup_weather"),
+                                            "the server's tool must be advertised to the model"
+                                        )
+                                        assert(
+                                            firstRequest.contains("the city to look up"),
+                                            s"the server's own property descriptions must reach the model; body: $firstRequest"
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+end ToolMcpTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeWireTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeWireTest.scala
@@ -398,7 +398,7 @@ class ClaudeCodeWireTest extends kyo.test.Test[Any]:
         val output =
             """{"type":"assistant","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":0,"cache_creation_input_tokens":29065}}}
               |{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":10,"output_tokens":38,"cache_read_input_tokens":5,"cache_creation_input_tokens":29065}}""".stripMargin
-        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output)).map { result =>
+        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output, 0)).map { result =>
             assert(
                 result == Result.succeed(AIStats(29080L, Present(5L), 38L, Absent, 1)),
                 s"the aggregate must win: input 10+5+29065, cached 5, output 38, one turn; got $result"
@@ -413,7 +413,7 @@ class ClaudeCodeWireTest extends kyo.test.Test[Any]:
             """{"type":"assistant","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":2,"cache_creation_input_tokens":100}}}
               |{"type":"assistant","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":2,"cache_creation_input_tokens":100}}}
               |{"type":"assistant","message":{"id":"msg_2","role":"assistant","content":[],"usage":{"input_tokens":50,"output_tokens":7,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}""".stripMargin
-        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output)).map { result =>
+        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output, 0)).map { result =>
             assert(
                 result == Result.succeed(AIStats(162L, Present(2L), 11L, Absent, 1)),
                 s"msg_1 counts once (112 in, 4 out) plus msg_2 (50 in, 7 out), one turn; got $result"
@@ -423,7 +423,7 @@ class ClaudeCodeWireTest extends kyo.test.Test[Any]:
 
     "turnUsage on output with no usage anywhere reports one turn of zeros" in {
         val output = """{"type":"system","subtype":"init","session_id":"s"}"""
-        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output)).map { result =>
+        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output, 0)).map { result =>
             assert(result == Result.succeed(AIStats(0L, Absent, 0L, Absent, 1)), s"got $result")
         }
     }

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/CodexCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/CodexCompletionTest.scala
@@ -100,4 +100,46 @@ class CodexCompletionTest extends kyo.test.Test[Any]:
         assert(params.approvalPolicy == "never", s"the session must never prompt for approvals: ${params.approvalPolicy}")
     }
 
+    "a thread/tokenUsage/updated notification reaches the event channel" in {
+        // The turn's token counts ride this one notification, and the consumer that reads them
+        // (`collectTurn`) sits behind the event channel. An unrouted method never reaches the channel,
+        // because the handler's default unknown-notification policy is Drop, so the consumer is dead
+        // code and every Codex turn reports zero tokens while looking like it simply had none.
+        val counts =
+            CodexWire.TokenCounts(
+                inputTokens = Present(1200L),
+                cachedInputTokens = Present(400L),
+                outputTokens = Present(85L),
+                reasoningOutputTokens = Present(64L)
+            )
+        val notification =
+            CodexWire.TokenUsageNotification("thread-1", "turn-1", CodexWire.ThreadTokenUsage(total = Present(counts)))
+        Scope.run {
+            for
+                transports <- JsonRpcTransport.inMemory
+                (ours, peers) = transports
+                events <- Channel.init[CodexWire.RpcEvent](8)
+                _      <- JsonRpcHandler.init(ours, CodexCompletion.eventRoutes(events)*)
+                peer   <- JsonRpcHandler.init(peers)
+                _      <- peer.notify("thread/tokenUsage/updated", Structure.encode(notification))
+                // Bounded, so a dropped notification reports as a timeout instead of hanging the suite.
+                event <- Abort.run[Timeout](Async.timeout(5.seconds)(events.take))
+            yield
+                assert(event.isSuccess, s"the notification must reach the event channel, got: $event")
+                val received = event.getOrThrow
+                assert(received.method == "thread/tokenUsage/updated", s"method mismatch: ${received.method}")
+                val decoded = Structure.decode[CodexWire.TokenUsageNotification](received.params).getOrThrow
+                val total   = decoded.tokenUsage.total.getOrElse(CodexWire.TokenCounts())
+                assert(total.inputTokens.getOrElse(0L) == 1200L, s"input tokens must survive the hop: $total")
+                assert(total.cachedInputTokens.getOrElse(0L) == 400L, s"cached input tokens must survive the hop: $total")
+                assert(total.outputTokens.getOrElse(0L) == 85L, s"output tokens must survive the hop: $total")
+                assert(total.reasoningOutputTokens.getOrElse(0L) == 64L, s"reasoning tokens must survive the hop: $total")
+                // The mapping the turn then applies, so the route and the arithmetic are pinned together.
+                val stats = CodexWire.usageStats(counts)
+                assert(stats.inputTokens == 1200L && stats.outputTokens == 85L, s"usage mapping: $stats")
+                assert(stats.totalTokens == 1285L, s"totalTokens: ${stats.totalTokens}")
+            end for
+        }
+    }
+
 end CodexCompletionTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/HarnessCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/HarnessCompletionTest.scala
@@ -118,4 +118,14 @@ class HarnessCompletionTest extends kyo.test.Test[Any]:
         assert(!AIHarnessException("p", "garbled").isInstanceOf[AIProviderException], "a harness malfunction is per-call")
     }
 
+    "every backend declares whether it streams incrementally" in {
+        // The declaration is the signal a chat UI reads instead of discovering in production feel, so it
+        // has to be right per family rather than merely present. The HTTP families stream over SSE; the
+        // command harnesses report a finished turn, so their stream arrives in one piece.
+        assert(Completion.openAI.streamsIncrementally, "the OpenAI family streams over SSE")
+        assert(Completion.anthropic.streamsIncrementally, "the Anthropic family streams over SSE")
+        assert(!Completion.claudeCode.streamsIncrementally, "the Claude Code harness reports a finished turn")
+        assert(!Completion.codex.streamsIncrementally, "the Codex harness reports a finished turn")
+    }
+
 end HarnessCompletionTest

--- a/kyo-schema-json/shared/src/main/scala/kyo/Json.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/Json.scala
@@ -701,6 +701,107 @@ object Json:
                     // tree's variant, not via the wire bytes.
                     Obj(List.empty, List.empty)
         end fromStructure
+
+        /** Recovers a `Structure.Type` from a JsonSchema: the runtime inverse of [[fromStructure]].
+          *
+          * A schema that only exists at runtime carries no Scala type, so nothing can validate a value
+          * against it: an MCP server's tool `inputSchema` and a hand-built descriptor both arrive as this
+          * AST and no further. The recovered type is the one `Structure.conform` reads, which is what lets
+          * a shape-dynamic `Schema[Structure.Value]` carry a schema it was never derived from.
+          *
+          * The recovery is structural, not total, and the losses are the parts no `Structure.Type` node
+          * can hold: JSON Schema's value constraints (`pattern`, `minLength`, numeric bounds) are dropped,
+          * a description survives only in property position (where `Structure.Field.doc` carries it), an
+          * object declaring both properties and `additionalProperties` recovers as its properties alone,
+          * and `type: null` recovers as `Unit`, which re-derives as `{}`. What a model acts on does
+          * survive a `toStructure` / `fromStructure` round trip: property names, types, nesting, the
+          * required set, and per-property descriptions.
+          *
+          * Product and sum nodes are named by their path from the root, because [[fromStructure]] guards
+          * recursion by name: two sibling objects sharing one name would re-derive the second as an empty
+          * `{}`, silently erasing its properties.
+          */
+        private[kyo] def toStructure(schema: JsonSchema): Structure.Type =
+            toStructure(schema, "Root")
+
+        private def toStructure(schema: JsonSchema, path: String): Structure.Type =
+            schema match
+                case _: Str     => stringStructure
+                case _: Integer => longStructure
+                case _: Num     => doubleStructure
+                case _: Bool    => booleanStructure
+                // `Unit` is the only kind `Structure.conform` accepts any value for, which is the closest
+                // reading of a JSON `null` type that the structural vocabulary offers.
+                case _: Null => unitStructure
+
+                case Nullable(inner) =>
+                    Structure.Type.Optional("Option", anyTag, toStructure(inner, path))
+
+                case arr: Arr =>
+                    Structure.Type.Collection("Chunk", anyTag, toStructure(arr.items, s"$path[]"))
+
+                case OneOf(variants) =>
+                    Structure.Type.Sum(
+                        path,
+                        anyTag,
+                        Chunk.empty,
+                        Chunk.from(variants.map((name, sub) => Structure.Variant(name, toStructure(sub, s"$path.$name")))),
+                        Chunk.empty
+                    )
+
+                case Obj(properties, required, additionalProperties, _, _, _) =>
+                    if properties.nonEmpty then
+                        val requiredNames = required.toSet
+                        Structure.Type.Product(
+                            path,
+                            anyTag,
+                            Chunk.empty,
+                            Chunk.from(properties.map { (name, sub) =>
+                                Structure.Field(
+                                    name,
+                                    toStructure(sub, s"$path.$name"),
+                                    doc = descriptionOf(sub),
+                                    optional = !requiredNames.contains(name)
+                                )
+                            })
+                        )
+                    else
+                        additionalProperties match
+                            // An object with no declared properties but a typed `additionalProperties` is
+                            // the JSON Schema spelling of a string-keyed map.
+                            case Present(valueSchema) =>
+                                Structure.Type.Mapping("Map", anyTag, stringStructure, toStructure(valueSchema, s"$path{}"))
+                            // `{}` declares no constraints, which is exactly what the open type means.
+                            case Absent => Structure.Type.Open(anyTag)
+                    end if
+            end match
+        end toStructure
+
+        /** The description a node carries, if its variant has one. */
+        private def descriptionOf(schema: JsonSchema): Maybe[String] =
+            schema match
+                case o: Obj     => o.description
+                case a: Arr     => a.description
+                case s: Str     => s.description
+                case n: Num     => n.description
+                case i: Integer => i.description
+                case b: Bool    => b.description
+                case n: Null    => n.description
+                case _          => Absent
+
+        // Reuse the derived structures so a recovered primitive is indistinguishable from the one a
+        // `Schema[String]` (and friends) produces, tag included.
+        private lazy val stringStructure: Structure.Type  = summon[Schema[String]].structure
+        private lazy val longStructure: Structure.Type    = summon[Schema[Long]].structure
+        private lazy val doubleStructure: Structure.Type  = summon[Schema[Double]].structure
+        private lazy val booleanStructure: Structure.Type = summon[Schema[Boolean]].structure
+        private lazy val unitStructure: Structure.Type    = summon[Schema[Unit]].structure
+
+        // A recovered node has no Scala type behind it, so every non-primitive carries the `Any` tag.
+        // Nothing downstream reads it: `conform` dispatches on the node kind and `fromStructure` on the
+        // node's shape.
+        private lazy val anyTag: Tag[Any] = Tag[Any]
+
     end JsonSchema
 
 end Json

--- a/kyo-schema-json/shared/src/test/scala/kyo/JsonSchemaStructureTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/kyo/JsonSchemaStructureTest.scala
@@ -1,0 +1,198 @@
+package kyo
+
+import Json.JsonSchema
+
+/** Covers `JsonSchema.toStructure`, the runtime inverse of `JsonSchema.fromStructure`.
+  *
+  * A schema that arrives at runtime (an MCP server's tool `inputSchema`, a hand-built descriptor) has no
+  * Scala type behind it, so the only way to validate a value against it is to recover the structural type
+  * `Structure.conform` reads. These tests pin both halves of that contract: the recovered type validates
+  * the values the schema describes, and re-deriving a JsonSchema from it preserves the parts a model acts
+  * on (property names, types, nesting, the required set, and property descriptions).
+  */
+class JsonSchemaStructureTest extends kyo.test.Test[Any]:
+
+    private def conforms(value: Structure.Value, tpe: Structure.Type): Boolean =
+        Structure.conform(value, tpe).isEmpty
+
+    private def violation(value: Structure.Value, tpe: Structure.Type): String =
+        Structure.conform(value, tpe).getOrElse("<conformed>")
+
+    "primitives recover the derived structural type" - {
+        "string" in {
+            assert(JsonSchema.toStructure(JsonSchema.Str()).equals(summon[Schema[String]].structure))
+        }
+        "integer" in {
+            assert(JsonSchema.toStructure(JsonSchema.Integer()).equals(summon[Schema[Long]].structure))
+        }
+        "number" in {
+            assert(JsonSchema.toStructure(JsonSchema.Num()).equals(summon[Schema[Double]].structure))
+        }
+        "boolean" in {
+            assert(JsonSchema.toStructure(JsonSchema.Bool()).equals(summon[Schema[Boolean]].structure))
+        }
+    }
+
+    "an object recovers a product whose fields carry name, type, optionality and doc" in {
+        val schema = JsonSchema.Obj(
+            properties = List(
+                "sql"   -> JsonSchema.Str(description = Present("the query to run")),
+                "limit" -> JsonSchema.Integer()
+            ),
+            required = List("sql")
+        )
+        JsonSchema.toStructure(schema) match
+            case p: Structure.Type.Product =>
+                assert(p.fields.map(_.name) == Chunk("sql", "limit"))
+                val sql = p.fields(0)
+                val lim = p.fields(1)
+                assert(sql.fieldType.equals(summon[Schema[String]].structure))
+                assert(sql.doc == Present("the query to run"))
+                assert(!sql.optional, "a required property must not be optional")
+                assert(lim.fieldType.equals(summon[Schema[Long]].structure))
+                assert(lim.optional, "a property absent from `required` must be optional")
+            case other => fail(s"expected a Product, got: $other")
+        end match
+    }
+
+    "conformance against a recovered object type" - {
+        val schema = JsonSchema.Obj(
+            properties = List(
+                "sql"   -> JsonSchema.Str(),
+                "limit" -> JsonSchema.Integer()
+            ),
+            required = List("sql")
+        )
+        val tpe = JsonSchema.toStructure(schema)
+
+        "accepts a record carrying the required field" in {
+            assert(conforms(Structure.Value.Record(Chunk("sql" -> Structure.Value.Str("select 1"))), tpe))
+        }
+        "accepts a record carrying every field" in {
+            val value = Structure.Value.Record(Chunk(
+                "sql"   -> Structure.Value.Str("select 1"),
+                "limit" -> Structure.Value.Integer(10)
+            ))
+            assert(conforms(value, tpe))
+        }
+        "rejects a record missing the required field" in {
+            val value = Structure.Value.Record(Chunk("limit" -> Structure.Value.Integer(10)))
+            assert(violation(value, tpe).contains("missing required field 'sql'"))
+        }
+        "rejects a required field of the wrong kind" in {
+            val value = Structure.Value.Record(Chunk("sql" -> Structure.Value.Bool(true)))
+            assert(violation(value, tpe).contains("sql"))
+        }
+        "rejects a non-object" in {
+            assert(violation(Structure.Value.Str("select 1"), tpe).contains("expected an object"))
+        }
+    }
+
+    "nested objects keep distinct product names so re-derivation does not read them as a cycle" in {
+        // `fromStructure` guards recursion by product NAME: two distinct nested objects sharing a name
+        // would make the second re-derive as an empty `{}`, silently erasing its properties.
+        val schema = JsonSchema.Obj(
+            properties = List(
+                "origin"      -> JsonSchema.Obj(List("city" -> JsonSchema.Str()), List("city")),
+                "destination" -> JsonSchema.Obj(List("code" -> JsonSchema.Str()), List("code"))
+            ),
+            required = List("origin", "destination")
+        )
+        val roundTripped = JsonSchema.fromStructure(JsonSchema.toStructure(schema))
+        roundTripped match
+            case JsonSchema.Obj(properties, required, _, _, _, _) =>
+                assert(required.toSet == Set("origin", "destination"))
+                val byName = properties.toMap
+                assert(byName("origin") == JsonSchema.Obj(List("city" -> JsonSchema.Str()), List("city")))
+                assert(byName("destination") == JsonSchema.Obj(List("code" -> JsonSchema.Str()), List("code")))
+            case other => fail(s"expected an Obj, got: $other")
+        end match
+    }
+
+    "arrays recover a collection over the element type" in {
+        val schema = JsonSchema.Arr(JsonSchema.Obj(List("name" -> JsonSchema.Str()), List("name")))
+        JsonSchema.toStructure(schema) match
+            case c: Structure.Type.Collection =>
+                assert(c.elementType.isInstanceOf[Structure.Type.Product])
+            case other => fail(s"expected a Collection, got: $other")
+        end match
+
+        val tpe = JsonSchema.toStructure(schema)
+        val ok = Structure.Value.Sequence(Chunk(
+            Structure.Value.Record(Chunk("name" -> Structure.Value.Str("a")))
+        ))
+        assert(conforms(ok, tpe))
+        val bad = Structure.Value.Sequence(Chunk(Structure.Value.Record(Chunk.empty)))
+        assert(violation(bad, tpe).contains("missing required field 'name'"))
+    }
+
+    "a nullable property recovers an optional that accepts null" in {
+        val schema = JsonSchema.Obj(
+            properties = List("note" -> JsonSchema.Nullable(JsonSchema.Str())),
+            required = List("note")
+        )
+        val tpe = JsonSchema.toStructure(schema)
+        assert(conforms(Structure.Value.Record(Chunk("note" -> Structure.Value.Null)), tpe))
+        assert(conforms(Structure.Value.Record(Chunk("note" -> Structure.Value.Str("hi"))), tpe))
+        assert(violation(Structure.Value.Record(Chunk("note" -> Structure.Value.Integer(1))), tpe).contains("note"))
+    }
+
+    "an open object recovers a mapping over its additionalProperties" in {
+        val schema = JsonSchema.Obj(
+            properties = List.empty,
+            required = List.empty,
+            additionalProperties = Present(JsonSchema.Str())
+        )
+        JsonSchema.toStructure(schema) match
+            case m: Structure.Type.Mapping =>
+                assert(m.keyType.equals(summon[Schema[String]].structure))
+                assert(m.valueType.equals(summon[Schema[String]].structure))
+            case other => fail(s"expected a Mapping, got: $other")
+        end match
+    }
+
+    "an unconstrained object recovers the open type, which accepts any value" in {
+        val tpe = JsonSchema.toStructure(JsonSchema.Obj(List.empty, List.empty))
+        assert(tpe.isInstanceOf[Structure.Type.Open])
+        assert(conforms(Structure.Value.Record(Chunk("anything" -> Structure.Value.Integer(1))), tpe))
+    }
+
+    "a oneOf recovers a sum over its variants" in {
+        val schema = JsonSchema.OneOf(List(
+            "text"  -> JsonSchema.Obj(List("body" -> JsonSchema.Str()), List("body")),
+            "image" -> JsonSchema.Obj(List("url" -> JsonSchema.Str()), List("url"))
+        ))
+        JsonSchema.toStructure(schema) match
+            case s: Structure.Type.Sum =>
+                assert(s.variants.map(_.name) == Chunk("text", "image"))
+            case other => fail(s"expected a Sum, got: $other")
+        end match
+    }
+
+    "re-deriving a JsonSchema from the recovered type preserves what a model acts on" in {
+        // The load-bearing round trip: an MCP tool's inputSchema is recovered and re-derived, and the
+        // property names, types, required set, nesting and per-property descriptions all survive.
+        val original = JsonSchema.Obj(
+            properties = List(
+                "sql"     -> JsonSchema.Str(description = Present("a read-only SELECT")),
+                "limit"   -> JsonSchema.Integer(description = Present("max rows")),
+                "tags"    -> JsonSchema.Arr(JsonSchema.Str()),
+                "options" -> JsonSchema.Obj(List("verbose" -> JsonSchema.Bool()), List("verbose"))
+            ),
+            required = List("sql", "tags", "options")
+        )
+        val roundTripped = JsonSchema.fromStructure(JsonSchema.toStructure(original))
+        roundTripped match
+            case JsonSchema.Obj(properties, required, _, _, _, _) =>
+                assert(properties.map(_._1) == List("sql", "limit", "tags", "options"))
+                assert(required.toSet == Set("sql", "tags", "options"))
+                val byName = properties.toMap
+                assert(byName("sql") == JsonSchema.Str(description = Present("a read-only SELECT")))
+                assert(byName("limit") == JsonSchema.Integer(description = Present("max rows")))
+                assert(byName("tags") == JsonSchema.Arr(JsonSchema.Str()))
+                assert(byName("options") == JsonSchema.Obj(List("verbose" -> JsonSchema.Bool()), List("verbose")))
+            case other => fail(s"expected an Obj, got: $other")
+        end match
+    }
+
+end JsonSchemaStructureTest


### PR DESCRIPTION
### Problem

kyo ships an MCP server module and an LLM module, and they could not compose. MCP's premise is that a tool set drops into any host, and this was the one place in the stack where that visibly did not hold.

The blocker was a missing primitive, not a missing convenience. `Tool.init[In]` needs a static `Schema[In]` at compile time, while an MCP server publishes its tools' schemas over the wire, so a host has no Scala type to name. Because no `Tool` constructor took a runtime schema, a user could not write the bridge either. The only way through was hand-wrapping each tool while naming both its types, which works for a server you wrote yourself and never for a third-party one.

The same modules also reported things that were not true. Codex reported zero tokens on every turn, so the budget guardrail the README documents summed zero and could never fire. `turns` reported 1 for a generation that made three tool calls. `AI.stream[String]` is documented as incremental with no caveat, yet a 250-word answer arrives from the command harnesses as a single chunk, so a chat UI shows a blank screen for the whole generation with nothing in the API saying why.

### Solution

`Tool.fromMcp(client)` walks a connected server's published tools and builds one `Tool` per entry from its wire metadata. It takes no type parameters, so it works against a server whose Scala types are not on the classpath.

Underneath it, `Tool.initDynamic` is the primitive that was missing: a tool built from a JSON Schema held as a value, with arguments arriving as an open `Structure.Value`. The declared schema binds, checked before the body runs and on the tool-error channel, so a malformed call is repaired by the model rather than reaching a body that never agreed to receive it. Recovering the structural type that check needs is what `JsonSchema.toStructure` does, and it is why this spans two modules: the converter serves only the constructor and is dead code without it. Tools also now carry the schema they advertise instead of always deriving one, since re-deriving a third-party schema drops `pattern`, bounds and descriptions before the model sees them.

The reporting fixes are smaller. Codex's usage was a mapping gap, not a harness limit: the app-server does report it, on a notification absent from the route table, and an unrouted notification is dropped rather than delivered unhandled. `turns` is floored at tool calls plus one on both harness backends, which run their own tool loop inside a single kyo turn. Streaming incrementality is declared per backend instead of promised everywhere. `stream` gains the inline-input overloads `gen` has.

### Notes

The bridge's acceptance test is stricter than "types not on the classpath": the server's tool is built from a runtime `ToolMeta`, so its input type does not exist in Scala at all, and an `AI.gen` still calls it end to end. JVM, JS and Native.

Verified live against OpenAI, Codex and Claude Code, which caught an earlier form of the turn-count fix still reporting 1 for a real tool call.

Correction to the finding this came from: object streaming is not incremental on the harness backends either, so it cannot serve as evidence the streaming machinery is fine. Both modes are the same defect.

Does not point at a server launched as a subprocess; that needs a client-side stdio transport. The bridge works over `inMemory`, `unixDomain` and any custom wire, and needs no change when that lands.
