### PR TITLE
[kyo-ui] send what moved, and make chart defaults readable

### DIFF
--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -217,7 +217,7 @@ In kyo-ui:
 
 - The function that constructs the `UI` value runs once. There is no component function that re-runs on every state change.
 - A `signal.render(f)` boundary is a subscription to the signal at the granularity of `f`. Only `f` re-runs when the signal emits, and the framework patches the DOM only at the path where the boundary was anchored.
-- There is no virtual DOM. The boundary holds the previous rendered AST for that subtree, generates a fresh one, and emits a `Replace` diff at its anchor path. The browser-side runtime applies the diff via `outerHTML` (or the server-push transport pushes it over the WebSocket).
+- There is no virtual DOM. The boundary holds the previous rendered AST for that subtree and generates a fresh one; the server-push transport compares the two and sends a `Replace` only for the nodes that actually differ, addressed by their own paths, so a chart whose data moved but whose axes, gridlines and legend did not sends its marks and nothing else. An unchanged re-render sends nothing. The comparison walks into an SVG subtree, where a node is exactly its attributes and its children, and replaces the enclosing node whole anywhere it cannot decompose. The browser-side runtime applies each diff via `outerHTML`; in-process it replaces the boundary whole, since there the update is a DOM write rather than bytes on a wire.
 - Subscription granularity is determined at the call site. `div(name: Signal[String])` is a fine-grained subscription on one text node. `when(loggedIn)(bigSubtree)` is a coarse subscription that swaps a whole subtree. Both are explicit choices in the code, not framework defaults to argue with.
 - There is no `useMemo`, `useCallback`, or `React.memo` equivalent because nothing gets re-executed that you did not opt into. The cost of "rendering" a subtree is the cost of the closure inside its boundary, and you wrote that closure.
 
@@ -983,7 +983,7 @@ The same `y` also accepts a `Signal[Double]` for a threshold that tracks live st
 
 ### Typed values pick the scale
 
-Each encoding's scale is chosen from the static type of its accessor, so you rarely declare a scale at all. `Int`/`Double` select a linear scale, `String` and enums select a band (categorical) scale, and `Instant` selects a time scale. In the running domain, `month: String` gives a band x-scale and `revenue: Double` a linear y-scale, with nothing to annotate:
+Each encoding's scale is chosen from the static type of its accessor, so you rarely declare a scale at all. `Int`/`Double` select a linear scale, `String` and enums select a band (categorical) scale, and `Instant` selects a time scale, whose default tick labels are times at the granularity the tick step implies rather than epoch numbers. Format them yourself with `.xAxis(_.formatTime(i => ...))`, which is handed the `Instant` the axis was typed with; `.format` remains the formatter for a numeric axis. In the running domain, `month: String` gives a band x-scale and `revenue: Double` a linear y-scale, with nothing to annotate:
 
 ```scala
 val typedChart: Svg.Root < Sync =
@@ -1069,6 +1069,8 @@ val themed: Svg.Root < Sync =
         .theme(_.dark.palette(Chart.Palette.Okabe).font("monospace"))
         .lower
 ```
+
+> **Note:** the named palettes are published against a light panel, and two of them start with a color that is nearly invisible on a dark one (Okabe-Ito's first entry is pure black by definition, Viridis's is near-black purple). Paired with `.dark`, or with a background you chose, kyo lightens or darkens only the entries that fall below WCAG 2.1 SC 1.4.11's 3:1 against that panel and leaves every readable one exactly as published; on the default light panel nothing is changed. A palette you pass as an explicit color list, and an explicit `colorScale`, are your own colors and are used exactly as given wherever they are drawn.
 
 ### A second axis
 

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -99,7 +99,9 @@ private[kyo] object DomBackend:
         private def svgContextAt(path: Seq[String]): Boolean =
             ReactiveUI.findNode(root, path).map(_.svgContext).getOrElse(false)
 
-        def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async =
+        // In-process: the update is a DOM write, not bytes on a wire, so this replaces the region whole
+        // rather than diffing it. `previous` is what the server-side exchange uses to send only what moved.
+        def onChange(path: Seq[String], previous: Maybe[UI], ui: UI)(using Frame): Unit < Async =
             HtmlRenderer.render(ui, path).map { html =>
                 // Always wrap the rendered html in the reactive boundary element so the node carrying
                 // data-kyo-path=path survives subsequent replacements. A Fragment, Text, or RawHtml value

--- a/kyo-ui/js/src/test/scala/kyo/DomTestEnv.scala
+++ b/kyo-ui/js/src/test/scala/kyo/DomTestEnv.scala
@@ -10,14 +10,26 @@ import scala.scalajs.js
   * runs unmodified. The load is lazy and idempotent: suites that never touch the DOM never require jsdom, and repeated
   * calls reuse the first window.
   *
-  * jsdom must be resolvable from the repo root: `npm install --no-save jsdom@^30` (CI does this in the setup action;
-  * the repo ignores *.json, so there is no package.json to install from).
+  * jsdom must be resolvable from the repo root: `npm install --no-save --no-fund --no-audit jsdom@^30`, the same
+  * command CI runs in its setup action. The repo ignores *.json, so there is no package.json to install from, and a
+  * fresh checkout has no node_modules; the load below restates Node's resolution failure with that command in it.
   */
 private[kyo] object DomTestEnv:
 
     lazy val install: Unit =
         if js.typeOf(js.Dynamic.global.document) == "undefined" then
-            val jsdom = js.Dynamic.global.require("jsdom")
+            val jsdom =
+                try js.Dynamic.global.require("jsdom")
+                catch
+                    case ex: js.JavaScriptException =>
+                        // Node's own message is "Cannot find module 'jsdom'", which names neither the suite that
+                        // needs it nor the command that supplies it. Restate it so a local run is self-explaining;
+                        // CI installs jsdom in its setup action, so this path is the local-checkout one.
+                        throw new IllegalStateException(
+                            "the DOM-backed kyo-ui tests need jsdom, which is not resolvable from the repository root. " +
+                                "Install it with: npm install --no-save --no-fund --no-audit jsdom@^30",
+                            ex
+                        )
             // pretendToBeVisual enables requestAnimationFrame, which DomBackend uses to start SMIL animations.
             // jsdom still performs no layout: getBoundingClientRect stays zeroed, so measurement behavior belongs
             // in the real-Chrome suites, not here.

--- a/kyo-ui/shared/src/main/scala/kyo/Chart.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Chart.scala
@@ -463,7 +463,8 @@ object Chart:
         tickRotation: Double = 0.0,
         tickAnchor: TextAnchor = TextAnchor.Middle,
         reversed: Boolean = false,
-        padding: Double = 0.0
+        padding: Double = 0.0,
+        tickFormatTime: Maybe[Instant => String] = Absent
     ):
         def label(s: String): AxisConfig             = copy(axisLabel = Present(s))
         def grid: AxisConfig                         = copy(showGrid = true)
@@ -473,6 +474,16 @@ object Chart:
         def pad(fraction: Double): AxisConfig        = copy(padding = fraction)
         def rotateTicks(degrees: Double): AxisConfig = copy(tickRotation = degrees)
         def anchor(a: TextAnchor): AxisConfig        = copy(tickAnchor = a)
+
+        /** Formats the tick labels of a TIME axis from the instant each tick sits at.
+          *
+          * `format` hands the callback a `Double`, which on a time axis is a count of epoch milliseconds:
+          * the type the encoding was written with, and which chose the scale, is gone by the time it reaches
+          * the caller, who then has to turn a number back into a date. This overload keeps it. It applies
+          * only where an instant is meaningful, so it is ignored on a linear or band axis, where `format`
+          * remains the formatter.
+          */
+        def formatTime(f: Instant => String): AxisConfig = copy(tickFormatTime = Present(f))
 
     end AxisConfig
 
@@ -609,7 +620,14 @@ object Chart:
         gridColor: Maybe[Style.Color] = Absent,
         fontFamily: Maybe[String] = Absent,
         fontSize: Maybe[Double] = Absent,
-        titleFontSize: Maybe[Double] = Absent
+        titleFontSize: Maybe[Double] = Absent,
+        /** The named [[Palette]] `palette` came from, when it came from one.
+          *
+          * A named palette is kyo's own choice of colors, published against a light panel, so it is
+          * reconciled against a panel that is not one (see [[Chart.Palette]]). An explicit color list is the
+          * caller's, and is used exactly as given wherever it is drawn.
+          */
+        paletteName: Maybe[Palette] = Absent
     ) derives CanEqual:
         def light: Theme = copy(isDark = false)
         def dark: Theme  = copy(isDark = true)
@@ -638,10 +656,13 @@ object Chart:
         def titleFontSize(px: Double): Theme = copy(titleFontSize = Present(px))
 
         /** Sets the categorical palette from a named [[Palette]]. */
-        def palette(p: Palette): Theme = copy(palette = Present(Palette.colors(p)))
+        def palette(p: Palette): Theme = copy(palette = Present(Palette.colors(p)), paletteName = Present(p))
 
-        /** Sets the categorical palette from an explicit color list. */
-        def palette(colors: Seq[Style.Color]): Theme = copy(palette = Present(Chunk.from(colors)))
+        /** Sets the categorical palette from an explicit color list. Used exactly as given: these are the
+          * caller's colors, not kyo's, so they are never reconciled against the panel.
+          */
+        def palette(colors: Seq[Style.Color]): Theme =
+            copy(palette = Present(Chunk.from(colors)), paletteName = Absent)
 
     end Theme
 
@@ -785,6 +806,15 @@ object Chart:
       * is the Okabe-Ito 8-color set, the recommended accessible choice for categorical data.
       * `Viridis` is an 8-category perceptually-derived set. `Tableau10` is the Tableau 10
       * categorical palette. Resolve a palette to its colors with `Palette.colors(p)`.
