### PR TITLE
[kyo-pod, kyo-sql] fix container teardown, prove readiness, and reuse fixtures across test processes

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -140,6 +140,10 @@ runs:
         # rejects), which fails every kyo-pod container integration test; runc accepts the config
         # podman writes. The image podman on the 20260810.x images works with runc too (verified
         # by the #1881 probe on both architectures), so the pin is safe in both worlds.
+        # This is the STARTING choice, not the final one: container-check.sh below probes whether
+        # the pinned runtime can actually stop a container and flips to the alternative when it
+        # cannot. The #1881 probe only ever validated create/start/exec, which is how a stack that
+        # starts containers it can never kill got through this gate.
         mkdir -p "$HOME/.config/containers"
         printf '[engine]\nruntime = "runc"\n' > "$HOME/.config/containers/containers.conf"
         mkdir -p "$XDG_RUNTIME_DIR/podman"
@@ -168,9 +172,11 @@ runs:
         echo "podman version: $(podman --version 2>/dev/null); cgroupManager: $(podman info --format '{{.Host.CgroupManager}}' 2>/dev/null)"
         podman info | grep -iE 'cgroup|rootless' || true
         podman version
-        # Health gate: exercises the full podman cycle (create, start, exec) and the docker
-        # daemon, with per-component diagnostics, so a broken container stack fails here with a
-        # named cause instead of surfacing two hours later across the kyo-pod suites (#1881).
+        # Health gate: exercises the full podman cycle (create, start, exec, and stop of a
+        # SIGTERM-ignoring container) and the docker daemon, with per-component diagnostics, so a
+        # broken container stack fails here with a named cause instead of surfacing two hours
+        # later across the kyo-pod suites (#1881). It also selects the OCI runtime that can
+        # actually tear a container down, and pre-pulls the database fixture images.
         # Pass --warn-only to degrade the gate to a loud warning annotation.
         bash scripts/container-check.sh
 

--- a/build.sbt
+++ b/build.sbt
@@ -2709,6 +2709,9 @@ lazy val `kyo-pod` =
         .crossType(CrossType.Full)
         .in(file("kyo-pod"))
         .dependsOn(`kyo-core`, `kyo-http`)
