### PR TITLE
[ci] run the Native leg as a pool of fresh sbt drivers with honest completion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,11 @@ jobs:
     # JVM full runs peak at ~95-100 min on Linux (browser/UI/caliban suites serialize under a
     # shared Chrome instance that cannot take concurrent CDP connections) and run slower on the
     # Windows pole, where runner-slot contention has pushed a full JVM run past 180 min. The binding
-    # pole is the Native aggregate build+test on the slower linux-arm64 runner: linux-x64 Native
-    # completes in ~200 min, so arm64 needs headroom well past 240 min and hit the old cap. 360 min
-    # (the GitHub-hosted job ceiling) bounds a genuine hang while giving the slowest pole real headroom.
+    # pole is Native on the slower linux-arm64 runner: it links every module the plan selects
+    # (~90s+ per link under the NATIVE_LINK_CPUS cap) and then runs every one of their test
+    # binaries. The old "linux-x64 Native completes in ~200 min" figure came from runs that
+    # reported success after starting 10 of 58 modules, so it never measured a full pass. 360 min
+    # (the GitHub-hosted job ceiling) bounds a genuine hang while giving that pole real headroom.
     timeout-minutes: 360
     strategy:
       fail-fast: false
@@ -80,25 +82,37 @@ jobs:
       # because .jvmopts holds no conflicting duplicates for them.
       JAVA_OPTS: "-Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
       JVM_OPTS:  "-Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
-      # No heavy-module isolation on Native: the previous heavy (kyo-schema-tests, whose whole-program
-      # optimize needed its own ~12G driver) is dropped from the Native leg via NATIVE_SKIP below, and every
-      # remaining (KEPT) native module already ran inside the heap-capped aggregate before, so none needs its
-      # own driver. Left empty so ci-test.sh runs the whole KEPT set in one aggregate session.
+      # No heavy-module pre-link on Native: the previous heavy (kyo-schema-tests, whose whole-program
+      # optimize needed its own ~12G driver) is dropped from the Native leg via NATIVE_SKIP below, and the
+      # link pool already gives every remaining (KEPT) module a driver carrying at most NATIVE_LINK_BATCH
+      # modules of accumulated heap, so none needs a driver to itself. Left empty; ci-test.sh then links
+      # the whole plan through the pool with no isolated pre-link ahead of it.
       NATIVE_HEAVY: ""
       # Drop the app/integration tier from the Native leg entirely: native link is ~90s+ per module and one
       # link per module dominates the Native rows, while these modules' behavior is platform-shared and
-      # already covered on JVM/JS. ci-test.sh applies this as `--exclude` to every native phase (both compile
-      # phases and the run), so a skipped module is neither compiled-for-test nor linked nor run; a KEPT module
-      # that dependsOn a skipped one still compiles that dependency's main on demand, so the build never breaks.
+      # already covered on JVM/JS. ci-test.sh applies this as `--exclude` to the plan and the cross pass, the
+      # two invocations that select for themselves, so a skipped module never enters the plan and is neither
+      # linked nor run; a KEPT module that dependsOn a skipped one still compiles that dependency's main on
+      # demand, so the build never breaks.
       # KEPT (native-specific behavior): the effect-runtime foundation, kyo-net, kyo-tasty, the schema readers
       # (json/yaml/ion), kyo-http, kyo-test-*, stm/actor/flow, and modules with native-specific source.
       NATIVE_SKIP: "${{ matrix.target == 'Native' && 'kyo-aeron,kyo-sql,kyo-sql-postgres,kyo-sql-mysql,kyo-sql-tests,kyo-pod,kyo-ui,kyo-browser,kyo-slack,kyo-mcp,kyo-jsonrpc,kyo-jsonrpc-http,kyo-lsp,kyo-ai,kyo-markdown,kyo-zio,kyo-zio-test,kyo-scheduler-zio,kyo-stats-otlp,kyo-reactive-streams,kyo-case-app,kyo-compat-future,kyo-compat-kyo,kyo-compat-zio,kyo-schema-tests,kyo-schema-protobuf,kyo-schema-msgpack,kyo-schema-bson,kyo-stats-registry,kyo-tasty-fixtures-internal' || '' }}"
-      # Cap the isolated heavy-module link+test driver to 2 CPUs (-XX:ActiveProcessorCount). The
-      # scala-native toolchain sizes its optimizer pool and its concurrent clang forks from
-      # availableProcessors, and that fork fleet stacked on the driver heap is what overcommits the
-      # 16GB runner (kernel OOM, exit 143). ci-test.sh applies this to the heavy --only session only;
-      # the compile phases and the aggregate run keep all 4 CPUs.
-      NATIVE_LINK_CPUS: "${{ matrix.target == 'Native' && '2' || '' }}"
+      # Cap the Native link drivers to 3 CPUs (-XX:ActiveProcessorCount). The scala-native toolchain
+      # sizes its optimizer pool and its concurrent clang forks from availableProcessors, and that fork
+      # fleet stacked on the driver heap is what overcommits the 16GB runner (kernel OOM, exit 143) when
+      # one driver accumulates every module's link. The batched pool caps a driver at NATIVE_LINK_BATCH
+      # modules of accumulated heap, which frees headroom for one more optimizer thread: the old 2-CPU
+      # cap was sized for a driver already carrying the whole set and left the box half idle (load 1.5
+      # to 2 on 4 vCPUs) across a three hour link phase. ci-test.sh applies this to every nativeLink
+      # invocation; the plan process, the test batches, and the cross pass keep all 4 CPUs.
+      NATIVE_LINK_CPUS: "${{ matrix.target == 'Native' && '3' || '' }}"
+      # Modules per sbt process in the Native link and test pools. Each batch is a fresh driver, so none
+      # carries more than 8 modules of accumulated heap and metaspace into a link or a test fork; the
+      # measured accumulation delta (+2.2G RSS) builds up around the tenth module of a shared driver. A
+      # full run pays ~4 extra sbt startups (~1 min each) per pool and, in exchange, a crash re-runs one
+      # batch instead of the whole phase. Native target only.
+      NATIVE_LINK_BATCH: "${{ matrix.target == 'Native' && '8' || '' }}"
+      NATIVE_TEST_BATCH: "${{ matrix.target == 'Native' && '8' || '' }}"
       # Below 512MB free the runner is minutes from dying WITHOUT uploading its log (observed twice
       # on Native rows). ci-monitor.sh then prints the disk attribution and TERM-kills the build,
       # converting an unattributable runner loss into a normal red job with the evidence in the log.
@@ -125,8 +139,9 @@ jobs:
       # right after its test binary links, to keep the row's ~40 modules inside the runner's disk; a
       # drop that leaves state describing the deleted IR makes the next link hand clang object paths
       # for files nobody wrote, and the row dies an hour in on a missing .ll.o with no diagnostic. This
-      # guard reproduces the link-prune-relink cycle on kyo-data (the cheapest module with a Native test
-      # binary), so a hook regression fails fast in a couple of minutes instead of hours into the row.
+      # guard reproduces the link-prune-relink cycle on kyo-data, the cheapest module with a Native test
+      # binary. It runs the same pinned-version plain task the link pool runs, so the pool's batch finds
+      # the binary already linked and the guard costs the row a couple of minutes while failing fast.
       - name: native relink guard (${{ inputs.os }})
         if: ${{ matrix.target == 'Native' }}
         shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ ThisBuild / useConsoleForROGit := (baseDirectory.value / ".git").isFile
 
 Global / commands += Repeat.command
 Global / commands += TestKyo.command
+Global / commands += TestKyo.doneCommand
 
 // Cap concurrent scaladoc runs. Each one is a forked JVM holding a whole module's TASTy graph
 // (see `Compile / doc` in kyo-settings), so a handful in parallel is enough to exhaust a 16GB