+      *
+      * Every one of these is published against a LIGHT panel, and two of them start with a color that is
+      * nearly invisible on a dark one: Okabe-Ito's first entry is pure black by definition and Viridis's is
+      * near-black purple. Paired with `.dark` (the pairing an accessibility-minded caller reaches for) the
+      * first series, the one most charts give their headline metric, came out at 1.4:1 and 1.0:1 against the
+      * `#1f2937` panel where WCAG 2.1 SC 1.4.11 asks for 3:1. So on a panel these palettes were not specified
+      * against (a dark theme, or an explicitly chosen background) kyo lightens or darkens only the entries
+      * that fall below that bar and leaves every readable one exactly as published. On the default light
+      * panel the colors are the published ones, unchanged.
       */
     enum Palette derives CanEqual:
         case Default

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -276,7 +276,9 @@ object UI:
                 Channel.use[Unit](256) { channel =>
                     val exchange =
                         new UIExchange:
-                            def onChange(path: Seq[String], changedUI: UI)(using Frame): Unit < Async =
+                            // The stream re-renders the whole page per change, so which nodes moved is not
+                            // information it can use: `previous` is ignored here on purpose.
+                            def onChange(path: Seq[String], previous: Maybe[UI], changedUI: UI)(using Frame): Unit < Async =
                                 // runPartial drops only a Closed (the consumer stopped draining); a Panic propagates.
                                 Abort.runPartial[Closed](channel.put(())).unit
                     // Scope.run owns the root region Fiber.init: when the stream consumer stops draining,

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ChartAxes.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ChartAxes.scala
@@ -129,9 +129,34 @@ private[kyo] object ChartAxes:
     private[kyo] def pointSeparatorColor(theme: Theme): Style.Color =
         if theme.isDark then DarkBg else LightBg
 
-    /** Resolve the palette used for per-mark default colors: the theme palette when set, else `DefaultPalette`. */
+    /** Resolve the palette used for per-mark default colors: the theme palette when set, else
+      * `DefaultPalette`.
+      *
+      * Where the colors are kyo's own (a named `Chart.Palette`, or this default) they are reconciled against
+      * the panel whenever that panel is not the light one they were published against. Every named palette is
+      * specified against white, and two of them start with a color that is nearly invisible on a dark panel:
+      * Okabe-Ito's first entry is pure black by definition and Viridis's is near-black purple, so the first
+      * series, the one most charts give their headline metric, rendered at 1.4:1 and 1.0:1 on `#1f2937` where
+      * WCAG 2.1 SC 1.4.11 asks for 3:1. `ChartContrast.reconcile` lifts only the entries below that bar.
+      *
+      * An explicit color list, and an explicit `colorScale`, are the caller's own colors and are used exactly
+      * as given. On the default light panel nothing is reconciled at all: the published palettes render as
+      * published.
+      */
     private[kyo] def themePalette(theme: Theme): Chunk[Style.Color] =
-        theme.palette.getOrElse(DefaultPalette)
+        val base = theme.palette.getOrElse(DefaultPalette)
+        // kyo's own colors: a named palette, or the built-in default when the caller set none.
+        val kyoChosen = theme.paletteName.isDefined || theme.palette.isEmpty
+        // The panel these palettes were published against is the light default; anything else (a dark theme,
+        // or a chosen background) is a panel they were not specified for.
+        val publishedPanel = !theme.isDark && theme.background.isEmpty
+        if kyoChosen && !publishedPanel then ChartContrast.reconcilePalette(base, panelBackground(theme))
+        else base
+    end themePalette
+
+    /** The panel fill a mark is drawn against: the theme override when set, else the theme's own default. */
+    private[kyo] def panelBackground(theme: Theme): Style.Color =
+        theme.background.getOrElse(if theme.isDark then DarkBg else LightBg)
 
     /** Resolve the default color for the mark at `markIndex` (cycling the theme palette).
       *
@@ -297,9 +322,7 @@ private[kyo] object ChartAxes:
                             .x2(axisX).y2(py)
                             .stroke(Svg.Paint.Color(chrome))
                 // tick label: apply the formatter to the domain value, not the pixel position
-                val labelStr = cfg.tickFormat match
-                    case Present(f) => f(tick.value)
-                    case Absent     => tick.label
+                val labelStr = tickText(ys, cfg, tick)
                 // Resolve the effective anchor. When the user has not set cfg.tickAnchor
                 // (the default TextAnchor.Middle), keep the side-default (End for left, Start for
                 // right). Only switch to the configured anchor when the user explicitly called
@@ -426,6 +449,55 @@ private[kyo] object ChartAxes:
         else base
     end tickLabel
 
+    /** The text of one tick label, in precedence order.
+      *
+      * A time-typed formatter wins on a time scale, because it is the only one that can see the instant. A
+      * numeric formatter comes next, then the scale's own label, which for a time scale is already a
+      * span-appropriate calendar label rather than a count of milliseconds.
+      */
+    private[kyo] def tickText(scale: Scale, cfg: AxisConfig, tick: Scale.Tick): String =
+        scale match
+            case _: Scale.Time =>
+                cfg.tickFormatTime match
+                    case Present(f) => f(Instant.Epoch + tick.value.toLong.millis)
+                    case Absent =>
+                        cfg.tickFormat match
+                            case Present(f) => f(tick.value)
+                            case Absent     => tick.label
+            case _ =>
+                cfg.tickFormat match
+                    case Present(f) => f(tick.value)
+                    case Absent     => tick.label
+    end tickText
+
+    /** Approximate rendered width of one tick-label glyph, the same average advance the layout's
+      * margin math uses. The labels are short, so one average is accurate enough to decide whether a
+      * label at the plot edge would run off the SVG.
+      */
+    private val TickLabelCharW = 7.0
+
+    /** The anchor for an x tick label, pulled in at the edges so a wide label cannot be cut in half.
+      *
+      * A centred label at the last tick extends half its width past the tick, which on a full-width plot is
+      * past the SVG edge: the label is then truncated mid-value, which reads as a different, wrong number
+      * rather than as a clipped one. Anchoring the overflowing end inward keeps the whole label. Only the
+      * default (unset) anchor is adjusted; an explicit `.anchor(...)` is the caller's decision and stands.
+      */
+    private[kyo] def xTickAnchor(
+        cfg: AxisConfig,
+        labelStr: String,
+        px: Double,
+        svgW: Double,
+        fontSize: Double
+    ): Svg.TextAnchor =
+        if cfg.tickAnchor != TextAnchor.Middle || cfg.tickRotation != 0.0 then toSvgAnchor(cfg.tickAnchor)
+        else
+            val half = labelStr.length * TickLabelCharW * (fontSize / 12.0) / 2.0
+            if px + half > svgW then Svg.TextAnchor.End
+            else if px - half < 0.0 then Svg.TextAnchor.Start
+            else Svg.TextAnchor.Middle
+    end xTickAnchor
+
     /** Build the x-axis: tick marks and tick labels along the bottom. */
     private[kyo] def buildXAxis(
         layout: Layout,
@@ -462,11 +534,10 @@ private[kyo] object ChartAxes:
                         .x2(px).y2(axisY + TickLen)
                         .stroke(Svg.Paint.Color(chrome))
                 // tick label: apply the formatter to the domain value when present
-                val xLabelStr = cfg.tickFormat match
-                    case Present(f) => f(tick.value)
-                    case Absent     => tick.label
-                // Map cfg.tickAnchor to the SVG token and build the tick label element with
-                // font, anchor, and optional rotation applied via the shared tickLabel helper.
+                val xLabelStr = tickText(xs, cfg, tick)
+                // Build the tick label with font, anchor, and optional rotation applied via the shared
+                // tickLabel helper. The anchor is pulled inward at the plot edges so a wide label at the
+                // first or last tick is not cut off by the SVG boundary.
                 val tickLabelElem: Svg.SvgElement =
                     tickLabel(
                         px,
@@ -474,7 +545,7 @@ private[kyo] object ChartAxes:
                         xLabelStr,
                         chrome,
                         Svg.DominantBaseline.Hanging,
-                        toSvgAnchor(cfg.tickAnchor),
+                        xTickAnchor(cfg, xLabelStr, px, layout.svgW, theme.fontSize.getOrElse(12.0)),
                         cfg,
                         theme
                     )

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ChartContrast.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ChartContrast.scala
@@ -1,0 +1,100 @@
+package kyo.internal
+
+import kyo.*
+
+/** WCAG contrast arithmetic, and the palette reconciliation that keeps a series visible on its panel.
+  *
+  * A categorical palette is specified against an assumed background. Okabe-Ito, the color-vision-accessible
+  * set, begins with pure black because it is specified against white; Viridis begins with near-black purple
+  * for the same reason. Offered as a peer of a dark theme with nothing reconciling the two, the documented
+  * accessible choice renders its FIRST series, the one most charts put their headline metric in, at 1.4:1
+  * against a `#1f2937` panel. WCAG 2.1 SC 1.4.11 asks for 3:1 on a non-text graphical object.
+  *
+  * So a palette color is not used as given: it is lightened (on a dark panel) or darkened (on a light one)
+  * until it clears the threshold, which leaves every already-readable entry untouched and rescues only the
+  * ones that would have been invisible.
+  */
+private[kyo] object ChartContrast:
+
+    /** The WCAG 2.1 SC 1.4.11 minimum for a non-text graphical object. */
+    private[kyo] val MinRatio: Double = 3.0
+
+    /** The sRGB components of `c`, or `Absent` for a color whose channels are not knowable here (a CSS
+      * variable, `transparent`, or a hex form with no opaque RGB reading).
+      */
+    private[kyo] def rgbOf(c: Style.Color): Maybe[(Int, Int, Int)] =
+        c match
+            case Style.Color.Rgb(r, g, b)     => Present((r, g, b))
+            case Style.Color.Rgba(r, g, b, _) => Present((r, g, b))
+            case Style.Color.Hex(v)           => hexRgb(v)
+            case Style.Color.Transparent      => Absent
+            case Style.Color.Var(_)           => Absent
+
+    private def hexRgb(value: String): Maybe[(Int, Int, Int)] =
+        val v                 = if value.startsWith("#") then value.substring(1) else value
+        def pair(i: Int): Int = Integer.parseInt(v.substring(i, i + 2), 16)
+        def single(i: Int): Int =
+            val d = Integer.parseInt(v.substring(i, i + 1), 16); d * 16 + d
+        try
+            v.length match
+                case 3 | 4 => Present((single(0), single(1), single(2)))
+                case 6 | 8 => Present((pair(0), pair(2), pair(4)))
+                case _     => Absent
+        catch case ex: Throwable if scala.util.control.NonFatal(ex) => Absent
+        end try
+    end hexRgb
+
+    /** The WCAG relative luminance of one sRGB channel value. */
+    private def channel(v: Int): Double =
+        val s = v / 255.0
+        if s <= 0.03928 then s / 12.92 else math.pow((s + 0.055) / 1.055, 2.4)
+
+    /** The WCAG relative luminance of a color, or `Absent` when its channels are unknown. */
+    private[kyo] def relativeLuminance(c: Style.Color): Maybe[Double] =
+        rgbOf(c).map { case (r, g, b) =>
+            0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+        }
+
+    /** The WCAG contrast ratio between two colors, or `Absent` when either one's channels are unknown. */
+    private[kyo] def contrastRatio(a: Style.Color, b: Style.Color): Maybe[Double] =
+        for
+            la <- relativeLuminance(a)
+            lb <- relativeLuminance(b)
+        yield
+            val hi = math.max(la, lb)
+            val lo = math.min(la, lb)
+            (hi + 0.05) / (lo + 0.05)
+
+    /** `color`, blended toward white or black until it clears `minRatio` against `background`.
+      *
+      * The blend direction is away from the background's own luminance, so a dark panel lightens and a light
+      * one darkens. Blending toward a neutral keeps the hue: the orange stays orange, and only its lightness
+      * moves. A color that already clears the threshold is returned unchanged, as is one whose channels are
+      * not knowable (a CSS variable) or one no blend can rescue.
+      */
+    private[kyo] def reconcile(color: Style.Color, background: Style.Color, minRatio: Double = MinRatio): Style.Color =
+        val current = contrastRatio(color, background)
+        (current, rgbOf(color), relativeLuminance(background)) match
+            case (Present(ratio), _, _) if ratio >= minRatio => color
+            case (Present(_), Present((r, g, b)), Present(bgLum)) =>
+                val toward                        = if bgLum < 0.5 then 255 else 0
+                def blend(v: Int, t: Double): Int = math.round(v + (toward - v) * t).toInt
+                @annotation.tailrec
+                def loop(step: Int): Style.Color =
+                    if step > 20 then Style.Color.rgb(toward, toward, toward)
+                    else
+                        val t         = step / 20.0
+                        val candidate = Style.Color.rgb(blend(r, t), blend(g, t), blend(b, t))
+                        contrastRatio(candidate, background) match
+                            case Present(ratio) if ratio >= minRatio => candidate
+                            case _                                   => loop(step + 1)
+                loop(1)
+            case _ => color
+        end match
+    end reconcile
+
+    /** Every color in `palette`, reconciled against `background`. */
+    private[kyo] def reconcilePalette(palette: Chunk[Style.Color], background: Style.Color): Chunk[Style.Color] =
+        palette.map(reconcile(_, background))
+
+end ChartContrast

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ChartLegend.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ChartLegend.scala
@@ -317,11 +317,12 @@ private[kyo] object ChartLegend:
                 val (domLo, domHi) = domainExtentOf(categories, domOv)
                 categories.map { case (_, raw) => sequentialColor(raw, lo, hi, domLo, domHi) }
             case Absent =>
-                spec.theme.palette match
-                    case Present(p) => categories.zipWithIndex.map: (_, i) =>
-                            p(i % p.size)
-                    case Absent => categories.zipWithIndex.map: (_, i) =>
-                            ChartAxes.DefaultPalette(i % ChartAxes.DefaultPalette.size)
+                // Reconciled against the panel: a palette kyo picked must not render a series invisible on
+                // the theme it is paired with. An explicit colorScale above is the caller's own computation
+                // and is passed through untouched.
+                val palette = ChartAxes.themePalette(spec.theme)
+                categories.zipWithIndex.map: (_, i) =>
+                    palette(i % palette.size)
     end resolvePalette
 
     /** Convenience: resolve a palette from DefaultPalette for the stacked-bar Absent-spec fallback. */

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ChartScales.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ChartScales.scala
@@ -528,6 +528,25 @@ private[kyo] object ChartScales:
     private[kyo] def inferKind[A](ext: Extent, marks: Chunk[Mark[A]], isX: Boolean): Scale.Kind =
         ext match
             case _: Extent.Categories => Scale.Kind.Band
-            case _: Extent.Continuous => Scale.Kind.Linear
+            case _: Extent.Continuous =>
+                // The encoding already declares its scale family, and that is the only place the answer
+                // survives: an Instant folds into Extent.Continuous(epochMillis) exactly like a Double, so
+                // reading the extent alone put every time axis on a linear scale, whose ticks are numbers.
+                // The chart then printed a 13-digit epoch millisecond under every tick of a chart the caller
+                // had typed with Instant precisely so it would not have to.
+                if declaredXKind(marks).contains(Scale.Kind.Time) then Scale.Kind.Time
+                else Scale.Kind.Linear
+
+    /** The scale families the marks' x encodings declare, in mark order. */
+    private[kyo] def declaredXKind[A](marks: Chunk[Mark[A]]): Chunk[Scale.Kind] =
+        marks.flatMap {
+            case m: Mark.Bar[A, ?, ?]      => Chunk(m.x.plottable.kind)
+            case m: Mark.Line[A, ?, ?]     => Chunk(m.x.plottable.kind)
+            case m: Mark.Area[A, ?, ?]     => Chunk(m.x.plottable.kind)
+            case m: Mark.Point[A, ?, ?]    => Chunk(m.x.plottable.kind)
+            case _: Mark.Rule[A]           => Chunk.empty
+            case m: Mark.Text[A, ?, ?]     => Chunk(m.x.plottable.kind)
+            case m: Mark.ErrorBar[A, ?, ?] => Chunk(m.x.plottable.kind)
+        }
 
 end ChartScales

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
@@ -612,13 +612,19 @@ private[kyo] object ReactiveUI:
         if rui.isConst then
             Kyo.foreachDiscard(rui.children)(subscribeScoped(_, exchange, signalChangeTime))
         else
+            // The tree this region last rendered, so the exchange can send only what moved instead of the
+            // whole region.
+            // Unsafe: region-scoped, single-writer state created before the observe loop is forked, where no
+            // effect context exists to supply AllowUnsafe; only this region's own loop reads or writes it.
+            val rendered = AtomicRef.Unsafe.init(Maybe.empty[UI])(using AllowUnsafe.embrace.danger)
             // Per-value setup, run inside each value's fresh Scope: render the region and fork its children into
             // that scope, so the next value (or an interrupt) tears them down by cascade.
             def renderValue(current: UI): Unit < (Async & Scope) =
                 for
                     now          <- Clock.now
                     _            <- signalChangeTime.set(now)
-                    _            <- exchange.onChange(rui.path, current)
+                    previous     <- Sync.Unsafe.defer(rendered.getAndSet(Present(current)))
+                    _            <- exchange.onChange(rui.path, previous, current)
                     (newKids, _) <- walkStatic(current, rui.path, rui.svgContext)
                     _            <- Kyo.foreachDiscard(newKids)(subscribeScoped(_, exchange, signalChangeTime))
                 yield ()

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UIDiff.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UIDiff.scala
@@ -1,0 +1,105 @@
+package kyo.internal
+
+import kyo.*
+import kyo.UI.Ast.*
+import scala.annotation.tailrec
+
+/** Which nodes a reactive region's update could be addressed to.
+  *
+  * A region's update was always the whole region: it re-rendered its subtree and shipped every byte of it,
+  * because the diff granularity was the reactive boundary itself. For a chart that is one boundary over the
+  * entire lowered SVG, so a tick whose information content is a handful of numbers re-transmitted the
+  * background, the axes, the gridlines, every tick label and the legend along with the marks that actually
+  * moved, once a second, per connected viewer.
+  *
+  * Every element renders with its own `data-kyo-path`, and the client resolves a `Replace` by that path, so a
+  * nested element is addressable exactly the way the boundary is. This decides which nodes CAN be addressed;
+  * what actually goes on the wire is decided downstream, by comparing each candidate's rendered HTML against
+  * what was last sent for that path.
+  *
+  * That split is not an implementation detail, it is the correctness boundary. A node's rendering is NOT a
+  * function of its AST alone: an element bound to a `SignalRef` re-renders from the ref read afresh at render
+  * time, and its AST is the same object on every edit (see `ReactiveUI.normalize`). Deciding "unchanged" from
+  * the AST therefore silently drops real updates, which is why the decision is made on rendered bytes and this
+  * file only proposes candidates.
+  *
+  * The walk descends only where the node shape is uniform enough to compare exactly, which is the SVG subtree:
+  * every SVG element is `(svgAttrs, attrs, children)`, so "same node, different children" is a precise
+  * question there. It stops at a `foreignObject`, which bridges back to HTML where a user-editable field can
+  * live, at a child that renders no node of its own, and at a nested reactive region that owns its own
+  * subscription. Anywhere it cannot descend, the enclosing node is the single candidate, which is what every
+  * update was before.
+  */
+private[kyo] object UIDiff:
+
+    /** The (path, subtree) nodes an update to this region could be addressed to.
+      *
+      * A first render, and a region whose node cannot be decomposed, is the whole region at its own path.
+      * Otherwise it is the region's addressable descendants, each at its own path.
+      */
+    def plan(path: Seq[String], previous: Maybe[UI], current: UI): Chunk[(Seq[String], UI)] =
+        previous match
+            case Absent => Chunk((path, current))
+            case Present(p) =>
+                decompose(path, p, current).getOrElse(Chunk((path, current)))
+
+    /** `Present(candidates)` when the two nodes are the same element and their children can each be addressed
+      * on their own; `Absent` when the node cannot be decomposed and is the candidate itself.
+      */
+    private def decompose(path: Seq[String], a: UI, b: UI): Maybe[Chunk[(Seq[String], UI)]] =
+        (a, b) match
+            case (ea: Svg.SvgElement, eb: Svg.SvgElement) if sameShell(ea, eb) =>
+                @tailrec def loop(i: Int, acc: Chunk[(Seq[String], UI)]): Maybe[Chunk[(Seq[String], UI)]] =
+                    if i >= ea.children.size then Present(acc)
+                    else
+                        val cb = eb.children(i)
+                        if !addressable(cb) then Absent
+                        else
+                            val childPath = path :+ i.toString
+                            decompose(childPath, ea.children(i), cb) match
+                                case Present(sub) => loop(i + 1, acc.concat(sub))
+                                case Absent       => loop(i + 1, acc.append((childPath, cb)))
+                        end if
+                loop(0, Chunk.empty)
+            case _ => Absent
+
+    /** Whether the two nodes are the same element differing only in their children.
+      *
+      * `frame` is a `using` parameter on every SVG case class, so it sits outside the generated `equals` and a
+      * node built at a different call site still compares by its content. This comparison is over attributes,
+      * which are plain values; the children are what the caller goes on to address separately.
+      */
+    private def sameShell(a: Svg.SvgElement, b: Svg.SvgElement): Boolean =
+        // `equals` rather than `==`: neither SvgAttrs nor Attrs declares a CanEqual instance, and the
+        // comparison wanted here is exactly the structural one their generated equals performs.
+        a.children.nonEmpty &&
+            a.children.size == b.children.size &&
+            a.getClass.getName == b.getClass.getName &&
+            !opaqueContent(a) &&
+            a.svgAttrs.equals(b.svgAttrs) &&
+            a.attrs.equals(b.attrs)
+
+    /** Nodes never descended into.
+      *
+      * `title` and `desc` render a text field of their own alongside their children, so their content is not
+      * described by (attributes, children). `foreignObject` bridges back to HTML, where a bound input can
+      * live: its rendering reads state no comparison at this level can see.
+      */
+    private def opaqueContent(a: Svg.SvgElement): Boolean =
+        a match
+            case _: Svg.Title | _: Svg.Desc | _: Svg.ForeignObject => true
+            case _                                                 => false
+
+    /** Whether a child can be replaced on its own.
+      *
+      * Only an element renders a tag carrying `data-kyo-path`, which is what the client resolves a `Replace`
+      * against; a fragment, a text node or raw html has no node of its own to address. A nested reactive
+      * region is an element in the rendered output but owns its own subscription, so replacing it from the
+      * enclosing region would clobber a subtree that updates itself.
+      */
+    private def addressable(ui: UI): Boolean =
+        ui match
+            case _: Element => true
+            case _          => false
+
+end UIDiff

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UIExchange.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UIExchange.scala
@@ -2,7 +2,12 @@ package kyo.internal
 
 import kyo.*
 
-/** Reactive change notification. Transport-agnostic; each backend renders in its own format. */
+/** Reactive change notification. Transport-agnostic; each backend renders in its own format.
+  *
+  * `previous` is the tree this region last rendered, `Absent` on its first render. A backend that can address
+  * a nested node uses it to send only the parts that moved (see [[UIDiff]]); one that cannot ignores it and
+  * re-sends the region.
+  */
 private[kyo] trait UIExchange:
-    def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async
+    def onChange(path: Seq[String], previous: Maybe[UI], ui: UI)(using Frame): Unit < Async
 end UIExchange

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
@@ -66,33 +66,83 @@ private[kyo] object UIServer:
             private def svgContextAt(path: Seq[String]): Boolean =
                 ReactiveUI.findNode(root, path).map(_.svgContext).getOrElse(false)
 
+            // Both collections below are written CONCURRENTLY: subscribeScoped forks one fiber per reactive
+            // region and every one of them calls into this same exchange, so a plain mutable Map or Set here
+            // is a data race that can corrupt the table under a rehash, not merely lose an entry.
+
             // Pseudo-state CSS classes already carried by this connection's <style> (seeded from the
             // initial SSR page, then grown by every InjectCss this exchange sends), so a later
             // re-render reusing one of these classes never re-sends its rule. Connection-scoped: each
             // WS session gets its own set, matching the session-scoped subscription tree this exchange
             // already belongs to.
-            private val sentClasses = scala.collection.mutable.Set.from(seenClasses)
+            private val sentClasses = new java.util.concurrent.ConcurrentHashMap[String, java.lang.Boolean]
+            seenClasses.foreach(c => discard(sentClasses.put(c, java.lang.Boolean.TRUE)))
 
-            def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async =
-                HtmlRenderer.renderWithCss(ui, path).map { (html, rules) =>
-                    val newRules  = rules.filterNot(r => sentClasses.contains(r._1))
-                    val finalHtml = HtmlRenderer.wrapReactiveRegion(path, svgContextAt(path), html)
-                    val replaceOp = HtmlOp.Replace(path, finalHtml)
-                    // runPartial drops only a Closed (the socket closed mid-render -> the op is moot); a Panic
-                    // propagates to the region fiber rather than being swallowed by the discard.
-                    val sendReplace =
-                        Abort.runPartial[Closed](ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](replaceOp)))).unit
-                    if newRules.isEmpty then sendReplace
-                    else
-                        newRules.foreach(r => sentClasses += r._1)
-                        val injectOp = HtmlOp.InjectCss(newRules.map(_._2).mkString)
-                        // Send the new pseudo-state rule(s) before the replace that introduces the class
-                        // referencing them, so the element never paints unstyled between the two frames.
-                        Abort.runPartial[Closed](ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](injectOp)))).unit
-                            .andThen(sendReplace)
-                    end if
-                }
+            /** Per reactive region, the HTML last sent for each node BELOW it, so an update re-sends only the
+              * nodes whose rendered bytes actually changed.
+              *
+              * Rendered bytes, not the AST: a node's rendering is not a function of its AST alone. An element
+              * bound to a `SignalRef` re-renders from the ref read at render time and its AST is the same
+              * object on every edit, so an AST comparison would drop real updates. Connection-scoped, like
+              * `sentClasses`. Each region writes only its own key and replaces that key's value wholesale, so
+              * a structural change cannot leave stale paths behind.
+              */
+            private val sentBelowRegion =
+                new java.util.concurrent.ConcurrentHashMap[Seq[String], Map[Seq[String], String]]
+
+            def onChange(path: Seq[String], previous: Maybe[UI], ui: UI)(using Frame): Unit < Async =
+                val plan = UIDiff.plan(path, previous, ui)
+                if plan.size == 1 && plan.head._1 == path then
+                    // The whole region: sent unconditionally. The client compares against the LIVE DOM before
+                    // applying, which is what repairs a field the user has typed into; suppressing this here
+                    // would take that repair away.
+                    discard(sentBelowRegion.remove(path))
+                    sendReplacement(path, path, ui)
+                else
+                    // Only the nodes that moved. For a chart on a 1 Hz signal that is the marks group: the
+                    // background, axes, gridlines and legend render byte-identically to the tick before and
+                    // are not sent at all. An unchanged re-render of the whole region sends nothing.
+                    val previouslySent = Option(sentBelowRegion.get(path)).getOrElse(Map.empty)
+                    Kyo.foreach(plan) { (opPath, subtree) =>
+                        HtmlRenderer.renderWithCss(subtree, opPath).map((html, rules) => (opPath, html, rules))
+                    }.map { rendered =>
+                        discard(sentBelowRegion.put(path, rendered.map((opPath, html, _) => (opPath, html)).toMap))
+                        val changed = rendered.filterNot((opPath, html, _) => previouslySent.get(opPath).contains(html))
+                        Kyo.foreachDiscard(changed)((opPath, html, rules) => send(opPath, html, rules))
+                    }
+                end if
             end onChange