+        // Direct, not through kyo-http: `Container.init` opens a host-side TCP connection to prove a published
+        // port is actually served before it hands the caller a handle.
+        .dependsOn(`kyo-net`)
         .dependsOn(`kyo-system`)
         .withKyoTest
         .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -2133,8 +2133,9 @@ lazy val `kyo-aeron` =
         .nativeSettings(
             `native-settings`,
             // The UDP round-trip and URI-validation suites bind fixed high ports, which collide if
-            // suites run concurrently. (The JS and Wasm blocks need no equivalent: they inherit the
-            // global Test/parallelExecution := false.)
+            // suites run concurrently. `native-settings-base` now sets this too, for its own
+            // reason; kept here so a change there cannot silently reintroduce the port collision.
+            // (The JS and Wasm blocks need no equivalent: they inherit it from `js-settings`.)
             Test / parallelExecution := false,
             nativeConfig := {
                 val base = nativeConfig.value
@@ -3240,8 +3241,17 @@ def readFfiNativeManifest(cp: Seq[Attributed[File]], relDir: Seq[String], inBuil
 // the kyoNative aggregate (which has no native sources, hence no Test / nativeLink to transform) can
 // take these without the per-module link hook below.
 lazy val `native-settings-base` = Seq(
-    fork                                              := false,
-    bspEnabled                                        := false,
+    fork       := false,
+    bspEnabled := false,
+    // One test task per module, not one per suite. The scala-native TestAdapter keys its runner
+    // processes by sbt task thread id, and sbt's cached task pool reaps a thread after 60s idle, so
+    // one task per suite gives one FRESH runner process per suite whenever consecutive suites are
+    // more than a minute apart. Every kyo-sql suite is, which turned the per-process container
+    // singleton into per-suite provisioning: 24 worker processes and ~2 container starts each in one
+    // module. Serial tasks keep the module on one thread and therefore one worker. Nothing is lost in
+    // concurrency: Native leaf parallelism is already capped at 1 by kyo-test's LeafPool. Matches what
+    // `js-settings` does globally and what kyo-aeron already does for Native.
+    Test / parallelExecution                          := false,
     Test / testForkedParallel                         := false,
     Test / envVars += "SCALANATIVE_THREAD_STACK_SIZE" -> "33554432",
     libraryDependencies += "io.github.cquiroz"       %%% "scala-java-time" % "2.7.0",

--- a/kyo-pod/shared/src/main/scala/kyo/Container.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/Container.scala
@@ -64,7 +64,7 @@ final class Container private[kyo] (
 
     /** Send SIGTERM and wait up to `timeout` for graceful shutdown, then SIGKILL. */
     def stop(timeout: Duration)(using Frame): Unit < (Async & Abort[ContainerException]) =
-        ensurePendingExit.andThen(backend.stop(id, timeout))
+        ensurePendingExit.andThen(Container.stopWithFallback(backend, id, timeout))
 
     /** Send SIGTERM to the container process. */
     def kill(using Frame): Unit < (Async & Abort[ContainerException]) =
@@ -79,7 +79,7 @@ final class Container private[kyo] (
       * real exit code is lost. If the exit code matters, prefer `autoRemove(false)` and call `waitForExit` followed by `remove` manually.
       */
     def kill(signal: Signal)(using Frame): Unit < (Async & Abort[ContainerException]) =
-        ensurePendingExit.andThen(backend.kill(id, signal))
+        ensurePendingExit.andThen(Container.killWithFallback(backend, id, signal))
 
     /** When `autoRemove == true`, attach a `waitForExit` fiber before any destructive signal so the exit code is captured before the daemon
       * cleans the container up. Idempotent — subsequent calls are no-ops while a fiber is already attached.
@@ -128,7 +128,7 @@ final class Container private[kyo] (
 
     /** Delete this container. If `force` is true, kills the container first if running. */
     def remove(force: Boolean, removeVolumes: Boolean = false)(using Frame): Unit < (Async & Abort[ContainerException]) =
-        backend.remove(id, force, removeVolumes)
+        Container.removeWithFallback(backend, id, force, removeVolumes)
 
     /** Change the container's name. */
     def rename(newName: String)(using Frame): Unit < (Async & Abort[ContainerException]) =
@@ -494,14 +494,17 @@ object Container:
                                 case Result.Failure(e) => Log.warn(s"Container ${cid.value} $op failed: ${safeMessage(e)}")
                                 case Result.Panic(e)   => Log.warn(s"Container ${cid.value} $op panicked: ${safeMessage(e)}")
 
+                            // Every destructive step escalates to a host-side SIGKILL when the runtime reports the
+                            // container's process as unreaped, so a daemon that cannot kill its own container does
+                            // not turn each scoped fixture into a permanent corpse.
                             val shutdown: Unit < (Async & Abort[Nothing]) = config.stopSignal match
                                 case Present(signal) =>
-                                    Abort.run[ContainerException](b.kill(cid, signal)).map(logFailure("kill")).andThen(
+                                    Abort.run[ContainerException](killWithFallback(b, cid, signal)).map(logFailure("kill")).andThen(
                                         Abort.run[ContainerException](b.waitForExit(cid, config.stopTimeout))
                                             .map(r => logFailure("waitForExit")(r.map(_ => ())))
                                     )
                                 case Absent =>
-                                    Abort.run[ContainerException](b.stop(cid, config.stopTimeout)).map(logFailure("stop"))
+                                    Abort.run[ContainerException](stopWithFallback(b, cid, config.stopTimeout)).map(logFailure("stop"))
 
                             shutdown.andThen {
                                 // `removeVolumes = true` reaps anonymous volumes attached to the container (e.g. the
@@ -511,11 +514,13 @@ object Container:
                                 //
                                 // A force-remove can hit a transient ContainerBackendException under load and leak the container, so
                                 // retry; a genuinely-absent container surfaces as ContainerMissingException, which logFailure treats as done.
+                                // Each attempt goes through the unreaped-process fallback, so a runtime that reports the container's
+                                // process as still alive gets a host-side SIGKILL before the retry budget runs out.
                                 val removeSchedule =
                                     Schedule.exponentialBackoff(initial = 50.millis, factor = 2, maxBackoff = 500.millis).take(3)
                                 Abort.run[ContainerException] {
                                     Retry[ContainerBackendException](removeSchedule) {
-                                        b.remove(cid, force = true, removeVolumes = true)
+                                        removeWithFallback(b, cid, force = true, removeVolumes = true)
                                     }
                                 }.map(logFailure("remove"))
                             }
@@ -527,7 +532,7 @@ object Container:
                             AtomicRef.init(Absent: Maybe[Fiber[ExitCode, Abort[ContainerException]]]).map { pendingRef =>
                                 val container = new Container(cid, config, b, healthRef, pendingRef)
                                 runHealthCheck(container, config.healthCheck)
-                                    .andThen(waitForPortMappings(container))
+                                    .andThen(awaitPortsReady(container))
                                     .andThen(probePortConflict(container))
                                     .andThen(container)
                             }
@@ -590,14 +595,14 @@ object Container:
                         Abort.run[ContainerException] {
                             b.start(cid)
                                 .andThen(runHealthCheck(container, config.healthCheck))
-                                .andThen(waitForPortMappings(container))
+                                .andThen(awaitPortsReady(container))
                                 .andThen(probePortConflict(container))
                         }.map {
                             case Result.Success(_)                                => container
                             case e: (Result.Error[ContainerException] @unchecked) =>
                                 // Best-effort cleanup; reap anonymous volumes too — caller never received a
                                 // handle, so they can't reach those volumes through any other API.
-                                Abort.run[ContainerException](b.remove(cid, force = true, removeVolumes = true))
+                                Abort.run[ContainerException](removeWithFallback(b, cid, force = true, removeVolumes = true))
                                     .andThen(Abort.error(e))
                         }
                     }
@@ -824,6 +829,17 @@ object Container:
           * pressure; bumping this per-fixture avoids spurious teardown when the forwarder is just slow.
           */
         portMappingTimeout: Duration,
+        /** Whether this container is a long-lived service whose readiness `init` must prove rather than assume.
+          *
+          * With the default `false`, `init` accepts a container that has already exited (one-shot commands finish before any check can
+          * run) and treats an `inspect`-level port binding as the end of the port wait.
+          *
+          * With `true`, a container that exits before or during its health check fails startup, and every published TCP port must accept a
+          * host-side connection within [[portMappingTimeout]] before the handle is returned. Both are required for a database fixture: a
+          * stillborn engine and a bound-but-unserved port are otherwise indistinguishable from a healthy one until the first query. Set by
+          * every [[ContainerPredef]] fixture.
+          */
+        requireService: Boolean,
         healthCheck: HealthCheck
     ) derives CanEqual:
         // --- Builder methods ---
@@ -936,6 +952,8 @@ object Container:
 
         def portMappingTimeout(timeout: Duration): Config = copy(portMappingTimeout = timeout)
 
+        def requireService(value: Boolean): Config = copy(requireService = value)
+
         def healthCheck(hc: HealthCheck): Config = copy(healthCheck = hc)
 
     end Config
@@ -979,6 +997,7 @@ object Container:
             stopSignal = Absent,
             stopTimeout = 3.seconds,
             portMappingTimeout = 60.seconds,
+            requireService = false,
             healthCheck = HealthCheck.running
         )
 
@@ -2153,6 +2172,114 @@ object Container:
             case Absent     => ContainerBackend.detect()
         }
 
+    // --- Host-side kill fallback ---
+
+    /** Daemon message fragments that mean the runtime asked the OCI runtime to reap a container's process and the process outlived the
+      * request. Podman's libpod answers HTTP 500 `given PID did not die within timeout` on `/stop`, `/kill` and force-remove alike when its
+      * OCI runtime loses the ability to signal a container's init process, and `container state improper` for the half-killed state the
+      * container is then stuck in. Both leave the container's processes running with no daemon-side route to remove them.
+      */
+    private val unreapedProcessPhrases: Seq[String] =
+        Seq("did not die within timeout", "container state improper")
+
+    /** Whether `message` carries one of [[unreapedProcessPhrases]]. */
+    private[kyo] def isUnreapedProcessMessage(message: String): Boolean =
+        val lower = message.toLowerCase
+        unreapedProcessPhrases.exists(lower.contains)
+
+    /** As [[isUnreapedProcessMessage]], over a throwable's own message and its cause chain. The daemon body arrives on the cause for some
+      * transports, so both are read; the depth bound keeps a self-referential chain from looping.
+      */
+    private[kyo] def isUnreapedProcessFailure(error: Throwable): Boolean =
+        def text(t: Throwable, depth: Int): String =
+            if (t eq null) || depth > 4 then ""
+            else
+                val own =
+                    try Option(t.getMessage).getOrElse("")
+                    catch case scala.util.control.NonFatal(_) => ""
+                own + " " + text(t.getCause, depth + 1)
+        isUnreapedProcessMessage(text(error, 0))
+    end isUnreapedProcessFailure
+
+    /** The host-side SIGKILL issued when the runtime leaves a container's process unreaped. */
+    private[kyo] def hostKillCommand(pid: Int): Command = Command("kill", "-9", pid.toString)
+
+    /** Whether the host's process table attributes `pid` to `id`, read from the pid's cgroup membership: every cgroup-managed runtime names
+      * the container there (`libpod-<id>.scope` under podman, `docker-<id>.scope` or `/docker/<id>` under docker).
+      *
+      * This is the gate that makes the host-side SIGKILL safe. A runtime whose pids live in a VM (Docker Desktop, `podman machine`) reports
+      * a pid that means nothing on this host, and no `/proc/<pid>/cgroup` entry names the container, so the escalation declines rather than
+      * signalling an unrelated host process.
+      */
+    private[kyo] def cgroupNamesContainer(cgroup: String, id: Id): Boolean =
+        val short = Id.value(id).take(12)
+        short.nonEmpty && cgroup.contains(short)
+
+    private def hostPidBelongsTo(id: Id, pid: Int)(using Frame): Boolean < Sync =
+        Abort.run[FileReadException](Path("/proc", pid.toString, "cgroup").read).map {
+            case Result.Success(cgroup) => cgroupNamesContainer(cgroup, id)
+            case _                      => false
+        }
+
+    /** SIGKILL the host-side process of `id`, returning whether the signal was actually delivered. */
+    private[kyo] def hostKillContainerProcess(b: ContainerBackend, id: Id, op: String)(using Frame): Boolean < Async =
+        Abort.run[ContainerException](b.inspect(id)).map {
+            case Result.Success(info) if info.pid > 0 =>
+                hostPidBelongsTo(id, info.pid).map {
+                    case false => false
+                    case true =>
+                        Abort.run[CommandException](hostKillCommand(info.pid).redirectErrorStream(true).textWithExitCode).map {
+                            case Result.Success((_, ExitCode.Success)) =>
+                                Log.warn(
+                                    s"Container ${Id.value(id)} $op left its process unreaped by the runtime; SIGKILLed host pid ${info.pid}"
+                                ).andThen(true)
+                            case _ => false
+                        }
+                }
+            case _ => false
+        }
+
+    /** Runs `call` and, when it fails because the runtime could not reap the container's process, escalates through `hostKill` and runs
+      * `call` once more. Any other outcome passes through untouched, and a declined escalation re-raises the original failure so the caller
+      * still sees the daemon's own error.
+      *
+      * `hostKill` is a parameter rather than a fixed call so the escalation contract is exercisable without a container runtime.
+      */
+    private[kyo] def withUnreapedProcessFallback(hostKill: => Boolean < Async)(
+        call: => Unit < (Async & Abort[ContainerException])
+    )(using Frame): Unit < (Async & Abort[ContainerException]) =
+        def escalate(cause: Throwable, reraise: => Unit < Abort[ContainerException]): Unit < (Async & Abort[ContainerException]) =
+            if !isUnreapedProcessFailure(cause) then reraise
+            else
+                hostKill.map {
+                    case false => reraise
+                    case true  => call
+                }
+
+        Abort.run[ContainerException](call).map {
+            case Result.Success(_) => ()
+            case Result.Failure(e) => escalate(e, Abort.fail(e))
+            case Result.Panic(t)   => escalate(t, Abort.panic(t))
+        }
+    end withUnreapedProcessFallback
+
+    private[kyo] def stopWithFallback(b: ContainerBackend, id: Id, timeout: Duration)(using
+        Frame
+    ): Unit < (Async & Abort[ContainerException]) =
+        withUnreapedProcessFallback(hostKillContainerProcess(b, id, "stop"))(b.stop(id, timeout))
+
+    private[kyo] def killWithFallback(b: ContainerBackend, id: Id, signal: Signal)(using
+        Frame
+    ): Unit < (Async & Abort[ContainerException]) =
+        withUnreapedProcessFallback(hostKillContainerProcess(b, id, "kill"))(b.kill(id, signal))
+
+    /** Force-removes only escalate: a non-force remove failing on a running container is the API's own contract, not a broken runtime. */
+    private[kyo] def removeWithFallback(b: ContainerBackend, id: Id, force: Boolean, removeVolumes: Boolean)(using
+        Frame
+    ): Unit < (Async & Abort[ContainerException]) =
+        if !force then b.remove(id, force, removeVolumes)
+        else withUnreapedProcessFallback(hostKillContainerProcess(b, id, "remove"))(b.remove(id, force, removeVolumes))
+
     private def resolveBackend(config: BackendConfig)(using Frame): ContainerBackend < (Async & Abort[ContainerException]) =
         config match
             case BackendConfig.AutoDetect(meter, apiVersion, streamBufferSize) =>
@@ -2175,11 +2302,23 @@ object Container:
             case Result.Panic(ex)                             => Abort.panic(ex)
         }
 
+    /** What a dead container means during the health check: nothing for a one-shot (`init` is also used for containers that exit as soon as
+      * their command finishes, well before any check could run), a startup failure for a service fixture, where an engine that dies during
+      * boot is exactly the condition the check exists to catch.
+      *
+      * Without this split the escape laundered a stillborn database into a "healthy" handle, and the suite that received it failed every
+      * leaf on connect instead of failing once at init.
+      */
+    private def onDeadContainer(container: Container, reason: String, attempts: Int, lastError: String)(using
+        Frame
+    ): Unit < (Async & Abort[ContainerException]) =
+        if !container.config.requireService then ()
+        else Abort.fail(ContainerHealthCheckException(container.id, reason, attempts = attempts, lastError = lastError))
+
     private def runHealthCheck(container: Container, hc: HealthCheck)(using Frame): Unit < (Async & Abort[ContainerException]) =
-        // If the container already exited (e.g. command("true")), skip health check — `init` is
-        // also used for fast one-shots that exit before any check could run.
         isContainerAlive(container).map { alive =>
-            if !alive then ()
+            if !alive then
+                onDeadContainer(container, "container exited before its health check could run", attempts = 0, lastError = "")
             else
                 // Container is running, run health check with retry.
                 // Accumulate errors for diagnostic reporting on final failure.
@@ -2192,7 +2331,9 @@ object Container:
                         Abort.runWith[ContainerException](hc.check(container)) {
                             case Result.Success(_) =>
                                 container.healthState.set(ContainerHealthState(Present(hc)))
-                            case Result.Failure(_: ContainerMissingException) => ()
+                            case Result.Failure(e: ContainerMissingException) =>
+                                if !container.config.requireService then ()
+                                else Abort.fail(e)
                             case failure =>
                                 val errorMsg = failure match
                                     // Prefer the structured `lastError` for HealthCheckException — `getMessage` on
@@ -2205,7 +2346,13 @@ object Container:
                                 val nextAttempts  = attempts + 1
                                 // Check if container is still running before retrying
                                 isContainerAlive(container).map { stillAlive =>
-                                    if !stillAlive then ()
+                                    if !stillAlive then
+                                        onDeadContainer(
+                                            container,
+                                            "container exited while its health check was still failing",
+                                            attempts = nextAttempts,
+                                            lastError = formatRecentHealthCheckErrors(updatedErrors)
+                                        )
                                     else
                                         Clock.now.map { now =>
                                             retrySchedule.next(now) match
@@ -2278,46 +2425,115 @@ object Container:
         end if
     end probePortConflict
 
-    /** After health check passes, wait until every configured host port binding is observable via `inspect`. Backends report container
-      * state Running before the port-forwarding hook completes (rootless podman uses slirp4netns/pasta async; Docker Desktop's VM has a
-      * similar gap). Without this wait, callers who ask for `mappedPort` immediately after `init` race intermittently.
+    /** Wait until every configured port is ready for the caller, under one [[Container.Config.portMappingTimeout]] budget shared by both
+      * halves of "ready": the daemon reporting the binding, and (for a service fixture) the host actually accepting a connection on it.
       *
       * Skipped when no port bindings are configured (no race to worry about).
       */
-    private def waitForPortMappings(container: Container)(using Frame): Unit < (Async & Abort[ContainerException]) =
+    private def awaitPortsReady(container: Container)(using Frame): Unit < (Async & Abort[ContainerException]) =
         if container.config.ports.isEmpty then ()
         else
-            val budgetMs = container.config.portMappingTimeout.toMillis
             Clock.now.map { startedAt =>
-                val deadlineMs = startedAt.toJava.toEpochMilli + budgetMs
-                val maxPollMs  = portMappingMaxPoll.toMillis
+                val deadlineMs = startedAt.toJava.toEpochMilli + container.config.portMappingTimeout.toMillis
+                waitForPortMappings(container, startedAt, deadlineMs).andThen {
+                    if !container.config.requireService then ()
+                    else awaitPortsReachable(container, deadlineMs)
+                }
+            }
+
+    /** Connect deadline for one attempt of the host-side port probe. Bounded well below the wall-clock budget so a black-holed port retries
+      * instead of consuming the whole budget in a single connect.
+      */
+    private val portProbeConnectTimeout: Duration = 2.seconds
+
+    /** Open and immediately close a TCP connection to `host:port`, reporting whether the host accepted it. */
+    private def probeHostPort(host: String, port: Int)(using Frame): Boolean < Async =
+        // Unsafe: kyo-net publishes `connect` on the unsafe tier only. The bridge is confined to this probe — the
+        // connection is closed on the success path and no handle escapes — and a host-side connect is the only
+        // proof that the runtime's port forwarder is actually serving the published port.
+        Abort.run[kyo.net.NetException] {
+            Sync.Unsafe.defer(kyo.net.NetPlatform.transport.connect(host, port, portProbeConnectTimeout).safe).map(_.get)
+        }.map {
+            case Result.Success(conn) => Sync.Unsafe.defer(conn.close()).andThen(true)
+            case _                    => false
+        }
+
+    /** Wait until every published TCP host port of `container` accepts a host-side connection, failing at `deadlineMs`.
+      *
+      * [[waitForPortMappings]] proves only that the daemon recorded a binding; on rootless podman the forwarder that serves it comes up
+      * asynchronously and can fail to come up at all, and on any runtime the container's process can die between its health check and the
+      * caller's first connect. Either way `inspect` keeps reporting a bound port, so without this probe `init` returns a handle whose port
+      * refuses every connection.
+      */
+    private[kyo] def awaitPortsReachable(container: Container, deadlineMs: Long)(using
+        Frame
+    ): Unit < (Async & Abort[ContainerException]) =
+        val maxPollMs = portMappingMaxPoll.toMillis
+        container.inspect.map { info =>
+            val hostPorts = info.ports.filter(b => b.protocol == Config.Protocol.TCP && b.hostPort > 0).map(_.hostPort).distinct
+            Kyo.foreachDiscard(hostPorts) { hostPort =>
                 Loop(portMappingMinPoll.toMillis) { pollMs =>
-                    container.backend.inspect(container.id).map { info =>
-                        val allBound = container.config.ports.forall { pb =>
-                            info.ports.exists(b => b.containerPort == pb.containerPort && b.protocol == pb.protocol && b.hostPort > 0)
-                        }
-                        if allBound then Loop.done(())
-                        else
+                    probeHostPort(container.host, hostPort).map {
+                        case true => Loop.done(())
+                        case false =>
                             Clock.now.map { now =>
-                                val nowMs = now.toJava.toEpochMilli
-                                if nowMs >= deadlineMs then
-                                    val elapsedMs = nowMs - startedAt.toJava.toEpochMilli
-                                    val configured =
-                                        container.config.ports.map(p => s"${p.containerPort}/${p.protocol.cliName}").mkString(", ")
-                                    val observed =
-                                        info.ports.map(p => s"${p.containerPort}/${p.protocol.cliName}->${p.hostPort}").mkString(", ")
-                                    Abort.fail[ContainerException](ContainerOperationException(
-                                        s"Container ${container.id.value} ports not bound on host after ${elapsedMs}ms (budget ${budgetMs}ms). " +
-                                            s"Configured: [$configured]. Observed via inspect: [$observed]."
+                                if now.toJava.toEpochMilli >= deadlineMs then
+                                    Abort.fail[ContainerException](ContainerStartFailedException(
+                                        container.id,
+                                        s"host port $hostPort is published by the runtime but refuses connections"
                                     ))
                                 else
                                     Async.sleep(Duration.fromJava(java.time.Duration.ofMillis(pollMs)))
                                         .andThen(Loop.continue(math.min(pollMs * 2, maxPollMs)))
-                                end if
                             }
-                        end if
                     }
                 }
             }
+        }
+    end awaitPortsReachable
+
+    /** @see [[awaitPortsReachable]] — same probe, bounded by a duration from now. */
+    private[kyo] def awaitPortsReachableWithin(container: Container, within: Duration)(using
+        Frame
+    ): Unit < (Async & Abort[ContainerException]) =
+        Clock.now.map(now => awaitPortsReachable(container, now.toJava.toEpochMilli + within.toMillis))
+
+    /** Poll `inspect` until every configured port binding reports a bound host port. Backends report container state Running before the
+      * port-forwarding hook completes (rootless podman uses slirp4netns/pasta async; Docker Desktop's VM has a similar gap). Without this
+      * wait, callers who ask for `mappedPort` immediately after `init` race intermittently.
+      */
+    private def waitForPortMappings(container: Container, startedAt: Instant, deadlineMs: Long)(using
+        Frame
+    ): Unit < (Async & Abort[ContainerException]) =
+        val budgetMs  = container.config.portMappingTimeout.toMillis
+        val maxPollMs = portMappingMaxPoll.toMillis
+        Loop(portMappingMinPoll.toMillis) { pollMs =>
+            container.backend.inspect(container.id).map { info =>
+                val allBound = container.config.ports.forall { pb =>
+                    info.ports.exists(b => b.containerPort == pb.containerPort && b.protocol == pb.protocol && b.hostPort > 0)
+                }
+                if allBound then Loop.done(())
+                else
+                    Clock.now.map { now =>
+                        val nowMs = now.toJava.toEpochMilli
+                        if nowMs >= deadlineMs then
+                            val elapsedMs = nowMs - startedAt.toJava.toEpochMilli
+                            val configured =
+                                container.config.ports.map(p => s"${p.containerPort}/${p.protocol.cliName}").mkString(", ")
+                            val observed =
+                                info.ports.map(p => s"${p.containerPort}/${p.protocol.cliName}->${p.hostPort}").mkString(", ")
+                            Abort.fail[ContainerException](ContainerOperationException(
+                                s"Container ${container.id.value} ports not bound on host after ${elapsedMs}ms (budget ${budgetMs}ms). " +
+                                    s"Configured: [$configured]. Observed via inspect: [$observed]."
+                            ))
+                        else
+                            Async.sleep(Duration.fromJava(java.time.Duration.ofMillis(pollMs)))
+                                .andThen(Loop.continue(math.min(pollMs * 2, maxPollMs)))
+                        end if
+                    }
+                end if
+            }
+        }
+    end waitForPortMappings
 
 end Container

--- a/kyo-pod/shared/src/main/scala/kyo/Container.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/Container.scala
@@ -2295,12 +2295,22 @@ object Container:
                 val backend = new ShellBackend(cmd, meter, streamBufferSize)
                 backend.detect().andThen(backend)
 
-    /** Returns true if the container is still running or created; false if it has stopped, died, or been removed. A false result means the
-      * caller should abandon the current health-check attempt without raising an error.
+    /** Whether a container in `state` may still become healthy.
+      *
+      * `Created` counts as alive, and that is what keeps a `requireService` fixture from failing on its own startup: the window between
+      * `start` returning and the container reaching `Running` reports `Created` (podman's `configured` and `initialized` map there too, see
+      * `ContainerBackend.parseState`), so a health check issued in that window keeps polling on its schedule rather than reaching a verdict.
+      * Only a state the container cannot come back from ends the wait.
+      */
+    private[kyo] def isAliveState(state: State): Boolean =
+        state == State.Running || state == State.Created
+
+    /** Returns true if the container may still become healthy; false if it has stopped, died, or been removed. A false result means the
+      * caller should abandon the current health-check attempt.
       */
     private def isContainerAlive(container: Container)(using Frame): Boolean < (Async & Abort[ContainerException]) =
         Abort.runWith[ContainerException](container.backend.state(container.id)) {
-            case Result.Success(st)                           => st == State.Running || st == State.Created
+            case Result.Success(st)                           => isAliveState(st)
             case Result.Failure(_: ContainerMissingException) => false
             case Result.Failure(e)                            => Abort.fail(e)
             case Result.Panic(ex)                             => Abort.panic(ex)
@@ -2335,9 +2345,18 @@ object Container:
                         Abort.runWith[ContainerException](hc.check(container)) {
                             case Result.Success(_) =>
                                 container.healthState.set(ContainerHealthState(Present(hc)))
-                            case Result.Failure(e: ContainerMissingException) =>
-                                if !container.config.requireService then ()
-                                else Abort.fail(e)
+                            // The container vanished under the check. Same condition as the two
+                            // liveness escapes, so it produces the same verdict rather than a second
+                            // exception type for one meaning: the CI run that first exercised this
+                            // reported ContainerMissingException on one transport and
+                            // ContainerHealthCheckException on another for the very same dead container.
+                            case Result.Failure(_: ContainerMissingException) =>
+                                onDeadContainer(
+                                    container,
+                                    "container disappeared while its health check was running",
+                                    attempts = attempts,
+                                    lastError = formatRecentHealthCheckErrors(recentErrors)
+                                )
                             case failure =>
                                 val errorMsg = failure match
                                     // Prefer the structured `lastError` for HealthCheckException — `getMessage` on

--- a/kyo-pod/shared/src/main/scala/kyo/Container.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/Container.scala
@@ -2345,18 +2345,6 @@ object Container:
                         Abort.runWith[ContainerException](hc.check(container)) {
                             case Result.Success(_) =>
                                 container.healthState.set(ContainerHealthState(Present(hc)))
-                            // The container vanished under the check. Same condition as the two
-                            // liveness escapes, so it produces the same verdict rather than a second
-                            // exception type for one meaning: the CI run that first exercised this
-                            // reported ContainerMissingException on one transport and
-                            // ContainerHealthCheckException on another for the very same dead container.
-                            case Result.Failure(_: ContainerMissingException) =>
-                                onDeadContainer(
-                                    container,
-                                    "container disappeared while its health check was running",
-                                    attempts = attempts,
-                                    lastError = formatRecentHealthCheckErrors(recentErrors)
-                                )
                             case failure =>
                                 val errorMsg = failure match
                                     // Prefer the structured `lastError` for HealthCheckException — `getMessage` on
@@ -2367,16 +2355,15 @@ object Container:
                                     case _                 => "unknown error"
                                 val updatedErrors = appendRecentHealthCheckError(recentErrors, errorMsg)
                                 val nextAttempts  = attempts + 1
-                                // Check if container is still running before retrying
-                                isContainerAlive(container).map { stillAlive =>
-                                    if !stillAlive then
-                                        onDeadContainer(
-                                            container,
-                                            "container exited while its health check was still failing",
-                                            attempts = nextAttempts,
-                                            lastError = formatRecentHealthCheckErrors(updatedErrors)
-                                        )
-                                    else
+                                // Every failed attempt, including a ContainerMissingException from the
+                                // check itself, resolves against the container record before retrying.
+                                // The check's own error cannot be trusted for the verdict: docker's http
+                                // transport reports a missing exec target for a container that merely
+                                // exited and whose record still exists, so wording the verdict from that
+                                // error called an exited container "disappeared". One failure path, one
+                                // verdict, with the reason read from the record's actual state.
+                                Abort.runWith[ContainerException](container.backend.state(container.id)) {
+                                    case Result.Success(st) if isAliveState(st) =>
                                         Clock.now.map { now =>
                                             retrySchedule.next(now) match
                                                 case Present((delay, nextSchedule)) =>
@@ -2393,6 +2380,22 @@ object Container:
                                                         lastError = formatRecentHealthCheckErrors(updatedErrors)
                                                     ))
                                         }
+                                    case Result.Success(_) =>
+                                        onDeadContainer(
+                                            container,
+                                            "container exited while its health check was still failing",
+                                            attempts = nextAttempts,
+                                            lastError = formatRecentHealthCheckErrors(updatedErrors)
+                                        )
+                                    case Result.Failure(_: ContainerMissingException) =>
+                                        onDeadContainer(
+                                            container,
+                                            "container disappeared while its health check was running",
+                                            attempts = nextAttempts,
+                                            lastError = formatRecentHealthCheckErrors(updatedErrors)
+                                        )
+                                    case Result.Failure(e) => Abort.fail(e)
+                                    case Result.Panic(ex)  => Abort.panic(ex)
                                 }
                         }
                     loop(hc.schedule, 0, Seq.empty)

--- a/kyo-pod/shared/src/main/scala/kyo/Container.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/Container.scala
@@ -2437,7 +2437,7 @@ object Container:
                 val deadlineMs = startedAt.toJava.toEpochMilli + container.config.portMappingTimeout.toMillis
                 waitForPortMappings(container, startedAt, deadlineMs).andThen {
                     if !container.config.requireService then ()
-                    else awaitPortsReachable(container, deadlineMs)
+                    else Clock.now.map(now => awaitPortsReachable(container, portProbeDeadline(deadlineMs, now.toJava.toEpochMilli)))
                 }
             }
 
@@ -2446,16 +2446,34 @@ object Container:
       */
     private val portProbeConnectTimeout: Duration = 2.seconds
 
+    /** The floor on what the reachability probe gets once the mapping wait is done. */
+    private val portProbeMinBudget: Duration = 5.seconds
+
+    /** The deadline the reachability probe runs under, given the shared port-readiness deadline and the time the mapping wait finished.
+      *
+      * The two waits share one [[Container.Config.portMappingTimeout]] budget, and a mapping wait that exhausts it fails on its own terms
+      * with a "ports not bound" error. What this floor prevents is the adjacent case: a binding observed a few milliseconds BEFORE the
+      * deadline would otherwise leave the probe a sliver of budget, one failed connect against a forwarder still coming up, and a
+      * "refuses connections" failure for a container that was about to be ready. The probe answers in microseconds when the port is
+      * genuinely served, so the floor costs nothing on the happy path and bounds the overrun at [[portProbeMinBudget]].
+      */
+    private[kyo] def portProbeDeadline(mappingDeadlineMs: Long, nowMs: Long): Long =
+        math.max(mappingDeadlineMs, nowMs + portProbeMinBudget.toMillis)
+
     /** Open and immediately close a TCP connection to `host:port`, reporting whether the host accepted it. */
-    private def probeHostPort(host: String, port: Int)(using Frame): Boolean < Async =
+    private[kyo] def probeHostPort(host: String, port: Int)(using Frame): Boolean < Async =
         // Unsafe: kyo-net publishes `connect` on the unsafe tier only. The bridge is confined to this probe — the
         // connection is closed on the success path and no handle escapes — and a host-side connect is the only
         // proof that the runtime's port forwarder is actually serving the published port.
         Abort.run[kyo.net.NetException] {
             Sync.Unsafe.defer(kyo.net.NetPlatform.transport.connect(host, port, portProbeConnectTimeout).safe).map(_.get)
         }.map {
-            case Result.Success(conn) => Sync.Unsafe.defer(conn.close()).andThen(true)
-            case _                    => false
+            case Result.Success(conn) =>
+                // The connect is the answer; the close is only hygiene. A close that fails has already lost its
+                // descriptor, and letting that escape would panic out of `init` and turn a port that DID accept a
+                // connection into a startup failure.
+                Abort.run[Throwable](Sync.Unsafe.defer(conn.close())).andThen(true)
+            case _ => false
         }
 
     /** Wait until every published TCP host port of `container` accepts a host-side connection, failing at `deadlineMs`.

--- a/kyo-pod/shared/src/main/scala/kyo/Container.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/Container.scala
@@ -835,9 +835,13 @@ object Container:
           * run) and treats an `inspect`-level port binding as the end of the port wait.
           *
           * With `true`, a container that exits before or during its health check fails startup, and every published TCP port must accept a
-          * host-side connection within [[portMappingTimeout]] before the handle is returned. Both are required for a database fixture: a
-          * stillborn engine and a bound-but-unserved port are otherwise indistinguishable from a healthy one until the first query. Set by
-          * every [[ContainerPredef]] fixture.
+          * host-side connection AND HOLD IT within [[portMappingTimeout]] before the handle is returned. Both are required for a database
+          * fixture: a stillborn engine and a bound-but-unserved port are otherwise indistinguishable from a healthy one until the first
+          * query. Set by every [[ContainerPredef]] fixture.
+          *
+          * "Holds it" is part of the contract, not an implementation detail: rootless podman's `rootlessport` and docker's `docker-proxy`
+          * accept a connection before they dial the container, so accepting proves only that the forwarder exists. A service that accepts
+          * and immediately hangs up on every connection reads as not-ready here and must leave this `false`.
           */
         requireService: Boolean,
         healthCheck: HealthCheck
@@ -2460,19 +2464,50 @@ object Container:
     private[kyo] def portProbeDeadline(mappingDeadlineMs: Long, nowMs: Long): Long =
         math.max(mappingDeadlineMs, nowMs + portProbeMinBudget.toMillis)
 
-    /** Open and immediately close a TCP connection to `host:port`, reporting whether the host accepted it. */
+    /** How long a connected probe waits to see whether the far end keeps the connection. Long enough for a userland forwarder to dial its
+      * backend, fail, and drop the connection; short enough that a served port pays it once per init.
+      */
+    private val portProbeGrace: Duration = 500.millis
+
+    /** Whether `host:port` accepts a connection AND keeps it.
+      *
+      * A bare connect is not proof of readiness, which the first CI run against real runtimes demonstrated: both rootless podman's
+      * `rootlessport` and docker's `docker-proxy` are userland forwarders that complete the TCP handshake unconditionally and only then dial
+      * the container backend. A published port with nothing listening behind it therefore accepts the connect and drops it a moment later,
+      * and a connect-only probe called that ready.
+      *
+      * So the connect is followed by a grace period watching [[kyo.net.Connection.onClosing]], which fires on a peer FIN, a reset, or a
+      * read/write teardown and consumes no inbound bytes:
+      *   - closed within the grace: the forwarder's backend dial failed, the port is NOT served;
+      *   - still open at the grace deadline: something is holding the connection, whether it spoke first (MySQL sends a greeting) or waits
+      *     for the client to (Postgres). Served.
+      *
+      * The contract this sets for `requireService` is "a published port accepts a connection and holds it". A service that accepts and
+      * instantly hangs up on every connection reads as not-ready and must not use `requireService`; no [[ContainerPredef]] fixture does
+      * that.
+      */
     private[kyo] def probeHostPort(host: String, port: Int)(using Frame): Boolean < Async =
         // Unsafe: kyo-net publishes `connect` on the unsafe tier only. The bridge is confined to this probe — the
-        // connection is closed on the success path and no handle escapes — and a host-side connect is the only
-        // proof that the runtime's port forwarder is actually serving the published port.
+        // connection is closed on every path and no handle escapes — and a host-side connect is the only proof
+        // that the runtime's port forwarder is actually serving the published port.
         Abort.run[kyo.net.NetException] {
             Sync.Unsafe.defer(kyo.net.NetPlatform.transport.connect(host, port, portProbeConnectTimeout).safe).map(_.get)
         }.map {
             case Result.Success(conn) =>
-                // The connect is the answer; the close is only hygiene. A close that fails has already lost its
-                // descriptor, and letting that escape would panic out of `init` and turn a port that DID accept a
-                // connection into a startup failure.
-                Abort.run[Throwable](Sync.Unsafe.defer(conn.close())).andThen(true)
+                // The close runs on every path, including an interrupt during the grace wait. A close that fails
+                // has already lost its descriptor, and letting that escape would panic out of `init`.
+                Sync.ensure(Abort.run[Throwable](Sync.Unsafe.defer(conn.close())).unit) {
+                    connectionHeld(conn)
+                }
+            case _ => false
+        }
+
+    private def connectionHeld(conn: kyo.net.Connection)(using Frame): Boolean < Async =
+        Abort.run[Timeout](Async.timeout(portProbeGrace)(conn.onClosing.safe.get)).map {
+            // The grace expiring with no close observed is the readiness signal.
+            case Result.Failure(_: Timeout) => true
+            // A close within the grace is the unserved-port signature. Anything else is not a proof of
+            // readiness either, and reporting false only costs the caller another attempt.
             case _ => false
         }
 
@@ -2498,7 +2533,9 @@ object Container:
                                 if now.toJava.toEpochMilli >= deadlineMs then
                                     Abort.fail[ContainerException](ContainerStartFailedException(
                                         container.id,
-                                        s"host port $hostPort is published by the runtime but refuses connections"
+                                        s"host port $hostPort is published by the runtime but does not hold a connection: " +
+                                            "the connect is refused, or the port forwarder accepts it and drops it because " +
+                                            "nothing is listening behind it"
                                     ))
                                 else
                                     Async.sleep(Duration.fromJava(java.time.Duration.ofMillis(pollMs)))

--- a/kyo-pod/shared/src/main/scala/kyo/ContainerPredef.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/ContainerPredef.scala
@@ -222,6 +222,7 @@ object ContainerPredef:
                 .env("POSTGRES_DB", c.database)
                 .port(c.port, 0)
                 .command("postgres", "-c", "fsync=off")
+                .requireService(true)
                 .healthCheck(readinessLoop(Chunk("psql", "-U", c.username, "-d", c.database, "-c", "SELECT 1"), c.readinessBudget))
     end Postgres
 
@@ -422,6 +423,7 @@ object ContainerPredef:
                 .stopSignal(Container.Signal.SIGKILL)
                 .stopTimeout(defaultStopTimeout)
                 .portMappingTimeout(defaultPortMappingTimeout)
+                .requireService(true)
                 .healthCheck(readinessLoop(healthCmdBase, c.readinessBudget))
             applyEnv(base, c)
         end buildContainerConfig
@@ -530,6 +532,7 @@ object ContainerPredef:
         private[kyo] def buildContainerConfig(c: Config): Container.Config =
             Container.Config(c.image)
                 .port(c.port, 0)
+                .requireService(true)
                 .healthCheck(readinessLoop(Chunk("mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"), c.readinessBudget))
     end MongoDB
 

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
@@ -730,29 +730,26 @@ class ContainerItTest extends BasePodTest:
         }
 
         "a published port with a live listener starts normally" - runBackends {
-            // Two things this command has to get right, and an earlier version of it got both wrong.
-            //
-            // The listener must HOLD an accepted connection: `echo ok | nc` hangs up as soon as it has
-            // written, which is the accept-and-drop shape the probe now correctly calls not-ready.
-            // `sleep 60 |` keeps nc's stdin open so it holds the connection the way a real service does,
-            // and the loop restarts it because busybox nc serves one connection and exits (the
-            // in-container health check consumes one, the host-side probe another).
-            //
-            // The listener must also not BE the container: run it in the background behind
-            // `sleep infinity & wait`, the shape every other listener case here uses, so a hiccup in
-            // the listener cannot exit the container and get reported as "the fixture died".
-            val config = Container.Config("alpine")
-                .command(
-                    "sh",
-                    "-c",
-                    "trap 'exit 0' TERM; while true; do sleep 60 | nc -l -p 8080; done & sleep infinity & wait"
-                )
-                .port(8080, 0)
+            // nginx, not a hand-rolled nc fixture. This case needs a listener that HOLDS an
+            // accepted connection (the probe correctly rejects accept-then-drop) and serves
+            // every connection with no gap. Three nc/httpd shapes each failed one of those:
+            // `echo ok | nc` drops on write, `busybox httpd` is not an applet in stock alpine
+            // (the container died), and `while true; do sleep 60 | nc; done` leaves the port
+            // unserved for the rest of the 60s after a connection is consumed, because the
+            // shell waits for the whole pipeline before restarting nc. The health check eats
+            // nc's single connection, the probe then finds nobody listening, and init times
+            // out. nginx waits for the request line on every accepted connection, which is
+            // exactly the held-open shape a real service presents.
+            val img = ContainerImage("nginx:alpine")
+            val config = Container.Config(img)
+                .port(80, 0)
                 .requireService(true)
                 .portMappingTimeout(60.seconds)
-                .healthCheck(Container.HealthCheck.port(8080, Schedule.fixed(200.millis).take(30)))
-            Container.init(config).map { c =>
-                c.mappedPort(8080).map(hp => assert(hp > 0, s"expected a bound host port, got $hp"))
+                .healthCheck(Container.HealthCheck.port(80, Schedule.fixed(200.millis).take(30)))
+            ContainerImage.ensure(img).andThen {
+                Container.init(config).map { c =>
+                    c.mappedPort(80).map(hp => assert(hp > 0, s"expected a bound host port, got $hp"))
+                }
             }
         }
 

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
@@ -681,11 +681,16 @@ class ContainerItTest extends BasePodTest:
     // requireService — init proves readiness instead of assuming it
     //
     // Without these two gates a container that died during startup, or one whose
-    // published port has no live forwarder behind it, was handed to the caller as a
-    // healthy handle: `runHealthCheck` treated a dead container as "nothing to check"
-    // and the port wait trusted `inspect`. The caller then failed on every query
-    // against a port that refuses connections, which is how one stillborn database
-    // fixture turned into a whole failed suite.
+    // published port has nothing serving it, was handed to the caller as a healthy
+    // handle: `runHealthCheck` treated a dead container as "nothing to check" and the
+    // port wait trusted `inspect`. The caller then failed on every query against a
+    // port that answers nothing, which is how one stillborn database fixture turned
+    // into a whole failed suite.
+    //
+    // The port cases run against real forwarders here, which is what makes them worth
+    // the container: rootlessport and docker-proxy accept a connection before dialling
+    // the container, so "the connect succeeded" is not the readiness signal. Holding
+    // the connection is.
     // =========================================================================
 
     "requireService" - {
@@ -712,21 +717,25 @@ class ContainerItTest extends BasePodTest:
         }
 
         "a published port with nothing listening fails init" - runBackends {
-            // The container stays up, so only the host-side connect probe can tell that
-            // port 8080 is bound by the runtime and served by nobody.
+            // The container stays up and the runtime publishes the port, so nothing short of
+            // a host-side connection that is then dropped can tell that nobody serves it.
             val config = alpine.port(8080, 0)
                 .requireService(true)
                 .portMappingTimeout(5.seconds)
             Abort.run[ContainerException](Scope.run(Container.init(config))).map {
                 case Result.Failure(e: ContainerStartFailedException) =>
-                    assert(e.reason.contains("refuses connections"), s"expected a reachability reason, got ${e.reason}")
+                    assert(e.reason.contains("does not hold a connection"), s"expected a reachability reason, got ${e.reason}")
                 case other => fail(s"expected ContainerStartFailedException for an unserved port, got $other")
             }
         }
 
         "a published port with a live listener starts normally" - runBackends {
+            // busybox httpd rather than an `nc` loop: nc serves one connection and exits, and
+            // `echo ok | nc` hangs up as soon as it has written, which is the accept-and-drop
+            // shape the probe now (correctly) calls not-ready. httpd holds every connection
+            // until its request completes, which is what a real service does.
             val config = Container.Config("alpine")
-                .command("sh", "-c", "trap 'exit 0' TERM; while true; do echo ok | nc -l -p 8080; done")
+                .command("sh", "-c", "trap 'exit 0' TERM; busybox httpd -f -p 8080 -h /tmp")
                 .port(8080, 0)
                 .requireService(true)
                 .portMappingTimeout(60.seconds)

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
@@ -730,12 +730,23 @@ class ContainerItTest extends BasePodTest:
         }
 
         "a published port with a live listener starts normally" - runBackends {
-            // busybox httpd rather than an `nc` loop: nc serves one connection and exits, and
-            // `echo ok | nc` hangs up as soon as it has written, which is the accept-and-drop
-            // shape the probe now (correctly) calls not-ready. httpd holds every connection
-            // until its request completes, which is what a real service does.
+            // Two things this command has to get right, and an earlier version of it got both wrong.
+            //
+            // The listener must HOLD an accepted connection: `echo ok | nc` hangs up as soon as it has
+            // written, which is the accept-and-drop shape the probe now correctly calls not-ready.
+            // `sleep 60 |` keeps nc's stdin open so it holds the connection the way a real service does,
+            // and the loop restarts it because busybox nc serves one connection and exits (the
+            // in-container health check consumes one, the host-side probe another).
+            //
+            // The listener must also not BE the container: run it in the background behind
+            // `sleep infinity & wait`, the shape every other listener case here uses, so a hiccup in
+            // the listener cannot exit the container and get reported as "the fixture died".
             val config = Container.Config("alpine")
-                .command("sh", "-c", "trap 'exit 0' TERM; busybox httpd -f -p 8080 -h /tmp")
+                .command(
+                    "sh",
+                    "-c",
+                    "trap 'exit 0' TERM; while true; do sleep 60 | nc -l -p 8080; done & sleep infinity & wait"
+                )
                 .port(8080, 0)
                 .requireService(true)
                 .portMappingTimeout(60.seconds)

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerItTest.scala
@@ -678,6 +678,72 @@ class ContainerItTest extends BasePodTest:
     }
 
     // =========================================================================
+    // requireService — init proves readiness instead of assuming it
+    //
+    // Without these two gates a container that died during startup, or one whose
+    // published port has no live forwarder behind it, was handed to the caller as a
+    // healthy handle: `runHealthCheck` treated a dead container as "nothing to check"
+    // and the port wait trusted `inspect`. The caller then failed on every query
+    // against a port that refuses connections, which is how one stillborn database
+    // fixture turned into a whole failed suite.
+    // =========================================================================
+
+    "requireService" - {
+        "a container that exits before its health check fails init" - runBackends {
+            val config = Container.Config("alpine")
+                .command("sh", "-c", "exit 3")
+                .requireService(true)
+                .healthCheck(Container.HealthCheck.exec(
+                    Command("echo", "ok"),
+                    Present("ok"),
+                    Schedule.fixed(100.millis).take(20)
+                ))
+            Abort.run[ContainerException](Scope.run(Container.init(config))).map {
+                case Result.Failure(e: ContainerHealthCheckException) =>
+                    assert(e.getMessage.contains("exited"), s"expected an exit-shaped reason, got ${e.getMessage}")
+                case other => fail(s"expected ContainerHealthCheckException for a stillborn fixture, got $other")
+            }
+        }
+
+        "the same container without requireService still starts (one-shot contract preserved)" - runBackends {
+            Container.init(Container.Config("alpine").command("sh", "-c", "exit 3")).map { c =>
+                c.waitForExit.map(code => assert(code == ExitCode.Failure(3)))
+            }
+        }
+
+        "a published port with nothing listening fails init" - runBackends {
+            // The container stays up, so only the host-side connect probe can tell that
+            // port 8080 is bound by the runtime and served by nobody.
+            val config = alpine.port(8080, 0)
+                .requireService(true)
+                .portMappingTimeout(5.seconds)
+            Abort.run[ContainerException](Scope.run(Container.init(config))).map {
+                case Result.Failure(e: ContainerStartFailedException) =>
+                    assert(e.reason.contains("refuses connections"), s"expected a reachability reason, got ${e.reason}")
+                case other => fail(s"expected ContainerStartFailedException for an unserved port, got $other")
+            }
+        }
+
+        "a published port with a live listener starts normally" - runBackends {
+            val config = Container.Config("alpine")
+                .command("sh", "-c", "trap 'exit 0' TERM; while true; do echo ok | nc -l -p 8080; done")
+                .port(8080, 0)
+                .requireService(true)
+                .portMappingTimeout(60.seconds)
+                .healthCheck(Container.HealthCheck.port(8080, Schedule.fixed(200.millis).take(30)))
+            Container.init(config).map { c =>
+                c.mappedPort(8080).map(hp => assert(hp > 0, s"expected a bound host port, got $hp"))
+            }
+        }
+
+        "the same unserved port is accepted without requireService" - runBackends {
+            Container.init(alpine.port(8080, 0)).map { c =>
+                c.mappedPort(8080).map(hp => assert(hp > 0, s"expected a bound host port, got $hp"))
+            }
+        }
+    }
+
+    // =========================================================================
     // Health Check
     // =========================================================================
 

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
@@ -1441,27 +1441,57 @@ class ContainerTest extends BasePodTest:
 
     "Container.probeHostPort" - {
         // Unsafe: kyo-net publishes listen/close on the unsafe tier only, and a real listener is the
-        // only way to assert the probe's two answers without a container runtime.
+        // only way to assert the probe's three outcomes without a container runtime.
         import AllowUnsafe.embrace.danger
 
-        "reports true for a port with a live listener" in {
-            Sync.defer(kyo.net.NetPlatform.transport.listen("127.0.0.1", 0, 16)(_ => ()).safe).map(_.get).map { listener =>
-                Sync.ensure(Sync.defer(listener.close())) {
-                    Container.probeHostPort("127.0.0.1", listener.port).map { reachable =>
-                        assert(reachable, s"a bound listener on port ${listener.port} must be reachable")
-                    }
+        def withListener[A](handler: kyo.net.Connection => Unit)(f: kyo.net.Listener => A < (Async & Abort[Any]))(using
+            Frame
+        ): A < (Async & Abort[Any]) =
+            Sync.defer(kyo.net.NetPlatform.transport.listen("127.0.0.1", 0, 16)(handler).safe).map(_.get).map { listener =>
+                Sync.ensure(Sync.defer(listener.close()))(f(listener))
+            }
+
+        "reports true for a listener that accepts and stays silent" in {
+            // The Postgres shape: the server waits for the client to speak first, so readiness shows
+            // up as a connection that is simply still open.
+            withListener(_ => ()) { listener =>
+                Container.probeHostPort("127.0.0.1", listener.port).map { reachable =>
+                    assert(reachable, s"a listener holding the connection on port ${listener.port} must read as ready")
+                }
+            }
+        }
+
+        "reports true for a listener that speaks first" in {
+            // The MySQL shape: the server sends a greeting and keeps the connection.
+            val greeting: kyo.net.Connection => Unit = conn =>
+                discard(conn.outbound.offer(Span("mysql-greeting".getBytes("UTF-8")*)))
+            withListener(greeting) { listener =>
+                Container.probeHostPort("127.0.0.1", listener.port).map { reachable =>
+                    assert(reachable, s"a listener that greets on port ${listener.port} must read as ready")
+                }
+            }
+        }
+
+        // Regression guard for the CI failure this probe was rewritten for. rootlessport and
+        // docker-proxy complete the TCP handshake before dialling the container, so a published port
+        // with nothing behind it accepts and then drops. A connect-only probe called that ready and
+        // handed the suite a fixture whose every query was refused.
+        "reports false for a listener that accepts and immediately drops the connection" in {
+            withListener(conn => conn.close()) { listener =>
+                Container.probeHostPort("127.0.0.1", listener.port).map { reachable =>
+                    assert(!reachable, s"port ${listener.port} accepts but holds nothing and must not read as ready")
                 }
             }
         }
 
         "reports false for a port nothing is serving" in {
-            // Bind then close: the port was real and is now free, so the connect is refused rather
-            // than black-holed, which is exactly the shape of a container whose forwarder never came up.
-            Sync.defer(kyo.net.NetPlatform.transport.listen("127.0.0.1", 0, 16)(_ => ()).safe).map(_.get).map { listener =>
+            // Bind then close: the port was real and is now free, so the connect is refused outright,
+            // which is the shape of a container whose forwarder never came up at all.
+            withListener(_ => ()) { listener =>
                 val port = listener.port
                 Sync.defer(listener.close()).andThen {
                     Container.probeHostPort("127.0.0.1", port).map { reachable =>
-                        assert(!reachable, s"port $port has no listener and must not be reported reachable")
+                        assert(!reachable, s"port $port has no listener and must not read as ready")
                     }
                 }
             }

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
@@ -1413,6 +1413,39 @@ class ContainerTest extends BasePodTest:
     // Port readiness — the second half of requireService.
     // =========================================================================
 
+    "Container.isAliveState" - {
+        // This predicate is why `requireService` cannot fail a container on its own startup. A
+        // container between `start` and `Running` reports Created, so the health check keeps polling
+        // its schedule; only a state it cannot come back from ends the wait. Podman's `configured`
+        // and `initialized` reach here as Created via ContainerBackend.parseState.
+        "a running container may become healthy" in {
+            assert(Container.isAliveState(Container.State.Running))
+        }
+
+        "a created container may become healthy — the not-yet-running window is not a verdict" in {
+            assert(Container.isAliveState(Container.State.Created))
+        }
+
+        "podman's pre-start states arrive as Created and count as alive" in {
+            assert(Container.isAliveState(kyo.internal.ContainerBackend.parseState("configured")))
+            assert(Container.isAliveState(kyo.internal.ContainerBackend.parseState("initialized")))
+        }
+
+        "a stopped or dead container cannot" in {
+            assert(!Container.isAliveState(Container.State.Stopped))
+            assert(!Container.isAliveState(Container.State.Dead))
+        }
+
+        "a container being removed cannot" in {
+            assert(!Container.isAliveState(Container.State.Removing))
+        }
+
+        "paused and restarting do not count as alive for a startup wait" in {
+            assert(!Container.isAliveState(Container.State.Paused))
+            assert(!Container.isAliveState(Container.State.Restarting))
+        }
+    }
+
     "Container.portProbeDeadline" - {
         // Both readiness waits share one portMappingTimeout budget. A mapping wait that exhausts it
         // fails on its own terms; what this floor exists for is the adjacent case, where the binding

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
@@ -1248,6 +1248,167 @@ class ContainerTest extends BasePodTest:
         }
     }
 
+    // =========================================================================
+    // Host-side kill fallback — the escalation for a runtime that cannot reap
+    // its own container process ("given PID did not die within timeout").
+    // =========================================================================
+
+    "Container.isUnreapedProcessFailure" - {
+        "recognises podman's stop/kill/remove 'did not die' body" in {
+            val e = new RuntimeException(
+                """Daemon returned HTTP 500: {"cause":"given PID did not die within timeout","message":"..."}"""
+            )
+            assert(Container.isUnreapedProcessFailure(e))
+        }
+
+        "recognises the 'container state improper' sibling" in {
+            assert(Container.isUnreapedProcessFailure(new RuntimeException("HTTP 500: container state improper")))
+        }
+
+        "matches case-insensitively" in {
+            assert(Container.isUnreapedProcessMessage("GIVEN PID DID NOT DIE WITHIN TIMEOUT"))
+        }
+
+        "reads the cause chain, not only the top message" in {
+            val cause = new RuntimeException("given PID did not die within timeout")
+            assert(Container.isUnreapedProcessFailure(new RuntimeException("stop failed", cause)))
+        }
+
+        "does not fire on an unrelated daemon failure" in {
+            assert(!Container.isUnreapedProcessFailure(new RuntimeException("No such container: abc")))
+            assert(!Container.isUnreapedProcessMessage("port is already allocated"))
+        }
+
+        "tolerates a null message and a self-referential cause" in {
+            val loop = new RuntimeException(null: String):
+                override def getCause: Throwable = this
+            assert(!Container.isUnreapedProcessFailure(loop))
+        }
+    }
+
+    "Container.cgroupNamesContainer" - {
+        // The gate that keeps the host-side SIGKILL from signalling an unrelated host process:
+        // only a pid whose cgroup names this container is ever signalled.
+        "accepts a rootless podman libpod scope" in {
+            val id = Container.Id("3f9a1c2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8")
+            val cgroup =
+                "0::/user.slice/user-1001.slice/user@1001.service/user.slice/libpod-3f9a1c2b4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8.scope\n"
+            assert(Container.cgroupNamesContainer(cgroup, id))
+        }
+
+        "accepts a docker cgroup path" in {
+            val id = Container.Id("abcdef0123456789abcdef0123456789")
+            assert(Container.cgroupNamesContainer("0::/docker/abcdef0123456789abcdef0123456789\n", id))
+        }
+
+        "rejects a cgroup belonging to another container" in {
+            val id = Container.Id("abcdef0123456789abcdef0123456789")
+            assert(!Container.cgroupNamesContainer("0::/docker/999999999999999999999999\n", id))
+        }
+
+        "rejects an unrelated host process" in {
+            val id = Container.Id("abcdef0123456789abcdef0123456789")
+            assert(!Container.cgroupNamesContainer("0::/user.slice/user-501.slice/session-3.scope\n", id))
+        }
+
+        "rejects an empty id rather than matching everything" in {
+            assert(!Container.cgroupNamesContainer("0::/docker/abc\n", Container.Id("")))
+        }
+    }
+
+    "Container.hostKillCommand" - {
+        "is an unconditional SIGKILL of the given pid" in {
+            assert(Container.hostKillCommand(4242).args == Chunk("kill", "-9", "4242"))
+        }
+    }
+
+    "Container.withUnreapedProcessFallback" - {
+        // A daemon whose stop/kill/remove leaves the container's process running is the leak engine
+        // the SQL Native batch died of: without the escalation every scoped fixture became a corpse.
+        "passes a successful call straight through and never escalates" in {
+            for
+                calls     <- AtomicInt.init(0)
+                escalated <- AtomicInt.init(0)
+                _ <- Container.withUnreapedProcessFallback(escalated.incrementAndGet.andThen(true)) {
+                    calls.incrementAndGet.unit
+                }
+                callCount <- calls.get
+                killCount <- escalated.get
+            yield
+                assert(callCount == 1, s"expected one call, got $callCount")
+                assert(killCount == 0, s"a successful call must not escalate, got $killCount")
+        }
+
+        "escalates on 'did not die', then retries the call once" in {
+            for
+                calls     <- AtomicInt.init(0)
+                escalated <- AtomicInt.init(0)
+                result <- Abort.run[ContainerException] {
+                    Container.withUnreapedProcessFallback(escalated.incrementAndGet.andThen(true)) {
+                        calls.incrementAndGet.map { n =>
+                            if n == 1 then
+                                Abort.fail(ContainerOperationException("given PID did not die within timeout"))
+                            else ()
+                        }
+                    }
+                }
+                callCount <- calls.get
+                killCount <- escalated.get
+            yield
+                assert(result.isSuccess, s"the retry after the host kill should succeed, got $result")
+                assert(killCount == 1, s"expected exactly one escalation, got $killCount")
+                assert(callCount == 2, s"expected the call to run twice, got $callCount")
+        }
+
+        "re-raises the daemon failure when the escalation declines" in {
+            for
+                calls <- AtomicInt.init(0)
+                result <- Abort.run[ContainerException] {
+                    Container.withUnreapedProcessFallback(false) {
+                        calls.incrementAndGet.andThen(
+                            Abort.fail(ContainerOperationException("given PID did not die within timeout"))
+                        )
+                    }
+                }
+                callCount <- calls.get
+            yield
+                assert(result.isFailure, s"a declined escalation must surface the daemon failure, got $result")
+                assert(callCount == 1, s"a declined escalation must not retry, got $callCount")
+        }
+
+        "leaves an unrelated failure untouched" in {
+            for
+                escalated <- AtomicInt.init(0)
+                result <- Abort.run[ContainerException] {
+                    Container.withUnreapedProcessFallback(escalated.incrementAndGet.andThen(true)) {
+                        Abort.fail(ContainerMissingException(Container.Id("gone")))
+                    }
+                }
+                killCount <- escalated.get
+            yield
+                assert(killCount == 0, s"an unrelated failure must not escalate, got $killCount")
+                result match
+                    case Result.Failure(_: ContainerMissingException) => succeed("the original failure survives")
+                    case other                                        => fail(s"expected ContainerMissingException, got $other")
+        }
+
+        "surfaces a second failure from the retried call rather than looping" in {
+            for
+                calls <- AtomicInt.init(0)
+                result <- Abort.run[ContainerException] {
+                    Container.withUnreapedProcessFallback(true) {
+                        calls.incrementAndGet.andThen(
+                            Abort.fail(ContainerOperationException("given PID did not die within timeout"))
+                        )
+                    }
+                }
+                callCount <- calls.get
+            yield
+                assert(result.isFailure, s"a still-failing retry must fail, got $result")
+                assert(callCount == 2, s"the call must run exactly twice, got $callCount")
+        }
+    }
+
     "uniqueName" - {
         // Regression guard for the shared-/tmp collision: container suites are forked once per
         // runtime and those forks run concurrently on one machine. A bare `prefix-counter` resets

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerTest.scala
@@ -1409,6 +1409,65 @@ class ContainerTest extends BasePodTest:
         }
     }
 
+    // =========================================================================
+    // Port readiness — the second half of requireService.
+    // =========================================================================
+
+    "Container.portProbeDeadline" - {
+        // Both readiness waits share one portMappingTimeout budget. A mapping wait that exhausts it
+        // fails on its own terms; what this floor exists for is the adjacent case, where the binding
+        // lands a few milliseconds before the deadline and the probe would otherwise get one connect
+        // against a forwarder still coming up, then report "refuses connections" for a healthy port.
+        "leaves a roomy shared deadline untouched" in {
+            val now      = 1_000_000L
+            val deadline = now + 60_000L
+            assert(Container.portProbeDeadline(deadline, now) == deadline)
+        }
+
+        "floors the probe's budget when the mapping wait finished just under the deadline" in {
+            val now      = 1_000_000L
+            val deadline = now + 10L
+            val probe    = Container.portProbeDeadline(deadline, now)
+            assert(probe > deadline, s"the probe must not inherit a 10ms budget, got ${probe - now}ms")
+            assert(probe == now + 5_000L, s"expected the 5s floor, got ${probe - now}ms")
+        }
+
+        "floors the probe's budget when the shared deadline has already passed" in {
+            val now      = 1_000_000L
+            val deadline = now - 500L
+            assert(Container.portProbeDeadline(deadline, now) == now + 5_000L)
+        }
+    }
+
+    "Container.probeHostPort" - {
+        // Unsafe: kyo-net publishes listen/close on the unsafe tier only, and a real listener is the
+        // only way to assert the probe's two answers without a container runtime.
+        import AllowUnsafe.embrace.danger
+
+        "reports true for a port with a live listener" in {
+            Sync.defer(kyo.net.NetPlatform.transport.listen("127.0.0.1", 0, 16)(_ => ()).safe).map(_.get).map { listener =>
+                Sync.ensure(Sync.defer(listener.close())) {
+                    Container.probeHostPort("127.0.0.1", listener.port).map { reachable =>
+                        assert(reachable, s"a bound listener on port ${listener.port} must be reachable")
+                    }
+                }
+            }
+        }
+
+        "reports false for a port nothing is serving" in {
+            // Bind then close: the port was real and is now free, so the connect is refused rather
+            // than black-holed, which is exactly the shape of a container whose forwarder never came up.
+            Sync.defer(kyo.net.NetPlatform.transport.listen("127.0.0.1", 0, 16)(_ => ()).safe).map(_.get).map { listener =>
+                val port = listener.port
+                Sync.defer(listener.close()).andThen {
+                    Container.probeHostPort("127.0.0.1", port).map { reachable =>
+                        assert(!reachable, s"port $port has no listener and must not be reported reachable")
+                    }
+                }
+            }
+        }
+    }
+
     "uniqueName" - {
         // Regression guard for the shared-/tmp collision: container suites are forked once per
         // runtime and those forks run concurrently on one machine. A bare `prefix-counter` resets

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/internal/MysqlTestBackend.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/internal/MysqlTestBackend.scala
@@ -7,7 +7,7 @@ import kyo.internal.mysql.MysqlConnection
   * discovered by kyo-sql-tests through the `META-INF/services/kyo.internal.SqlTestBackend` entry so the backend-agnostic conformance battery
   * names no engine.
   *
-  * Provisioning relocates [[SqlSharedContainers.withFreshMysqlSchema]] verbatim: a per-JVM shared MySQL container memoized by the id `"mysql"`
+  * Provisioning relocates [[SqlSharedContainers.withFreshMysqlSchema]] verbatim: a shared MySQL container memoized by the id `"mysql"`
   * through [[SqlTestContainers.getOrInit]], a freshly-created database per leaf, an admin connection that runs the CREATE/GRANT/DROP SQL, and a
   * scoped per-test connection, all dropped on scope exit even when the body fails. The container config carries the same `performance_schema`
   * override [[containerConfig]] documents, so this descriptor and kyo-sql-tests share one container for the id whichever inits first.

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/CachingSha2FullAuthIntegrationTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/CachingSha2FullAuthIntegrationTest.scala
@@ -2,6 +2,7 @@ package kyo.mysql
 
 import kyo.*
 import kyo.OwnContainer
+import kyo.internal.SqlTestContainers
 
 /** Integration test for caching_sha2_password full-auth via pure-Scala RSA-OAEP.
   *
@@ -25,7 +26,10 @@ class CachingSha2FullAuthIntegrationTest extends SqlContainerTest:
     "caching_sha2_password full-auth via pure-Scala RSA-OAEP succeeds against fresh MySQL container".tagged("kyo.OwnContainer") in {
         Scope.run {
             // Fresh container = cold auth cache → server will issue full-auth (AuthMoreData 0x04).
-            ContainerPredef.MySQL.initWith(ContainerPredef.MySQL.Config.default) { mysql =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.MySQL.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedMysql(ContainerPredef.MySQL.Config.default, "mysql-caching-sha2-full-auth").map { mysql =>
                 mysql.container.mappedPort(mysql.config.port).flatMap { port =>
                     // Connect without TLS: forces the RSA-OAEP encrypted full-auth path.
                     MysqlClient.init(

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/CachingSha2IntegrationTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/CachingSha2IntegrationTest.scala
@@ -32,7 +32,10 @@ class CachingSha2IntegrationTest extends SqlContainerTest:
     private def withCachingSha2Container[A](
         f: ConnDetails => A < (Async & Abort[SqlException])
     )(using Frame): A < (Async & Abort[Throwable] & Scope) =
-        ContainerPredef.MySQL.initWith(ContainerPredef.MySQL.Config.default) { mysql =>
+        // Through `SqlTestContainers` rather than `ContainerPredef.MySQL.initWith` directly, so the
+        // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+        // process leaves something the reaper can find.
+        SqlTestContainers.initScopedMysql(ContainerPredef.MySQL.Config.default, "mysql-caching-sha2").map { mysql =>
             mysql.container.mappedPort(mysql.config.port).flatMap { port =>
                 val details = ConnDetails(
                     mysql.container.host,

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/MysqlTlsIntegrationTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/MysqlTlsIntegrationTest.scala
@@ -2,6 +2,7 @@ package kyo.mysql
 
 import kyo.*
 import kyo.OwnContainer
+import kyo.internal.SqlTestContainers
 import kyo.net.NetTlsConfig
 
 /** Integration tests for MySQL TLS upgrade (CLIENT_SSL mid-handshake).
@@ -33,7 +34,10 @@ class MysqlTlsIntegrationTest extends SqlContainerTest:
     private def withTlsContainer[A](
         f: TlsConnDetails => A < (Async & Abort[SqlException])
     )(using Frame): A < (Async & Abort[Throwable] & Scope) =
-        ContainerPredef.MySQL.initWith(ContainerPredef.MySQL.Config.default) { mysql =>
+        // Through `SqlTestContainers` rather than `ContainerPredef.MySQL.initWith` directly, so the
+        // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+        // process leaves something the reaper can find.
+        SqlTestContainers.initScopedMysql(ContainerPredef.MySQL.Config.default, "mysql-tls").map { mysql =>
             mysql.container.mappedPort(mysql.config.port).flatMap { port =>
                 val details = TlsConnDetails(
                     mysql.container.host,

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/Sha256PasswordIntegrationTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/Sha256PasswordIntegrationTest.scala
@@ -2,6 +2,7 @@ package kyo.mysql
 
 import kyo.*
 import kyo.OwnContainer
+import kyo.internal.SqlTestContainers
 import kyo.net.NetTlsConfig
 
 /** Integration test for MySQL sha256_password auth plugin.
@@ -42,7 +43,11 @@ class Sha256PasswordIntegrationTest extends SqlContainerTest:
     )(
         f: (String, Int, String, String, String) => A < (S & Async & Abort[SqlException] & Scope)
     )(using Frame): A < (S & Async & Abort[Throwable] & Scope) =
-        ContainerPredef.MySQL.initWith(ContainerPredef.MySQL.Config.default.serverArgs(serverArgs)) { mysql =>
+        // Through `SqlTestContainers` rather than `ContainerPredef.MySQL.initWith` directly, so the
+        // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+        // process leaves something the reaper can find.
+        val predef = ContainerPredef.MySQL.Config.default.serverArgs(serverArgs)
+        SqlTestContainers.initScopedMysql(predef, "mysql-sha256-password").map { mysql =>
             mysql.container.mappedPort(mysql.config.port).flatMap { port =>
                 val host = mysql.container.host
                 val user = mysql.username

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/internal/PostgresTestBackend.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/internal/PostgresTestBackend.scala
@@ -10,7 +10,7 @@ import kyo.internal.postgres.PostgresConnection
   * `"`-doubling identifier quoting, and the `CREATE`/`DROP DATABASE` SQL. kyo-sql-tests names no engine and reaches this behavior only through
   * [[withFreshSchema]] and the capability flags, so the coordinates a conformance body sees are engine-free.
   *
-  * The container is shared, not per-test: [[withFreshSchema]] memoizes one postgres container per JVM through
+  * The container is shared, not per-test: [[withFreshSchema]] memoizes one postgres container per process through
   * [[SqlTestContainers.getOrInit]] over the core [[SqlTestContainers.containers]] table, keyed by the descriptor id `"postgres"`, so a container
   * inited here shares the single entry with any other caller for that id. Each leaf then provisions a fresh database inside that shared
   * container and drops it on scope exit, so leaves never collide yet pay the container start once.

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/ScramPlusIntegrationTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/ScramPlusIntegrationTest.scala
@@ -112,7 +112,10 @@ class ScramPlusIntegrationTest extends SqlContainerTest:
     "connecting plaintext to a PG that offers PLUS falls back to SCRAM-SHA-256".tagged("kyo.OwnContainer") in {
         Scope.run {
             // Use a plain non-TLS Postgres container. Without TLS, no cert hash, so non-PLUS.
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-scram-plus-leaf").map { pg =>
                 pg.container.mappedPort(pg.config.port).flatMap { port =>
                     AtomicRef.init("").flatMap { mechanismRef =>
                         PostgresConnection.connectWithCertHashOverride(

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/RetryIntegrationTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/RetryIntegrationTest.scala
@@ -2,6 +2,7 @@ package kyo.postgres
 
 import kyo.*
 import kyo.OwnContainer
+import kyo.internal.SqlTestContainers
 
 /** Integration tests for retry policy via kyo.Retry + kyo.Schedule.
   *
@@ -15,7 +16,7 @@ import kyo.OwnContainer
   *
   * Container ownership: this suite mutates server state via `Container.pause` / `Container.unpause`. It cannot share the per-fork-JVM
   * Postgres singleton with other tests because pausing the singleton would freeze every concurrent caller. Each leaf therefore starts its
-  * own container via [[ContainerPredef.Postgres.initWith]] and carries the `kyo.OwnContainer` tag.
+  * own container via `SqlTestContainers.initScopedPostgres` and carries the `kyo.OwnContainer` tag.
   */
 class RetryIntegrationTest extends SqlContainerTest:
 
@@ -55,7 +56,10 @@ class RetryIntegrationTest extends SqlContainerTest:
       */
     "Container.pause then unpause mid-query: Retry bridges the downtime and produces >= 1 retry".tagged("kyo.OwnContainer") in {
         Scope.run {
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-retry").map { pg =>
                 pg.container.mappedPort(pg.config.port).flatMap { port =>
                     val url = pgUrl(pg, port)
                     // acquireTimeout = 1 second so paused-server connect attempts time out quickly

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/ScramIntegrationTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/ScramIntegrationTest.scala
@@ -35,7 +35,10 @@ class ScramIntegrationTest extends SqlContainerTest:
     "StartupExchange succeeds with SCRAM-SHA-256 server, connect completes without error".tagged("kyo.OwnContainer") in {
         Scope.run {
             // Default postgres:16 uses scram-sha-256; no authMethod override needed.
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-scram").map { pg =>
                 initScramClient(pg).flatMap { client =>
                     client.isAlive.map(alive => assert(alive))
                 }
@@ -45,9 +48,13 @@ class ScramIntegrationTest extends SqlContainerTest:
 
     "StartupExchange SCRAM wrong password raises SqlConnectionAuthenticationFailedException".tagged("kyo.OwnContainer") in {
         Scope.run {
-            ContainerPredef.Postgres.initWith(
-                ContainerPredef.Postgres.Config.default.password("correctpassword")
-            ) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(
+                ContainerPredef.Postgres.Config.default.password("correctpassword"),
+                "postgres-scram"
+            ).map { pg =>
                 pg.container.mappedPort(pg.config.port).flatMap { port =>
                     Abort.run[SqlException] {
                         Scope.run {
@@ -71,7 +78,10 @@ class ScramIntegrationTest extends SqlContainerTest:
 
     "StartupExchange SCRAM server signature verified, no error after successful SCRAM".tagged("kyo.OwnContainer") in {
         Scope.run {
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-scram").map { pg =>
                 // If server signature verification fails, connect raises SqlConnectionException.
                 // Success here proves the server signature was accepted.
                 initScramClient(pg).flatMap { client =>
@@ -83,7 +93,10 @@ class ScramIntegrationTest extends SqlContainerTest:
 
     "StartupExchange SCRAM populates ParameterStatus, server_version present after SCRAM connect".tagged("kyo.OwnContainer") in {
         Scope.run {
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-scram").map { pg =>
                 initScramClient(pg).flatMap { client =>
                     client.parameters.map { params =>
                         assert(
@@ -98,7 +111,10 @@ class ScramIntegrationTest extends SqlContainerTest:
 
     "StartupExchange SCRAM SELECT 1 returns correct result after authentication".tagged("kyo.OwnContainer") in {
         Scope.run {
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-scram").map { pg =>
                 initScramClient(pg).flatMap { client =>
                     // Use text literal '1' so the server returns text OID bytes (UTF-8 compatible in binary format).
                     client.query("SELECT '1'").map { rows =>
@@ -135,7 +151,10 @@ class ScramIntegrationTest extends SqlContainerTest:
 
     "StartupExchange SCRAM stores BackendKeyData, processId > 0 after SCRAM connect".tagged("kyo.OwnContainer") in {
         Scope.run {
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-scram").map { pg =>
                 initScramClient(pg).flatMap { client =>
                     client.query("SELECT pg_backend_pid()").flatMap { rows =>
                         assert(rows.nonEmpty, "pg_backend_pid() returned no rows")

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/SqlConfigTlsModeIntegrationTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/SqlConfigTlsModeIntegrationTest.scala
@@ -109,7 +109,10 @@ class SqlConfigTlsModeIntegrationTest extends SqlContainerTest:
 
     "sslmode=disable connects without TLS".tagged("kyo.OwnContainer") in {
         Scope.run {
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-tls-mode-leaf").map { pg =>
                 pg.container.mappedPort(pg.config.port).flatMap { port =>
                     val url = s"postgres://${pg.username}:${pg.password}@${pg.container.host}:$port/${pg.database}?sslmode=disable"
                     SqlClient.init(url).flatMap { client =>
@@ -367,7 +370,10 @@ class SqlConfigTlsModeIntegrationTest extends SqlContainerTest:
     "sslmode=allow connects plaintext when server permits plaintext".tagged("kyo.OwnContainer") in {
         Scope.run {
             // Plain Postgres container (no cert mount → no TLS support)
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-tls-mode-leaf").map { pg =>
                 pg.container.mappedPort(pg.config.port).flatMap { port =>
                     val url = s"postgres://${pg.username}:${pg.password}@${pg.container.host}:$port/${pg.database}?sslmode=allow"
                     SqlClient.init(url).flatMap { client =>
@@ -430,7 +436,10 @@ class SqlConfigTlsModeIntegrationTest extends SqlContainerTest:
     "sslmode=prefer falls back to plaintext when server refuses TLS".tagged("kyo.OwnContainer") in {
         Scope.run {
             // Plain Postgres container: no cert → SSLRequest returns 'N' → plaintext fallback.
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-tls-mode-leaf").map { pg =>
                 pg.container.mappedPort(pg.config.port).flatMap { port =>
                     val url = s"postgres://${pg.username}:${pg.password}@${pg.container.host}:$port/${pg.database}?sslmode=prefer"
                     SqlClient.init(url).flatMap { client =>

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/TlsIntegrationTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/TlsIntegrationTest.scala
@@ -210,7 +210,10 @@ class TlsIntegrationTest extends SqlContainerTest:
     "TLS connection, connect with Present(tls) to non-TLS Postgres raises SqlConnectionException".tagged("kyo.OwnContainer") in {
         Scope.run {
             // Start a standard (non-TLS) Postgres and try to connect with TLS required.
-            ContainerPredef.Postgres.initWith(ContainerPredef.Postgres.Config.default) { pg =>
+            // Through `SqlTestContainers` rather than `ContainerPredef.Postgres.initWith` directly, so the
+            // container carries the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels and a killed test
+            // process leaves something the reaper can find.
+            SqlTestContainers.initScopedPostgres(ContainerPredef.Postgres.Config.default, "postgres-tls-leaf").map { pg =>
                 pg.container.mappedPort(pg.config.port).flatMap { port =>
                     Abort.run[SqlException] {
                         Scope.run {

--- a/kyo-sql-tests/shared/src/test/scala/kyo/internal/SqlSharedContainers.scala
+++ b/kyo-sql-tests/shared/src/test/scala/kyo/internal/SqlSharedContainers.scala
@@ -5,17 +5,21 @@ import kyo.internal.mysql.MysqlConnection
 import kyo.internal.postgres.PostgresConnection
 
 /** The postgres/mysql `withFreshSchema` API for kyo-sql tests: it hands the caller a freshly-created database/schema scoped to the test's
-  * lifetime, provisioned against the per-JVM shared container fixture.
+  * lifetime, provisioned against the shared container fixture.
   *
   * The singleton container is memoized by descriptor id through [[SqlTestContainers.getOrInit]] over the shared
   * [[SqlTestContainers.containers]] table, which lives in the core test tree so both kyo-sql-tests and each backend module share one entry
   * per id: the first call for an id lazily initializes its container via [[SqlTestContainers.initSingleton]], concurrent callers await the
   * same [[kyo.Promise]] rather than starting a duplicate, and a failed startup removes that id's slot so the next caller may retry.
   *
-  * Containers are NOT torn down in-process. They carry the `kyo-sql-singleton` and `kyo-sql-owner-pid` labels, and
-  * [[SqlTestContainers.initSingleton]] removes every dead-owner container, together with its anonymous volumes, before creating a new
-  * singleton. Nothing in the build reaps them and nothing can: a force-killed test process runs no sbt hook either, which is why the reap
-  * sits on the creation path.
+  * That table is per process, so the sharing it gives is per process too. [[SqlTestContainers.initSingleton]] extends it across processes:
+  * it attaches to a live, healthy container left by an earlier test process whose fixture fingerprint matches, and only provisions when
+  * there is none.
+  *
+  * Containers are NOT torn down in-process. They carry the `kyo-sql-singleton`, `kyo-sql-owner-pid` and `kyo-sql-fixture` labels, and
+  * [[SqlTestContainers.initSingleton]] removes every container no live process owns, together with its anonymous volumes, on the creation
+  * path. Nothing in the build reaps them and nothing can: a force-killed test process runs no sbt hook either, which is why the reap sits
+  * there.
   */
 object SqlSharedContainers:
 
@@ -58,7 +62,7 @@ object SqlSharedContainers:
 
     // --- Public API ---
 
-    /** Run `f` against a fresh schema in the per-JVM shared container for `backend`. The schema is created on entry, the connection is scoped
+    /** Run `f` against a fresh schema in the shared container for `backend`. The schema is created on entry, the connection is scoped
       * to it, and the schema is dropped on exit (via [[Scope.ensure]], even if `f` fails).
       */
     def withFreshSchema[A, S](backend: Backend)(f: SchemaCtx => A < S)(using

--- a/kyo-sql/js-wasm/src/test/scala/kyo/internal/TestTempRoot.scala
+++ b/kyo-sql/js-wasm/src/test/scala/kyo/internal/TestTempRoot.scala
@@ -1,0 +1,28 @@
+package kyo.internal
+
+import kyo.*
+import scala.scalajs.js
+import scala.scalajs.js.annotation.*
+
+// Node's os module, reached through a namespace import for the reason TestProcessId records for
+// node:process: @JSImport compiles to require() under CommonJS and to import under ESModule, so one
+// facade serves both the JS and the WebAssembly backend.
+@js.native
+@JSImport("node:os", JSImport.Namespace)
+private object TestNodeOs extends js.Object:
+    def tmpdir(): String = js.native
+end TestNodeOs
+
+/** The system temporary-directory root, for [[SqlTestContainers]]'s co-owner registry.
+  *
+  * The registry is a cross-process rendezvous: every test process on the machine must resolve the SAME directory, so this is the platform's
+  * temp root itself rather than `Path.tempDir`, which mints a fresh private directory per call. Scala.js does not surface `java.io.tmpdir`
+  * as a system property, so the root comes from Node's `os.tmpdir()` instead. `Absent` means the platform has no temp root, which disables
+  * the registry.
+  */
+private[kyo] object TestTempRoot:
+
+    def get(using Frame): Maybe[String] < Sync =
+        Sync.defer(Maybe(TestNodeOs.tmpdir()).filter(_.nonEmpty))
+
+end TestTempRoot

--- a/kyo-sql/jvm/src/test/scala/kyo/internal/TestTempRoot.scala
+++ b/kyo-sql/jvm/src/test/scala/kyo/internal/TestTempRoot.scala
@@ -1,0 +1,16 @@
+package kyo.internal
+
+import kyo.*
+
+/** The system temporary-directory root, for [[SqlTestContainers]]'s co-owner registry.
+  *
+  * The registry is a cross-process rendezvous: every test process on the machine must resolve the SAME directory, so this is the platform's
+  * temp root itself rather than `Path.tempDir`, which mints a fresh private directory per call. `Absent` means the platform has no temp
+  * root, which disables the registry.
+  */
+private[kyo] object TestTempRoot:
+
+    def get(using Frame): Maybe[String] < Sync =
+        System.property[String]("java.io.tmpdir").map(_.filter(_.nonEmpty))
+
+end TestTempRoot

--- a/kyo-sql/native/src/test/scala/kyo/internal/TestTempRoot.scala
+++ b/kyo-sql/native/src/test/scala/kyo/internal/TestTempRoot.scala
@@ -1,0 +1,16 @@
+package kyo.internal
+
+import kyo.*
+
+/** The system temporary-directory root, for [[SqlTestContainers]]'s co-owner registry.
+  *
+  * The registry is a cross-process rendezvous: every test process on the machine must resolve the SAME directory, so this is the platform's
+  * temp root itself rather than `Path.tempDir`, which mints a fresh private directory per call. `Absent` means the platform has no temp
+  * root, which disables the registry.
+  */
+private[kyo] object TestTempRoot:
+
+    def get(using Frame): Maybe[String] < Sync =
+        System.property[String]("java.io.tmpdir").map(_.filter(_.nonEmpty))
+
+end TestTempRoot

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainers.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainers.scala
@@ -46,8 +46,11 @@ import kyo.*
   * would let the next reaper delete a container this process is using. A CO-OWNER REGISTRY closes that: adopting writes an empty file named
   * for this process's pid under `<tmpdir>/kyo-sql-container-owners/<short id>/`, and the reaper spares any container with a live co-owner
   * even when its label owner is gone. The claim is written before the health probe and removed again when the probe declines, so a
-  * container this process rejected does not stay un-reapable for the rest of the run. Every failure in the registry path resolves toward
-  * sparing, the same direction as the owner-pid predicate.
+  * container this process rejected does not stay un-reapable for the rest of the run.
+  *
+  * A claim that cannot be written declines the candidate: adoption without a claim is not a small risk to accept, because the reap that
+  * follows adoption in [[initSingleton]] would then remove the very container just handed to the caller. Every OTHER failure in the
+  * registry path resolves toward sparing, the same direction as the owner-pid predicate.
   */
 private[kyo] object SqlTestContainers:
 
@@ -79,6 +82,8 @@ private[kyo] object SqlTestContainers:
             case Present(adopted) => reapOrphans.andThen(adopted)
             case Absent =>
                 reapOrphans.andThen {
+                    // A failed claim is harmless here, unlike on the adoption path: this container's own
+                    // owner label already carries this process's live pid, so every reaper spares it.
                     Container.initUnscoped(labelled(cfg, tag)).map(c => claimOwnership(c.id).andThen(c))
                 }
         }
@@ -142,18 +147,24 @@ private[kyo] object SqlTestContainers:
       * The claim precedes the verification because the verification takes time, and a concurrent reaper reading an unclaimed container
       * during that window would remove it out from under this process. Releasing on a declined candidate is what keeps that ordering from
       * pinning a container nobody wants.
+      *
+      * A claim that could not be written declines the candidate outright. Continuing unclaimed is not a small risk to accept: the reap in
+      * [[initSingleton]] runs immediately after adoption, and an adoption candidate is usually one whose label owner is already dead, so an
+      * unclaimed adoption would have this very process force-remove the container it just returned to the caller.
       */
     private def adoptCandidate(summary: Container.Summary, cfg: Container.Config)(using Frame): Maybe[Container] < Async =
         Abort.run[ContainerException] {
             summary.attach.map { attached =>
-                claimOwnership(attached.id).andThen {
-                    attached.state.map {
-                        case Container.State.Running =>
-                            Container.awaitPortsReachableWithin(attached, adoptProbeTimeout)
-                                .andThen(cfg.healthCheck.check(attached))
-                                .andThen(Present(attached))
-                        case _ => Absent
-                    }
+                claimOwnership(attached.id).map {
+                    case false => Absent
+                    case true =>
+                        attached.state.map {
+                            case Container.State.Running =>
+                                Container.awaitPortsReachableWithin(attached, adoptProbeTimeout)
+                                    .andThen(cfg.healthCheck.check(attached))
+                                    .andThen(Present(attached))
+                            case _ => Absent
+                        }
                 }
             }
         }.map {
@@ -175,12 +186,19 @@ private[kyo] object SqlTestContainers:
 
     private def ownerDir(root: Path, id: Container.Id): Path = Path(root, id.value.take(12))
 
-    /** Record this process as a co-owner of `id`. */
-    private[kyo] def claimOwnership(root: Path, id: Container.Id)(using Frame): Unit < Async =
+    /** Record this process as a co-owner of `id`, reporting whether the claim is now readable by a reaper. A caller about to rely on the
+      * claim must treat `false` as "do not adopt": an unclaimed container is one every reaper is free to remove.
+      */
+    private[kyo] def claimOwnership(root: Path, id: Container.Id)(using Frame): Boolean < Async =
         // `mkFile` creates missing parents, so the per-container directory needs no separate step.
-        Abort.run[FileStructureException](Path(ownerDir(root, id), TestProcessId.pid.toString).mkFile).unit
+        Abort.run[FileStructureException](Path(ownerDir(root, id), TestProcessId.pid.toString).mkFile).map(_.isSuccess)
 
-    /** Drop this process's co-ownership of `id`. */
+    /** Drop this process's co-ownership of `id`.
+      *
+      * A removal that fails leaves this process's pid in the registry, which spares the container for the rest of the run and lets a later
+      * run reap it once the pid is dead. That is the same direction every other uncertainty here takes, so the failure is discarded rather
+      * than raised: declining to reap costs one cycle, and the alternative would fail a leaf over registry hygiene.
+      */
     private[kyo] def releaseOwnership(root: Path, id: Container.Id)(using Frame): Unit < Async =
         Abort.run[FileStructureException](Path(ownerDir(root, id), TestProcessId.pid.toString).remove).unit
 
@@ -205,14 +223,24 @@ private[kyo] object SqlTestContainers:
         }
     end hasLiveCoOwner
 
-    /** Forget every co-owner of `id`, called once the container itself is gone. */
+    /** Forget every co-owner of `id`, called once the container itself is gone.
+      *
+      * A removal that fails leaves a directory keyed by a container id that no longer exists, and `hasLiveCoOwner` is only ever asked about
+      * ids the daemon still lists, so nothing reads it again. The failure is therefore discarded: it litters a few empty files in the temp
+      * directory and cannot change a reap decision.
+      */
     private[kyo] def forgetOwners(root: Path, id: Container.Id)(using Frame): Unit < Async =
         Abort.run[FileStructureException](ownerDir(root, id).removeAll).unit
 
-    private def claimOwnership(id: Container.Id)(using Frame): Unit < Async =
+    /** Claim `id` for this process, reporting whether a reaper can now see the claim.
+      *
+      * A platform with no temp directory has no registry, so no claim can be recorded and `false` is the truthful answer: it disables
+      * adoption there and leaves the owner-pid label as the only predicate, which is how this object behaved before the registry existed.
+      */
+    private def claimOwnership(id: Container.Id)(using Frame): Boolean < Async =
         ownerRoot.map {
             case Present(root) => claimOwnership(root, id)
-            case Absent        => Kyo.unit
+            case Absent        => false
         }
 
     private def releaseOwnership(id: Container.Id)(using Frame): Unit < Async =

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainers.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainers.scala
@@ -179,10 +179,7 @@ private[kyo] object SqlTestContainers:
       * leaves the owner-pid label as the only predicate, exactly as before this registry existed).
       */
     private[kyo] def ownerRoot(using Frame): Maybe[Path] < Sync =
-        System.property[String]("java.io.tmpdir").map {
-            case Present(tmp) if tmp.nonEmpty => Present(Path(tmp, "kyo-sql-container-owners"))
-            case _                            => Absent
-        }
+        TestTempRoot.get.map(_.map(tmp => Path(tmp, "kyo-sql-container-owners")))
 
     private def ownerDir(root: Path, id: Container.Id): Path = Path(root, id.value.take(12))
 

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainers.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainers.scala
@@ -11,11 +11,11 @@ import kyo.*
   * directly: the labels are what make the leftovers findable.
   *
   * So the reap happens at CREATE time instead, which is the one moment a container-using run is guaranteed to reach. Each container is
-  * labelled `kyo-sql-singleton=<tag>` plus `kyo-sql-owner-pid=<pid of the creating test process>`. [[initSingleton]] first removes,
-  * together with its anonymous volumes, every labelled container whose owner process is dead, then creates the new container carrying both
-  * labels. A container with no owner label predates the label and is removed as well.
+  * labelled `kyo-sql-singleton=<tag>`, `kyo-sql-owner-pid=<pid of the creating test process>`, and `kyo-sql-fixture=<fingerprint of the
+  * config>`. [[initSingleton]] removes, together with its anonymous volumes, every labelled container that no live process owns. A
+  * container with no owner label predates the label and is removed as well.
   *
-  * A LIVE owner pid means the container belongs to a concurrently running test process (another module fork, platform leg, sbt session, or
+  * A LIVE owner means the container belongs to a concurrently running test process (another module fork, platform leg, sbt session, or
   * worktree) and it is always spared. Every uncertainty resolves toward sparing, which is what makes the predicate safe against those
   * concurrent forks: labels are applied atomically with create, a dead pid stays dead, a recycled pid spares an orphan for one more cycle,
   * a failed list aborts the sweep without removing anything, and an owner probe that fails in a way it does not recognise reports RUNNING
@@ -32,6 +32,22 @@ import kyo.*
   * any depth of the sweep arrives as `Result.Panic` and is discarded by the `unit`.
   *
   * Steady state is one run's population per daemon: the last run's containers linger until the next container-using run sweeps them.
+  *
+  * ==Cross-process reuse==
+  *
+  * The singleton table is per process, and a test binary is not one process per run: the Native runner is one process per module and the
+  * JVM is one per forked test group, so a plain per-process singleton provisions the same database once per process. [[initSingleton]]
+  * therefore looks for a live labelled container matching the requested fixture BEFORE creating one, and attaches to it instead. Reuse is
+  * gated on three things, in order: the fixture fingerprint label must match (a different image, command, environment, port set or mount
+  * is a different fixture), the container must be Running with every published port accepting a host-side connection, and the requested
+  * config's own health check must pass against it. Any doubt at any step provisions fresh.
+  *
+  * An adopted container's `kyo-sql-owner-pid` label still names the process that created it, which may already be dead, so the label alone
+  * would let the next reaper delete a container this process is using. A CO-OWNER REGISTRY closes that: adopting writes an empty file named
+  * for this process's pid under `<tmpdir>/kyo-sql-container-owners/<short id>/`, and the reaper spares any container with a live co-owner
+  * even when its label owner is gone. The claim is written before the health probe and removed again when the probe declines, so a
+  * container this process rejected does not stay un-reapable for the rest of the run. Every failure in the registry path resolves toward
+  * sparing, the same direction as the owner-pid predicate.
   */
 private[kyo] object SqlTestContainers:
 
@@ -41,12 +57,180 @@ private[kyo] object SqlTestContainers:
     /** Label key carrying the pid of the test process that created the container. */
     val ownerLabelKey: String = "kyo-sql-owner-pid"
 
-    /** Reap dead-owner singleton containers, then create a new singleton from `cfg` labelled with `tag` and this process's pid. */
+    /** Label key carrying [[fixtureFingerprint]] of the config the container was created from. Two fixtures may share a tag and still be
+      * incompatible (different server args, different auth plugin), so the tag alone cannot decide reuse.
+      */
+    val fixtureLabelKey: String = "kyo-sql-fixture"
+
+    /** How long an adoption candidate gets to accept a host-side connection. Short on purpose: a healthy container answers immediately, and
+      * anything slower is cheaper to replace than to wait for.
+      */
+    private val adoptProbeTimeout: Duration = 5.seconds
+
+    /** Attach to a live, healthy container for `tag`+`cfg` if there is one, otherwise reap dead-owner containers and create a fresh
+      * singleton labelled with `tag`, this process's pid, and the fixture fingerprint.
+      *
+      * The reap runs AFTER the adoption attempt so an adopted container's co-owner claim is already registered when the sweep reads it.
+      */
     def initSingleton(cfg: Container.Config, tag: String)(using
         Frame
     ): Container < (Async & Abort[ContainerException]) =
-        reapOrphans.andThen {
-            Container.initUnscoped(labelled(cfg, tag))
+        adoptLive(cfg, tag).map {
+            case Present(adopted) => reapOrphans.andThen(adopted)
+            case Absent =>
+                reapOrphans.andThen {
+                    Container.initUnscoped(labelled(cfg, tag)).map(c => claimOwnership(c.id).andThen(c))
+                }
+        }
+
+    // --- Adoption ---
+
+    /** A stable digest of the parts of a container config that decide whether two fixtures are interchangeable: image, command,
+      * environment, published ports and mounts. Sorted so `Dict` iteration order cannot change the value, and rendered from
+      * `String.hashCode`, whose result is fixed by the language spec on every platform this test tree runs on.
+      *
+      * Mounts are in it because the TLS fixtures bind a per-run directory of generated certificates: without them a container holding the
+      * previous run's certificates would look interchangeable with one holding this run's.
+      *
+      * A digest collision would mean adopting a container built from a different config; the health check the caller supplies still runs
+      * against it, so the failure mode is a rejected candidate rather than a silently wrong fixture.
+      */
+    private[kyo] def fixtureFingerprint(cfg: Container.Config): String =
+        val mounts = cfg.mounts.toSeq.map {
+            case Container.Config.Mount.Bind(source, target, readOnly) => s"mount:bind:$source:$target:$readOnly"
+            case Container.Config.Mount.Volume(name, target, readOnly) => s"mount:volume:$name:$target:$readOnly"
+            case Container.Config.Mount.Tmpfs(target, sizeBytes)       => s"mount:tmpfs:$target:${sizeBytes.getOrElse(0L)}"
+        }.sorted
+        val parts =
+            Seq(cfg.image.reference) ++
+                cfg.command.map(_.args.mkString(" ")).toList ++
+                cfg.env.toMap.toSeq.map((k, v) => s"env:$k=$v").sorted ++
+                cfg.ports.toSeq.map(p => s"port:${p.containerPort}/${p.protocol.cliName}").sorted ++
+                mounts
+        Integer.toHexString(parts.mkString(" ").hashCode)
+    end fixtureFingerprint
+
+    /** Whether a listed container's labels describe the fixture `tag`+`fingerprint` asks for. */
+    private[kyo] def matchesFixture(labels: Dict[String, String], tag: String, fingerprint: String): Boolean =
+        labels.get(singletonLabelKey).contains(tag) && labels.get(fixtureLabelKey).contains(fingerprint)
+
+    private def adoptLive(cfg: Container.Config, tag: String)(using Frame): Maybe[Container] < Async =
+        val fingerprint = fixtureFingerprint(cfg)
+        Abort.run[ContainerException] {
+            // Running containers only: a stopped one carries no port and no engine to probe.
+            Container.list(all = false, filters = Dict("label" -> Chunk(s"$singletonLabelKey=$tag"))).map { found =>
+                firstAdoptable(found.filter(s => matchesFixture(s.labels, tag, fingerprint)), cfg)
+            }
+        }.map {
+            case Result.Success(adopted) => adopted
+            case _                       => Absent
+        }
+    end adoptLive
+
+    private def firstAdoptable(candidates: Chunk[Container.Summary], cfg: Container.Config)(using
+        Frame
+    ): Maybe[Container] < Async =
+        if candidates.isEmpty then Absent
+        else
+            adoptCandidate(candidates.head, cfg).map {
+                case Present(adopted) => Present(adopted)
+                case Absent           => firstAdoptable(candidates.tail, cfg)
+            }
+
+    /** Claim, verify, and either keep or release one candidate.
+      *
+      * The claim precedes the verification because the verification takes time, and a concurrent reaper reading an unclaimed container
+      * during that window would remove it out from under this process. Releasing on a declined candidate is what keeps that ordering from
+      * pinning a container nobody wants.
+      */
+    private def adoptCandidate(summary: Container.Summary, cfg: Container.Config)(using Frame): Maybe[Container] < Async =
+        Abort.run[ContainerException] {
+            summary.attach.map { attached =>
+                claimOwnership(attached.id).andThen {
+                    attached.state.map {
+                        case Container.State.Running =>
+                            Container.awaitPortsReachableWithin(attached, adoptProbeTimeout)
+                                .andThen(cfg.healthCheck.check(attached))
+                                .andThen(Present(attached))
+                        case _ => Absent
+                    }
+                }
+            }
+        }.map {
+            case Result.Success(Present(adopted)) => Present(adopted)
+            case Result.Success(Absent)           => releaseOwnership(summary.id).andThen(Absent)
+            case _                                => releaseOwnership(summary.id).andThen(Absent)
+        }
+
+    // --- Co-owner registry ---
+
+    /** Root of the co-owner registry, `Absent` when the platform reports no temp directory (which disables adoption's reap protection and
+      * leaves the owner-pid label as the only predicate, exactly as before this registry existed).
+      */
+    private[kyo] def ownerRoot(using Frame): Maybe[Path] < Sync =
+        System.property[String]("java.io.tmpdir").map {
+            case Present(tmp) if tmp.nonEmpty => Present(Path(tmp, "kyo-sql-container-owners"))
+            case _                            => Absent
+        }
+
+    private def ownerDir(root: Path, id: Container.Id): Path = Path(root, id.value.take(12))
+
+    /** Record this process as a co-owner of `id`. */
+    private[kyo] def claimOwnership(root: Path, id: Container.Id)(using Frame): Unit < Async =
+        // `mkFile` creates missing parents, so the per-container directory needs no separate step.
+        Abort.run[FileStructureException](Path(ownerDir(root, id), TestProcessId.pid.toString).mkFile).unit
+
+    /** Drop this process's co-ownership of `id`. */
+    private[kyo] def releaseOwnership(root: Path, id: Container.Id)(using Frame): Unit < Async =
+        Abort.run[FileStructureException](Path(ownerDir(root, id), TestProcessId.pid.toString).remove).unit
+
+    /** Whether any process that adopted `id` is still running. An unreadable registry reports true, which spares the container: the same
+      * direction every other uncertainty in this object takes.
+      */
+    private[kyo] def hasLiveCoOwner(root: Path, id: Container.Id)(using Frame): Boolean < Async =
+        val dir = ownerDir(root, id)
+        Abort.run[FileReadException](dir.exists).map {
+            case Result.Success(false) => false
+            case Result.Success(true) =>
+                Abort.run[FileStructureException] {
+                    dir.list.map { entries =>
+                        Kyo.foreach(entries)(entry => TestProcessId.isAlive(entry.name.getOrElse("")))
+                            .map(_.exists(identity))
+                    }
+                }.map {
+                    case Result.Success(live) => live
+                    case _                    => true
+                }
+            case _ => true
+        }
+    end hasLiveCoOwner
+
+    /** Forget every co-owner of `id`, called once the container itself is gone. */
+    private[kyo] def forgetOwners(root: Path, id: Container.Id)(using Frame): Unit < Async =
+        Abort.run[FileStructureException](ownerDir(root, id).removeAll).unit
+
+    private def claimOwnership(id: Container.Id)(using Frame): Unit < Async =
+        ownerRoot.map {
+            case Present(root) => claimOwnership(root, id)
+            case Absent        => Kyo.unit
+        }
+
+    private def releaseOwnership(id: Container.Id)(using Frame): Unit < Async =
+        ownerRoot.map {
+            case Present(root) => releaseOwnership(root, id)
+            case Absent        => Kyo.unit
+        }
+
+    private def hasLiveCoOwner(id: Container.Id)(using Frame): Boolean < Async =
+        ownerRoot.map {
+            case Present(root) => hasLiveCoOwner(root, id)
+            case Absent        => false
+        }
+
+    private def forgetOwners(id: Container.Id)(using Frame): Unit < Async =
+        ownerRoot.map {
+            case Present(root) => forgetOwners(root, id)
+            case Absent        => Kyo.unit
         }
 
     /** Reap dead-owner containers, then create a SCOPE-MANAGED container from `cfg` carrying the same two labels.
@@ -63,9 +247,28 @@ private[kyo] object SqlTestContainers:
             Container.init(labelled(cfg, tag))
         }
 
+    /** [[initScoped]] for a [[ContainerPredef.MySQL]] fixture.
+      *
+      * `ContainerPredef.MySQL.initWith` reaches `Container.init` directly, so its containers carry none of these labels and no reaper can
+      * ever find them. That is exactly the shape the per-leaf auth and TLS suites used, and on a runtime whose teardown fails they became
+      * permanent, invisible corpses: 21 leaked mysqld from one module in one CI job. Routing them through here costs nothing and makes them
+      * findable.
+      */
+    def initScopedMysql(cfg: ContainerPredef.MySQL.Config, tag: String)(using
+        Frame
+    ): ContainerPredef.MySQL < (Async & Abort[ContainerException] & Scope) =
+        initScoped(ContainerPredef.MySQL.buildContainerConfig(cfg), tag).map(c => new ContainerPredef.MySQL(c, cfg))
+
+    /** [[initScoped]] for a [[ContainerPredef.Postgres]] fixture. @see [[initScopedMysql]] */
+    def initScopedPostgres(cfg: ContainerPredef.Postgres.Config, tag: String)(using
+        Frame
+    ): ContainerPredef.Postgres < (Async & Abort[ContainerException] & Scope) =
+        initScoped(ContainerPredef.Postgres.buildContainerConfig(cfg), tag).map(c => new ContainerPredef.Postgres(c, cfg))
+
     private def labelled(cfg: Container.Config, tag: String): Container.Config =
         cfg.label(singletonLabelKey, tag)
             .label(ownerLabelKey, TestProcessId.pid.toString)
+            .label(fixtureLabelKey, fixtureFingerprint(cfg))
 
     private def reapOrphans(using Frame): Unit < Async =
         Abort.run[ContainerException] {
@@ -75,20 +278,27 @@ private[kyo] object SqlTestContainers:
                         case Present(owner) =>
                             TestProcessId.isAlive(owner).map {
                                 case true  => Kyo.unit
-                                case false => removeWithVolumes(summary)
+                                case false => reapIfUnowned(summary)
                             }
                         case Absent =>
-                            removeWithVolumes(summary)
+                            reapIfUnowned(summary)
                 }
             }
         }.unit
+
+    /** The label owner is gone; the container still belongs to whichever process adopted it. */
+    private def reapIfUnowned(summary: Container.Summary)(using Frame): Unit < Async =
+        hasLiveCoOwner(summary.id).map {
+            case true  => Kyo.unit
+            case false => removeWithVolumes(summary)
+        }
 
     // `removeVolumes = true` is the whole point: the no-arg `remove` defaults it to false, which is how the
     // abandoned containers reached 700 anonymous postgres and mysql data volumes and 64G on this machine.
     private def removeWithVolumes(summary: Container.Summary)(using Frame): Unit < Async =
         Abort.run[ContainerException] {
             summary.attach.map(_.remove(force = true, removeVolumes = true))
-        }.unit
+        }.andThen(forgetOwners(summary.id))
 
     // --- Generic id-keyed memoizing singleton holder ---
 

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainersTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainersTest.scala
@@ -34,12 +34,14 @@ final private class StubTestBackend(
         }
 end StubTestBackend
 
-/** Mechanism test for the generic id-keyed singleton holder [[SqlTestContainers.getOrInit]], driven by a stub [[SqlTestBackend]] so it needs no
-  * live engine. Validates that:
+/** Mechanism tests for [[SqlTestContainers]], driven by a stub [[SqlTestBackend]] and a temp-directory registry so none of them needs a
+  * live engine or a container runtime. They cover:
   *
-  *   - Concurrent callers for one id share a single init (CAS + promise), no double-init.
-  *   - Two different ids get two resources; the same id shares one (id-keying).
-  *   - A failed init removes the id's slot so the next caller retries and succeeds (the reset the reaper/init path relies on).
+  *   - the generic id-keyed singleton holder [[SqlTestContainers.getOrInit]]: concurrent callers for one id share a single init (CAS +
+  *     promise) with no double-init, two different ids get two resources while the same id shares one, and a failed init removes that id's
+  *     slot so the next caller retries and succeeds rather than reading a poisoned promise;
+  *   - the fixture fingerprint that decides whether a leftover container is interchangeable with the one being asked for;
+  *   - the co-owner registry that keeps a container this process adopted from being reaped once its original owner dies.
   */
 class SqlTestContainersTest extends kyo.Test:
 
@@ -98,6 +100,185 @@ class SqlTestContainersTest extends kyo.Test:
             secondResult match
                 case Result.Success(v) => assert(v == 42, s"a retry after a failed init should succeed with 42, got $v")
                 case other             => fail(s"a retry after a failed init should succeed, got $other")
+    }
+
+    // --- Fixture fingerprint: what makes a leftover container reusable ---
+
+    private val mysqlCfg = ContainerPredef.MySQL.buildContainerConfig(ContainerPredef.MySQL.Config.default)
+
+    "fixtureFingerprint" - {
+        "is stable across calls for the same config" in {
+            assert(SqlTestContainers.fixtureFingerprint(mysqlCfg) == SqlTestContainers.fixtureFingerprint(mysqlCfg))
+        }
+
+        "ignores label and owner differences, which every container carries its own copy of" in {
+            val labelled = mysqlCfg.label("kyo-sql-owner-pid", "1234").label("kyo-sql-singleton", "mysql")
+            assert(SqlTestContainers.fixtureFingerprint(labelled) == SqlTestContainers.fixtureFingerprint(mysqlCfg))
+        }
+
+        "ignores the order environment variables were added in" in {
+            val a = Container.Config(ContainerImage("mysql:8.0")).env("A", "1").env("B", "2")
+            val b = Container.Config(ContainerImage("mysql:8.0")).env("B", "2").env("A", "1")
+            assert(SqlTestContainers.fixtureFingerprint(a) == SqlTestContainers.fixtureFingerprint(b))
+        }
+
+        "separates a different image" in {
+            val other = mysqlCfg.copy(image = ContainerImage("mysql:8.4"))
+            assert(SqlTestContainers.fixtureFingerprint(other) != SqlTestContainers.fixtureFingerprint(mysqlCfg))
+        }
+
+        "separates different server args — the whole reason a tag alone cannot decide reuse" in {
+            val tuned = ContainerPredef.MySQL.buildContainerConfig(
+                ContainerPredef.MySQL.Config.default.appendServerArgs("--performance-schema=ON")
+            )
+            assert(SqlTestContainers.fixtureFingerprint(tuned) != SqlTestContainers.fixtureFingerprint(mysqlCfg))
+        }
+
+        "separates a different environment" in {
+            val other = mysqlCfg.env("MYSQL_DATABASE", "other")
+            assert(SqlTestContainers.fixtureFingerprint(other) != SqlTestContainers.fixtureFingerprint(mysqlCfg))
+        }
+
+        "separates a different published port" in {
+            val other = mysqlCfg.port(9999, 0)
+            assert(SqlTestContainers.fixtureFingerprint(other) != SqlTestContainers.fixtureFingerprint(mysqlCfg))
+        }
+
+        // The TLS fixtures bind a per-run directory of generated certificates. A fingerprint blind
+        // to mounts would call last run's container interchangeable with this run's.
+        "separates a different bind mount" in {
+            val runA = mysqlCfg.bind(Path("/tmp/certs-a"), Path("/etc/ssl-my"), readOnly = true)
+            val runB = mysqlCfg.bind(Path("/tmp/certs-b"), Path("/etc/ssl-my"), readOnly = true)
+            assert(SqlTestContainers.fixtureFingerprint(runA) != SqlTestContainers.fixtureFingerprint(runB))
+            assert(SqlTestContainers.fixtureFingerprint(runA) != SqlTestContainers.fixtureFingerprint(mysqlCfg))
+        }
+    }
+
+    "matchesFixture" - {
+        val fingerprint = SqlTestContainers.fixtureFingerprint(mysqlCfg)
+        val labels = Dict(
+            SqlTestContainers.singletonLabelKey -> "mysql",
+            SqlTestContainers.fixtureLabelKey   -> fingerprint
+        )
+
+        "accepts a container with both the tag and the fingerprint" in {
+            assert(SqlTestContainers.matchesFixture(labels, "mysql", fingerprint))
+        }
+
+        "rejects a different tag" in {
+            assert(!SqlTestContainers.matchesFixture(labels, "postgres", fingerprint))
+        }
+
+        "rejects a matching tag with a different fixture" in {
+            assert(!SqlTestContainers.matchesFixture(labels, "mysql", "deadbeef"))
+        }
+
+        "rejects a container from before the fixture label existed" in {
+            val old = Dict(SqlTestContainers.singletonLabelKey -> "mysql")
+            assert(!SqlTestContainers.matchesFixture(old, "mysql", fingerprint))
+        }
+    }
+
+    // --- Co-owner registry ---
+    //
+    // The reaper removes a container whose `kyo-sql-owner-pid` names a dead process. Once a
+    // second process attaches to that container, the label alone would let the reaper delete it
+    // out from under its new owner. These cases pin the predicate that prevents that.
+
+    private def withRegistry[A](f: Path => A < (Async & Abort[Throwable]))(using
+        Frame,
+        kyo.test.AssertScope
+    ): A < (Async & Abort[Throwable]) =
+        Random.nextLong.map { token =>
+            System.property[String]("java.io.tmpdir").map {
+                case Present(tmp) =>
+                    val root = Path(tmp, s"kyo-sql-owner-test-${(token & Long.MaxValue).toHexString}")
+                    Sync.ensure(Abort.run[FileStructureException](root.removeAll).unit)(f(root))
+                case Absent => fail("no java.io.tmpdir on this platform; the registry cannot be exercised")
+            }
+        }
+
+    private val someId = Container.Id("0123456789abcdef0123456789abcdef")
+
+    "co-owner registry" - {
+        "reports no owner for a container nobody claimed" in {
+            withRegistry { root =>
+                SqlTestContainers.hasLiveCoOwner(root, someId).map(live => assert(!live))
+            }
+        }
+
+        "reports this process after it claims" in {
+            withRegistry { root =>
+                for
+                    _    <- SqlTestContainers.claimOwnership(root, someId)
+                    live <- SqlTestContainers.hasLiveCoOwner(root, someId)
+                yield assert(live, "the claiming process must count as a live owner")
+            }
+        }
+
+        "claiming is idempotent" in {
+            withRegistry { root =>
+                for
+                    _    <- SqlTestContainers.claimOwnership(root, someId)
+                    _    <- SqlTestContainers.claimOwnership(root, someId)
+                    live <- SqlTestContainers.hasLiveCoOwner(root, someId)
+                yield assert(live)
+            }
+        }
+
+        "releasing gives the container back to the reaper" in {
+            withRegistry { root =>
+                for
+                    _    <- SqlTestContainers.claimOwnership(root, someId)
+                    _    <- SqlTestContainers.releaseOwnership(root, someId)
+                    live <- SqlTestContainers.hasLiveCoOwner(root, someId)
+                yield assert(!live, "a released claim must not keep the container alive")
+            }
+        }
+
+        "a claim from a process that has since died does not spare the container" in {
+            withRegistry { root =>
+                // 999999999 exceeds the pid ceiling of every platform this suite runs on, so the
+                // liveness probe answers "no such process" rather than "cannot tell".
+                val dead = Path(root, someId.value.take(12), "999999999")
+                for
+                    _    <- dead.mkFile
+                    live <- SqlTestContainers.hasLiveCoOwner(root, someId)
+                yield assert(!live, "a dead co-owner must not keep the container alive")
+                end for
+            }
+        }
+
+        "a live claim outweighs a dead one" in {
+            withRegistry { root =>
+                for
+                    _    <- Path(root, someId.value.take(12), "999999999").mkFile
+                    _    <- SqlTestContainers.claimOwnership(root, someId)
+                    live <- SqlTestContainers.hasLiveCoOwner(root, someId)
+                yield assert(live)
+            }
+        }
+
+        "claims are per container, not global" in {
+            withRegistry { root =>
+                val other = Container.Id("fedcba9876543210fedcba9876543210")
+                for
+                    _          <- SqlTestContainers.claimOwnership(root, someId)
+                    otherOwned <- SqlTestContainers.hasLiveCoOwner(root, other)
+                yield assert(!otherOwned, "a claim on one container must not spare another")
+                end for
+            }
+        }
+
+        "forgetting the owners of a removed container clears its claims" in {
+            withRegistry { root =>
+                for
+                    _    <- SqlTestContainers.claimOwnership(root, someId)
+                    _    <- SqlTestContainers.forgetOwners(root, someId)
+                    live <- SqlTestContainers.hasLiveCoOwner(root, someId)
+                yield assert(!live)
+            }
+        }
     }
 
 end SqlTestContainersTest

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainersTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainersTest.scala
@@ -190,11 +190,11 @@ class SqlTestContainersTest extends kyo.Test:
         kyo.test.AssertScope
     ): A < (Async & Abort[Throwable]) =
         Random.nextLong.map { token =>
-            System.property[String]("java.io.tmpdir").map {
+            TestTempRoot.get.map {
                 case Present(tmp) =>
                     val root = Path(tmp, s"kyo-sql-owner-test-${(token & Long.MaxValue).toHexString}")
                     Sync.ensure(Abort.run[FileStructureException](root.removeAll).unit)(f(root))
-                case Absent => fail("no java.io.tmpdir on this platform; the registry cannot be exercised")
+                case Absent => fail("no temp root on this platform; the registry cannot be exercised")
             }
         }
 

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainersTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlTestContainersTest.scala
@@ -210,9 +210,43 @@ class SqlTestContainersTest extends kyo.Test:
         "reports this process after it claims" in {
             withRegistry { root =>
                 for
-                    _    <- SqlTestContainers.claimOwnership(root, someId)
-                    live <- SqlTestContainers.hasLiveCoOwner(root, someId)
-                yield assert(live, "the claiming process must count as a live owner")
+                    claimed <- SqlTestContainers.claimOwnership(root, someId)
+                    live    <- SqlTestContainers.hasLiveCoOwner(root, someId)
+                yield
+                    assert(claimed, "a writable registry must report the claim as recorded")
+                    assert(live, "the claiming process must count as a live owner")
+            }
+        }
+
+        // The claim's return value is the whole safety interlock for adoption: the reap in
+        // initSingleton runs right after an adoption, and an adoption candidate is normally one
+        // whose label owner is already dead, so an unclaimed adoption has this process force-remove
+        // the container it just returned. A claim that cannot be written MUST say so.
+        "a claim that cannot be written reports false" in {
+            withRegistry { root =>
+                // A regular file where the per-container directory belongs: nothing can be created
+                // under it, so the claim cannot land.
+                val blocker = Path(root, someId.value.take(12))
+                for
+                    _       <- blocker.mkFile
+                    claimed <- SqlTestContainers.claimOwnership(root, someId)
+                yield assert(!claimed, "an unwritable registry must not report a recorded claim")
+                end for
+            }
+        }
+
+        "a claim under an unusable registry root reports false and leaves nothing to spare it" in {
+            withRegistry { root =>
+                // The root itself is a regular file, so neither the claim nor a later reader can see
+                // anything: claim false AND hasLiveCoOwner false is exactly the combination adoption
+                // must refuse to walk into.
+                for
+                    _       <- root.mkFile
+                    claimed <- SqlTestContainers.claimOwnership(root, someId)
+                    live    <- SqlTestContainers.hasLiveCoOwner(root, someId)
+                yield
+                    assert(!claimed, "an unusable registry root must not report a recorded claim")
+                    assert(!live, "nothing spares this container, which is why the claim must be believed")
             }
         }
 

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -39,12 +39,15 @@ set -uo pipefail
 # retry stays scoped to what did not pass. The strategy is derived from the platform;
 # no caller selects it.
 #
+# Between Native test batches the runner sweeps leftover containers and pins the
+# per-module test-worker count; both are hygiene, neither can change a verdict.
+#
 # Reads CI, SBT_TASK_LIMIT, JAVA_OPTS, JVM_OPTS, NATIVE_HEAVY, NATIVE_SKIP,
-# NATIVE_LINK_CPUS, NATIVE_LINK_BATCH, and NATIVE_TEST_BATCH from the environment;
-# mutates none of them (the nativeLink invocations append -XX:ActiveProcessorCount
-# when NATIVE_LINK_CPUS is set). The caller (a CI workflow, or build.sh --env
-# podman-ci) owns the environment, so this one runner is correct in every
-# environment.
+# NATIVE_LINK_CPUS, NATIVE_LINK_BATCH, NATIVE_TEST_BATCH, NATIVE_WORKER_MAX, and
+# CONTAINER_SWEEP from the environment; mutates none of them (the nativeLink
+# invocations append -XX:ActiveProcessorCount when NATIVE_LINK_CPUS is set). The
+# caller (a CI workflow, or build.sh --env podman-ci) owns the environment, so
+# this one runner is correct in every environment.
 
 PLATFORMS="JVM JS Native Wasm"
 ACTIONS="test testDiff compile link"
@@ -72,14 +75,18 @@ contains_word() {
 # sizes and per-batch retry; the completion marker separating a finished pass
 # from a truncated one; NATIVE_SKIP reaching the plan and the cross pass; the
 # platform-derived strategy; the exit-code mapping; the resolution-retry
-# wrapper; and the NATIVE_LINK_CPUS cap reaching every link invocation and no
-# other process.
+# wrapper; the NATIVE_LINK_CPUS cap reaching every link invocation and no other
+# process; the per-module test-worker ceiling; and the batch-boundary container
+# sweep with its host-side backstop, driven by a fake podman so the case runs on
+# a machine with no container runtime.
 if [ "${1:-}" = "--self-test" ]; then
     SELF="$0"
     PASS=0; FAIL=0; TOTAL=0
     SELFDIR=$(mktemp -d)
     CALLS="$SELFDIR/calls.log"
     HEAP="$SELFDIR/heap.log"
+    OUT="$SELFDIR/out.log"
+    PODCALLS="$SELFDIR/podman.log"
     trap 'rm -rf "$SELFDIR"' EXIT
 
     # The modules the fake sbt writes when the runner asks it to plan; cases
@@ -120,15 +127,38 @@ if [ "${1:-}" = "--self-test" ]; then
         chmod +x "$SELFDIR/sbt"
     }
 
+    # A fake podman for the container-sweep cases: every invocation is recorded,
+    # `ps -aq` answers from a file, and `rm -af --volumes` runs $1 — which empties
+    # that file for a runtime that can remove containers, and does nothing for the
+    # one whose stop/kill leave the process running.
+    make_fake_podman() {
+        {
+            printf '#!/usr/bin/env bash\n'
+            printf 'printf "%%s\\n" "$*" >> "%s"\n' "$PODCALLS"
+            printf 'case "$*" in\n'
+            printf '    "ps -aq") cat "%s" 2>/dev/null ;;\n' "$SELFDIR/podman-ps"
+            printf '    "rm -af --volumes") %s ;;\n' "$1"
+            printf '    inspect*) echo 12345 ;;\n'
+            printf 'esac\n'
+            printf 'exit 0\n'
+        } > "$SELFDIR/podman"
+        chmod +x "$SELFDIR/podman"
+    }
+
+    rm -f "$SELFDIR/podman" "$SELFDIR/podman-ps"
+
     # Run the real runner under the fake sbt. Sets CT_EXIT (the runner exit
-    # code) and leaves the recorded calls in CALLS for the assertion. Trailing
-    # VAR=value pairs enter the runner's environment.
+    # code) and leaves the recorded calls in CALLS and the runner's own output in
+    # OUT for the assertion. Trailing VAR=value pairs enter the runner's
+    # environment. CONTAINER_SWEEP=0 by default so a case that does not opt in
+    # can never touch a real runtime on a developer machine.
     run_runner_env() {
         local body="$1" platform="$2" action="$3"; shift 3
-        : > "$CALLS"; : > "$HEAP"
+        : > "$CALLS"; : > "$HEAP"; : > "$OUT"; : > "$PODCALLS"
         make_fake_sbt "$body"
-        env PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 RESOLVE_BACKOFF=0 "$@" \
-            "$SELF" "$platform" "$action" >/dev/null 2>&1
+        env PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 RESOLVE_BACKOFF=0 \
+            CONTAINER_SWEEP=0 "$@" \
+            "$SELF" "$platform" "$action" > "$OUT" 2>&1
         CT_EXIT=$?
     }
 
@@ -144,6 +174,11 @@ if [ "${1:-}" = "--self-test" ]; then
     calls_have()   { grep -qF -- "$1" "$CALLS"; }
     calls_lack()   { ! grep -qF -- "$1" "$CALLS"; }
     heap_nth_has() { sed -n "${1}p" "$HEAP" | grep -qF -- "$2"; }
+    out_has()      { grep -qF -- "$1" "$OUT"; }
+    out_lacks()    { ! grep -qF -- "$1" "$OUT"; }
+    pod_has()      { grep -qF -- "$1" "$PODCALLS"; }
+    pod_count()    { [ "$(grep -cF -- "$1" "$PODCALLS")" = "$2" ]; }
+    pod_empty()    { [ ! -s "$PODCALLS" ]; }
 
     # Register a case: name + an assertion expression already evaluated by
     # the caller into $? . PASS when the caller passed 'true'.
@@ -489,7 +524,58 @@ echo "Tests: succeeded 99, failed 0"; echo "[testKyo] completed"; exit 0'
     then record ok "a crashed test batch re-runs through testKyo --quick; attempt 1 is the full batch"
     else record no "a crashed test batch re-runs through testKyo --quick; attempt 1 is the full batch"; fi
 
-    # 47-48: argument validation exits 2 before any sbt.
+    # 47-48: the per-module test-worker ceiling.
+    # One scala-native runner process per SUITE is the topology that re-provisioned a module's
+    # container singletons 24 times in one CI job; one per MODULE is the fixed shape.
+    FAKE_PLAN="kyo-dataNative"
+    run_runner Native test 'if [[ "$*" == *"--phase link"* ]]; then exit 0; fi
+echo "Starting process '"'"'/t/kyo-data-test'"'"' on port '"'"'1'"'"'."
+echo "Starting process '"'"'/t/kyo-data-test'"'"' on port '"'"'2'"'"'."
+echo "Starting process '"'"'/t/kyo-data-test'"'"' on port '"'"'3'"'"'."
+echo "Tests: succeeded 100, failed 0"; echo "[testKyo] completed"; exit 0'
+    if out_has "3 native test-runner processes for 1 module(s)" \
+       && out_has "::warning title=native test workers::" && exit_is 0
+    then record ok "a per-suite worker count warns without failing the batch"
+    else record no "a per-suite worker count warns without failing the batch"; fi
+
+    run_runner Native test 'if [[ "$*" == *"--phase link"* ]]; then exit 0; fi
+echo "Starting process '"'"'/t/kyo-data-test'"'"' on port '"'"'1'"'"'."
+echo "Starting process '"'"'/t/kyo-data-test'"'"' on port '"'"'2'"'"'."
+echo "Tests: succeeded 100, failed 0"; echo "[testKyo] completed"; exit 0'
+    if out_lacks "::warning title=native test workers::" \
+       && out_has "native test-runner processes: 2 for 1 module(s)" && exit_is 0
+    then record ok "one controller plus one worker per module does not warn"
+    else record no "one controller plus one worker per module does not warn"; fi
+
+    # 49-51: the batch-boundary container sweep.
+    FAKE_PLAN="kyo-dataNative"
+    printf 'aaa\nbbb\n' > "$SELFDIR/podman-ps"
+    make_fake_podman ': > "'"$SELFDIR"'/podman-ps"'
+    run_runner_env "$PASS_BODY" Native test CONTAINER_SWEEP=1
+    if pod_has "rm -af --volumes" && pod_count "rm -af --volumes" 1 \
+       && ! pod_has "inspect" && exit_is 0
+    then record ok "the sweep removes a batch's containers and stops there when they go"
+    else record no "the sweep removes a batch's containers and stops there when they go"; fi
+
+    # A runtime that cannot reap a container's process leaves survivors behind `rm -af`;
+    # the host-side kill is what the next batch depends on.
+    printf 'aaa\nbbb\n' > "$SELFDIR/podman-ps"
+    make_fake_podman ':'
+    run_runner_env "$PASS_BODY" Native test CONTAINER_SWEEP=1
+    if pod_has "inspect --format {{.State.Pid}} aaa" \
+       && pod_count "rm -af --volumes" 2 && exit_is 0
+    then record ok "survivors of rm -af are killed host-side and swept again"
+    else record no "survivors of rm -af are killed host-side and swept again"; fi
+
+    printf 'aaa\n' > "$SELFDIR/podman-ps"
+    make_fake_podman ': > "'"$SELFDIR"'/podman-ps"'
+    run_runner_env "$PASS_BODY" Native test
+    if pod_empty && exit_is 0
+    then record ok "CONTAINER_SWEEP=0 touches no container runtime at all"
+    else record no "CONTAINER_SWEEP=0 touches no container runtime at all"; fi
+    rm -f "$SELFDIR/podman" "$SELFDIR/podman-ps"
+
+    # 52-53: argument validation exits 2 before any sbt.
     run_runner Frob test 'exit 0'
     if exit_is 2 && calls_count 0; then record ok "unknown platform exits 2 before any sbt"
     else record no "unknown platform exits 2 before any sbt"; fi
@@ -504,7 +590,7 @@ echo "Tests: succeeded 99, failed 0"; echo "[testKyo] completed"; exit 0'
 
     echo ""
     echo "Results: $PASS/$TOTAL passed, $FAIL failed"
-    [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq 48 ]
+    [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq 53 ]
     exit $?
 fi
 
@@ -833,6 +919,65 @@ run_watched() {
     return 1
 }
 
+# Remove every container the batch left behind, so one batch's corpses cannot tax the next.
+#
+# `rm -af` alone is not enough on a runtime whose stop/kill cannot reap a container's process
+# (HTTP 500 "given PID did not die within timeout"): the remove fails and the container keeps
+# running. The pkill backstop kills what the runtime would not, host-side, and a second sweep
+# then removes the now-dead containers. Everything is best-effort and never changes the batch
+# verdict: this is hygiene between batches, not a test result.
+#
+# CONTAINER_SWEEP=0 disables it (the self-test and any local run that wants its containers kept).
+sweep_containers() {
+    local when="$1"
+    [ "${CONTAINER_SWEEP:-1}" = "0" ] && return 0
+    command -v podman >/dev/null 2>&1 || return 0
+    local before
+    before=$(podman ps -aq 2>/dev/null | wc -l | tr -d ' ')
+    [ "${before:-0}" = "0" ] && return 0
+    log "container sweep $when: $before container(s)"
+    podman rm -af --volumes >/dev/null 2>&1
+    local left
+    left=$(podman ps -aq 2>/dev/null | wc -l | tr -d ' ')
+    if [ "${left:-0}" != "0" ]; then
+        log "container sweep: $left container(s) survived rm -af; killing their processes host-side"
+        local id pid
+        for id in $(podman ps -aq 2>/dev/null); do
+            pid=$(podman inspect --format '{{.State.Pid}}' "$id" 2>/dev/null)
+            [ -n "$pid" ] && [ "$pid" != "0" ] && kill -9 "$pid" 2>/dev/null
+        done
+        podman rm -af --volumes >/dev/null 2>&1
+        log "container sweep: $(podman ps -aq 2>/dev/null | wc -l | tr -d ' ') container(s) remain"
+    fi
+    return 0
+}
+
+# The scala-native TestAdapter spawns one test-runner process per sbt task thread, and sbt's
+# cached task pool reaps a thread after 60s idle. With one test task per suite, every suite
+# slower than a minute lands on a fresh thread and therefore a fresh runner process, each one
+# re-provisioning that module's per-process fixtures: one CI module reached 24 worker processes
+# and 7GB. `Test / parallelExecution := false` on Native (build.sbt, native-settings-base) makes
+# it one task per module and so one worker; this is the pin that says so. A batch's log should
+# carry at most one controller plus one worker per module.
+#
+# Warns rather than fails: the count is a build-topology invariant, not a test result, and a
+# module legitimately gains a second worker if sbt ever splits its task. NATIVE_WORKER_MAX
+# tunes the per-module ceiling.
+check_worker_count() {
+    local batch="$1" modules starts allowed
+    [ -n "$LOG" ] && [ -f "$LOG" ] || return 0
+    modules=$(printf '%s\n' "$batch" | tr ',' '\n' | grep -c .)
+    starts=$(grep -c "Starting process" "$LOG" 2>/dev/null || echo 0)
+    allowed=$(( modules * ${NATIVE_WORKER_MAX:-2} ))
+    if [ "$starts" -gt "$allowed" ]; then
+        log "WARNING: $starts native test-runner processes for $modules module(s) (expected at most $allowed)"
+        echo "::warning title=native test workers::$starts test-runner processes started for $modules module(s); expected at most $allowed. A per-suite worker means Test / parallelExecution is back on for Native."
+    else
+        log "native test-runner processes: $starts for $modules module(s) (ceiling $allowed)"
+    fi
+    return 0
+}
+
 run_native() {
     local arg; arg=$(run_arg)
 
@@ -884,6 +1029,8 @@ run_native() {
     # modules spawn; the plan and the links above run at the full .jvmopts heap.
     for batch in $(plan_batches "$NATIVE_TEST_BATCH"); do
         run_watched "test batch $batch" $(run_phase_heap) "testKyo --scala 3 --modules $batch Native" || return 1
+        check_worker_count "$batch"
+        sweep_containers "after test batch $batch"
     done
     # The cross-build modules select themselves per Scala 2.x version, so they are outside the plan
     # and outside both pools.

--- a/scripts/container-check.sh
+++ b/scripts/container-check.sh
@@ -5,17 +5,29 @@ set -uo pipefail
 #
 # Usage: container-check.sh [--warn-only]
 #
-# Runs two checks and prints component diagnostics for each:
-#   1. podman: create + start + exec a real container. This is the exact cycle the 20260810.x
-#      runner image regression broke (conmon without journald support exited 1 on every start,
-#      and each exec then failed with HTTP 500 "container state improper"; see #1881). The
-#      resolved OCI runtime and conmon paths are printed first, so a failure names the
-#      component instead of a bare exit code.
-#   2. docker: the daemon answers `docker version`. Ubuntu's runc package Conflicts with
+# Runs three checks and prints component diagnostics for each:
+#   1. podman startup: create + start + exec a real container. This is the exact cycle the
+#      20260810.x runner image regression broke (conmon without journald support exited 1 on
+#      every start, and each exec then failed with HTTP 500 "container state improper"; see
+#      #1881). The resolved OCI runtime and conmon paths are printed first, so a failure names
+#      the component instead of a bare exit code.
+#   2. podman teardown: stop a container that ignores SIGTERM and assert its host process is
+#      really gone. The #1881 probe validated create/start/exec and stopped there, so it passed
+#      on a stack whose stop/kill/rm-f all answer HTTP 500 "given PID did not die within
+#      timeout" and leave the container running forever. That is a leak engine, not a flake: one
+#      CI job accumulated 28 unkillable mysqld totalling 4.6G and paid ~45s per scoped teardown.
+#      When the configured OCI runtime fails this gate the script retries under the alternative
+#      runtime and, if that one passes, pins it in containers.conf and restarts the API service.
+#   3. docker: the daemon answers `docker version`. Ubuntu's runc package Conflicts with
 #      containerd.io, and an apt resolution that removes docker-ce has taken the daemon out
 #      from under CI before; the kyo-pod suites run half of their container cases against it.
 #
-# Both checks always run, so one broken runtime does not hide the state of the other. By
+# It also pre-pulls the database images the kyo-pod and kyo-sql fixtures use, into whichever
+# runtimes answered, so first-use pull latency and registry flake stay out of the test timing
+# budget. Those pulls are best-effort: a failed pre-pull warns and leaves first-use pulling to
+# the suite, exactly as before.
+#
+# Both runtime checks always run, so one broken runtime does not hide the state of the other. By
 # default any failed check fails the job. With --warn-only the same checks and diagnostics run,
 # but the script emits a GitHub warning annotation and exits 0: the switch for maintainers who
 # later decide the gate should be loud instead of fatal, without restructuring the workflow.
@@ -32,6 +44,11 @@ fi
 [ $# -eq 0 ] || { echo "usage: $0 [--warn-only]" >&2; exit 2; }
 
 failed=""
+
+# Images every container-using suite needs. Pre-pulled rather than left to first use so a slow
+# or flaky registry is a setup-step failure with its own log line instead of minutes charged to
+# whichever test happened to ask for the image first.
+FIXTURE_IMAGES="docker.io/library/postgres:16-alpine docker.io/library/mysql:8.0"
 
 check_podman() {
     podman version
@@ -57,6 +74,114 @@ check_podman() {
     podman rm -f setup-probe >/dev/null 2>&1 || true
 }
 
+# --- podman teardown gate ---
+
+# One stop/kill cycle against a container that refuses to die politely, which is what every
+# database fixture is: `trap "" TERM` makes SIGTERM a no-op, so only the runtime's SIGKILL can
+# end it, and that SIGKILL is the step the broken stack cannot perform. 0 when the container
+# ends up in a terminal state AND its host process is gone; 1 otherwise. The pid check is the
+# part that matters: the daemon reporting "exited" while the process still runs is exactly the
+# state that leaked 28 mysqld in one job.
+teardown_probe() {
+    local name="teardown-probe" pid status rc=0
+    podman rm -f "$name" >/dev/null 2>&1 || true
+    if ! podman run -d --name "$name" docker.io/library/alpine:3 \
+        sh -c 'trap "" TERM; sleep 300' >/dev/null 2>&1; then
+        echo "teardown probe could not start its container" >&2
+        return 1
+    fi
+    # The trap is installed by the shell after exec, so a stop racing the very first
+    # instructions would test nothing.
+    sleep 1
+    pid="$(podman inspect --format '{{.State.Pid}}' "$name" 2>/dev/null)"
+    podman stop -t 1 "$name" >/dev/null 2>&1 || true
+    status="$(podman inspect --format '{{.State.Status}}' "$name" 2>/dev/null)"
+    if [ "$status" != "exited" ] && [ "$status" != "stopped" ]; then
+        echo "teardown probe: container is '$status' after stop -t 1, expected exited" >&2
+        rc=1
+    fi
+    if [ -n "$pid" ] && [ "$pid" != "0" ] && kill -0 "$pid" 2>/dev/null; then
+        echo "teardown probe: container process $pid is still alive after stop" >&2
+        rc=1
+    fi
+    if ! podman rm -f "$name" >/dev/null 2>&1; then
+        echo "teardown probe: force-remove failed" >&2
+        rc=1
+    fi
+    podman rm -f "$name" >/dev/null 2>&1 || true
+    return "$rc"
+}
+
+# Restart the rootless API service so a containers.conf runtime change takes effect: libpod
+# reads its engine config once, at service start. Mirrors the workflow's "Start podman" step,
+# which is the only other place that starts this service.
+restart_podman_service() {
+    local sock="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+    pkill -u "$(id -u)" -f "podman system service" 2>/dev/null || true
+    rm -f "$sock"
+    nohup podman system service --time=0 "unix://$sock" >> /tmp/podman.log 2>&1 &
+    for _ in $(seq 1 30); do
+        [ -S "$sock" ] && return 0
+        sleep 1
+    done
+    echo "podman API socket did not come back up after a runtime switch" >&2
+    return 1
+}
+
+pin_oci_runtime() {
+    mkdir -p "$HOME/.config/containers"
+    printf '[engine]\nruntime = "%s"\n' "$1" > "$HOME/.config/containers/containers.conf"
+}
+
+check_podman_teardown() {
+    local configured alternative
+    configured="$(podman info --format '{{.Host.OCIRuntime.Name}}' 2>/dev/null)"
+    echo "podman teardown gate: probing OCI runtime '${configured:-unknown}'"
+    if teardown_probe; then
+        echo "podman teardown check passed (stop kills a SIGTERM-ignoring container)"
+        return
+    fi
+
+    # The runc pin exists for the pre-20260810 crun's "unknown version specified" start failure
+    # (#1881); it was validated for create/start/exec and never for stop. If the other runtime
+    # is installed and can tear a container down, it is strictly better than a stack that
+    # cannot: a container that starts but never dies is the worse of the two failure modes.
+    case "$configured" in
+        crun) alternative=runc ;;
+        *)    alternative=crun ;;
+    esac
+    if ! command -v "$alternative" >/dev/null 2>&1; then
+        echo "podman teardown check failed and no alternative OCI runtime is installed." >&2
+        echo "Every scoped container fixture will leak: stop, kill and force-remove all leave the" >&2
+        echo "container's process running (HTTP 500 'given PID did not die within timeout')." >&2
+        failed=1
+        return
+    fi
+
+    echo "podman teardown gate: '${configured:-unknown}' cannot stop a container; retrying under '$alternative'"
+    pin_oci_runtime "$alternative"
+    if ! restart_podman_service; then
+        failed=1
+        return
+    fi
+    if teardown_probe; then
+        echo "podman teardown check passed under '$alternative' (pinned in containers.conf)"
+        echo "::warning title=podman OCI runtime switched::'${configured:-unknown}' could not stop a container; the job now runs under '$alternative'."
+        return
+    fi
+
+    echo "podman teardown check failed under both '${configured:-unknown}' and '$alternative'." >&2
+    if [ -f /tmp/podman.log ]; then
+        echo "service log:" >&2
+        tail -50 /tmp/podman.log >&2
+    fi
+    # Leave the originally configured runtime in place: neither works, and the pin the workflow
+    # chose is the one the rest of CI was validated against.
+    pin_oci_runtime "${configured:-runc}"
+    restart_podman_service || true
+    failed=1
+}
+
 check_docker() {
     if docker version; then
         echo "docker check passed"
@@ -68,8 +193,32 @@ check_docker() {
     fi
 }
 
+# Best-effort by design: a missing image costs the first suite that wants it a pull, which is
+# the pre-existing behavior. Failing the gate on it would trade a timing improvement for a new
+# way to lose a whole job to registry flake.
+prepull_fixture_images() {
+    local runtime image
+    for runtime in "$@"; do
+        for image in $FIXTURE_IMAGES; do
+            if "$runtime" pull -q "$image" >/dev/null 2>&1; then
+                echo "$runtime pre-pulled $image"
+            else
+                echo "::warning title=fixture image pre-pull failed::$runtime could not pull $image; the first suite that needs it will pull it instead."
+            fi
+        done
+    done
+}
+
 check_podman
+podman_ok=$([ -z "$failed" ] && echo 1 || echo "")
+check_podman_teardown
 check_docker
+
+runtimes=""
+[ -n "$podman_ok" ] && runtimes="podman"
+docker version >/dev/null 2>&1 && runtimes="$runtimes docker"
+# shellcheck disable=SC2086
+[ -n "$runtimes" ] && prepull_fixture_images $runtimes
 
 if [ -n "$failed" ]; then
     if [ -n "$warn_only" ]; then


### PR DESCRIPTION
Stacked on #1901. Once the runner started honestly running the SQL integration suites on Native (they had been silently skipped, see the base PR), the logs exposed a chain of container-lifecycle defects that made those suites stall for hours and then fail wholesale. The bugs are in product and test-support code, not CI, and most of them bite the JVM leg and local development too.

## What the CI logs showed

* podman could not kill mysql containers on the runners: every stop and force-remove failed with HTTP 500 "given PID did not die within timeout" (36 occurrences in one job), so unreapable mysqld processes accumulated to 4.6G across a batch.
* Each SQL suite ran in its own test process (the scala-native test adapter spawns one runner process per sbt thread, and sbt's cached pool gives every >60s suite a fresh thread), so the per-process database singleton collapsed into per-suite provisioning: ~2 minutes per backend, per suite.
* Under the resulting memory pressure, fresh containers increasingly came up with mysqld dead at startup. The health-check loop silently tolerated a dead container, the port wait only inspected the daemon instead of connecting, and the singleton memoized the poisoned handle, so every leaf of a suite failed with connect-refused against the same port.

## The fixes

* Teardown: when the runtime's stop/kill/remove reports the unreaped-process failure, kyo-pod now falls back to a host-side SIGKILL, gated on `/proc/<pid>/cgroup` actually naming the container (a VM-backed daemon reports guest pids; killing those blindly would hit an unrelated host process). Main's remove retry wraps the fallback.
* Honest init: database fixtures set a new `requireService` flag. Under it, a container that dies during the health-check loop fails init, and after the port-mapping wait the init probes the published port from the host. The probe proves a service holds the connection rather than that a forwarder accepted it: rootlessport and docker-proxy complete the TCP handshake unconditionally and only then dial the backend, so connect-success alone is meaningless. The probe watches for the peer teardown instead; a connection dropped within the grace is the unserved-port signature, one held open (postgres waits for the client) or speaking first (mysql greets) is ready.
* One worker per module: `Test / parallelExecution := false` in native-settings-base (the pattern js-settings and kyo-aeron already use), so the container singleton provisions once per module.
* Reuse across processes: SqlTestContainers labels every fixture with a config fingerprint and adopts a live, healthy container from a previous process instead of provisioning a new pair, with a co-owner registry so an adopted container is not reaped while its new owner lives. A failed ownership claim declines the adoption and provisions fresh; the registry being unavailable disables adoption rather than running unprotected.
* Hygiene: the CI setup pre-pulls the database images, container-check.sh gains a teardown gate that verifies the runtime can actually kill a TERM-ignoring container (switching crun/runc if not), the per-leaf SQL fixtures route through the labelled scoped path, and the Native test batches sweep leftover containers at their boundaries.

## Validation

* kyo-pod and kyo-sql JVM suites: 945 passed, 0 failed, including 40 new regression tests (kill-fallback classification and escalation semantics, cgroup gating, fingerprint stability and separation, co-owner claim/release/adoption-decline, and the four port-probe outcomes driven by real kyo-net listeners: silent listener, greeting listener, accept-then-close, no listener).
* The accept-then-close probe case decides in 2ms via the close event, not a timeout, and is the exact shape of the CI failure that motivated it.
* ci-test.sh --self-test: 53 cases (sweep and worker-count behaviors on top of the base PR's 48).
* This machine has no container runtime, so the integration-level cases (ContainerItTest against podman and docker, the teardown gate end-to-end) ride the CI runs in flight on this stack; a JVM diff run exercising exactly those suites is linked below when it lands.

One earlier CI run of this branch caught the probe's first version accepting a forwarder with a dead backend on both runtimes; the current version fails that case and its fixture (a busybox `nc` loop that was itself an accept-and-drop server) was replaced with a held-connection httpd.