--- a/project/TestKyo.scala
+++ b/project/TestKyo.scala
@@ -11,10 +11,26 @@ import scala.sys.process.*
 
 /** Unified test command for CI and local use.
   *
-  * Usage: testKyo diff vs origin/main, all platforms, current Scala testKyo JVM diff vs origin/main, JVM only testKyo --all full test, all
-  * platforms testKyo --all JVM full test, JVM only testKyo --scala 2.13.18 JVM diff, Scala 2.13, JVM only (auto-discovers modules) testKyo
-  * --all --scala 2.13.18 JVM full test, Scala 2.13, JVM only testKyo origin/feature JVM diff vs specific ref, JVM only testKyo --dry-run
-  * JVM show what would run without executing
+  * Usage:
+  *   - `testKyo` diff vs origin/main, all platforms, every Scala version
+  *   - `testKyo JVM` diff vs origin/main, JVM only
+  *   - `testKyo --all Native` full test, Native only
+  *   - `testKyo --scala 2.13.18 JVM` diff, Scala 2.13, JVM only (auto-discovers modules)
+  *   - `testKyo --scala 3 --all JVM` full test, primary Scala 3 version only
+  *   - `testKyo --cross JVM` the Scala 2.x cross-build passes only
+  *   - `testKyo --exclude kyo-aeron,kyo-sql --all Native` full test minus those cross-projects
+  *   - `testKyo --only kyo-schema-tests --all Native` only that cross-project
+  *   - `testKyo --quick --all JVM` re-run only what sbt has not recorded as passing
+  *   - `testKyo --phase link --scala 3 --modules kyo-dataNative,kyo-coreNative Native` link exactly those modules
+  *   - `testKyo --dry-run --plan-file /tmp/p Native` write the selected modules to /tmp/p, run nothing
+  *   - `testKyo origin/feature JVM` diff vs a specific ref
+  *   - `testKyo --dry-run JVM` show what would run without executing
+  *
+  * A run is a sequence of passes: the primary Scala version, then one per Scala 2.x cross-build
+  * version. All passes go out as ONE `;`-chained command string (per pass: version switch, module
+  * tasks, completion marker). sbt queues a submitted command string rather than running it in
+  * place, so passes submitted as separate strings are unordered against each other and their tasks
+  * run at whichever version the queue last selected.
   */
 object TestKyo {
 
@@ -24,142 +40,233 @@ object TestKyo {
     // and full-run paths both exclude them and treat any change scoped to one as "run all".
     private val aggregateProjects = Set("kyoJVM", "kyoJS", "kyoNative", "kyoWasm")
 
+    private val phases = Seq("compile-main", "compile-test", "link", "test")
+
     private def log(msg: String): Unit = println(s"[testKyo] $msg")
 
+    private val doneCommandName = "testKyoDone"
+
+    /** Prints the line that marks a pass as run to completion. Each pass chains it after its own
+      * tasks, so its absence from a run's output means the pass stopped short of its module list.
+      * scripts/ci-test.sh reads it to tell a truncated Native pass from a green one.
+      */
+    def doneCommand: Command = Command.command(doneCommandName) { state =>
+        log("completed")
+        state
+    }
+
     /** The per-module sbt task for a phase. compile-main compiles only main sources; compile-test
-      * compiles test sources (main resolved from disk); test (default) runs the tests. Running the
-      * phases as separate sbt processes keeps the driver from holding a full compile heap while test
-      * forks run, which is what over-commits the memory-constrained CI runners.
+      * compiles test sources (main resolved from disk); link links the Native test binary; test
+      * (default) runs the tests, as `testQuick` under `--quick` so a re-invocation re-runs only the
+      * tests sbt did not record as passing. Running the phases as separate sbt processes keeps the
+      * driver from holding a full compile heap while test forks run, which is what over-commits the
+      * memory-constrained CI runners.
       */
     private def taskFor(phase: String, name: String, quick: Boolean): String = phase match {
         case "compile-main" => s"$name/Compile/compile"
         case "compile-test" => s"$name/Test/compile"
+        case "link"         => s"$name/Test/nativeLink"
         case _              => if (quick) s"$name/testQuick" else s"$name/test"
     }
 
     private def phaseLabel(phase: String): String = phase match {
         case "compile-main" => "compiling main for"
         case "compile-test" => "compiling test for"
+        case "link"         => "linking"
         case _              => "testing"
     }
 
+    final private case class Args(
+        isAll: Boolean,
+        isDryRun: Boolean,
+        isCross: Boolean,
+        isQuick: Boolean,
+        scalaArg: Option[String],
+        phase: String,
+        modules: Option[Seq[String]],
+        exclude: Set[String],
+        only: Set[String],
+        planFile: Option[String],
+        platform: Option[String],
+        baseRef: String
+    )
+
     def command: Command = Command.args("testKyo", "") { (state, args) =>
-        val isAll    = args.contains("--all")
-        val isDryRun = args.contains("--dry-run")
-        // --quick emits `testQuick` per module, so a re-invocation re-runs only the tests sbt did not record as
-        // passed. The native crash-retry loop (ci-test.sh) uses it so a crashed suite's re-run stays scoped to failures.
-        val isQuick         = args.contains("--quick")
-        val scalaIdx        = args.indexOf("--scala")
-        val scalaVersionArg = if (scalaIdx >= 0 && scalaIdx + 1 < args.length) Some(args(scalaIdx + 1)) else None
-        // Phase selects the per-module task: compile-main, compile-test, or test (default). CI runs the
-        // three phases as separate sbt processes so the driver never holds a full compile heap while test
-        // forks run (see .github/workflows/build.yml and taskFor).
-        val phaseIdx = args.indexOf("--phase")
-        val phase    = if (phaseIdx >= 0 && phaseIdx + 1 < args.length) args(phaseIdx + 1) else "test"
+        parseArgs(args) match {
+            case Left(err) =>
+                state.log.error(s"testKyo: $err")
+                state.fail
+            case Right(parsed) => run(state, parsed)
+        }
+    }
 
-        // --exclude <base>[,...] drops modules by cross-project base name (platform suffix stripped); --only keeps
-        // only those. Complements: CI's Native pass runs the heavy module in an isolated driver via --only and the
-        // rest via --exclude, so each is linked and run exactly once. Both honor the diff/scala/platform scoping.
-        val excludeIdx = args.indexOf("--exclude")
-        val excludeBases: Set[String] =
-            (if (excludeIdx >= 0 && excludeIdx + 1 < args.length) args(excludeIdx + 1) else "")
-                .split(",").map(_.trim).filter(_.nonEmpty).toSet
-        val onlyIdx = args.indexOf("--only")
-        val onlyBases: Set[String] =
-            (if (onlyIdx >= 0 && onlyIdx + 1 < args.length) args(onlyIdx + 1) else "")
-                .split(",").map(_.trim).filter(_.nonEmpty).toSet
+    /** Parse the command line, or return the argument error that must fail the invocation. An
+      * unknown `--flag` is an error rather than a base ref: a mistyped `--modules` silently
+      * becoming a git ref would run the wrong module set.
+      */
+    private def parseArgs(args: Seq[String]): Either[String, Args] = {
+        var isAll    = false
+        var isDryRun = false
+        var isCross  = false
+        var isQuick  = false
+        var scalaArg = Option.empty[String]
+        var phase    = "test"
+        var modules  = Option.empty[Seq[String]]
+        var exclude  = Set.empty[String]
+        var only     = Set.empty[String]
+        var planFile = Option.empty[String]
+        var error    = Option.empty[String]
+        val rest     = collection.mutable.ListBuffer.empty[String]
 
-        val remaining = args
-            .filterNot(a => a == "--all" || a == "--dry-run" || a == "--quick")
-            .filterNot(a => a == "--scala" || (scalaIdx >= 0 && args.indexOf(a) == scalaIdx + 1))
-            .filterNot(a => a == "--phase" || (phaseIdx >= 0 && args.indexOf(a) == phaseIdx + 1))
-            .filterNot(a => a == "--exclude" || (excludeIdx >= 0 && args.indexOf(a) == excludeIdx + 1))
-            .filterNot(a => a == "--only" || (onlyIdx >= 0 && args.indexOf(a) == onlyIdx + 1))
+        def valueAt(i: Int, flag: String): Option[String] =
+            if (i + 1 < args.length && !args(i + 1).startsWith("--")) Some(args(i + 1))
+            else {
+                error = error.orElse(Some(s"$flag requires a value"))
+                None
+            }
 
-        val (platformArgs, refArgs) = remaining.partition(a => platformNames.exists(_.equalsIgnoreCase(a)))
+        def csv(v: Option[String]): Seq[String] = v.toSeq.flatMap(_.split(",").toSeq.map(_.trim).filter(_.nonEmpty))
+
+        var i = 0
+        while (i < args.length) {
+            args(i) match {
+                case "--all" =>
+                    isAll = true; i += 1
+                case "--dry-run" =>
+                    isDryRun = true; i += 1
+                case "--cross" =>
+                    isCross = true; i += 1
+                case "--quick" =>
+                    isQuick = true; i += 1
+                case "--scala" =>
+                    scalaArg = valueAt(i, "--scala"); i += 2
+                case "--phase" =>
+                    phase = valueAt(i, "--phase").getOrElse(phase); i += 2
+                case "--plan-file" =>
+                    planFile = valueAt(i, "--plan-file"); i += 2
+                case "--modules" =>
+                    modules = valueAt(i, "--modules").map(v => csv(Some(v)))
+                    i += 2
+                case "--exclude" =>
+                    exclude = csv(valueAt(i, "--exclude")).toSet; i += 2
+                case "--only" =>
+                    only = csv(valueAt(i, "--only")).toSet; i += 2
+                case a if a.startsWith("--") =>
+                    error = error.orElse(Some(s"unknown argument: $a")); i += 1
+                case a =>
+                    rest += a; i += 1
+            }
+        }
+
+        val (platformArgs, refArgs) = rest.toSeq.partition(a => platformNames.exists(_.equalsIgnoreCase(a)))
         val platform                = platformArgs.headOption.map(a => platformNames.find(_.equalsIgnoreCase(a)).get)
         val baseRef                 = refArgs.headOption.getOrElse("origin/main")
 
+        val invalid =
+            if (isCross && scalaArg.isDefined) Some("--cross and --scala select different passes; pass only one")
+            else if (isCross && modules.isDefined) Some("--cross and --modules cannot be combined")
+            else if (isAll && modules.isDefined) Some("--all and --modules cannot be combined")
+            else if (modules.isDefined && (exclude.nonEmpty || only.nonEmpty))
+                Some("--modules is an execution list, --exclude/--only filter a selection; pass only one")
+            else if (modules.exists(_.isEmpty)) Some("--modules needs a comma-separated module list")
+            else if (!phases.contains(phase)) Some(s"unknown phase '$phase', expected one of ${phases.mkString(", ")}")
+            else None
+
+        error.orElse(invalid)
+            .toLeft(Args(isAll, isDryRun, isCross, isQuick, scalaArg, phase, modules, exclude, only, planFile, platform, baseRef))
+    }
+
+    private def run(state: State, a: Args): State = {
         val extracted = Project.extract(state)
         val scala3    = extracted.get(scalaVersion)
 
-        // Resolve --scala 2 / --scala 3 to actual versions from the build
-        val scalaVersionOpt = scalaVersionArg.map(resolveScalaVersion(_, extracted))
-        val runBothScala    = scalaVersionOpt.isEmpty
+        // One pass per Scala version, in execution order. --cross drops the primary pass, --scala
+        // and --modules pin a single one; the default is the primary version plus 2.13 for the
+        // cross-build library modules and 2.12 for the sbt plugins.
+        val versions =
+            if (a.isCross) findScala2Versions(extracted)
+            else a.scalaArg.map(resolveScalaVersion(_, extracted)) match {
+                case Some(v)                     => Seq(v)
+                case None if a.modules.isDefined => Seq(scala3)
+                case None                        => scala3 +: findScala2Versions(extracted)
+            }
 
-        log(s"scala: ${scalaVersionOpt.getOrElse(s"$scala3 + 2.x")}, platform: ${platform.getOrElse("all")}, mode: ${if (isAll) "all"
-            else s"diff vs $baseRef"}")
+        val mode =
+            if (a.modules.isDefined) "explicit module list"
+            else if (a.isAll) "all"
+            else s"diff vs ${a.baseRef}"
+        log(s"scala: ${if (versions.isEmpty) "none" else versions.mkString(" + ")}, platform: ${a.platform.getOrElse("all")}, mode: $mode")
 
-        // Run for the specified or primary Scala version
-        val targetScala = scalaVersionOpt.getOrElse(scala3)
-
-        def commandForScala(sv: String): String =
-            if (isAll || scalaVersionOpt.isDefined) runAll(state, platform, sv, phase, excludeBases, onlyBases, isQuick)
-            else runDiff(state, baseRef, platform, sv, phase, excludeBases, onlyBases, isQuick)
-
-        // Assemble the whole run as ONE ordered command string. sbt's Command.process queues onto the state's remaining
-        // commands rather than running inline, so a separate call per Scala-version pass drains out of order: the ++
-        // switches run first, then all batches under whatever version was switched to last. One ordered string runs
-        // each batch under its preceding ++. Module selection reads crossScalaVersions, computed without switching.
-        val parts = scala.collection.mutable.ListBuffer.empty[String]
-        scalaVersionOpt.foreach(v => if (v != scala3) parts += s"++$v")
-        val primary = commandForScala(targetScala)
-        if (primary.nonEmpty) parts += primary
-        if (runBothScala) findScala2Versions(extracted) match {
-            case Nil      => log("no Scala 2.x cross-build modules found")
-            case versions =>
-                // One pass per distinct Scala 2.x version: 2.13 for the cross-build library modules,
-                // 2.12 for the sbt plugins (kyo-compat-plugin, kyo-doctest-plugin).
-                versions.foreach { v =>
-                    val cmd = commandForScala(v)
-                    if (cmd.nonEmpty) { log(s"including Scala $v cross-build modules"); parts += s"++$v"; parts += cmd }
-                }
-                // Restore the primary version if any pass switched away from it.
-                if (parts.exists(_.startsWith("++"))) parts += s"++$scala3"
-        }
-
-        val plan = parts.mkString("; ")
-        if (isDryRun || plan.isEmpty) state
-        else Command.process(plan, state, msg => state.log.error(msg))
+        if (versions.isEmpty) {
+            log("no Scala 2.x cross-build modules found")
+            a.planFile.foreach(writePlan(_, Nil))
+            log("completed")
+            state
+        } else
+            selectPasses(state, a, versions) match {
+                case Left(err) =>
+                    state.log.error(s"testKyo: $err")
+                    state.fail
+                case Right(passes) =>
+                    a.planFile.foreach(writePlan(_, passes.flatMap(_._2).distinct.sorted))
+                    execute(state, a, scala3, passes)
+            }
     }
 
-    // --- Full test mode ---
-
-    private def runAll(
+    /** The modules each pass runs, in pass order. Selection reads crossScalaVersions and the
+      * project graph, neither of which `++` changes, so every pass is resolved from the unswitched
+      * state and the whole run can go out as one ordered command chain.
+      *
+      * `--exclude`/`--only` filter here, where selection happens, by cross-project base name;
+      * `--modules` replaces selection outright and so is never combined with them.
+      */
+    private def selectPasses(
         state: State,
-        platform: Option[String],
-        scalaVersion: String,
-        phase: String = "test",
-        exclude: Set[String] = Set.empty,
-        only: Set[String] = Set.empty,
-        quick: Boolean = false
-    ): String = {
+        a: Args,
+        versions: Seq[String]
+    ): Either[String, Seq[(String, Seq[String])]] = {
         val extracted = Project.extract(state)
         val structure = extracted.structure
         val allRefs   = structure.allProjectRefs
 
-        val testable = allRefs.filter { ref =>
-            val name        = ref.project
-            val versions    = (ref / crossScalaVersions).get(structure.data).getOrElse(Nil)
-            val isAggregate = aggregateProjects.contains(name)
-            val platformMatch = if (isAggregate) false
-            else platform match {
+        def exists(name: String): Boolean = allRefs.exists(_.project == name)
+
+        def crossVersions(name: String): Seq[String] =
+            allRefs.find(_.project == name).flatMap(ref => (ref / crossScalaVersions).get(structure.data)).getOrElse(Nil)
+
+        def platformMatch(name: String): Boolean =
+            !aggregateProjects.contains(name) && (a.platform match {
                 case Some(p) => matchesPlatform(name, p)
                 case None    => true
-            }
-            val matchesScala = versions.contains(scalaVersion)
-            platformMatch && matchesScala && !exclude.contains(baseName(name)) && (only.isEmpty || only.contains(baseName(name)))
-        }
+            })
 
-        if (testable.isEmpty) {
-            log(s"no projects found for Scala $scalaVersion and platform ${platform.getOrElse("all")}")
-            ""
-        } else {
-            val sorted = testable.map(_.project).sorted
-            log(s"${phaseLabel(phase)} ${sorted.size} projects (Scala $scalaVersion): ${sorted.mkString(", ")}")
-            val commands = sorted.map(name => taskFor(phase, name, quick)).mkString("; ")
-            log(s"running: $commands")
-            commands
+        def selected(name: String): Boolean =
+            !a.exclude.contains(baseName(name)) && (a.only.isEmpty || a.only.contains(baseName(name)))
+
+        a.modules match {
+            case Some(names) =>
+                // An explicit list is one pass and never a filter: an unusable name fails the
+                // invocation so a batched runner cannot skip modules it believes it ran.
+                val version     = versions.head
+                val unknown     = names.filterNot(exists)
+                val offPlatform = names.filter(n => exists(n) && !platformMatch(n))
+                val offVersion  = names.filter(n => exists(n) && platformMatch(n) && !crossVersions(n).contains(version))
+                if (unknown.nonEmpty) Left(s"unknown modules: ${unknown.mkString(", ")}")
+                else if (offPlatform.nonEmpty)
+                    Left(s"modules outside platform ${a.platform.getOrElse("all")}: ${offPlatform.mkString(", ")}")
+                else if (offVersion.nonEmpty) Left(s"modules not cross-built for Scala $version: ${offVersion.mkString(", ")}")
+                else Right(Seq(version -> names.sorted))
+            case None =>
+                val restrict = if (a.isAll) None else diffSelection(state, a, allRefs, extracted)
+                Right(versions.map { v =>
+                    val eligible =
+                        allRefs.map(_.project).filter(n => platformMatch(n) && selected(n) && crossVersions(n).contains(v))
+                    val chosen = restrict match {
+                        case Some(selection) => eligible.filter(selection.contains)
+                        case None            => eligible
+                    }
+                    v -> chosen.sorted
+                })
         }
     }
 
@@ -169,85 +276,96 @@ object TestKyo {
     // changed lines (see buildSbtAffectedProjects), widening to all only when a changed line cannot
     // be pinned to a project. Otherwise, run only affected modules + their transitive dependents.
 
-    private def runDiff(
+    /** The modules a diff selects, before the per-pass platform and Scala filters, or None when the
+      * change is global and every module must run.
+      */
+    private def diffSelection(
         state: State,
-        baseRef: String,
-        platform: Option[String],
-        scalaVersion: String,
-        phase: String = "test",
-        exclude: Set[String] = Set.empty,
-        only: Set[String] = Set.empty,
-        quick: Boolean = false
-    ): String = {
-        val changedFiles = diffFiles(baseRef)
+        a: Args,
+        allRefs: Seq[ProjectRef],
+        extracted: Extracted
+    ): Option[Set[String]] = {
+        val changedFiles = diffFiles(a.baseRef)
         if (changedFiles.isEmpty) {
-            log(s"no changed files vs $baseRef, skipping tests")
-            return ""
+            log(s"no changed files vs ${a.baseRef}, skipping tests")
+            return Some(Set.empty)
         }
 
-        log(s"${changedFiles.size} changed files vs $baseRef:")
+        log(s"${changedFiles.size} changed files vs ${a.baseRef}:")
         changedFiles.foreach(f => log(s"  $f"))
 
         if (metaBuildChanged(changedFiles)) {
             log("meta-build changed (project/ or .github/), running all modules")
-            return runAll(state, platform, scalaVersion, phase, exclude, only, quick)
+            return None
         }
 
-        val extracted = Project.extract(state)
-        val structure = extracted.structure
-        val allRefs   = structure.allProjectRefs
-        val allNames  = allRefs.map(_.project).toSet
-        val bd        = extracted.get(buildDependencies)
+        val allNames = allRefs.map(_.project).toSet
+        val bd       = extracted.get(buildDependencies)
 
         // A build.sbt change maps to the projects whose settings changed; None means a changed
         // line could not be attributed to specific projects, so fall back to running all modules.
         val buildSbtProjects: Set[String] =
             if (!changedFiles.contains("build.sbt")) Set.empty
-            else buildSbtAffectedProjects(extracted, baseRef) match {
+            else buildSbtAffectedProjects(extracted, a.baseRef) match {
                 case Some(names) => names
-                case None        => return runAll(state, platform, scalaVersion, phase, exclude, only, quick)
+                case None        => return None
             }
 
         val directlyChanged = (changedFiles.flatMap(fileToProjects(_, allNames)) ++ buildSbtProjects).toSet
-        val filtered = platform match {
+        val filtered = a.platform match {
             case Some(p) => directlyChanged.filter(matchesPlatform(_, p))
             case None    => directlyChanged
         }
 
         if (filtered.isEmpty) {
             log("no affected projects found, skipping tests")
-            return ""
+            return Some(Set.empty)
         }
 
+        log(s"directly changed: ${filtered.toSeq.sorted.mkString(", ")}")
         val dependentMap = transitiveDependents(allRefs, bd)
-        val allAffected = filtered.flatMap { name =>
+        Some(filtered.flatMap { name =>
             allRefs.find(_.project == name) match {
                 case Some(ref) => dependentMap.getOrElse(ref, Set.empty).map(_.project) + name
                 case None      => Set(name)
             }
-        }
+        })
+    }
 
-        val toTest = (platform match {
-            case Some(p) => allAffected.filter(matchesPlatform(_, p))
-            case None    => allAffected
-        }).filter { name =>
-            !exclude.contains(baseName(name)) && (only.isEmpty || only.contains(baseName(name))) &&
-            allRefs.find(_.project == name).exists { ref =>
-                (ref / crossScalaVersions).get(structure.data).getOrElse(Nil).contains(scalaVersion)
+    /** Submit every pass as one `;`-chained command string: switch, tasks, completion marker, and
+      * the restore switch after the last pass that moved off the primary version. A pass that
+      * selects nothing contributes no tasks, so it prints its marker here.
+      */
+    private def execute(state: State, a: Args, scala3: String, passes: Seq[(String, Seq[String])]): State = {
+        val chain   = collection.mutable.ListBuffer.empty[String]
+        var current = scala3
+        passes.foreach { case (version, modules) =>
+            if (modules.isEmpty) {
+                log(s"Scala $version: no modules selected")
+                log("completed")
+            } else {
+                val switch = if (version == current) Nil else Seq(s"++$version")
+                val parts  = (switch ++ modules.map(taskFor(a.phase, _, a.isQuick))) :+ doneCommandName
+                current = version
+                log(s"Scala $version, ${phaseLabel(a.phase)} ${modules.size} modules: ${modules.mkString(", ")}")
+                log(s"pass: ${parts.mkString("; ")}")
+                chain ++= parts
             }
         }
-
-        if (toTest.isEmpty) {
-            log("no testable affected projects found, skipping tests")
-            ""
-        } else {
-            val sorted = toTest.toSeq.sorted
-            log(s"directly changed: ${filtered.toSeq.sorted.mkString(", ")}")
-            log(s"with dependents (${phaseLabel(phase)}): ${sorted.mkString(", ")}")
-            val commands = sorted.map(name => taskFor(phase, name, quick)).mkString("; ")
-            log(s"running: $commands")
-            commands
+        if (current != scala3) {
+            log(s"restoring Scala $scala3 after the last pass")
+            chain += s"++$scala3"
         }
+        if (chain.isEmpty || a.isDryRun) state
+        else Command.process(chain.mkString("; "), state, msg => state.log.error(msg))
+    }
+
+    /** The selected modules, one per line, for the runner that partitions them into batches. */
+    private def writePlan(path: String, modules: Seq[String]): Unit = {
+        val file = new File(path)
+        Option(file.getAbsoluteFile.getParentFile).foreach(IO.createDirectory)
+        IO.writeLines(file, modules)
+        log(s"plan: ${modules.size} modules written to $path")
     }
 
     // --- Helpers ---

--- a/scripts/build-selftest.sh
+++ b/scripts/build-selftest.sh
@@ -179,24 +179,28 @@ if echo "$out" | grep -qF "env=direct arch=native action=test"
 then record ok "the pre-run echo is unconditional and appears before ci-test.sh runs"
 else record no "the pre-run echo is unconditional and appears before ci-test.sh runs"; fi
 
-# 13. podman-ci mirrors build.yml's Native env (heavy-module isolation + link CPU cap) for the
-# Native target only, so a local Native run reproduces the row's link staging; JVM stays clean.
+# 13. podman-ci mirrors build.yml's Native env (heavy-module pre-link, link CPU cap, and the link and
+# test pool batch sizes) for the Native target only, so a local Native run reproduces the row's link
+# staging; JVM stays clean.
 make_podman_stub 0; reset_logs
 run_build --env podman-ci test Native >/dev/null 2>&1 || true
 native_env_ok=no
-if podman_log_has "-e NATIVE_HEAVY=kyo-schema-tests" && podman_log_has "-e NATIVE_LINK_CPUS=2"; then native_env_ok=yes; fi
+if podman_log_has "-e NATIVE_HEAVY=kyo-schema-tests" && podman_log_has "-e NATIVE_LINK_CPUS=3" \
+   && podman_log_has "-e NATIVE_LINK_BATCH=8" && podman_log_has "-e NATIVE_TEST_BATCH=8"; then native_env_ok=yes; fi
 reset_logs
 run_build --env podman-ci test JVM >/dev/null 2>&1 || true
-if [ "$native_env_ok" = yes ] && podman_log_lacks "NATIVE_HEAVY"
-then record ok "podman-ci Native gets NATIVE_HEAVY + NATIVE_LINK_CPUS; JVM does not"
-else record no "podman-ci Native gets NATIVE_HEAVY + NATIVE_LINK_CPUS; JVM does not"; fi
+if [ "$native_env_ok" = yes ] && podman_log_lacks "NATIVE_HEAVY" && podman_log_lacks "NATIVE_LINK_BATCH"
+then record ok "podman-ci Native gets the pool env (heavy, CPUs, batches); JVM does not"
+else record no "podman-ci Native gets the pool env (heavy, CPUs, batches); JVM does not"; fi
 
-# 14. a host NATIVE_HEAVY / NATIVE_LINK_CPUS value overrides the defaults into the container.
+# 14. a host value overrides each of those defaults into the container.
 make_podman_stub 0; reset_logs
-NATIVE_HEAVY="kyo-foo" NATIVE_LINK_CPUS=3 run_build --env podman-ci test Native >/dev/null 2>&1 || true
-if podman_log_has "-e NATIVE_HEAVY=kyo-foo" && podman_log_has "-e NATIVE_LINK_CPUS=3"
-then record ok "a host NATIVE_HEAVY / NATIVE_LINK_CPUS override reaches the container"
-else record no "a host NATIVE_HEAVY / NATIVE_LINK_CPUS override reaches the container"; fi
+NATIVE_HEAVY="kyo-foo" NATIVE_LINK_CPUS=1 NATIVE_LINK_BATCH=4 NATIVE_TEST_BATCH=2 \
+    run_build --env podman-ci test Native >/dev/null 2>&1 || true
+if podman_log_has "-e NATIVE_HEAVY=kyo-foo" && podman_log_has "-e NATIVE_LINK_CPUS=1" \
+   && podman_log_has "-e NATIVE_LINK_BATCH=4" && podman_log_has "-e NATIVE_TEST_BATCH=2"
+then record ok "a host pool-env override reaches the container"
+else record no "a host pool-env override reaches the container"; fi
 
 # Negative control: a deliberately wrong check must flip FAIL to prove the harness
 # is not vacuous. Not counted in the scenario total.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -281,15 +281,20 @@ run_in_container() {
         envs+=(-e CI=true -e SBT_TASK_LIMIT=1
                -e "JAVA_OPTS=$CI_DRIVER_OPTS"
                -e "JVM_OPTS=$CI_DRIVER_OPTS")
-        # Mirror build.yml's Native env so a podman-ci Native run reproduces the row's link staging.
-        # NATIVE_SKIP (the app/integration tier dropped from the Native leg) is forwarded so a host value
-        # reproduces the CI cut; it is empty by default here, so a bare `build.sh podman-ci test Native`
-        # links the whole set (set NATIVE_SKIP=<the build.yml list> to match the CI Native row exactly).
-        # A host NATIVE_HEAVY / NATIVE_LINK_CPUS value wins. Native target only, matching the workflow's
-        # `matrix.target == 'Native'` gate.
+        # Mirror build.yml's Native env so a podman-ci Native run reproduces the row's link staging:
+        # the link CPU cap and the pool batch sizes carry the workflow's values. NATIVE_SKIP (the
+        # app/integration tier dropped from the Native leg) is forwarded so a host value reproduces the
+        # CI cut; it is empty by default here, so a bare `build.sh podman-ci test Native` links the whole
+        # set (set NATIVE_SKIP=<the build.yml list> to match the CI Native row exactly). NATIVE_HEAVY is
+        # the one deliberate difference: the workflow leaves it empty because its NATIVE_SKIP list drops
+        # kyo-schema-tests from the Native leg entirely, while a local run that keeps the whole set still
+        # wants that module pre-linked in a driver of its own. A host value wins for each. Native target
+        # only, matching the workflow's `matrix.target == 'Native'` gate.
         if [ "$platform" = Native ]; then
             envs+=(-e "NATIVE_HEAVY=${NATIVE_HEAVY-kyo-schema-tests}"
-                   -e "NATIVE_LINK_CPUS=${NATIVE_LINK_CPUS-2}"
+                   -e "NATIVE_LINK_CPUS=${NATIVE_LINK_CPUS-3}"
+                   -e "NATIVE_LINK_BATCH=${NATIVE_LINK_BATCH-8}"
+                   -e "NATIVE_TEST_BATCH=${NATIVE_TEST_BATCH-8}"
                    -e "NATIVE_SKIP=${NATIVE_SKIP-}")
         fi
     fi

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -12,24 +12,39 @@ set -uo pipefail
 #
 # JVM, JS, and Wasm run as three separate sbt processes (compile-main, then
 # compile-test, then run) so the driver never holds the whole compile heap while
-# the test phase forks. Native takes the same compile-upfront split and then links
-# each module exactly once, inside its own test session: it compiles main and test
-# (no link), runs the heavy modules isolated in a full-heap, CPU-capped driver via
-# `testKyo --only`, then runs the rest in the capped aggregate driver via
-# `testKyo --exclude`, under a crash-retry loop that tolerates libunwind shutdown
-# hangs and mid-RPC errno-104 resets. Linking must stay inside the test session and
-# must not be split into an upfront link: Scala Native's cross-invocation build-skip
-# is unreliable (scala-native #2514), so an upfront link in a separate sbt process
-# gets relinked from scratch by the test session, and the `native-settings` work-dir
-# prune (guarding #1821 disk pressure) has by then deleted the codegen cache, making
-# that second link a full re-codegen. One in-session link per module sidesteps both.
-# The strategy is derived from the platform; no caller selects it.
+# the test phase forks. Each of those processes chains its Scala passes in one
+# ordered command string, so one process covers the primary version and the 2.x
+# cross-builds.
 #
-# Reads CI, SBT_TASK_LIMIT, JAVA_OPTS, JVM_OPTS, NATIVE_HEAVY, and
-# NATIVE_LINK_CPUS from the environment; mutates none of them (the heavy --only
-# session appends -XX:ActiveProcessorCount when NATIVE_LINK_CPUS is set). The
-# caller (a CI workflow, or build.sh --env podman-ci) owns the environment, so this
-# one runner is correct in every environment.
+# Native runs a pool of fresh drivers over one module plan:
+#
+#   1. plan       one sbt process writes the selected modules to a file
+#   2. pre-link   each NATIVE_HEAVY module the plan selects, alone in its driver
+#   3. link pool  the plan in batches of NATIVE_LINK_BATCH modules
+#   4. test pool  the plan in batches of NATIVE_TEST_BATCH modules
+#   5. cross      the Scala 2.x cross-build modules
+#
+# Splitting the link out of the test session works only because every process in
+# the pool pins its Scala version (`--scala 3`, zero `++`), so each project resolves
+# to the same effective version everywhere and zinc's analysis and Scala Native's
+# "Build skipped" check both carry across the process boundary. The `native-settings`
+# work-dir prune (guarding #1821 disk pressure) keeps `build-checksum` and the linked
+# binary, which are the entire input to that check. A version-mismatched split, which
+# is what a `++` round trip used to produce, relinks from scratch instead: that is the
+# shape scala-native #2514 describes.
+#
+# A crash-retry loop wraps each test batch and the cross pass, tolerating libunwind
+# shutdown hangs and mid-RPC errno-104 resets but never a pass that stopped short of
+# its module list (see DONE_MARKER), and re-running through `testKyo --quick` so a
+# retry stays scoped to what did not pass. The strategy is derived from the platform;
+# no caller selects it.
+#
+# Reads CI, SBT_TASK_LIMIT, JAVA_OPTS, JVM_OPTS, NATIVE_HEAVY, NATIVE_SKIP,
+# NATIVE_LINK_CPUS, NATIVE_LINK_BATCH, and NATIVE_TEST_BATCH from the environment;
+# mutates none of them (the nativeLink invocations append -XX:ActiveProcessorCount
+# when NATIVE_LINK_CPUS is set). The caller (a CI workflow, or build.sh --env
+# podman-ci) owns the environment, so this one runner is correct in every
+# environment.
 
 PLATFORMS="JVM JS Native Wasm"
 ACTIONS="test testDiff compile link"
@@ -53,11 +68,12 @@ contains_word() {
 # call log and the JAVA_OPTS it inherited to a heap log, so each case asserts
 # the RECORDED CALLS or the RECORDED HEAP, not just the exit code: the
 # JVM/JS/Wasm three-phase split (compile-main, compile-test, run) on full AND
-# diff; the Native compile-upfront then single-link path (two compile phases, no
-# nativeLink, the heavy module isolated via --only ahead of the --exclude
-# aggregate); the platform-derived strategy; the exit-code mapping; and the
-# NATIVE_LINK_CPUS cap reaching the isolated heavy session but not the compiles
-# or the aggregate run.
+# diff; the Native plan/pre-link/link-pool/test-pool/cross flow with its batch
+# sizes and per-batch retry; the completion marker separating a finished pass
+# from a truncated one; NATIVE_SKIP reaching the plan and the cross pass; the
+# platform-derived strategy; the exit-code mapping; the resolution-retry
+# wrapper; and the NATIVE_LINK_CPUS cap reaching every link invocation and no
+# other process.
 if [ "${1:-}" = "--self-test" ]; then
     SELF="$0"
     PASS=0; FAIL=0; TOTAL=0
@@ -66,35 +82,65 @@ if [ "${1:-}" = "--self-test" ]; then
     HEAP="$SELFDIR/heap.log"
     trap 'rm -rf "$SELFDIR"' EXIT
 
+    # The modules the fake sbt writes when the runner asks it to plan; cases
+    # reassign it to shape the pools. FAKE_SKIP is the comma-separated base-name
+    # list the plan writer honors, so a NATIVE_SKIP case can assert that a
+    # skipped module never reaches a batch. PASS_BODY is a complete green pass:
+    # test output plus the completion marker the tolerance branches require.
+    FAKE_PLAN="kyo-dataNative kyo-preludeNative"
+    FAKE_SKIP=""
+    PASS_BODY='echo "Tests: succeeded 100, failed 0"; echo "[testKyo] completed"; exit 0'
+
     # Build a fake sbt whose body is $1; every call appends its full
     # argument string to CALLS and the JAVA_OPTS it inherited to HEAP, so an
     # assertion can read both the call sequence and the heap the sbt subprocess
-    # saw.
+    # saw. A --plan-file call is the planning process: it writes FAKE_PLAN minus
+    # anything FAKE_SKIP names to the requested path and exits without reaching
+    # the body, the way testKyo applies --exclude where selection happens.
     make_fake_sbt() {
         {
             printf '#!/usr/bin/env bash\n'
             printf 'printf "%%s\\n" "$*" >> "%s"\n' "$CALLS"
             printf 'printf "%%s\\n" "${JAVA_OPTS:-}" >> "%s"\n' "$HEAP"
+            printf 'all="$*"\n'
+            printf 'if [ "${all#*--plan-file }" != "$all" ]; then\n'
+            printf '    rest="${all#*--plan-file }"; path="${rest%%%% *}"\n'
+            printf '    : > "$path"\n'
+            printf '    for m in %s; do\n' "$FAKE_PLAN"
+            printf '        skipped=no\n'
+            printf '        for s in $(printf "%%s" "%s" | tr "," " "); do\n' "$FAKE_SKIP"
+            printf '            [ "$m" = "${s}Native" ] && skipped=yes\n'
+            printf '        done\n'
+            printf '        [ "$skipped" = no ] && printf "%%s\\n" "$m" >> "$path"\n'
+            printf '    done\n'
+            printf '    exit 0\n'
+            printf 'fi\n'
             printf '%s\n' "$1"
         } > "$SELFDIR/sbt"
         chmod +x "$SELFDIR/sbt"
     }
 
     # Run the real runner under the fake sbt. Sets CT_EXIT (the runner exit
-    # code) and leaves the recorded calls in CALLS for the assertion.
-    run_runner() {
-        local platform="$1" action="$2" body="$3"
+    # code) and leaves the recorded calls in CALLS for the assertion. Trailing
+    # VAR=value pairs enter the runner's environment.
+    run_runner_env() {
+        local body="$1" platform="$2" action="$3"; shift 3
         : > "$CALLS"; : > "$HEAP"
         make_fake_sbt "$body"
-        PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 RESOLVE_BACKOFF=0 \
+        env PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 RESOLVE_BACKOFF=0 "$@" \
             "$SELF" "$platform" "$action" >/dev/null 2>&1
         CT_EXIT=$?
+    }
+
+    run_runner() {  # run_runner <platform> <action> <body>
+        run_runner_env "$3" "$1" "$2"
     }
 
     # Assertion helpers, evaluated against CT_EXIT and CALLS.
     exit_is()      { [ "$CT_EXIT" = "$1" ]; }
     calls_count()  { [ "$(wc -l < "$CALLS" | tr -d ' ')" = "$1" ]; }
     call_nth_is()  { [ "$(sed -n "${1}p" "$CALLS")" = "$2" ]; }
+    call_nth_has() { sed -n "${1}p" "$CALLS" | grep -qF -- "$2"; }
     calls_have()   { grep -qF -- "$1" "$CALLS"; }
     calls_lack()   { ! grep -qF -- "$1" "$CALLS"; }
     heap_nth_has() { sed -n "${1}p" "$HEAP" | grep -qF -- "$2"; }
@@ -132,18 +178,6 @@ if [ "${1:-}" = "--self-test" ]; then
     then record ok "JS and Wasm take the same three-process split"
     else record no "JS and Wasm take the same three-process split"; fi
 
-    # 2b. The run-phase heap cap is applied to the out-of-JVM targets' run process and to nothing else:
-    # not the JVM run (its tests run in the driver), and not the compile phases.
-    run_runner JVM test 'exit 0'
-    jvm_uncapped=no
-    if call_nth_is 3 "testKyo --all JVM"; then jvm_uncapped=yes; fi
-    run_runner Native test 'echo "Tests: succeeded 1, failed 0"; exit 0'
-    if [ "$jvm_uncapped" = yes ] \
-       && calls_have "-J-Xmx6G testKyo --all Native" \
-       && calls_lack "-J-Xmx6G testKyo --phase"
-    then record ok "run-phase heap cap: out-of-JVM run only, never JVM or compile"
-    else record no "run-phase heap cap: out-of-JVM run only, never JVM or compile"; fi
-
     # 3. Phase-split fails fast on a compile-main failure.
     run_runner JVM test 'exit 1'
     if calls_count 1 && call_nth_is 1 "testKyo --phase compile-main --all JVM" && exit_is 1
@@ -164,100 +198,180 @@ if [ "${1:-}" = "--self-test" ]; then
     then record ok "compile action runs only the two compile phases"
     else record no "compile action runs only the two compile phases"; fi
 
-    # 6. Native compiles main+test upfront, then runs once, with no upfront link.
-    run_runner Native test 'case "$*" in *--phase*) exit 0;; esac; echo "Tests: succeeded 100, failed 0"; exit 0'
-    if calls_count 3 \
-       && call_nth_is 1 "testKyo --phase compile-main --all Native" \
-       && call_nth_is 2 "testKyo --phase compile-test --all Native" \
-       && call_nth_is 3 "-J-Xmx6G testKyo --all Native" \
-       && calls_lack "nativeLink" && exit_is 0
-    then record ok "Native compiles upfront then runs once, no upfront link"
-    else record no "Native compiles upfront then runs once, no upfront link"; fi
-
-    # 7. Native fails fast on a compile-main failure, before linking or running anything.
-    run_runner Native test 'case "$*" in *"--phase compile-main"*) exit 1;; esac; echo "Tests: succeeded 1, failed 0"; exit 0'
-    if calls_count 1 && call_nth_is 1 "testKyo --phase compile-main --all Native" && exit_is 1
-    then record ok "Native fails fast on a compile-main failure"
-    else record no "Native fails fast on a compile-main failure"; fi
-
-    # 8. NATIVE_HEAVY runs the heavy module isolated via --only, then the rest via --exclude; no link.
-    : > "$CALLS"; : > "$HEAP"; make_fake_sbt 'case "$*" in *--phase*) exit 0;; esac; echo "Tests: succeeded 100, failed 0"; exit 0'
-    PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 \
-        NATIVE_HEAVY="kyo-schema-tests" "$SELF" Native test >/dev/null 2>&1
-    CT_EXIT=$?
+    # 6. Native plans first, then links the plan in batches, before any test process, and never links
+    # the kyoNative aggregate (only the planned modules are linked at all).
+    run_runner Native test "$PASS_BODY"
     if calls_count 4 \
-       && call_nth_is 3 "testKyo --only kyo-schema-tests --all Native" \
-       && call_nth_is 4 "-J-Xmx6G testKyo --exclude kyo-schema-tests --all Native" \
-       && calls_lack "nativeLink" && exit_is 0
-    then record ok "NATIVE_HEAVY runs the heavy module via --only, then the rest via --exclude"
-    else record no "NATIVE_HEAVY runs the heavy module via --only, then the rest via --exclude"; fi
+       && call_nth_has 1 "testKyo --dry-run --plan-file" && call_nth_has 1 "--scala 3 --all Native" \
+       && call_nth_is 2 "testKyo --phase link --scala 3 --modules kyo-dataNative,kyo-preludeNative Native" \
+       && call_nth_is 3 "-J-Xmx6G testKyo --scala 3 --modules kyo-dataNative,kyo-preludeNative Native" \
+       && call_nth_is 4 "-J-Xmx6G testKyo --cross --all Native" \
+       && calls_lack "kyoNative/Test/nativeLink" && exit_is 0
+    then record ok "Native plans, then links the plan before any test process"
+    else record no "Native plans, then links the plan before any test process"; fi
 
-    # 8a. NATIVE_LINK_CPUS caps the isolated heavy --only session, never the compiles or the aggregate run.
-    : > "$CALLS"; : > "$HEAP"; make_fake_sbt 'case "$*" in *--phase*) exit 0;; esac; echo "Tests: succeeded 100, failed 0"; exit 0'
-    PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 \
-        NATIVE_HEAVY="kyo-schema-tests" NATIVE_LINK_CPUS=2 "$SELF" Native test >/dev/null 2>&1
-    CT_EXIT=$?
-    if ! heap_nth_has 1 "-XX:ActiveProcessorCount=2" && ! heap_nth_has 2 "-XX:ActiveProcessorCount=2" \
-       && heap_nth_has 3 "-XX:ActiveProcessorCount=2" && ! heap_nth_has 4 "-XX:ActiveProcessorCount=2" \
+    # 7. The Native test path never sends a compile phase: the plan's link batches compile what they
+    # link, so a separate upfront compile would be the duplicate work the pool exists to remove.
+    run_runner Native test "$PASS_BODY"
+    if calls_lack "--phase compile-main" && calls_lack "--phase compile-test"
+    then record ok "the Native test path never sends a compile phase"
+    else record no "the Native test path never sends a compile phase"; fi
+
+    # 8. The Native compile action is the compile phases and nothing else: no plan, no link, no run.
+    run_runner Native compile 'exit 0'
+    if calls_count 2 \
+       && call_nth_is 1 "testKyo --phase compile-main Native" \
+       && call_nth_is 2 "testKyo --phase compile-test Native" \
+       && calls_lack "--plan-file" && calls_lack "--phase link" && exit_is 0
+    then record ok "the Native compile action runs the two compile phases and nothing else"
+    else record no "the Native compile action runs the two compile phases and nothing else"; fi
+
+    # 9. A link-batch failure exits 1 before any test process.
+    run_runner Native test 'if [[ "$*" == *"--phase link"* ]]; then exit 3; fi
+'"$PASS_BODY"
+    if calls_count 2 && calls_lack "testKyo --scala 3 --modules" && calls_lack "--cross" && exit_is 1
+    then record ok "a Native link-batch failure exits 1 before any test process"
+    else record no "a Native link-batch failure exits 1 before any test process"; fi
+
+    # 10. The run-phase heap cap reaches the Native test batches and the cross pass and nothing else:
+    # not the plan, not the link batches, and not the JVM run (its tests run in the driver).
+    run_runner JVM test 'exit 0'
+    jvm_uncapped=no
+    if call_nth_is 3 "testKyo --all JVM"; then jvm_uncapped=yes; fi
+    run_runner Native test "$PASS_BODY"
+    if [ "$jvm_uncapped" = yes ] \
+       && calls_have "-J-Xmx6G testKyo --scala 3 --modules" \
+       && calls_have "-J-Xmx6G testKyo --cross" \
+       && calls_lack "-J-Xmx6G testKyo --dry-run" \
+       && calls_lack "-J-Xmx6G testKyo --phase link"
+    then record ok "run-phase heap cap: Native test batches and cross only, never plan, link, or JVM"
+    else record no "run-phase heap cap: Native test batches and cross only, never plan, link, or JVM"; fi
+
+    # 11. NATIVE_HEAVY pre-links a planned heavy module in its own process before the link pool.
+    FAKE_PLAN="kyo-schema-testsNative kyo-dataNative"
+    run_runner_env "$PASS_BODY" Native test NATIVE_HEAVY="kyo-schema-tests"
+    if call_nth_has 1 "--plan-file" \
+       && call_nth_is 2 "kyo-schema-testsNative/Test/nativeLink" \
+       && call_nth_is 3 "testKyo --phase link --scala 3 --modules kyo-schema-testsNative,kyo-dataNative Native" \
        && exit_is 0
-    then record ok "NATIVE_LINK_CPUS caps the heavy --only session, never the compiles or aggregate"
-    else record no "NATIVE_LINK_CPUS caps the heavy --only session, never the compiles or aggregate"; fi
+    then record ok "NATIVE_HEAVY pre-links a planned heavy module before the link pool"
+    else record no "NATIVE_HEAVY pre-links a planned heavy module before the link pool"; fi
 
-    # 8b. A heavy --only failure aborts before the --exclude aggregate run.
-    : > "$CALLS"; : > "$HEAP"
-    make_fake_sbt 'case "$*" in *--phase*) exit 0;; *--only*) echo "Tests: succeeded 5, failed 1"; exit 1;; esac; echo "Tests: succeeded 100, failed 0"; exit 0'
-    PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 \
-        NATIVE_HEAVY="kyo-schema-tests" "$SELF" Native test >/dev/null 2>&1
-    CT_EXIT=$?
-    if calls_count 3 && call_nth_is 3 "testKyo --only kyo-schema-tests --all Native" \
-       && calls_lack "--exclude" && exit_is 1
-    then record ok "a heavy --only failure aborts before the --exclude aggregate run"
-    else record no "a heavy --only failure aborts before the --exclude aggregate run"; fi
+    # 12. NATIVE_LINK_CPUS caps the pre-link and every link batch, and nothing else.
+    run_runner_env "$PASS_BODY" Native test NATIVE_HEAVY="kyo-schema-tests" NATIVE_LINK_CPUS=2
+    if ! heap_nth_has 1 "-XX:ActiveProcessorCount=2" \
+       && heap_nth_has 2 "-XX:ActiveProcessorCount=2" \
+       && heap_nth_has 3 "-XX:ActiveProcessorCount=2" \
+       && ! heap_nth_has 4 "-XX:ActiveProcessorCount=2" \
+       && ! heap_nth_has 5 "-XX:ActiveProcessorCount=2" && exit_is 0
+    then record ok "NATIVE_LINK_CPUS caps link invocations, never plan, test, or cross"
+    else record no "NATIVE_LINK_CPUS caps link invocations, never plan, test, or cross"; fi
 
-    # 8c. NATIVE_SKIP (with no heavy) threads --exclude into BOTH compile phases and the aggregate run, and
-    # runs no isolated --only session.
-    : > "$CALLS"; : > "$HEAP"; make_fake_sbt 'case "$*" in *--phase*) exit 0;; esac; echo "Tests: succeeded 100, failed 0"; exit 0'
-    PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 \
-        NATIVE_SKIP="kyo-aeron,kyo-sql" "$SELF" Native test >/dev/null 2>&1
-    CT_EXIT=$?
-    if calls_count 3 \
-       && call_nth_is 1 "testKyo --phase compile-main --exclude kyo-aeron,kyo-sql --all Native" \
-       && call_nth_is 2 "testKyo --phase compile-test --exclude kyo-aeron,kyo-sql --all Native" \
-       && call_nth_is 3 "-J-Xmx6G testKyo --exclude kyo-aeron,kyo-sql --all Native" \
+    # 13. A heavy pre-link failure aborts before the link pool and before any tests.
+    run_runner_env 'if [[ "$*" == *"kyo-schema-testsNative/Test/nativeLink"* ]]; then exit 3; fi
+'"$PASS_BODY" Native test NATIVE_HEAVY="kyo-schema-tests"
+    if calls_count 2 && call_nth_is 2 "kyo-schema-testsNative/Test/nativeLink" \
+       && calls_lack "--phase link" && calls_lack "testKyo --scala 3 --modules" && exit_is 1
+    then record ok "NATIVE_HEAVY pre-link failure aborts before the link pool and tests"
+    else record no "NATIVE_HEAVY pre-link failure aborts before the link pool and tests"; fi
+
+    # 14. A NATIVE_HEAVY module the plan does not select is never pre-linked.
+    FAKE_PLAN="kyo-dataNative kyo-preludeNative"
+    run_runner_env "$PASS_BODY" Native test NATIVE_HEAVY="kyo-schema-tests"
+    if calls_lack "kyo-schema-testsNative/Test/nativeLink" \
+       && call_nth_is 2 "testKyo --phase link --scala 3 --modules kyo-dataNative,kyo-preludeNative Native" \
+       && exit_is 0
+    then record ok "an unplanned NATIVE_HEAVY module is not pre-linked"
+    else record no "an unplanned NATIVE_HEAVY module is not pre-linked"; fi
+
+    # 15. NATIVE_SKIP reaches the two selecting invocations, the plan and the cross pass. The batches
+    # consume the already-filtered plan by exact module name, so they carry no --exclude of their own.
+    FAKE_PLAN="kyo-dataNative kyo-aeronNative kyo-preludeNative"
+    FAKE_SKIP="kyo-aeron"
+    run_runner_env "$PASS_BODY" Native test NATIVE_SKIP="kyo-aeron,kyo-sql"
+    if call_nth_has 1 "--exclude kyo-aeron,kyo-sql" \
+       && call_nth_is 4 "-J-Xmx6G testKyo --cross --exclude kyo-aeron,kyo-sql --all Native" \
+       && calls_lack "--modules kyo-dataNative,kyo-aeronNative" \
        && calls_lack "--only" && exit_is 0
-    then record ok "NATIVE_SKIP excludes in both compiles and the aggregate; no --only session"
-    else record no "NATIVE_SKIP excludes in both compiles and the aggregate; no --only session"; fi
+    then record ok "NATIVE_SKIP reaches the plan and the cross pass; batches carry no --exclude"
+    else record no "NATIVE_SKIP reaches the plan and the cross pass; batches carry no --exclude"; fi
 
-    # 8d. A heavy module that is also in NATIVE_SKIP is dropped from --only (an isolated session that selected
-    # nothing would fail on "no test output"); with no heavy left, the whole KEPT set runs in the aggregate,
-    # which excludes the skip set.
-    : > "$CALLS"; : > "$HEAP"; make_fake_sbt 'case "$*" in *--phase*) exit 0;; esac; echo "Tests: succeeded 100, failed 0"; exit 0'
-    PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 \
-        NATIVE_HEAVY="kyo-schema-tests" NATIVE_SKIP="kyo-schema-tests,kyo-aeron" "$SELF" Native test >/dev/null 2>&1
-    CT_EXIT=$?
-    if calls_count 3 && calls_lack "--only" \
-       && call_nth_is 3 "-J-Xmx6G testKyo --exclude kyo-schema-tests,kyo-aeron --all Native" \
-       && exit_is 0
-    then record ok "a heavy module also in NATIVE_SKIP is dropped from --only; aggregate excludes the skip set"
-    else record no "a heavy module also in NATIVE_SKIP is dropped from --only; aggregate excludes the skip set"; fi
+    # 16. A module NATIVE_SKIP names is absent from the plan, so neither pool ever sees it.
+    if call_nth_is 2 "testKyo --phase link --scala 3 --modules kyo-dataNative,kyo-preludeNative Native" \
+       && call_nth_is 3 "-J-Xmx6G testKyo --scala 3 --modules kyo-dataNative,kyo-preludeNative Native" \
+       && calls_lack "kyo-aeronNative"
+    then record ok "a skipped module is absent from the plan and from both pools"
+    else record no "a skipped module is absent from the plan and from both pools"; fi
+    FAKE_SKIP=""
 
-    # 9-20: Native crash-retry / check_log scenarios.
-    # The two compile phases must pass, so the body exits 0 for any --phase call and applies the
-    # scenario ($3) to the aggregate run.
+    # 17. An empty plan links and tests nothing, and still runs the cross pass (a diff can touch only
+    # cross-built modules).
+    FAKE_PLAN=""
+    run_runner Native test "$PASS_BODY"
+    if calls_count 2 && call_nth_is 2 "-J-Xmx6G testKyo --cross --all Native" && exit_is 0
+    then record ok "an empty plan skips both pools and still runs the cross pass"
+    else record no "an empty plan skips both pools and still runs the cross pass"; fi
+
+    # 18. NATIVE_LINK_BATCH partitions the plan into ordered link processes; the link action stops there.
+    FAKE_PLAN="m1Native m2Native m3Native m4Native m5Native m6Native m7Native"
+    run_runner_env 'exit 0' Native link NATIVE_LINK_BATCH=3
+    if calls_count 4 \
+       && call_nth_is 2 "testKyo --phase link --scala 3 --modules m1Native,m2Native,m3Native Native" \
+       && call_nth_is 3 "testKyo --phase link --scala 3 --modules m4Native,m5Native,m6Native Native" \
+       && call_nth_is 4 "testKyo --phase link --scala 3 --modules m7Native Native" && exit_is 0
+    then record ok "NATIVE_LINK_BATCH partitions the plan into ordered link processes"
+    else record no "NATIVE_LINK_BATCH partitions the plan into ordered link processes"; fi
+
+    # 19. NATIVE_TEST_BATCH partitions the test pool, and a crash retries only its own batch.
+    rm -f "$SELFDIR/crash"
+    run_runner_env 'if [[ "$*" == *"--phase link"* ]]; then exit 0; fi
+if [[ "$*" == *"m4Native,m5Native,m6Native"* ]] && [ ! -f "'"$SELFDIR"'/crash" ]; then
+    touch "'"$SELFDIR"'/crash"; exit 137
+fi
+'"$PASS_BODY" Native test NATIVE_TEST_BATCH=3
+    rm -f "$SELFDIR/crash"
+    if calls_count 7 \
+       && call_nth_is 3 "-J-Xmx6G testKyo --scala 3 --modules m1Native,m2Native,m3Native Native" \
+       && call_nth_is 4 "-J-Xmx6G testKyo --scala 3 --modules m4Native,m5Native,m6Native Native" \
+       && call_nth_is 5 "-J-Xmx6G testKyo --scala 3 --modules m4Native,m5Native,m6Native Native --quick" \
+       && call_nth_is 6 "-J-Xmx6G testKyo --scala 3 --modules m7Native Native" \
+       && call_nth_is 7 "-J-Xmx6G testKyo --cross --all Native" && exit_is 0
+    then record ok "a crashed test batch is retried alone, the other batches run once"
+    else record no "a crashed test batch is retried alone, the other batches run once"; fi
+
+    # 20. A clean Tests: tail without the completion marker is a truncated pass, not a green one: the
+    # regression guard for a Native job that started 10 of 58 modules, went quiet, and reported success.
+    FAKE_PLAN="kyo-dataNative"
+    run_runner Native test 'if [[ "$*" == *"--phase link"* ]]; then exit 0; fi
+echo "Tests: succeeded 100, failed 0"; exit 1'
+    if calls_count 4 \
+       && call_nth_is 3 "-J-Xmx6G testKyo --scala 3 --modules kyo-dataNative Native" \
+       && call_nth_is 4 "-J-Xmx6G testKyo --scala 3 --modules kyo-dataNative Native --quick" \
+       && calls_lack "--cross" && exit_is 1
+    then record ok "a clean tail without the completion marker is retried, then fails"
+    else record no "a clean tail without the completion marker is retried, then fails"; fi
+
+    # 21-42: Native crash-retry / check_log scenarios, applied to the test batches.
+    # The plan and link calls must pass, so the body branches on $*.
+    FAKE_PLAN="kyo-dataNative kyo-preludeNative"
     nat() {  # nat <name> <expected-exit> <run-body>
-        run_runner Native test "case \"\$*\" in *--phase*) exit 0;; esac; $3"
+        run_runner Native test "if [[ \"\$*\" == *'--phase link'* ]]; then exit 0; fi
+$3"
         if exit_is "$2"; then record ok "$1"; else record no "$1"; fi
     }
-    nat "clean Native pass exits 0"                 0 'echo "Tests: succeeded 100, failed 0"; exit 0'
+    nat "clean Native pass exits 0"                 0 "$PASS_BODY"
     nat "real Native test failures exit 1"          1 'echo "Tests: succeeded 90, failed 3"; exit 1'
-    nat "Native crash after a clean pass tolerated" 0 'echo "Tests: succeeded 100, failed 0"; exit 137'
+    nat "Native crash after a completed pass tolerated" 0 'echo "Tests: succeeded 100, failed 0"
+echo "[testKyo] completed"; exit 137'
     nat "Native kill before any tests exits 1"      1 'exit 137'
-    nat "Native hang after pass tolerated"          0 'echo "Tests: succeeded 163, failed 0"; sleep 600'
+    nat "Native hang after a completed pass tolerated" 0 'echo "Tests: succeeded 163, failed 0"
+echo "[testKyo] completed"; sleep 600'
     nat "Native hang after a failure exits 1"       1 'echo "Tests: succeeded 90, failed 2"; sleep 600'
     nat "Native hang with no output exits 1"        1 'sleep 600'
     nat "Native multi-suite all-pass exits 0"       0 'echo "Tests: succeeded 64, failed 0"
 echo "Tests: succeeded 45, failed 0"
-echo "Tests: succeeded 163, failed 0"; exit 0'
+echo "Tests: succeeded 163, failed 0"
+echo "[testKyo] completed"; exit 0'
     nat "Native multi-suite one failure exits 1"    1 'echo "Tests: succeeded 64, failed 0"
 echo "Tests: succeeded 45, failed 2"; exit 1'
     nat "Native kill mid-compile after pass exits 1" 1 'echo "Tests: succeeded 64, failed 0"
@@ -266,7 +380,7 @@ echo "[info] compiling 39 Scala sources to /target/test-classes ..."; sleep 600'
 echo "  - t *** FAILED *** (15 seconds)"
 echo "Exception in thread \"main\" java.net.SocketException: read failed, errno: 104"
 echo "    at scala.scalanative.testinterface.NativeRPC.loop(Unknown Source)"; exit 1
-else rm -f "'"$SELFDIR"'/rpc"; echo "Tests: succeeded 100, failed 0"; exit 0; fi'
+else rm -f "'"$SELFDIR"'/rpc"; echo "Tests: succeeded 100, failed 0"; echo "[testKyo] completed"; exit 0; fi'
     rm -f "$SELFDIR/rpc"
     nat "Native FAILED without rpc crash stays a failure" 1 'echo "  - t *** FAILED *** (15 seconds)"
 echo "Exception in thread \"main\" java.lang.RuntimeException: oops"; exit 1'
@@ -283,7 +397,7 @@ echo "[info] Optimizing (debug mode) (4000 ms)"; sleep 600'
     nat "Native teardown SIGABRT after a passing suite is retried then passes" 0 'if [ ! -f "'"$SELFDIR"'/abrt" ]; then touch "'"$SELFDIR"'/abrt"
 echo "Tests: succeeded 99, failed 0"
 echo "[warn] Process /x/kyo-jsonrpc-test finished with non-zero value 134 (0x86)"; exit 134
-else rm -f "'"$SELFDIR"'/abrt"; echo "Tests: succeeded 99, failed 0"; exit 0; fi'
+else rm -f "'"$SELFDIR"'/abrt"; echo "Tests: succeeded 99, failed 0"; echo "[testKyo] completed"; exit 0; fi'
     rm -f "$SELFDIR/abrt"
     nat "Native persistent teardown SIGABRT fails after retries" 1 'echo "Tests: succeeded 99, failed 0"
 echo "[warn] Process /x/kyo-jsonrpc-test finished with non-zero value 134 (0x86)"; exit 134'
@@ -294,7 +408,7 @@ echo "[warn] Process /x/kyo-jsonrpc-test finished with non-zero value 134 (0x86)
     nat "Native SIGSEGV (raw signal 11) after a passing suite is retried then passes" 0 'if [ ! -f "'"$SELFDIR"'/segv" ]; then touch "'"$SELFDIR"'/segv"
 echo "Tests: succeeded 75, failed 0"
 echo "[warn] Process /x/kyo-schema-yaml-test finished with non-zero value 11 (0xb)"; exit 11
-else rm -f "'"$SELFDIR"'/segv"; echo "Tests: succeeded 75, failed 0"; exit 0; fi'
+else rm -f "'"$SELFDIR"'/segv"; echo "Tests: succeeded 75, failed 0"; echo "[testKyo] completed"; exit 0; fi'
     rm -f "$SELFDIR/segv"
     nat "Native persistent SIGSEGV (raw signal 11) fails after retries" 1 'echo "Tests: succeeded 75, failed 0"
 echo "[warn] Process /x/kyo-schema-yaml-test finished with non-zero value 11 (0xb)"; exit 11'
@@ -303,6 +417,7 @@ echo "[warn] Process /x/kyo-schema-yaml-test finished with non-zero value 11 (0x
     # as SIGSEGV and pulled into the retry path. With the anchor it falls through to the post-suite
     # tolerance branch (exit 0); without the anchor it would be retried and, being persistent, fail as 1.
     nat "Native exit 116 (contains 11 but is not SIGSEGV) is not retried as a crash" 0 'echo "Tests: succeeded 75, failed 0"
+echo "[testKyo] completed"
 echo "[warn] Process /x/kyo-schema-yaml-test finished with non-zero value 116 (0x74)"; exit 116'
 
     # scala-native #4992 module-init null: a concurrent first-touch reader reads a null module instance,
@@ -313,7 +428,7 @@ echo "[warn] Process /x/kyo-schema-yaml-test finished with non-zero value 116 (0
 echo "Tests: succeeded 74, failed 1"
 echo "  - reads scalar primitives directly from event values *** FAILED ***"
 echo "java.lang.ClassCastException: null cannot be cast to scala.math.BigInt"; exit 1
-else rm -f "'"$SELFDIR"'/nullcast"; echo "Tests: succeeded 75, failed 0"; exit 0; fi'
+else rm -f "'"$SELFDIR"'/nullcast"; echo "Tests: succeeded 75, failed 0"; echo "[testKyo] completed"; exit 0; fi'
     rm -f "$SELFDIR/nullcast"
     nat "Native persistent module-init null fails after retries" 1 'echo "Tests: succeeded 74, failed 1"
 echo "java.lang.ClassCastException: null cannot be cast to scala.math.BigInt"; exit 1'
@@ -358,20 +473,23 @@ echo "Tests: succeeded 100, failed 0"; exit 0'
     then record ok "a real compile error is not retried (no resolution signature)"
     else record no "a real compile error is not retried (no resolution signature)"; fi
 
-    # A native crash-retry re-runs through testKyo --quick: attempt 1 is the full run, the retry appends
-    # --quick so only the tests sbt did not record as passed (the crashed suites) re-run.
+    # A native crash-retry re-runs its batch through testKyo --quick: attempt 1 is the full batch, the
+    # retry appends --quick so only the tests sbt did not record as passing (the crashed suites) re-run.
+    # The plan invocation must not pick the flag up, so the count is exactly one.
     rm -f "$SELFDIR/qk"
-    run_runner Native test 'case "$*" in *--phase*) exit 0;; esac
-if [ ! -f "'"$SELFDIR"'/qk" ]; then touch "'"$SELFDIR"'/qk"
+    run_runner Native test 'if [[ "$*" == *"--phase link"* ]]; then exit 0; fi
+if [[ "$*" == *--modules* ]] && [ ! -f "'"$SELFDIR"'/qk" ]; then touch "'"$SELFDIR"'/qk"
 echo "Tests: succeeded 99, failed 0"
 echo "[warn] Process /x/kyo-schema-yaml-test finished with non-zero value 134 (0x86)"; exit 134
-else rm -f "'"$SELFDIR"'/qk"; echo "Tests: succeeded 99, failed 0"; exit 0; fi'
+fi
+echo "Tests: succeeded 99, failed 0"; echo "[testKyo] completed"; exit 0'
     rm -f "$SELFDIR/qk"
-    if exit_is 0 && [ "$(grep -c -- '--quick' "$CALLS")" = 1 ] && tail -1 "$CALLS" | grep -q -- '--quick'
-    then record ok "native crash-retry re-runs through testKyo --quick; attempt 1 is the full run"
-    else record no "native crash-retry re-runs through testKyo --quick; attempt 1 is the full run"; fi
+    if exit_is 0 && [ "$(grep -c -- '--quick' "$CALLS")" = 1 ] \
+       && calls_have "testKyo --scala 3 --modules kyo-dataNative,kyo-preludeNative Native --quick"
+    then record ok "a crashed test batch re-runs through testKyo --quick; attempt 1 is the full batch"
+    else record no "a crashed test batch re-runs through testKyo --quick; attempt 1 is the full batch"; fi
 
-    # 21-22: argument validation exits 2 before any sbt.
+    # 47-48: argument validation exits 2 before any sbt.
     run_runner Frob test 'exit 0'
     if exit_is 2 && calls_count 0; then record ok "unknown platform exits 2 before any sbt"
     else record no "unknown platform exits 2 before any sbt"; fi
@@ -386,7 +504,7 @@ else rm -f "'"$SELFDIR"'/qk"; echo "Tests: succeeded 99, failed 0"; exit 0; fi'
 
     echo ""
     echo "Results: $PASS/$TOTAL passed, $FAIL failed"
-    [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq 39 ]
+    [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq 48 ]
     exit $?
 fi
 
@@ -411,31 +529,42 @@ POLL_INTERVAL=${POLL_INTERVAL:-10}
 RESOLVE_BACKOFF=${RESOLVE_BACKOFF:-20}
 
 # Space-separated module names (e.g. "kyo-schema-tests", which links every serialization format
-# into one binary) whose whole-program native-link optimize peak needs an isolated, full-heap sbt
-# driver. Each runs its link+test in its own process via `testKyo --only`, keeping that optimize off
-# the aggregate driver, which is heap-capped for fork headroom (run_phase_heap, below) and would OOM
-# under it. Measured before the format-module split: the then-monolithic kyo-schema alone peaked
-# ~7.7G RSS in a clean process vs ~9.9G stacked on an accumulated aggregate driver, which OOM-killed
-# the capped Native driver. The aggregate run excludes these via `testKyo --exclude`, so each is
-# linked and run exactly once. Empty by default; the CI workflow sets it for the Native target.
+# into one binary) whose SOLO native-link optimize peak needs an isolated, fresh-heap sbt driver.
+# Each is linked first in its own process, ahead of the link pool, so its whole-program optimize
+# never runs in a driver whose preceding modules have already filled the heap and metaspace.
+# Measured before the format-module split: the then-monolithic kyo-schema alone peaked ~7.7G RSS in
+# a clean process vs ~9.9G in an accumulated driver (the delta is that accumulation), which
+# OOM-killed the 8G-capped Native driver. nativeLink is disk-cached per project, so the link pool
+# skips a module already linked here, and a module the plan does not select is not pre-linked at
+# all. Empty by default; the CI workflow sets it for the Native target.
 NATIVE_HEAVY="${NATIVE_HEAVY:-}"
 
 # Space- or comma-separated base names dropped from the Native leg ENTIRELY (the app/integration tier:
 # database, messaging, container, browser/UI, and interop modules whose behavior is platform-shared and
 # already covered on JVM/JS). Native link is the dominant CI cost (~90s+ per module, one link each), so
-# excluding these keeps the Native rows viable. Applied as `--exclude` to every native phase (both
-# compile phases and the run), so an excluded module is neither compiled-for-test nor linked nor run. A
-# KEPT module that dependsOn an excluded one still compiles that dependency's main on demand, so the build
-# never breaks; only the excluded module's own tests stop running natively. Empty by default (so the
-# self-test and any standalone run keep the full set); the CI workflow sets it for the Native target.
+# excluding these keeps the Native rows viable. Applied as `--exclude` to the two invocations that do
+# their own selection, the plan and the cross pass, so an excluded module never enters the plan and is
+# therefore neither linked nor run; the batches consume the plan by exact module name and need no
+# filter of their own. A KEPT module that dependsOn an excluded one still compiles that dependency's
+# main on demand, so the build never breaks; only the excluded module's own tests stop running
+# natively. Empty by default (so the self-test and any standalone run keep the full set); the CI
+# workflow sets it for the Native target.
 NATIVE_SKIP="${NATIVE_SKIP:-}"
 
-# When non-empty, the isolated heavy-module native-link drivers run with
-# -XX:ActiveProcessorCount=$NATIVE_LINK_CPUS: the heavy `testKyo --only` link+test session (test path)
-# and the standalone pre-links (link action). The scala-native toolchain sizes its optimizer pool and
-# its concurrent clang forks from availableProcessors, and that fork fleet stacked on the driver heap
-# is what overcommits the 16GB CI runners. The compile phases and the aggregate run keep every CPU.
+# When non-empty, every nativeLink invocation runs with -XX:ActiveProcessorCount=$NATIVE_LINK_CPUS:
+# each link batch and each NATIVE_HEAVY pre-link. The scala-native toolchain sizes its optimizer pool
+# and its concurrent clang forks from availableProcessors, and that fork fleet stacked on the driver
+# heap is what overcommits the 16GB CI runners. Scoped to the link invocations only; the plan process,
+# the test batches, and the cross pass keep every CPU.
 NATIVE_LINK_CPUS="${NATIVE_LINK_CPUS:-}"
+
+# Modules per sbt process in the Native link and test pools. Each batch is a fresh driver, so no
+# driver carries more than this many modules of heap and metaspace; the measured accumulation delta
+# (+2.2G RSS) builds up around the tenth module of a shared driver. A crash then costs one batch
+# instead of the whole phase. Empty or 0 runs the whole plan in one process, which is the shape a
+# local run wants; the CI workflow sets both for the Native target.
+NATIVE_LINK_BATCH="${NATIVE_LINK_BATCH:-}"
+NATIVE_TEST_BATCH="${NATIVE_TEST_BATCH:-}"
 
 log() { echo "=== [ci-test] $(date '+%H:%M:%S') $* ==="; }
 
@@ -462,8 +591,8 @@ sbt_resolve_retry() {
     done
 }
 
-# sbt for a standalone native link invocation (the link action's pre-links and aggregate link):
-# applies the NATIVE_LINK_CPUS cap when set. The flag is added via the invocation's environment;
+# sbt for a native link invocation (a NATIVE_HEAVY pre-link or a link-pool batch): applies the
+# NATIVE_LINK_CPUS cap when set. The flag is added via the invocation's environment;
 # .jvmopts only overrides flags it duplicates, so a flag that appears only here always reaches the JVM.
 # Routes through sbt_resolve_retry so a transient resolution failure at link time is retried too.
 link_sbt() {
@@ -519,11 +648,45 @@ run_phase_split() {
     esac
 }
 
-# -- Native: compile upfront, then link+run each module once (heavy isolated), under crash-retry --
+# -- Native: plan once, then link and test that plan in a pool of fresh drivers, under crash-retry --
 LOG=""
 tail_pid=""
 watchdog_killed=0
-native_cleanup() { rm -f "$LOG"; [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null; }
+
+# The modules the run selects, computed once by the planning process and partitioned by both pools,
+# so link and test operate on the identical list and each batch's membership is in the runner log.
+PLAN="${RUNNER_TEMP:-/tmp}/kyo-native-plan.$$"
+
+# The line testKyo chains after each pass's tasks (project/TestKyo.scala). A pass that ends without
+# it stopped short of its module list.
+DONE_MARKER="[testKyo] completed"
+
+native_cleanup() { rm -f "$LOG" "$PLAN"; [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null; }
+
+# Join the non-empty fragments of a native testKyo command with single spaces, so an unset
+# NATIVE_SKIP or an empty run-arg leaves no stray double space in the command sbt receives.
+native_cmd() {
+    local out="" part
+    for part in "$@"; do [ -n "$part" ] && out="${out:+$out }$part"; done
+    printf '%s' "$out"
+}
+
+# Partition the plan into comma-separated module lists of at most $1 modules, one batch per line,
+# preserving plan order. An empty or non-positive size puts every module in one batch; an empty
+# plan yields no batches at all.
+plan_batches() {
+    grep -v '^[[:space:]]*$' "$PLAN" | awk -v n="${1:-0}" '
+        { mods[NR] = $0 }
+        END {
+            if (NR == 0) exit
+            if (n <= 0) n = NR
+            for (i = 1; i <= NR; i += n) {
+                line = mods[i]
+                for (j = i + 1; j < i + n && j <= NR; j++) line = line "," mods[j]
+                print line
+            }
+        }'
+}
 
 file_size() { wc -c < "$1" 2>/dev/null | tr -d ' '; }
 
@@ -544,7 +707,7 @@ crashed_native_runner() {
         && grep -qE 'scala\.scalanative\.testinterface\.NativeRPC' "$LOG"
 }
 
-# 0 pass, 1 real failure, 2 no test output. Called only after a nonzero exit or a watchdog kill.
+# 0 pass, 1 real failure, 2 no verdict (retry). Called only after a nonzero exit or a watchdog kill.
 check_log() {
     if crashed_native_runner; then
         log "native test runner crashed mid-RPC (errno 104): retrying"
@@ -575,13 +738,13 @@ check_log() {
     fi
     if grep -qE "Tests:" "$LOG"; then
         # At least one suite passed and none failed, yet the process still died (nonzero exit or a
-        # watchdog kill). That is tolerable only as a shutdown crash/hang AFTER the last suite, with
-        # nothing left running. Each module now links inside the run, so a later module's compile,
-        # link, or optimize, or a driver OOM-kill mid-optimize (exit 137), after an earlier module's
-        # Tests: line means real work was cut short. Scan the region after the last Tests: line for any
-        # work-in-progress marker and fail the run when one is present, on BOTH the watchdog and the
-        # self-exit paths. Bare "[error]" is deliberately excluded so a genuine post-suite shutdown
-        # crash stays tolerated.
+        # watchdog kill). That is tolerable only as a shutdown crash/hang AFTER the batch's last
+        # module, with nothing left running. Each module links inside its batch's session on a
+        # second run, so a later module's compile, link, or optimize, or a driver OOM-kill
+        # mid-optimize (exit 137), after an earlier module's Tests: line means real work was cut
+        # short. Scan the region after the last Tests: line for any work-in-progress marker and fail
+        # the run when one is present, on BOTH the watchdog and the self-exit paths. Bare "[error]"
+        # is deliberately excluded so a genuine post-suite shutdown crash stays tolerated.
         last_test_line=$(grep -nE "Tests:" "$LOG" | tail -1 | cut -d: -f1)
         post_test=""
         if [ -n "$last_test_line" ]; then
@@ -591,6 +754,15 @@ check_log() {
         fi
         if [ -n "$post_test" ]; then
             log "process died with work in progress after the last suite: $post_test"; return 1
+        fi
+        # A clean `Tests:` tail with nothing in progress only says "nothing has failed yet": it reads
+        # the same whether the pass ran out its module list or died at a module boundary with modules
+        # still queued, which is how a Native job that started 10 of 58 modules reported success. The
+        # marker is what separates the two, so without it the pass is truncated: retry, do not
+        # tolerate. The legitimate libunwind shutdown hang still passes, since the marker prints from
+        # the command chain before the JVM exits.
+        if ! grep -qF -- "$DONE_MARKER" "$LOG"; then
+            log "clean tests but no '$DONE_MARKER': the pass stopped short of its module list"; return 2
         fi
         if [ "$watchdog_killed" -eq 1 ]; then
             log "watchdog killed after the final Tests: line: tolerating shutdown hang"
@@ -602,27 +774,29 @@ check_log() {
     return 2
 }
 
-# Run one sbt invocation ("$@") under the stale-output watchdog and native crash-retry loop: a hung
-# process (no output for STALE_TIMEOUT) is killed and retried, a mid-RPC errno-104 reset is retried, a
-# clean pass or a real test failure returns immediately. Returns 0 (pass) or 1 (real failure, or no test
-# output after MAX_RETRIES). The caller sets the driver heap (a leading -J-Xmx arg) and any
-# NATIVE_LINK_CPUS cap via the environment; this loop just runs whatever sbt command it is handed.
-run_native_retry() {
-    LOG=$(mktemp)
-    trap native_cleanup EXIT
+# Run one sbt invocation ("$@", after the label) under the stale-output watchdog and native
+# crash-retry loop: a hung process (no output for STALE_TIMEOUT) is killed and retried, a mid-RPC
+# errno-104 reset is retried, a clean pass or a real test failure returns immediately. Returns 0
+# (pass) or 1 (real failure, or no verdict after MAX_RETRIES). Because it wraps ONE batch, a crash
+# costs that batch's modules rather than the whole test phase. The caller sets the driver heap (a
+# leading -J-Xmx arg) and any NATIVE_LINK_CPUS cap via the environment; this loop just runs whatever
+# sbt command it is handed.
+run_watched() {
+    local label="$1"; shift
+    local -a base=("$@")
     local attempt
     for attempt in $(seq 1 "$MAX_RETRIES"); do
-        # A retry re-runs through testKyo --quick so only the tests sbt did not record as passed run
-        # again: a crashed native suite is left unrecorded and re-runs, while every module that already
-        # passed is skipped, keeping the reroll off the whole module set the first attempt cleared (a
-        # per-process-startup crash rerolled across ~50 modules never converges). The testKyo command is
-        # the final positional arg; an optional -J-Xmx heap arg precedes it.
-        local -a cmd=("$@")
+        # A retry re-runs through testKyo --quick so only the tests sbt did not record as passing run
+        # again: a crashed native suite is left unrecorded and re-runs, while every module in the
+        # batch that already passed is skipped, keeping the reroll off the modules the first attempt
+        # cleared. The testKyo command is the final positional arg; an optional -J-Xmx heap arg
+        # precedes it.
+        local -a cmd=("${base[@]}")
         if [ "$attempt" -ge 2 ]; then
             local li=$(( ${#cmd[@]} - 1 ))
             case "${cmd[$li]}" in *testKyo*) cmd[$li]="${cmd[$li]} --quick" ;; esac
         fi
-        log "attempt $attempt/$MAX_RETRIES running: sbt ${cmd[*]}"
+        log "attempt $attempt/$MAX_RETRIES $label: sbt ${cmd[*]}"
         : > "$LOG"; watchdog_killed=0
         if command -v setsid >/dev/null 2>&1; then
             setsid sbt "${cmd[@]}" >> "$LOG" 2>&1 &
@@ -650,97 +824,71 @@ run_native_retry() {
         done
         wait "$sbt_pid" 2>/dev/null; exit_code=$?
         kill "$tail_pid" 2>/dev/null; wait "$tail_pid" 2>/dev/null; tail_pid=""
-        if [ "$exit_code" -eq 0 ]; then log "tests passed"; return 0; fi
+        if [ "$exit_code" -eq 0 ]; then log "$label passed"; return 0; fi
         check_log; rc=$?
         [ "$rc" -le 1 ] && return "$rc"
-        log "no test output: retrying..."
+        log "no verdict from $label: retrying..."
     done
-    log "FAILED: no test output after $MAX_RETRIES attempts"
+    log "FAILED: $label produced no verdict after $MAX_RETRIES attempts"
     return 1
-}
-
-# Assemble a native `testKyo` command with no stray double-spaces, folding NATIVE_SKIP into the exclude.
-# Args: phase(or "")  only_csv(or "")  extra_exclude_csv(or "")  skip_csv(or "")  run_arg(or "").
-# With an empty skip and extra the output matches the pre-NATIVE_SKIP form for the `test` action (a non-empty
-# run-arg), so the self-test's exact-match assertions still hold; the empty-arg compile/testDiff actions collapse
-# what used to be a double space to a single one, which sbt ignores.
-native_testkyo() {
-    local phase="$1" only="$2" extra="$3" skip="$4" arg="$5" excl cmd="testKyo"
-    [ -n "$phase" ] && cmd="$cmd --phase $phase"
-    [ -n "$only" ]  && cmd="$cmd --only $only"
-    excl="$extra"; [ -n "$skip" ] && excl="${extra:+$extra,}$skip"
-    [ -n "$excl" ]  && cmd="$cmd --exclude $excl"
-    [ -n "$arg" ]   && cmd="$cmd $arg"
-    printf '%s Native' "$cmd"
 }
 
 run_native() {
     local arg; arg=$(run_arg)
 
-    # Comma-separated base names to drop from every native phase (empty by default; CI sets NATIVE_SKIP).
-    local skip_csv; skip_csv=$(printf '%s' "$NATIVE_SKIP" | tr -s ', ' ',' | sed 's/^,//; s/,$//')
+    # Comma-separated base names to drop from the Native leg (empty by default; CI sets NATIVE_SKIP).
+    # Only the two invocations that select for themselves, the plan and the cross pass, take it.
+    local skip_csv skip_flag
+    skip_csv=$(printf '%s' "$NATIVE_SKIP" | tr -s ', ' ',' | sed 's/^,//; s/,$//')
+    skip_flag=""; [ -n "$skip_csv" ] && skip_flag="--exclude $skip_csv"
 
-    # compile: compile main and test only, no link, no run.
+    # compile: compile main and test only, no plan, no link, no run.
     if [ "$ACTION" = "compile" ]; then
-        sbt_resolve_retry "$(native_testkyo compile-main '' '' "$skip_csv" "$arg")" || return $?
-        sbt_resolve_retry "$(native_testkyo compile-test '' '' "$skip_csv" "$arg")" || return $?
+        sbt_resolve_retry "$(native_cmd 'testKyo --phase compile-main' "$skip_flag" "$arg" Native)" || return $?
+        sbt_resolve_retry "$(native_cmd 'testKyo --phase compile-test' "$skip_flag" "$arg" Native)" || return $?
         return 0
     fi
 
-    # link: compile + a standalone aggregate link, no run. This is the local/standalone
-    # link-validation action (build.sh); CI's Native path is the 'test' action below, which links
-    # inside the test session instead. NATIVE_HEAVY still gets its own isolated driver here.
-    if [ "$ACTION" = "link" ]; then
-        for heavy in $NATIVE_HEAVY; do
+    trap native_cleanup EXIT
+
+    # One selection for the whole run: the shell partitions this file, so both pools work the
+    # identical module list and each batch's membership lands in the runner log.
+    local plan_cmd; plan_cmd=$(native_cmd "testKyo --dry-run --plan-file $PLAN" "$skip_flag" '--scala 3' "$arg" Native)
+    log "planning native modules: sbt $plan_cmd"
+    sbt_resolve_retry "$plan_cmd" || { log "native planning failed"; return 1; }
+    if [ ! -f "$PLAN" ]; then
+        log "native planning wrote no plan file ($PLAN)"; return 1
+    fi
+    log "plan: $(tr '\n' ' ' < "$PLAN")"
+
+    local heavy
+    for heavy in $NATIVE_HEAVY; do
+        if grep -qxF -- "${heavy}Native" "$PLAN"; then
             log "pre-linking heavy native module in an isolated driver: sbt ${heavy}Native/Test/nativeLink"
             link_sbt "${heavy}Native/Test/nativeLink" || { log "native pre-link of $heavy failed"; return 1; }
-        done
-        log "linking native test binaries: sbt kyoNative/Test/nativeLink"
-        link_sbt "kyoNative/Test/nativeLink" || { log "native linking failed"; return 1; }
+        fi
+    done
+
+    local batch
+    for batch in $(plan_batches "$NATIVE_LINK_BATCH"); do
+        log "linking native test binaries: sbt testKyo --phase link --scala 3 --modules $batch Native"
+        link_sbt "testKyo --phase link --scala 3 --modules $batch Native" \
+            || { log "native linking failed for $batch"; return 1; }
+    done
+    if [ "$ACTION" = "link" ]; then
         log "link complete"; return 0
     fi
 
-    # test / testDiff: single-link. Compile upfront (no link) so a compile error fails fast, then run
-    # the heavy modules isolated and the rest in the aggregate. Each module links exactly once, inside
-    # its test session (see the file header on scala-native #2514 / #1822).
-    sbt_resolve_retry "$(native_testkyo compile-main '' '' "$skip_csv" "$arg")" || return $?
-    sbt_resolve_retry "$(native_testkyo compile-test '' '' "$skip_csv" "$arg")" || return $?
-
-    # Comma-separated base names for the --only / --exclude split (NATIVE_HEAVY is space-separated).
-    local heavy_csv; heavy_csv=$(printf '%s' "$NATIVE_HEAVY" | tr -s ' ' ',' | sed 's/^,//; s/,$//')
-    # Drop any heavy module that is also in NATIVE_SKIP: a `--only` session that selected nothing would make
-    # run_native_retry fail on "no test output". After the drop an all-skipped heavy leaves heavy_csv empty and
-    # the `--only` session is skipped, so the whole KEPT set runs in the aggregate.
-    if [ -n "$heavy_csv" ] && [ -n "$skip_csv" ]; then
-        local kept_heavy="" h
-        for h in $(printf '%s' "$heavy_csv" | tr ',' ' '); do
-            case ",$skip_csv," in *",$h,"*) : ;; *) kept_heavy="${kept_heavy:+$kept_heavy,}$h" ;; esac
-        done
-        heavy_csv="$kept_heavy"
-    fi
-    if [ -n "$heavy_csv" ]; then
-        # Heavy modules: link+run in their own full-heap driver (the .jvmopts 12G, uncapped) so the
-        # whole-program optimize does not stack on the aggregate's accumulated heap, CPU-capped so the
-        # clang fork fleet does not overcommit the runner. --only is diff-gated by testKyo, so in a diff
-        # run the heavy runs only when it is actually affected. A heavy module that is also in NATIVE_SKIP
-        # is excluded here, so its --only session runs nothing.
-        local heavy_cmd; heavy_cmd=$(native_testkyo '' "$heavy_csv" '' "$skip_csv" "$arg")
-        log "linking+running heavy native modules isolated: sbt $heavy_cmd"
-        (
-            if [ -n "$NATIVE_LINK_CPUS" ]; then
-                export JAVA_OPTS="${JAVA_OPTS:-} -XX:ActiveProcessorCount=$NATIVE_LINK_CPUS"
-                export JVM_OPTS="${JVM_OPTS:-} -XX:ActiveProcessorCount=$NATIVE_LINK_CPUS"
-            fi
-            run_native_retry "$heavy_cmd"
-        ) || return $?
-        # The rest: the run-phase heap cap keeps headroom for the podman/chrome forks the container and
-        # browser modules spawn; every heavy module (and every skipped module) is excluded here.
-        local rest_cmd; rest_cmd=$(native_testkyo '' '' "$heavy_csv" "$skip_csv" "$arg")
-        log "linking+running remaining native modules: sbt $rest_cmd"
-        run_native_retry $(run_phase_heap) "$rest_cmd"
-    else
-        run_native_retry $(run_phase_heap) "$(native_testkyo '' '' '' "$skip_csv" "$arg")"
-    fi
+    LOG=$(mktemp)
+    # The run-phase heap cap keeps headroom for the podman/chrome forks the container and browser
+    # modules spawn; the plan and the links above run at the full .jvmopts heap.
+    for batch in $(plan_batches "$NATIVE_TEST_BATCH"); do
+        run_watched "test batch $batch" $(run_phase_heap) "testKyo --scala 3 --modules $batch Native" || return 1
+    done
+    # The cross-build modules select themselves per Scala 2.x version, so they are outside the plan
+    # and outside both pools.
+    run_watched "cross pass" $(run_phase_heap) "$(native_cmd 'testKyo --cross' "$skip_flag" "$arg" Native)" || return 1
+    return 0
 }
 
 # -- strategy derivation: the platform decides, never the caller --


### PR DESCRIPTION
A kyo-system PR (#1863) pushed both Native jobs into the 6-hour job ceiling twice in a row, and digging into the logs turned up more than a slow build. This PR restructures the Native leg of ci-test.sh around one module plan and a pool of fresh sbt drivers, and closes two honesty gaps in the runner along the way.

## What the logs showed

* The old flow did the expensive work twice: an upfront aggregate `kyoNative/Test/nativeLink` linked all 58 modules (even on a diff run selecting 30), then the testKyo process recompiled and relinked the affected subtree from scratch. The duplication came from testKyo's `++` round trip pinning kyo-config/kyo-scheduler/kyo-stats-registry at 3.3.8 in the test process while the link processes built them at 3.8.4, invalidating zinc across the graph. #1895 fixed the version pinning on main; this PR removes the duplicated work path itself.
* A green full Native run was not actually a full run: the test phase could die at a module boundary with a clean tail and the crash tolerance in check_log could not tell that from a completed pass. One observed "successful" run started 10 of 58 module binaries. check_log now requires a completion marker (`[testKyo] completed`, printed by the command chain of every pass) before tolerating a crash or hang, so a truncated run retries and then fails instead of reporting green.
* One driver accumulating every module's link peaked at 12.5G RSS with the box at the edge for hours. The measured accumulation delta (+2.2G) builds up around the tenth module of a shared driver.

## The new Native flow

```
plan       testKyo --dry-run --plan-file <file> --scala 3 [--exclude NATIVE_SKIP] Native
pre-link   NATIVE_HEAVY ∩ plan, each in its own capped driver
link pool  batches of NATIVE_LINK_BATCH modules: testKyo --phase link --scala 3 --modules a,b,... Native
test pool  batches of NATIVE_TEST_BATCH modules, each under the crash-retry loop
cross      testKyo --cross Native (the real 2.12/2.13 passes)
```

The selection is computed once and written to a plan file; the shell partitions it, so the link and test pools operate on the identical list and the log shows batch membership. Each batch is a fresh driver, so none carries more than 8 modules of accumulated heap, and a crash retries one batch instead of the whole phase. Zinc and the nativeLink disk cache hit across process boundaries now that every process agrees on the effective Scala versions; the CI runs show `Build skipped` and zero recompiles inside test batches.

testKyo gains `--phase link`, `--cross`, `--modules a,b,c` (validated against the build, loud failure on unknown names), and `--plan-file`, alongside the existing `--exclude`/`--only`/`--quick`. NATIVE_SKIP composes with the plan: a skipped module never enters it.

## Validation

* ci-test.sh --self-test: 48 cases (from 39), covering batch partitioning and membership, per-batch retry isolation, the marker-less truncation shape (retried, then exit 1), hang-after-marker tolerance, NATIVE_SKIP reaching the plan and cross pass, and the CPU cap on every link invocation and no test invocation.
* Cross-process cache reuse verified directly: a plain-task compile followed by `testKyo --scala 3 --modules kyo-preludeNative Native` in a fresh process does zero compiles, zero relinks, `Build skipped`, tests run, marker printed.
* Prior validation runs of this flow (pre-rebase) on both linux poles: link count equals plan size, zero relinks inside test batches, per-batch retry saved two batches that hit the known shutdown-hang shape.
* Two full-scale runs on both poles are in flight on this branch stack and will be linked here when they land.

NATIVE_LINK_CPUS moves from 2 to 3: the 2-CPU cap was sized for a driver already carrying the whole set; with accumulation bounded per batch the extra optimizer thread uses headroom the logs showed idle.