+
+            /** Render and send one replacement whole. `regionPath` is the reactive boundary; `opPath` is the
+              * node being replaced. Only the boundary carries the region wrapper: a descendant renders its own
+              * tag, with its own `data-kyo-path`, which is what the client resolves the op against.
+              */
+            private def sendReplacement(regionPath: Seq[String], opPath: Seq[String], ui: UI)(using Frame): Unit < Async =
+                HtmlRenderer.renderWithCss(ui, opPath).map { (html, rules) =>
+                    val finalHtml =
+                        if opPath == regionPath then HtmlRenderer.wrapReactiveRegion(opPath, svgContextAt(opPath), html)
+                        else html
+                    send(opPath, finalHtml, rules)
+                }
+
+            /** Emit one `Replace`, preceded by any pseudo-state rule it introduces. */
+            private def send(opPath: Seq[String], html: String, rules: Seq[(String, String)])(using Frame): Unit < Async =
+                val newRules  = rules.filterNot(r => sentClasses.containsKey(r._1))
+                val replaceOp = HtmlOp.Replace(opPath, html)
+                // runPartial drops only a Closed (the socket closed mid-render -> the op is moot); a Panic
+                // propagates to the region fiber rather than being swallowed by the discard.
+                val sendReplace =
+                    Abort.runPartial[Closed](ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](replaceOp)))).unit
+                if newRules.isEmpty then sendReplace
+                else
+                    newRules.foreach(r => discard(sentClasses.put(r._1, java.lang.Boolean.TRUE)))
+                    val injectOp = HtmlOp.InjectCss(newRules.map(_._2).mkString)
+                    // Send the new pseudo-state rule(s) before the replace that introduces the class
+                    // referencing them, so the element never paints unstyled between the two frames.
+                    Abort.runPartial[Closed](ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](injectOp)))).unit
+                        .andThen(sendReplace)
+                end if
+            end send
 
     private def dispatchEvent(handle: (Seq[String], UIEvent) => Boolean < Async, payload: HttpWebSocket.Payload)(using
         Frame

--- a/kyo-ui/shared/src/test/scala/kyo/ChartContrastItTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/ChartContrastItTest.scala
@@ -1,0 +1,110 @@
+package kyo
+
+import kyo.Browser.*
+import kyo.Chart.*
+import kyo.internal.ChartContrast
+import scala.language.implicitConversions
+
+/** The palette-versus-theme reconciliation, read back out of a real browser.
+  *
+  * `ChartContrastTest` covers the arithmetic and the lowering: it walks the `Svg` tree `Chart.lower` produces
+  * and asserts the stroke it carries clears 3:1. That leaves one link untested, and it is the link the report
+  * was written from: what `HtmlRenderer` puts on the page, and therefore what the viewer's eye actually
+  * receives. A stroke correct in the AST but dropped, overridden, or shadowed by a CSS rule on the way to the
+  * DOM would pass there and still render the headline series invisible.
+  *
+  * So this reads `getComputedStyle` off the live nodes in Chrome and recomputes the ratio against the panel's
+  * own computed fill, which is the check the finding describes: with
+  * `.theme(_.dark.palette(Chart.Palette.Okabe))`, series 1 must not come back `rgb(0, 0, 0)` on the near-black
+  * panel, and every series must clear WCAG 2.1 SC 1.4.11's 3:1.
+  */
+class ChartContrastItTest extends UITest:
+
+    private case class Row(x: String, y: Double)
+
+    private val rows = Chunk(Row("a", 1.0), Row("b", 3.0), Row("c", 2.0))
+
+    /** A chart carrying the pairing the report names: the accessible palette on the dark theme it is not
+      * published against.
+      */
+    private def chartPage(using Frame): UI < Sync =
+        for
+            chart <- Chart(rows)(line(x = _.x, y = _.y))
+                .theme(_.dark.palette(Palette.Okabe))
+                .lower
+        yield UI.div(chart).id("panel")
+
+    /** Reads the panel's computed fill and every stroked path's computed stroke.
+      *
+      * The channels are pulled apart in the page rather than in Scala, so what crosses the boundary is
+      * `r g b|r g b;r g b`, with no commas or quotes to unpick.
+      *
+      * The panel is taken as the widest `rect` because `ChartAxes.buildBackground` emits exactly one, and it
+      * spans the whole SVG canvas rather than just the plot rectangle (deliberately, so the axis margins read
+      * as dark too). Its fill is the same color `panelBackground` returns, which is the background the
+      * reconciliation targets, so it is the right thing to measure the strokes against.
+      */
+    private val readColors: String =
+        """(() => {
+          |  const chan = (s) => {
+          |    const m = String(s).match(/(\d+)\D+(\d+)\D+(\d+)/);
+          |    return m ? (m[1] + ' ' + m[2] + ' ' + m[3]) : '';
+          |  };
+          |  const svg = document.querySelector('svg');
+          |  if (!svg) return 'no-svg';
+          |  const rects = Array.from(svg.querySelectorAll('rect'));
+          |  if (rects.length === 0) return 'no-rect';
+          |  const panel = rects.reduce((a, b) =>
+          |    (b.getBoundingClientRect().width > a.getBoundingClientRect().width) ? b : a);
+          |  const fill = chan(getComputedStyle(panel).fill);
+          |  if (!fill) return 'no-panel-fill';
+          |  const strokes = Array.from(svg.querySelectorAll('path'))
+          |    .map(p => getComputedStyle(p).stroke)
+          |    .filter(s => s && s !== 'none')
+          |    .map(chan)
+          |    .filter(s => s !== '');
+          |  if (strokes.length === 0) return 'no-strokes';
+          |  return fill + '|' + strokes.join(';');
+          |})()""".stripMargin
+
+    /** Parses the `r g b` form the script above emits. */
+    private def parseTriple(s: String)(using Frame, kyo.test.AssertScope): Style.Color =
+        val parts = s.trim.split(' ').filter(_.nonEmpty)
+        if parts.length != 3 then fail(s"expected three channels, got [$s]")
+        else
+            val channels = parts.map(_.toIntOption)
+            if channels.exists(_.isEmpty) then fail(s"non-numeric channel in [$s]")
+            else Style.Color.rgb(channels(0).get, channels(1).get, channels(2).get)
+        end if
+    end parseTriple
+
+    "the reconciled palette survives the render" - {
+
+        "every series clears 3:1 against the panel, as the browser computes both" in {
+            withUI(chartPage) {
+                for raw <- Browser.eval(readColors)
+                yield
+                    assert(raw.contains("|"), s"the page reported a problem instead of colors: $raw")
+                    val panelPart  = raw.takeWhile(_ != '|')
+                    val strokePart = raw.dropWhile(_ != '|').drop(1)
+                    val panel      = parseTriple(panelPart)
+                    val strokes    = strokePart.split(';').toList.filter(_.nonEmpty).map(parseTriple)
+                    assert(strokes.nonEmpty, s"no strokes came back: $raw")
+
+                    strokes.foreach { color =>
+                        // The exact rendering the finding reported, and the reason it exists: Okabe-Ito's
+                        // first entry is pure black by definition, because the palette is specified against
+                        // white.
+                        assert(
+                            color != Style.Color.rgb(0, 0, 0),
+                            s"a series rendered pure black on the dark panel, which is the bug: $raw"
+                        )
+                        val ratio = ChartContrast.contrastRatio(color, panel)
+                            .getOrElse(fail(s"no computable ratio for $color on $panel"))
+                        assert(ratio >= 3.0, f"a series is $ratio%.2f:1 against the panel, below WCAG's 3:1 ($raw)")
+                    }
+            }
+        }
+    }
+
+end ChartContrastItTest

--- a/kyo-ui/shared/src/test/scala/kyo/ChartContrastTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/ChartContrastTest.scala
@@ -1,0 +1,155 @@
+package kyo
+
+import kyo.Chart.*
+import kyo.internal.ChartAxes
+import kyo.internal.ChartContrast
+import scala.language.implicitConversions
+
+/** Tests for the palette-versus-theme reconciliation.
+  *
+  * `Chart.Palette.Okabe` is documented as the color-vision-accessible choice, so it is what an
+  * accessibility-minded caller picks, and `.dark` is what they pair it with. Okabe-Ito's first entry is pure
+  * black by definition (the palette is specified against white), and the dark theme's panel is `#1f2937`, so
+  * series 1, the one most charts give their headline metric, rendered at 1.43:1 against its own background.
+  * WCAG 2.1 SC 1.4.11 requires 3:1 for a non-text graphical object.
+  */
+class ChartContrastTest extends kyo.test.Test[Any]:
+
+    private val DarkPanel  = Style.Color.hex("#1f2937").getOrElse(Style.Color.black)
+    private val LightPanel = Style.Color.white
+
+    private def ratio(a: Style.Color, b: Style.Color)(using Frame, kyo.test.AssertScope): Double =
+        ChartContrast.contrastRatio(a, b) match
+            case Present(v) => v
+            case Absent     => fail(s"expected a computable contrast ratio for $a on $b")
+
+    "contrast arithmetic" - {
+
+        "matches the WCAG reference values" in {
+            // Black on white is the definition of 21:1; a color against itself is 1:1.
+            assert(math.abs(ratio(Style.Color.black, Style.Color.white) - 21.0) < 0.01)
+            assert(math.abs(ratio(Style.Color.white, Style.Color.white) - 1.0) < 0.001)
+            // The reported measurement: rgb(0,0,0) on #1f2937.
+            assert(math.abs(ratio(Style.Color.rgb(0, 0, 0), DarkPanel) - 1.43) < 0.01)
+        }
+
+        "reads rgb, rgba and every hex length" in {
+            assert(ChartContrast.rgbOf(Style.Color.rgb(1, 2, 3)) == Present((1, 2, 3)))
+            assert(ChartContrast.rgbOf(Style.Color.rgba(1, 2, 3, 0.5)) == Present((1, 2, 3)))
+            assert(ChartContrast.rgbOf(Style.Color.hex("#ff8000").getOrElse(Style.Color.black)) == Present((255, 128, 0)))
+            assert(ChartContrast.rgbOf(Style.Color.hex("#f80").getOrElse(Style.Color.black)) == Present((255, 136, 0)))
+            assert(ChartContrast.rgbOf(Style.Color.transparent).isEmpty)
+            assert(ChartContrast.rgbOf(Style.Color.variable("accent")).isEmpty)
+        }
+    }
+
+    "reconcile" - {
+
+        "leaves a color that already clears the threshold exactly as specified" in {
+            val orange = Style.Color.rgb(230, 159, 0) // Okabe-Ito entry 2, 6.8:1 on the dark panel
+            assert(ratio(orange, DarkPanel) >= 3.0)
+            assert(ChartContrast.reconcile(orange, DarkPanel) == orange)
+        }
+
+        "lightens a color that is invisible on a dark panel" in {
+            val fixed = ChartContrast.reconcile(Style.Color.rgb(0, 0, 0), DarkPanel)
+            assert(fixed != Style.Color.rgb(0, 0, 0))
+            assert(ratio(fixed, DarkPanel) >= 3.0)
+        }
+
+        "darkens a color that is invisible on a light panel" in {
+            val nearWhite = Style.Color.rgb(250, 250, 250)
+            assert(ratio(nearWhite, LightPanel) < 3.0)
+            val fixed = ChartContrast.reconcile(nearWhite, LightPanel)
+            assert(ratio(fixed, LightPanel) >= 3.0)
+        }
+
+        "keeps the hue: a dark blue rescued on a dark panel is still more blue than red" in {
+            val darkBlue = Style.Color.rgb(0, 0, 60)
+            val fixed    = ChartContrast.reconcile(darkBlue, DarkPanel)
+            ChartContrast.rgbOf(fixed) match
+                case Present((r, g, b)) => assert(b > r && b > g, s"expected a blue-dominant result, got ($r, $g, $b)")
+                case Absent             => fail("expected a readable color")
+        }
+
+        "passes a color through unchanged when its channels are not knowable" in {
+            val v = Style.Color.variable("accent")
+            assert(ChartContrast.reconcile(v, DarkPanel) == v)
+        }
+    }
+
+    "a named palette is reconciled against a panel it was not published against" - {
+
+        def onDark(p: Palette)(using Frame, kyo.test.AssertScope): Unit =
+            val theme   = Theme.default.dark.palette(p)
+            val panel   = ChartAxes.panelBackground(theme)
+            val palette = ChartAxes.themePalette(theme)
+            assert(palette.size == Palette.colors(p).size)
+            palette.foreach { c =>
+                assert(ratio(c, panel) >= 3.0, s"$p entry $c is ${ratio(c, panel)}:1 on $panel")
+            }
+        end onDark
+
+        "Okabe on dark clears 3:1, starting with the entry that did not" in {
+            // The exact reported failure: series 1 was rgb(0, 0, 0) on #1f2937, at 1.43:1.
+            val theme   = Theme.default.dark.palette(Palette.Okabe)
+            val palette = ChartAxes.themePalette(theme)
+            assert(palette.head != Style.Color.rgb(0, 0, 0))
+            onDark(Palette.Okabe)
+        }
+        "Viridis on dark clears 3:1" in { onDark(Palette.Viridis) }
+        "Tableau10 on dark clears 3:1" in { onDark(Palette.Tableau10) }
+        "Default on dark clears 3:1" in { onDark(Palette.Default) }
+
+        "an entry that already clears the bar on dark is left exactly as published" in {
+            val published  = Palette.colors(Palette.Okabe)
+            val reconciled = ChartAxes.themePalette(Theme.default.dark.palette(Palette.Okabe))
+            val panel      = ChartAxes.panelBackground(Theme.default.dark)
+            published.zip(reconciled).foreach { (before, after) =>
+                if ratio(before, panel) >= 3.0 then assert(after == before, s"$before was readable and should not have moved")
+            }
+        }
+
+        "on the light panel the palettes are published untouched" in {
+            // The named palettes are specified against white, and not all of them clear 3:1 there (Okabe-Ito's
+            // yellow does not). Rewriting them on their own panel would restyle every existing chart to chase
+            // a bar the published palette never met; kyo reconciles only where IT paired the palette with a
+            // panel the palette was not written for.
+            List(Palette.Default, Palette.Okabe, Palette.Viridis, Palette.Tableau10).foreach { p =>
+                assert(ChartAxes.themePalette(Theme.default.light.palette(p)) == Palette.colors(p))
+            }
+            assert(ChartAxes.themePalette(Theme.default) == ChartAxes.themePalette(Theme.default))
+        }
+
+        "an explicit color list is the caller's own and is never reconciled" in {
+            val invisible = Chunk(Style.Color.rgb(0, 0, 0), Style.Color.rgb(10, 10, 10))
+            val theme     = Theme.default.dark.palette(invisible.toSeq)
+            assert(ChartAxes.themePalette(theme) == invisible)
+        }
+    }
+
+    "a mark's default color is the reconciled one" in {
+        case class Row(x: String, y: Double)
+        val rows = Chunk(Row("a", 1.0), Row("b", 2.0))
+        val spec = Chart(rows)(line(x = _.x, y = _.y))
+            .theme(_.dark.palette(Palette.Okabe))
+        spec.lower.map { root =>
+            val strokes = root.children.flatMap {
+                case g: Svg.G =>
+                    g.children.flatMap {
+                        case p: Svg.Path =>
+                            p.svgAttrs.stroke match
+                                case Present(Svg.Paint.Color(c)) => Chunk(c)
+                                case _                           => Chunk.empty
+                        case _ => Chunk.empty
+                    }
+                case _ => Chunk.empty
+            }
+            assert(strokes.nonEmpty, "expected at least one stroked line path")
+            assert(!strokes.contains(Style.Color.rgb(0, 0, 0)), "the headline series is black on a near-black panel")
+            val panel = ChartAxes.panelBackground(Theme.default.dark)
+            strokes.foreach(c => assert(ratio(c, panel) >= 3.0, s"stroke $c is ${ratio(c, panel)}:1 on $panel"))
+        }
+    }
+
+end ChartContrastTest

--- a/kyo-ui/shared/src/test/scala/kyo/ChartTimeAxisTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/ChartTimeAxisTest.scala
@@ -1,0 +1,139 @@
+package kyo
+
+import kyo.Chart.*
+import kyo.internal.ChartAxes
+import kyo.internal.ChartScales
+import kyo.internal.Scale
+import scala.language.implicitConversions
+
+/** Tests for the time axis an `Instant` encoding selects, and for the tick labels it produces.
+  *
+  * The README says an `Instant` x-encoding selects a time scale. It did not: an `Instant` folds into the same
+  * `Extent.Continuous` a `Double` does, and the scale kind was inferred from the extent alone, so a chart of
+  * the last minute was labelled `1785879980000 ... 1785880060000` under ticks that a time scale had never
+  * chosen. The last of those labels then ran off the right edge and was truncated mid-number, which reads as
+  * a different, wrong value rather than as a clipped one.
+  */
+class ChartTimeAxisTest extends kyo.test.Test[Any]:
+
+    private val PlotX = 60.0
+    private val PlotW = 560.0
+    private val SvgW  = 640.0
+
+    case class Hit(at: Instant, count: Double)
+    given CanEqual[Hit, Hit] = CanEqual.derived
+
+    /** A minute of samples, one every twenty seconds, starting at a round epoch second. */
+    private val start: Instant = Instant.Epoch + 1785879980L.seconds
+
+    private val rows: Chunk[Hit] =
+        Chunk(
+            Hit(start, 10.0),
+            Hit(start + 20.seconds, 20.0),
+            Hit(start + 40.seconds, 30.0),
+            Hit(start + 60.seconds, 40.0)
+        )
+
+    private def frameTextsIn(root: Svg.Root): Chunk[Svg.Text] =
+        root.children.flatMap:
+            case t: Svg.Text => Chunk(t)
+            case _           => Chunk.empty
+
+    private def xTickLabels(root: Svg.Root): Chunk[String] =
+        frameTextsIn(root)
+            .filter(t => t.svgAttrs.dominantBaseline.contains(Svg.DominantBaseline.Hanging))
+            .map(_.children.collect { case UI.Ast.Text(v) => v }.mkString)
+
+    "an Instant x-encoding selects a time scale" in {
+        val spec = Chart(rows)(line(x = _.at, y = _.count))
+        val kind = ChartScales.declaredXKind(spec.marks)
+        assert(kind.contains(Scale.Kind.Time))
+        spec.lower.map { _ =>
+            // The inference path is what regressed: an Instant produces a Continuous extent, so a
+            // scale kind read off the extent alone can only ever say Linear.
+            val inferred = ChartScales.inferKind(
+                kyo.internal.Extent.Continuous(0.0, 1.0),
+                spec.marks,
+                isX = true
+            )
+            assert(inferred == Scale.Kind.Time)
+        }
+    }
+
+    "a Double x-encoding still selects a linear scale" in {
+        case class Point(x: Double, y: Double)
+        val spec = Chart(Chunk(Point(0.0, 1.0), Point(1.0, 2.0)))(line(x = _.x, y = _.y))
+        val inferred = ChartScales.inferKind(
+            kyo.internal.Extent.Continuous(0.0, 1.0),
+            spec.marks,
+            isX = true
+        )
+        assert(inferred == Scale.Kind.Linear)
+    }
+
+    "the default tick labels of a time axis are times, not epoch milliseconds" in {
+        Chart(rows)(line(x = _.at, y = _.count)).lower.map { root =>
+            val labels = xTickLabels(root)
+            assert(labels.nonEmpty)
+            // The exact defect: a 13-digit integer under every tick.
+            assert(labels.forall(l => !l.matches("\\d{13}")), s"got raw epoch millis: $labels")
+            // A sub-day tick step formats as HH:mm.
+            assert(labels.forall(_.matches("\\d{2}:\\d{2}")), s"expected HH:mm labels, got: $labels")
+        }
+    }
+
+    "formatTime hands the callback the Instant the axis was typed with" in {
+        val seen = collection.mutable.ArrayBuffer.empty[Instant]
+        val spec = Chart(rows)(line(x = _.at, y = _.count))
+            .xAxis(_.formatTime { i =>
+                seen += i
+                "T"
+            })
+        spec.lower.map { root =>
+            assert(xTickLabels(root).forall(_ == "T"))
+            assert(seen.nonEmpty)
+            // Every instant handed over is inside the sampled window, so the callback saw the real
+            // domain value rather than a pixel or a re-derived number.
+            assert(seen.forall(_.between(start - 1.minute, start + 2.minutes)))
+        }
+    }
+
+    "formatTime is ignored on a non-time axis, where format remains the formatter" in {
+        case class Point(x: Double, y: Double)
+        val spec = Chart(Chunk(Point(0.0, 1.0), Point(1.0, 2.0)))(line(x = _.x, y = _.y))
+            .xAxis(_.formatTime(_ => "T").format(v => s"n$v"))
+        spec.lower.map { root =>
+            val labels = xTickLabels(root)
+            assert(labels.nonEmpty)
+            assert(labels.forall(_.startsWith("n")), s"expected the numeric formatter to win, got: $labels")
+        }
+    }
+
+    "a numeric formatter still applies on a time axis when no time formatter is set" in {
+        val spec = Chart(rows)(line(x = _.at, y = _.count)).xAxis(_.format(v => s"ms$v"))
+        spec.lower.map { root =>
+            assert(xTickLabels(root).forall(_.startsWith("ms")))
+        }
+    }
+
+    "an x tick label at the right edge is anchored inward instead of running off the SVG" in {
+        val cfg  = AxisConfig.default
+        val wide = "1785880060000"
+        // A centred label at the last tick extends half its width past the plot edge, which is past the
+        // SVG edge: the renderer then cuts it mid-value.
+        assert(ChartAxes.xTickAnchor(cfg, wide, PlotX + PlotW, SvgW, 12.0) == Svg.TextAnchor.End)
+        // The mirror case at the left edge. The default 60px left margin keeps even a 13-character label
+        // inside the SVG at plotX, so the adjustment only fires for a plot that starts nearer the edge.
+        assert(ChartAxes.xTickAnchor(cfg, wide, PlotX, SvgW, 12.0) == Svg.TextAnchor.Middle)
+        assert(ChartAxes.xTickAnchor(cfg, wide, 20.0, SvgW, 12.0) == Svg.TextAnchor.Start)
+        assert(ChartAxes.xTickAnchor(cfg, "12:00", SvgW / 2.0, SvgW, 12.0) == Svg.TextAnchor.Middle)
+        // A time label at the last tick fits, which is the point of defaulting to one.
+        assert(ChartAxes.xTickAnchor(cfg, "12:00", PlotX + PlotW, SvgW, 12.0) == Svg.TextAnchor.Middle)
+    }
+
+    "an explicitly chosen anchor is never overridden by the edge adjustment" in {
+        val cfg = AxisConfig.default.anchor(TextAnchor.Start)
+        assert(ChartAxes.xTickAnchor(cfg, "1785880060000", PlotX + PlotW, SvgW, 12.0) == Svg.TextAnchor.Start)
+    }
+
+end ChartTimeAxisTest

--- a/kyo-ui/shared/src/test/scala/kyo/TypedEventTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/TypedEventTest.scala
@@ -18,7 +18,7 @@ class TypedEventTest extends kyo.test.Test[Any]:
 
     /** Minimal UIExchange stub that discards onChange notifications. */
     private class NoopExchange extends UIExchange:
-        def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async = ()
+        def onChange(path: Seq[String], previous: Maybe[UI], ui: UI)(using Frame): Unit < Async = ()
 
     /** Normalize a UI, subscribe it with a NoopExchange, and return the dispatch handle. The dispatch handle re-reads
       * the current signal state on each event, so it stays valid after the subscription's Scope closes; these tests

--- a/kyo-ui/shared/src/test/scala/kyo/UIEventWiringTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIEventWiringTest.scala
@@ -19,7 +19,7 @@ class UIEventWiringTest extends kyo.test.Test[Any]:
 
     /** Minimal UIExchange stub that discards onChange notifications. */
     private class NoopExchange extends UIExchange:
-        def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async = ()
+        def onChange(path: Seq[String], previous: Maybe[UI], ui: UI)(using Frame): Unit < Async = ()
 
     /** Normalize a UI, subscribe it with a NoopExchange, and return the dispatch handle. The dispatch handle re-reads
       * the current signal state on each event, so it stays valid after the subscription's Scope closes; these tests

--- a/kyo-ui/shared/src/test/scala/kyo/internal/ReactiveUITeardownTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/ReactiveUITeardownTest.scala
@@ -25,7 +25,7 @@ class ReactiveUITeardownTest extends kyo.test.Test[Any]:
     // A no-op exchange: the teardown/cascade proof does not depend on rendered output, only on subscription liveness.
     private val stubExchange: UIExchange =
         new UIExchange:
-            def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async = ()
+            def onChange(path: Seq[String], previous: Maybe[UI], ui: UI)(using Frame): Unit < Async = ()
 
     "bound input re-renders the latest value across back-to-back changes (convergence)".ignore(
         "interrupt-driven Scope finalizer teardown can stall before the result is observed; known finalizer-execution-on-interrupt issue, comprehensive fix pending"
@@ -43,7 +43,7 @@ class ReactiveUITeardownTest extends kyo.test.Test[Any]:
             // Exchange that renders each emitted input region to HTML and records it (the real onChange wire behavior).
             recordingExchange =
                 new UIExchange:
-                    def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async =
+                    def onChange(path: Seq[String], previous: Maybe[UI], ui: UI)(using Frame): Unit < Async =
                         HtmlRenderer.render(ui, path).map(html => rendered.updateAndGet(_.append(html)).unit)
             tree = UI.input.id("i").value(ref)
             live <- AtomicInt.init(0)

--- a/kyo-ui/shared/src/test/scala/kyo/internal/UIDiffTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/UIDiffTest.scala
@@ -1,0 +1,302 @@
+package kyo.internal
+
+import kyo.*
+import kyo.Chart.*
+import scala.language.implicitConversions
+
+/** Tests for the reactive-region diff.
+  *
+  * Server-driven mode re-rendered and re-transmitted the whole region on every change, because the diff
+  * granularity was the reactive boundary. `Chart(signal)(...)` is one boundary over the entire lowered SVG, so
+  * a 1 Hz sample shipped the background, the axes, every gridline and tick label, and the legend along with
+  * the marks that actually moved: 90 KB a frame, per connected viewer, for five doubles of new information.
+  *
+  * `plan` decides which nodes CAN be addressed, never which ones changed. What is actually sent is decided by
+  * the transport, on rendered bytes, because a node's rendering is not a function of its AST: an element bound
+  * to a `SignalRef` re-renders from the ref read at render time and its AST is the same object on every edit.
+  */
+class UIDiffTest extends kyo.test.Test[Any]:
+
+    private val region = Seq("0", "1")
+
+    private def svg(children: Svg.SvgChild*): Svg.Root = Svg.svg(children*)
+
+    private def rect(x: Double): Svg.Rect = Svg.rect.x(x).y(0.0).width(10.0).height(10.0)
+
+    /** Rebuilds `previous` by applying every replacement the plan names, which is what the client does.
+      *
+      * This is the completeness check the byte counting cannot make: sending less is only correct if what the
+      * viewer ends up with is still exactly what the server rendered.
+      */
+    private def applyPlan(previous: UI, plan: Chunk[(Seq[String], UI)])(using Frame, kyo.test.AssertScope): UI =
+        plan.foldLeft(previous)((tree, entry) => replaceAt(tree, entry._1.drop(region.size), entry._2))
+
+    private def replaceAt(tree: UI, suffix: Seq[String], replacement: UI)(using Frame, kyo.test.AssertScope): UI =
+        if suffix.isEmpty then replacement
+        else
+            val i = suffix.head.toInt
+            tree match
+                case r: Svg.Root =>
+                    r.copy(children = r.children.updated(i, replaceAt(r.children(i), suffix.tail, replacement)))(using r.frame)
+                case g: Svg.G =>
+                    g.copy(children = g.children.updated(i, replaceAt(g.children(i), suffix.tail, replacement)))(using g.frame)
+                case other =>
+                    fail(s"the plan addressed a child of $other, which this test cannot rebuild")
+            end match
+
+    "plan" - {
+
+        "a first render is the whole region" in {
+            val ui   = svg(rect(1.0))
+            val plan = UIDiff.plan(region, Absent, ui)
+            assert(plan.size == 1)
+            assert(plan.head._1 == region)
+            assert(plan.head._2 == ui)
+        }
+
+        "an identical re-render still yields candidates, never an empty plan" in {
+            // The invariant an AST comparison breaks: a SignalRef-bound element's AST is the same object on
+            // every edit (ReactiveUI.normalize maps the bound leaf to the constant `ui`) and its rendering
+            // reads the ref afresh, so deciding "nothing changed" here would drop real updates.
+            val ui   = svg(rect(1.0), rect(2.0))
+            val plan = UIDiff.plan(region, Present(svg(rect(1.0), rect(2.0))), ui)
+            assert(plan.map(_._1) == Chunk(region :+ "0", region :+ "1"))
+        }
+
+        "a decomposable node yields one candidate per child, at each child's own path" in {
+            val before = svg(rect(1.0), rect(2.0), rect(3.0))
+            val after  = svg(rect(1.0), rect(9.0), rect(3.0))
+            val plan   = UIDiff.plan(region, Present(before), after)
+            assert(plan.map(_._1) == Chunk(region :+ "0", region :+ "1", region :+ "2"))
+            assert(plan.map(_._2) == Chunk(rect(1.0), rect(9.0), rect(3.0)))
+        }
+
+        "a change on the node itself replaces the whole region" in {
+            val before = svg(rect(1.0))
+            val after  = Svg.svg.width(999.0)(rect(1.0))
+            val plan   = UIDiff.plan(region, Present(before), after)
+            assert(plan.size == 1)
+            assert(plan.head._1 == region)
+        }
+
+        "a different number of children replaces the whole region" in {
+            val plan = UIDiff.plan(region, Present(svg(rect(1.0))), svg(rect(1.0), rect(2.0)))
+            assert(plan.size == 1)
+            assert(plan.head._1 == region)
+        }
+
+        "the walk descends more than one level" in {
+            def group(x: Double) = Svg.g(Svg.g(rect(x)))
+            val before           = svg(group(1.0), group(2.0))
+            val after            = svg(group(1.0), group(5.0))
+            val plan             = UIDiff.plan(region, Present(before), after)
+            assert(plan.map(_._1) == Chunk(region ++ Seq("0", "0", "0"), region ++ Seq("1", "0", "0")))
+        }
+
+        "a foreignObject is never descended into: it bridges back to HTML, where a bound field can live" in {
+            val before = svg(Svg.foreignObject(UI.div(UI.span("a"))))
+            val after  = svg(Svg.foreignObject(UI.div(UI.span("b"))))
+            val plan   = UIDiff.plan(region, Present(before), after)
+            assert(plan.map(_._1) == Chunk(region :+ "0"))
+        }
+
+        "a changed child with no node of its own replaces the enclosing region" in {
+            // A text node renders no tag, so it carries no data-kyo-path for the client to resolve against.
+            val before = Svg.text.x(1.0)("a")
+            val after  = Svg.text.x(1.0)("b")
+            val plan   = UIDiff.plan(region, Present(before), after)
+            assert(plan.size == 1)
+            assert(plan.head._1 == region)
+        }
+
+        "a title's text is not mistaken for an unchanged node" in {
+            // title carries a text field beside its children, so it is compared whole rather than descended.
+            val before = svg(Svg.title("before"))
+            val after  = svg(Svg.title("after"))
+            val plan   = UIDiff.plan(region, Present(before), after)
+            assert(plan.size == 1)
+            assert(plan.head._1 == region :+ "0")
+        }
+    }
+
+    /** What the transport actually sends for a tick: the plan's candidates whose rendered bytes differ from
+      * the ones last sent. The transport compares rendered HTML, never the AST, because a node's rendering is
+      * not a function of its AST (a SignalRef-bound element re-renders from the ref, with the same AST).
+      */
+    private def wireOf(before: UI, after: UI)(using Frame): Chunk[(Seq[String], UI, String)] < Sync =
+        def render(previous: UI, current: UI): Chunk[(Seq[String], UI, String)] < Sync =
+            Kyo.foreach(UIDiff.plan(region, Present(previous), current))((path, ui) =>
+                HtmlRenderer.render(ui, path).map((path, ui, _))
+            )
+        for
+            lastSent   <- render(before, before)
+            candidates <- render(before, after)
+        yield
+            val previously = lastSent.map((path, _, html) => (path, html)).toMap
+            candidates.filterNot((path, _, html) => previously.get(path).contains(html))
+        end for
+    end wireOf
+
+    /** A chart on fixed scales, so the frame is genuinely the same nodes from tick to tick. */
+    private def chartAt(offset: Double): Chart[UIDiffTest.Point] =
+        val rows = Chunk.from((0 until 60).map(i => UIDiffTest.Point(i.toDouble, 20.0 + offset + (i % 7))))
+        Chart(rows)(line(x = _.x, y = _.y))
+            .xScale(_.linear(0.0, 60.0))
+            .yScale(_.linear(0.0, 100.0))
+            .xAxis(_.grid.ticks(6))
+            .yAxis(_.grid.ticks(5))
+    end chartAt
+
+    /** A live dashboard's chart: a sliding window over wall-clock time, so the x axis ADVANCES from tick to
+      * tick and the frame is genuinely different, not merely re-rendered.
+      *
+      * Every other chart fixture here pins both scales, which is the easy case: the frame is the same nodes
+      * and the diff elides all of it. This is the case a real dashboard actually runs, and the question it
+      * answers is whether the diff still addresses below the region when part of the frame legitimately
+      * changed, or collapses back to sending the whole region.
+      */
+    private def liveChartAt(offsetSeconds: Int): Chart[UIDiffTest.Sample] =
+        val start = Instant.Epoch + offsetSeconds.seconds
+        // The values move with the window, not just the timestamps. A fixture whose y values are a function
+        // of the index alone renders a byte-identical marks path at every offset, which would leave these
+        // leaves testing a moved axis over unchanged marks: the easier case, not the dashboard one.
+        val rows = Chunk.from((0 until 30).map(i => UIDiffTest.Sample(start + i.seconds, 20.0 + ((i + offsetSeconds) % 7))))
+        Chart(rows)(line(x = _.at, y = _.v))
+            .xScale(_.time)
+            .yScale(_.linear(0.0, 100.0))
+            .xAxis(_.grid.ticks(6))
+            .yAxis(_.grid.ticks(5))
+    end liveChartAt
+
+    "a chart whose frame itself moves" - {
+
+        "still addresses below the region: a moving x axis does not collapse the update to the whole region" in {
+            for
+                before <- liveChartAt(0).lower
+                after  <- liveChartAt(600).lower
+            yield
+                val plan = UIDiff.plan(region, Present(before), after)
+                assert(plan.nonEmpty)
+                assert(
+                    plan.forall(_._1.size > region.size),
+                    s"a moving axis collapsed the update back to the whole region: ${plan.map(_._1)}"
+                )
+            end for
+        }
+
+        "sends the axis that moved and the marks, and still withholds the panel background" in {
+            for
+                before <- liveChartAt(0).lower
+                after  <- liveChartAt(600).lower
+                whole  <- HtmlRenderer.render(after, region)
+                sent   <- wireOf(before, after)
+            yield
+                val payload = sent.map(_._3).mkString
+                assert(payload.nonEmpty, "the window moved, so something must go on the wire")
+                assert(whole.contains("<rect"), "the whole render carries the panel background")
+                // The panel background is a fixed-geometry node on fixed scales; it is the frame element that
+                // stays put even when the axis does not, so it is the one that must never be re-sent.
+                assert(!payload.contains("<rect"), s"the panel background was re-sent:\n$payload")
+                // Both the axis labels and the marks moved here, so both are on the wire and the saving is
+                // the rest of the frame: the panel background, the gridlines, the y axis and the legend.
+                assert(payload.contains("<path") || payload.contains("<polyline"), "the marks moved, so they must be sent")
+                // Measured on this fixture: 1193 bytes sent against 3177 for the whole region, a 2.66x cut,
+                // against 3.1x on the fixed-scale fixture above. Lower is the correct direction: an advancing
+                // axis puts its labels on the wire too. Neither number approaches the 1010x that a data
+                // channel pushing values would give, and the reason is structural rather than a shortfall in
+                // the walk: a `line` mark is ONE path element, so moving any point rewrites the whole `d`.
+                assert(payload.length < whole.length, s"sent ${payload.length} of ${whole.length}")
+            end for
+        }
+
+        "applying only what went on the wire still reproduces the whole render" in {
+            // The correctness half, on the harder input: when part of the frame moved, the nodes withheld
+            // must still be exactly the nodes the viewer already had.
+            for
+                before <- liveChartAt(0).lower
+                after  <- liveChartAt(600).lower
+                sent   <- wireOf(before, after)
+                rebuilt = applyPlan(before, sent.map((path, ui, _) => (path, ui)))
+                rebuiltHtml <- HtmlRenderer.render(rebuilt, region)
+                wholeHtml   <- HtmlRenderer.render(after, region)
+            yield assert(rebuiltHtml == wholeHtml)
+        }
+
+        "an idle tick on a time axis sends nothing" in {
+            for
+                before <- liveChartAt(0).lower
+                after  <- liveChartAt(0).lower
+                sent   <- wireOf(before, after)
+            yield assert(sent.isEmpty, s"an unchanged tick would have sent ${sent.map(_._1)}")
+        }
+    }
+
+    "a chart tick sends its marks, not its frame" - {
+
+        "the candidates are below the region, never the region itself" in {
+            for
+                before <- chartAt(0.0).lower
+                after  <- chartAt(5.0).lower
+            yield
+                val plan = UIDiff.plan(region, Present(before), after)
+                assert(plan.nonEmpty, "the data moved, so something must be addressable")
+                assert(plan.forall(_._1.size > region.size), s"expected candidates below the region, got ${plan.map(_._1)}")
+            end for
+        }
+
+        "the payload carries the marks and none of the frame" in {
+            for
+                before <- chartAt(0.0).lower
+                after  <- chartAt(5.0).lower
+                whole  <- HtmlRenderer.render(after, region)
+                sent   <- wireOf(before, after)
+            yield
+                val payload = sent.map(_._3).mkString
+                // The frame's own elements: the panel background rect and the gridlines are unchanged nodes
+                // and must not appear in what is sent.
+                assert(whole.contains("<rect"), "the whole render carries the panel background")
+                assert(!payload.contains("<rect"), s"the panel background was re-sent:\n$payload")
+                assert(payload.contains("<path") || payload.contains("<polyline"), "the marks must be sent")
+                // Measured on this fixture: 1291 bytes sent against 3976 for the whole region, a 3.1x cut,
+                // and the frame's share is exactly what disappears. The marks themselves are still sent in
+                // full every tick: a sliding window moves every point, so nothing about them is unchanged.
+                assert(
+                    payload.length * 2 < whole.length,
+                    s"the diffed payload (${payload.length}) must be less than half the whole region (${whole.length})"
+                )
+            end for
+        }
+
+        "applying only what went on the wire renders exactly what the server would have sent whole" in {
+            // The correctness half of the byte saving: the nodes that were NOT sent have to be the nodes the
+            // viewer already had. Rendered HTML is the comparison, because that is what the viewer ends up
+            // with, and two different values can render to the same bytes.
+            for
+                before <- chartAt(0.0).lower
+                after  <- chartAt(5.0).lower
+                sent   <- wireOf(before, after)
+                rebuilt = applyPlan(before, sent.map((path, ui, _) => (path, ui)))
+                rebuiltHtml <- HtmlRenderer.render(rebuilt, region)
+                wholeHtml   <- HtmlRenderer.render(after, region)
+            yield
+                assert(sent.nonEmpty, "the data moved, so something must go on the wire")
+                assert(rebuiltHtml == wholeHtml)
+            end for
+        }
+
+        "an idle tick renders byte-identical candidates, so nothing goes on the wire" in {
+            for
+                before <- chartAt(0.0).lower
+                after  <- chartAt(0.0).lower
+                sent   <- wireOf(before, after)
+            yield assert(sent.isEmpty, s"an unchanged tick would have sent ${sent.map(_._1)}")
+        }
+    }
+
+end UIDiffTest
+
+object UIDiffTest:
+    case class Point(x: Double, y: Double)
+    case class Sample(at: Instant, v: Double)
+    given CanEqual[Point, Point] = CanEqual.derived
+end UIDiffTest


### PR DESCRIPTION
### Problem

Three defects in the reactive and charting surfaces, all of them visible to anyone who renders a chart or drives a signal.

Server-driven mode re-rendered and re-transmitted the WHOLE region on every change, because the diff granularity was the reactive boundary itself. `Chart(signal)(...)` is one boundary over the entire lowered SVG, so a tick carrying a handful of numbers re-sent the background, the axes, every gridline and tick label, and the legend along with the marks that actually moved, once a second, per connected viewer.

An `Instant` x-encoding rendered its default tick labels as 13-digit epoch milliseconds, because the x scale's kind was inferred from the data's runtime shape and ignored the kind the encoding itself declares. The rightmost label could also be cut mid-value at the SVG edge.

`Chart.Palette.Okabe` is documented as the colour-vision-accessible choice, so it is what an accessibility-minded caller picks, and `.dark` is what they pair it with. Okabe-Ito's first entry is pure black by definition, because the palette is specified against white, so the dark theme's `#1f2937` panel rendered the headline series at 1.43:1. WCAG 2.1 SC 1.4.11 asks 3:1 for a non-text graphical object.

### Solution

The reactive boundary now keeps the tree it last rendered, and `UIDiff` turns (previous, current) into the set of nodes to replace. Every element already renders with its own `data-kyo-path` and the client resolves a `Replace` against it, so a nested node is addressable exactly as the boundary is: no client change. An unchanged re-render sends nothing at all.

The split between what CAN be addressed and what IS sent is the correctness boundary, not an implementation detail. A node's rendering is not a function of its AST alone: an element bound to a `SignalRef` re-renders from the ref read at render time and its AST is the same object on every edit, so deciding "unchanged" from the AST silently drops real updates. `UIDiff.plan` therefore proposes candidates only, and the transport decides on rendered bytes.

The x scale's kind now comes from the encoding's declared `Plottable.kind`, so an `Instant` selects a time scale and its default labels are span-appropriate times. `AxisConfig.formatTime` hands the callback the `Instant`; `format` stays the numeric formatter. A label that would cross the SVG edge anchors inward instead of being cut.

`ChartContrast` reconciles a palette against the panel it will be drawn on, lifting only entries below 3:1 and leaving readable ones exactly as published. It applies to kyo's own colours (a named `Chart.Palette`, or the built-in default) and only on a panel they were not published against: a dark theme, or a chosen background. An explicit colour list and an explicit `colorScale` are the caller's own and are never touched.

### Notes

The diff's saving is bounded by what a chart is: measured 2.66x on a sliding time window where both the axis and the marks move, 3.1x on fixed scales. It does not approach the ratio a data channel pushing values would give, and the reason is structural rather than a shortfall in the walk: a `line` mark is ONE path element, so moving any single point rewrites the whole `d`. Closing that remainder means shipping values and re-pathing on the client, which is a new capability and a change to the rendering model.

The first cut of the palette work reconciled everything, which changed the default light rendering and broke 14 tests that correctly pinned it; the scoped rule is the second cut.

Also fixed here, found while reviewing this branch's own diff: the `UIExchange`'s per-connection state is written by one fiber PER REACTIVE REGION concurrently, and both the sent-HTML map this change adds and the pre-existing sent-classes set were plain non-thread-safe collections, where a concurrent rehash can corrupt the table rather than merely lose an entry. Both are `ConcurrentHashMap` now.

`DomTestEnv` needs jsdom, which CI installs and a fresh checkout does not; its failure now names the command that supplies it instead of Node's bare "Cannot find module".
