### PR TITLE
[kyo-test] make the published artifacts usable outside the monorepo

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,8 +15,10 @@ inputs:
 runs:
   using: composite
   steps:
+    # JVM is in this list for the kyo-test-sbt-publish scripted suite: it runs in the 2.12 pass of
+    # the JVM target and its js-plugin sub-build links and runs a real Scala.js test binary.
     - uses: actions/setup-node@v6.4.0
-      if: ${{ inputs.target == 'JS' || inputs.target == 'Wasm' }}
+      if: ${{ inputs.target == 'JS' || inputs.target == 'Wasm' || inputs.target == 'JVM' }}
       with:
         node-version: '24'
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -46,6 +46,17 @@ fileOverride {
   "glob:**/kyo-doctest/plugin/**" {
     runner.dialect = scala212
   }
+  # src only: the scripted sub-builds under sbt-publish/src/sbt-test are Scala 3 consumer projects,
+  # and the scala3 default is right for them.
+  "glob:**/kyo-test/sbt/src/**" {
+    runner.dialect = scala212
+  }
+  "glob:**/kyo-test/sbt-publish/src/main/**" {
+    runner.dialect = scala212
+  }
+  "glob:**/kyo-test/sbt-publish/src/test/**" {
+    runner.dialect = scala212
+  }
   "glob:**/kyo-ffi/plugin/**" {
     runner.dialect = scala212
   }

--- a/build.sbt
+++ b/build.sbt
@@ -261,6 +261,22 @@ Global / onLoad := {
         )
     }
 
+    // Guards publishability of the sbt plugins, which ship only by virtue of being aggregated here.
+    // A scripted suite cannot cover this: scriptedDependencies publishLocals the plugin project
+    // directly and passes whether or not any aggregate contains it.
+    locally {
+        // The expected type picks ProjectDefinition.aggregate over Project.aggregate(refs*).
+        val refs: Seq[ProjectReference] = kyoJVM.aggregate
+        val aggregated                  = refs.collect { case LocalProject(id) => id }.toSet
+        val missing                     = Set("kyo-test-sbt", "kyo-test-sbt-publish").diff(aggregated)
+        if (missing.nonEmpty) {
+            throw new IllegalStateException(
+                s"kyoJVM must aggregate ${missing.toList.sorted.mkString(", ")}; " +
+                    "projects outside the aggregate are never published by ci-release."
+            )
+        }
+    }
+
     val project =
         System.getProperty("platform", "JVM").toUpperCase match {
             case "JVM"    => kyoJVM
@@ -404,6 +420,9 @@ lazy val kyoJVM: Project = project
         `kyo-compat-plugin`,
         `kyo-doctest`.jvm,
         `kyo-doctest-plugin`,
+        // ci-release publishes from this root; an unaggregated project builds and tests but never ships.
+        `kyo-test-sbt`,
+        `kyo-test-sbt-publish`,
         `kyo-test-api`.jvm,
         `kyo-test-runner`.jvm,
         `kyo-test-prop`.jvm,
@@ -3490,54 +3509,23 @@ lazy val `kyo-test-api` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-data`)
+        .dependsOn(`kyo-core`)
         .in(file("kyo-test/api"))
         .settings(
             `kyo-settings`,
             libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
         )
         .jvmSettings(
-            mimaCheck(false),
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value
+            mimaCheck(false)
         )
         .nativeSettings(
-            `native-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeNative") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreNative") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeNative") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreNative") / Compile / fullClasspath).value
+            `native-settings`
         )
         .jsSettings(
-            `js-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJS") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJS") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJS") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJS") / Compile / fullClasspath).value
+            `js-settings`
         )
         .wasmSettings(
-            `wasm-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeWasm") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreWasm") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeWasm") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreWasm") / Compile / fullClasspath).value
+            `wasm-settings`
         )
 
 lazy val `kyo-test-runner` =
@@ -3554,51 +3542,19 @@ lazy val `kyo-test-runner` =
         .jvmSettings(
             mimaCheck(false),
             Compile / mainClass                   := Some("kyo.test.runner.Cli"),
-            libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value
+            libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided
         )
         .nativeSettings(
             `native-settings`,
-            libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeNative") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreNative") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeNative") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreNative") / Compile / fullClasspath).value
+            libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided
         )
         .jsSettings(
             `js-settings`,
-            libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJS") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJS") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJS") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJS") / Compile / fullClasspath).value
+            libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided
         )
         .wasmSettings(
             `wasm-settings`,
-            libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeWasm") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreWasm") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeWasm") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreWasm") / Compile / fullClasspath).value
+            libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided
         )
 
 lazy val `kyo-test-prop` =
@@ -3613,48 +3569,16 @@ lazy val `kyo-test-prop` =
             libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
         )
         .jvmSettings(
-            mimaCheck(false),
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value
+            mimaCheck(false)
         )
         .nativeSettings(
-            `native-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeNative") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreNative") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeNative") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreNative") / Compile / fullClasspath).value
+            `native-settings`
         )
         .jsSettings(
-            `js-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJS") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJS") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJS") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJS") / Compile / fullClasspath).value
+            `js-settings`
         )
         .wasmSettings(
-            `wasm-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeWasm") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreWasm") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeWasm") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreWasm") / Compile / fullClasspath).value
+            `wasm-settings`
         )
 
 lazy val `kyo-test-snapshot` =
@@ -3680,14 +3604,6 @@ lazy val `kyo-test-snapshot` =
         )
         .jvmSettings(
             mimaCheck(false),
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
             Compile / unmanagedSourceDirectories +=
                 baseDirectory.value.getParentFile / "jvm-native" / "src" / "main" / "scala",
             Test / unmanagedSourceDirectories +=
@@ -3695,14 +3611,6 @@ lazy val `kyo-test-snapshot` =
         )
         .nativeSettings(
             `native-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeNative") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreNative") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeNative") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreNative") / Compile / fullClasspath).value,
             Compile / unmanagedSourceDirectories +=
                 baseDirectory.value.getParentFile / "jvm-native" / "src" / "main" / "scala",
             Test / unmanagedSourceDirectories +=
@@ -3710,28 +3618,12 @@ lazy val `kyo-test-snapshot` =
         )
         .jsSettings(
             `js-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJS") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJS") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeJS") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreJS") / Compile / fullClasspath).value,
             scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
         )
         // WASM keeps WasmPlatform's ESModule linker kind (no CommonJSModule override): the
         // @JSImport("node:fs") snapshot facade resolves as an ESM import under Node.
         .wasmSettings(
-            `wasm-settings`,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeWasm") / Compile / fullClasspath).value,
-            Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-coreWasm") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-preludeWasm") / Compile / fullClasspath).value,
-            Test / unmanagedClasspath ++=
-                (LocalProject("kyo-coreWasm") / Compile / fullClasspath).value
+            `wasm-settings`
         )
 
 lazy val `kyo-test-sbt` =
@@ -3746,8 +3638,13 @@ lazy val `kyo-test-sbt` =
             sbtPlugin          := true,
             scalaVersion       := "2.12.20",
             crossScalaVersions := Seq("2.12.20"),
-            addSbtPlugin("org.scala-js"     % "sbt-scalajs"      % "1.21.0"),
-            addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.10")
+            // Must never lag project/plugins.sbt: a consumer who takes ScalaJSPlugin through this
+            // plugin links kyo's published artifacts with these versions, and Scala.js IR is
+            // forward-incompatible. Scala Native NIR has the same directional constraint.
+            addSbtPlugin("org.scala-js"     % "sbt-scalajs"      % "1.22.0"),
+            addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12"),
+            // Supplies platformDepsCrossVersion, which SbtKyoTestPlugin re-crosses through.
+            addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.2")
         )
 
 lazy val `kyo-test-sbt-publish` =
@@ -3764,5 +3661,39 @@ lazy val `kyo-test-sbt-publish` =
             buildInfoKeys                          := Seq[BuildInfoKey](BuildInfoKey.map(version) { case (_, v) => ("kyoVersion", v) }),
             buildInfoPackage                       := "kyo.test.sbt",
             buildInfoObject                        := "BuildInfo",
-            libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
+            libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test,
+            scriptedLaunchOpts := Seq(
+                // The native sub-build links a real binary in this JVM; 1G (enough for the other
+                // three) OOMs inside nativeLink.
+                "-Xmx4G",
+                "-Dplugin.version=" + version.value,
+                "-Dkyo.scalaVersion=" + scala3Version
+            ),
+            scriptedBufferLog := false,
+            // The sub-builds resolve kyo-test-runner from ivy-local, and publishLocal is not
+            // transitive, so the whole classpath closure has to be published first. Derived from the
+            // build graph rather than listed: the closure reaches kyo-config through
+            // kyo-scheduler -> kyo-stats-registry, which a hand-maintained list silently misses.
+            scriptedDependencies := Def.taskDyn {
+                val build = thisProjectRef.value.build
+                val deps  = buildDependencies.value.classpathTransitive
+                val roots = Seq("kyo-test-runnerJVM", "kyo-test-runnerJS", "kyo-test-runnerNative")
+                    .map(id => ProjectRef(build, id))
+                val closure = roots.flatMap(r => r +: deps.getOrElse(r, Nil)).distinct
+                Def.task {
+                    publishLocal.all(ScopeFilter(inProjects(closure *))).value
+                    (`kyo-test-sbt` / publishLocal).value
+                    publishLocal.value
+                    ()
+                }
+            }.value,
+            // Gate the suite through the normal test task so CI picks it up with no bespoke step.
+            // Skipped on Windows: scripted's nested sbt flakily fails to create its named-pipe boot
+            // server there (sbt/sbt#6777), failing the batch reload before any test runs.
+            Test / test := (Test / test).dependsOn(Def.taskDyn {
+                if (sys.props.getOrElse("os.name", "").toLowerCase.contains("win"))
+                    Def.task(streams.value.log.info("scripted skipped on Windows (sbt#6777)"))
+                else
+                    Def.task((scripted.toTask("")).value)
+            }).value
         )

--- a/kyo-test/README.md
+++ b/kyo-test/README.md
@@ -640,4 +640,27 @@ addSbtPlugin("io.getkyo" % "sbt-kyo-test-publish" % "<version>")
 lazy val myProject = project.enablePlugins(SbtKyoTestPlugin)
 ```
 
+The plugin resolves the right `kyo-test-runner` artifact for the project's platform and registers the
+matching framework class. To wire it by hand instead, do both yourself:
+
+```scala doctest:expect=skipped
+// JVM
+libraryDependencies += "io.getkyo" %% "kyo-test-runner" % "<version>" % Test
+Test / testFrameworks += new TestFramework("kyo.test.runner.SbtFramework")
+
+// Scala.js and Scala Native (%%% comes from the platform's own sbt plugin)
+libraryDependencies += "io.getkyo" %%% "kyo-test-runner" % "<version>" % Test
+Test / testFrameworks += new TestFramework("kyo.test.runner.JsFramework")     // Scala.js
+Test / testFrameworks += new TestFramework("kyo.test.runner.NativeFramework") // Scala Native
+```
+
+Use `%%` on the JVM: `%%%` is contributed by the Scala.js and Scala Native sbt plugins, so it does not
+exist in a JVM-only build. Use `+=` rather than `:=` for `testFrameworks`, since `:=` drops ScalaTest,
+JUnit, MUnit, and every other framework the project registers.
+
+> **Note:** sbt discovers a framework only through `Test / testFrameworks`, by class name. If the name
+> is wrong, or the artifact for the platform is missing, sbt finds no fingerprints and reports
+> `Total 0` with no error and a successful exit. Zero tests with a green build is the signature of a
+> wiring problem, not of a suite that has nothing to run.
+
 > **Note:** suite discovery from the command-line runner is JVM-only (it reads the `META-INF/services/kyo.test.Test` service-loader file); on JS and Native the CLI discovers nothing, so run those platforms through sbt, whose own fingerprint-based discovery finds every `Test` subclass. `JUnitXmlReporter` is JVM-only as well.

--- a/kyo-test/runner/js-wasm/src/main/resources/META-INF/services/sbt.testing.Framework
+++ b/kyo-test/runner/js-wasm/src/main/resources/META-INF/services/sbt.testing.Framework
@@ -1,0 +1,1 @@
+kyo.test.runner.JsFramework

--- a/kyo-test/runner/js-wasm/src/main/scala/kyo/test/runner/JsFramework.scala
+++ b/kyo-test/runner/js-wasm/src/main/scala/kyo/test/runner/JsFramework.scala
@@ -7,11 +7,14 @@ import sbt.testing.SubclassFingerprint
 
 /** Scala.js test-interface Framework entry point for kyo-test.
   *
-  * Structurally identical to [[SbtFramework]] on JVM. Discovered by the Scala.js test runner via the `sbt.testing.Framework` SPI. The
-  * scalajs-test-interface re-uses the same `sbt.testing` package; fingerprint matching and runner creation are identical.
+  * Structurally identical to [[SbtFramework]] on JVM. The scalajs-test-interface re-uses the same `sbt.testing` package; fingerprint
+  * matching and runner creation are identical.
   *
-  * The `@EnableReflectiveInstantiation` annotation is required by sbt-scalajs's `TestAdapter`, which uses
-  * `scala.scalajs.reflect.Reflect.lookupInstantiatableClass` to load Framework instances at test-run time.
+  * sbt-scalajs's `TestAdapter` loads this class by name from `Test / testFrameworks`, using
+  * `scala.scalajs.reflect.Reflect.lookupInstantiatableClass`; that is what makes the `@EnableReflectiveInstantiation` annotation
+  * load-bearing. The META-INF/services/sbt.testing.Framework file in this jar serves SPI-based tools such as scala-cli's test runner, not
+  * sbt. A class the adapter cannot instantiate is dropped silently, so a wiring mistake surfaces as zero tests and a successful exit
+  * rather than as an error.
   *
   * JS-specific behaviour:
   *   - `parallelism > 1` is silently capped to 1 (JS is single-threaded). [[JsTask]] logs a warning to stderr at task execution time when

--- a/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/SbtFramework.scala
+++ b/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/SbtFramework.scala
@@ -7,9 +7,13 @@ import sbt.testing.SubclassFingerprint
 
 /** sbt test-interface Framework entry point for kyo-test.
   *
-  * Discovered by sbt via the META-INF/services/sbt.testing.Framework service-loader file. sbt uses [[fingerprints]] to scan the test
-  * classpath for classes that extend `kyo.test.Test` and have a no-arg constructor, then passes each match to [[runner]] as a
+  * sbt finds this class by name from `Test / testFrameworks`, not through a service loader; the META-INF/services/sbt.testing.Framework
+  * file in this jar serves tools that do discover by SPI, such as scala-cli's test runner. Once loaded, sbt uses [[fingerprints]] to scan
+  * the test classpath for classes that extend `kyo.test.Test` and have a no-arg constructor, then passes each match to [[runner]] as a
   * [[sbt.testing.TaskDef]].
+  *
+  * A framework sbt cannot find contributes no fingerprints, so a wiring mistake surfaces as zero tests and a successful exit rather than
+  * as an error.
   */
 class SbtFramework extends Framework:
 

--- a/kyo-test/runner/native/src/main/scala/kyo/test/runner/NativeFramework.scala
+++ b/kyo-test/runner/native/src/main/scala/kyo/test/runner/NativeFramework.scala
@@ -7,9 +7,14 @@ import sbt.testing.SubclassFingerprint
 
 /** Scala Native test-interface Framework entry point for kyo-test.
   *
-  * Structurally identical to [[SbtFramework]] on JVM and [[JsFramework]] on Scala.js. Discovered by the Scala Native test runner via the
-  * `sbt.testing.Framework` SPI. The scala-native-test-interface re-uses the same `sbt.testing` package; fingerprint matching and runner
-  * creation are identical.
+  * Structurally identical to [[SbtFramework]] on JVM and [[JsFramework]] on Scala.js. The scala-native-test-interface re-uses the same
+  * `sbt.testing` package; fingerprint matching and runner creation are identical.
+  *
+  * The Scala Native `TestAdapter` loads this class by name from `Test / testFrameworks`, via
+  * `scala.scalanative.reflect.Reflect.lookupInstantiatableClass`; that is what makes the `@EnableReflectiveInstantiation` annotation
+  * below load-bearing. The META-INF/services/sbt.testing.Framework file in this jar serves SPI-based tools such as scala-cli's test
+  * runner, not sbt. A class the adapter cannot instantiate is dropped silently, so a wiring mistake surfaces as zero tests and a
+  * successful exit rather than as an error.
   *
   * Native-specific behaviour:
   *   - Parallelism is kept at 1 by default (our test fixture is single-threaded for simplicity, matching the plan).

--- a/kyo-test/sbt-publish/src/main/scala/kyo/test/sbt/SbtKyoTestPlugin.scala
+++ b/kyo-test/sbt-publish/src/main/scala/kyo/test/sbt/SbtKyoTestPlugin.scala
@@ -1,5 +1,6 @@
 package kyo.test.sbt
 
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import sbt._
 import sbt.Keys._
 
@@ -15,9 +16,16 @@ import sbt.Keys._
   *   .enablePlugins(SbtKyoTestPlugin)
   * }}}
   *
-  * `SbtKyoTestPlugin` extends [[KyoTestPlugin]] and additionally injects
-  * `"io.getkyo" %% "kyo-test-runner" % <version> % Test` into `libraryDependencies`,
-  * so external consumers do not need a manual `dependsOn` or explicit runner dep.
+  * `SbtKyoTestPlugin` extends [[KyoTestPlugin]] and additionally injects the matching `kyo-test-runner` into
+  * `libraryDependencies`, so external consumers need no manual `dependsOn` or explicit runner dep.
+  *
+  * The dependency is re-crossed through `platformDepsCrossVersion` so each platform resolves its own artifact. A plain `%%` yields the JVM
+  * jar everywhere; on JS and Native that still compiles, since the jar carries `.tasty`, but the framework class never reaches the linked
+  * test binary and the run reports zero tests and exits successfully.
+  *
+  * Keep this injection here rather than in [[KyoTestJsPlugin]] / [[KyoTestNativePlugin]]: those auto-trigger on
+  * `KyoTestPlugin && Scala{JS,Native}Plugin`, and `kyo-test-runner` enables `KyoTestPlugin` itself, so it would gain a dependency on its
+  * own published artifact.
   *
   * Monorepo projects continue to use `dependsOn(`kyo-test-runner` % Test)` directly
   * and are unaffected by this plugin.
@@ -27,6 +35,7 @@ object SbtKyoTestPlugin extends AutoPlugin {
     override def requires = KyoTestPlugin
 
     override def projectSettings: Seq[Setting[?]] = Seq(
-        libraryDependencies += "io.getkyo" %% "kyo-test-runner" % BuildInfo.kyoVersion % Test
+        libraryDependencies += ("io.getkyo" %% "kyo-test-runner" % BuildInfo.kyoVersion % Test)
+            .cross(platformDepsCrossVersion.value)
     )
 }

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/js-plugin/build.sbt
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/js-plugin/build.sbt
@@ -1,0 +1,10 @@
+// ScalaJSPlugin is taken transitively from sbt-kyo-test, never declared here. That is what makes
+// this sub-build fail if kyo-test-sbt's sbt-scalajs pin drifts behind the version kyo builds its
+// artifacts with: a sub-build carrying its own pin would mask the mismatch.
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(ScalaJSPlugin, SbtKyoTestPlugin)
+  .settings(
+    scalaVersion := sys.props("kyo.scalaVersion"),
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
+  )

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/js-plugin/project/plugins.sbt
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/js-plugin/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.getkyo" % "sbt-kyo-test-publish" % sys.props("plugin.version"))

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/js-plugin/src/test/scala/MySuite.scala
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/js-plugin/src/test/scala/MySuite.scala
@@ -1,0 +1,20 @@
+import kyo.test.Test
+
+class MySuite extends Test[Any]:
+    "passes" in {
+        assert(1 + 1 == 2)
+    }
+end MySuite
+
+/** Deliberately red.
+  *
+  * Broken wiring (missing artifact, wrong framework class, incomplete POM) makes sbt discover nothing
+  * and report success, so a suite that only asserts a green build cannot tell a working setup from a
+  * broken one. The `test` script requires this suite to fail; a green result here means discovery
+  * silently found no tests.
+  */
+class FailingSuite extends Test[Any]:
+    "fails" in {
+        assert(1 + 1 == 3)
+    }
+end FailingSuite

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/js-plugin/test
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/js-plugin/test
@@ -1,0 +1,10 @@
+# Compiles only if the POM carries kyo-core, which the leaf body type needs.
+> Test/compile
+
+# Discovery has to find and pass a green suite.
+> testOnly MySuite
+
+# And has to report a red one as red. This is the assertion that matters: with no framework
+# registered sbt runs nothing and exits 0, so only expecting a failure here separates a working
+# setup from a silently empty one.
+-> testOnly FailingSuite

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-manual/build.sbt
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-manual/build.sbt
@@ -1,0 +1,10 @@
+// The wiring kyo-test/README.md documents for consumers who do not use the plugin, kept executable
+// so a rename of the framework class or a change to the artifact coordinate fails here rather than
+// silently invalidating the README.
+lazy val root = project
+  .in(file("."))
+  .settings(
+    scalaVersion := sys.props("kyo.scalaVersion"),
+    libraryDependencies += "io.getkyo" %% "kyo-test-runner" % sys.props("plugin.version") % Test,
+    Test / testFrameworks += new TestFramework("kyo.test.runner.SbtFramework")
+  )

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-manual/src/test/scala/MySuite.scala
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-manual/src/test/scala/MySuite.scala
@@ -1,0 +1,20 @@
+import kyo.test.Test
+
+class MySuite extends Test[Any]:
+    "passes" in {
+        assert(1 + 1 == 2)
+    }
+end MySuite
+
+/** Deliberately red.
+  *
+  * Broken wiring (missing artifact, wrong framework class, incomplete POM) makes sbt discover nothing
+  * and report success, so a suite that only asserts a green build cannot tell a working setup from a
+  * broken one. The `test` script requires this suite to fail; a green result here means discovery
+  * silently found no tests.
+  */
+class FailingSuite extends Test[Any]:
+    "fails" in {
+        assert(1 + 1 == 3)
+    }
+end FailingSuite

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-manual/test
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-manual/test
@@ -1,0 +1,10 @@
+# Compiles only if the POM carries kyo-core, which the leaf body type needs.
+> Test/compile
+
+# Discovery has to find and pass a green suite.
+> testOnly MySuite
+
+# And has to report a red one as red. This is the assertion that matters: with no framework
+# registered sbt runs nothing and exits 0, so only expecting a failure here separates a working
+# setup from a silently empty one.
+-> testOnly FailingSuite

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-plugin/build.sbt
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-plugin/build.sbt
@@ -1,0 +1,9 @@
+// A consumer wired exactly as kyo-test/README.md documents the plugin path: enable the plugin and
+// declare nothing else. The plugin has to supply the runner artifact for this platform and register
+// the framework class.
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SbtKyoTestPlugin)
+  .settings(
+    scalaVersion := sys.props("kyo.scalaVersion")
+  )

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-plugin/project/plugins.sbt
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-plugin/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.getkyo" % "sbt-kyo-test-publish" % sys.props("plugin.version"))

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-plugin/src/test/scala/MySuite.scala
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-plugin/src/test/scala/MySuite.scala
@@ -1,0 +1,20 @@
+import kyo.test.Test
+
+class MySuite extends Test[Any]:
+    "passes" in {
+        assert(1 + 1 == 2)
+    }
+end MySuite
+
+/** Deliberately red.
+  *
+  * Broken wiring (missing artifact, wrong framework class, incomplete POM) makes sbt discover nothing
+  * and report success, so a suite that only asserts a green build cannot tell a working setup from a
+  * broken one. The `test` script requires this suite to fail; a green result here means discovery
+  * silently found no tests.
+  */
+class FailingSuite extends Test[Any]:
+    "fails" in {
+        assert(1 + 1 == 3)
+    }
+end FailingSuite

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-plugin/test
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/jvm-plugin/test
@@ -1,0 +1,10 @@
+# Compiles only if the POM carries kyo-core, which the leaf body type needs.
+> Test/compile
+
+# Discovery has to find and pass a green suite.
+> testOnly MySuite
+
+# And has to report a red one as red. This is the assertion that matters: with no framework
+# registered sbt runs nothing and exits 0, so only expecting a failure here separates a working
+# setup from a silently empty one.
+-> testOnly FailingSuite

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/native-plugin/build.sbt
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/native-plugin/build.sbt
@@ -1,0 +1,12 @@
+// ScalaNativePlugin is taken transitively from sbt-kyo-test, never declared here, so a pin that
+// drifts behind the version kyo builds its artifacts with fails this sub-build instead of hiding.
+//
+// This is also the only sub-build that proves the platform-suffixed artifact actually reaches the
+// linked binary: the JVM jar compiles fine against a Native project but contributes no NIR, so a
+// wrong cross-version links clean and runs nothing.
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(ScalaNativePlugin, SbtKyoTestPlugin)
+  .settings(
+    scalaVersion := sys.props("kyo.scalaVersion")
+  )

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/native-plugin/project/plugins.sbt
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/native-plugin/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.getkyo" % "sbt-kyo-test-publish" % sys.props("plugin.version"))

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/native-plugin/src/test/scala/MySuite.scala
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/native-plugin/src/test/scala/MySuite.scala
@@ -1,0 +1,20 @@
+import kyo.test.Test
+
+class MySuite extends Test[Any]:
+    "passes" in {
+        assert(1 + 1 == 2)
+    }
+end MySuite
+
+/** Deliberately red.
+  *
+  * Broken wiring (missing artifact, wrong framework class, incomplete POM) makes sbt discover nothing
+  * and report success, so a suite that only asserts a green build cannot tell a working setup from a
+  * broken one. The `test` script requires this suite to fail; a green result here means discovery
+  * silently found no tests.
+  */
+class FailingSuite extends Test[Any]:
+    "fails" in {
+        assert(1 + 1 == 3)
+    }
+end FailingSuite

--- a/kyo-test/sbt-publish/src/sbt-test/kyo-test/native-plugin/test
+++ b/kyo-test/sbt-publish/src/sbt-test/kyo-test/native-plugin/test
@@ -1,0 +1,10 @@
+# Compiles only if the POM carries kyo-core, which the leaf body type needs.
+> Test/compile
+
+# Discovery has to find and pass a green suite.
+> testOnly MySuite
+
+# And has to report a red one as red. This is the assertion that matters: with no framework
+# registered sbt runs nothing and exits 0, so only expecting a failure here separates a working
+# setup from a silently empty one.
+-> testOnly FailingSuite

--- a/kyo-test/sbt/src/main/scala/kyo/test/sbt/KyoTestJsPlugin.scala
+++ b/kyo-test/sbt/src/main/scala/kyo/test/sbt/KyoTestJsPlugin.scala
@@ -11,7 +11,7 @@ object KyoTestJsPlugin extends AutoPlugin {
     override def trigger  = allRequirements
     override def requires = KyoTestPlugin && ScalaJSPlugin
 
-    override def projectSettings: Seq[Setting[_]] = Seq(
+    override def projectSettings: Seq[Setting[?]] = Seq(
         testFrameworks := testFrameworks.value
             .filterNot(_.implClassNames.contains("kyo.test.runner.SbtFramework")) :+
             new TestFramework("kyo.test.runner.JsFramework")

--- a/kyo-test/sbt/src/main/scala/kyo/test/sbt/KyoTestNativePlugin.scala
+++ b/kyo-test/sbt/src/main/scala/kyo/test/sbt/KyoTestNativePlugin.scala
@@ -11,7 +11,7 @@ object KyoTestNativePlugin extends AutoPlugin {
     override def trigger  = allRequirements
     override def requires = KyoTestPlugin && ScalaNativePlugin
 
-    override def projectSettings: Seq[Setting[_]] = Seq(
+    override def projectSettings: Seq[Setting[?]] = Seq(
         testFrameworks := testFrameworks.value
             .filterNot(_.implClassNames.contains("kyo.test.runner.SbtFramework")) :+
             new TestFramework("kyo.test.runner.NativeFramework")

--- a/kyo-test/sbt/src/main/scala/kyo/test/sbt/KyoTestPlugin.scala
+++ b/kyo-test/sbt/src/main/scala/kyo/test/sbt/KyoTestPlugin.scala
@@ -32,7 +32,7 @@ object KyoTestPlugin extends AutoPlugin {
     override def trigger  = noTrigger
     override def requires = sbt.plugins.JvmPlugin
 
-    override def projectSettings: Seq[Setting[_]] = Seq(
+    override def projectSettings: Seq[Setting[?]] = Seq(
         testFrameworks += new TestFramework("kyo.test.runner.SbtFramework")
     )
 }


### PR DESCRIPTION
Fixes #1889

Problem
-------
kyo-test could not be consumed from outside this repository on any platform. Reported as #1889 against Scala Native, reproduced there and on the JVM.

Four independent defects sit on the consumer path, and they share a failure mode worth naming: sbt discovers no framework, reports Total 0, and exits successfully. A broken setup is indistinguishable from a suite with nothing to run, so nothing fails loudly and the first signal is a user noticing their tests never ran.

They also share a reason for surviving. Every module here reaches kyo-test through WithKyoTest, which supplies both the classpath the published POMs were missing and the framework class name a consumer otherwise has to guess. The monorepo exercises a path no external user can take, so it stayed green while the shipped artifacts were unusable.

The four: the documented plugin was never published, because neither plugin project was in an aggregate and ci-release publishes from the platform root; the framework class names appear nowhere a consumer reads; the POMs omitted kyo-core, kyo-prelude, and kyo-kernel, since all four modules supplied them through unmanagedClasspath, which never reaches publish metadata; and SbtKyoTestPlugin injected the runner with %%, resolving the JVM artifact on every platform.

Solution
--------
One dependsOn(kyo-core) on kyo-test-api replaces all 64 prelude/core unmanagedClasspath settings; kyo-core carries the rest transitively and the other three modules already depend on kyo-test-api. Both plugin projects join the kyoJVM aggregate, and the injected runner dependency is re-crossed through platformDepsCrossVersion so each platform resolves its own artifact. The manual wiring is documented for all three platforms, and the Framework scaladocs are reattributed: sbt loads by class name from Test/testFrameworks, while the META-INF service file serves SPI-based tools such as scala-cli's test runner.

Four scripted sub-builds guard the path against published-shape coordinates, each with a passing suite and a deliberately failing one. Requiring the failure is the point: asserting only a green build would pass against every defect above. The JS and Native sub-builds take their platform plugin transitively from sbt-kyo-test, so a stale pin fails there instead of reaching consumers.

Notes
-----
The new edge looks like it closes a loop, since kyo-data, kyo-kernel, and kyo-prelude use .withKyoTest below kyo-core. It does not: WithKyoTest wires the reverse edge as a Test-scope LocalProject task reference, so no project-graph edge exists in that direction, and the new edge is Compile scope, which never depends on Test. The removed settings created the identical task chain and differed only in being invisible to makePom.

Aggregating the plugins pulls them into scalafmtAll for the first time, where the global scala3 dialect would rewrite 2.12 sources into syntax that does not compile, so both get the scala212 fileOverride every other sbt plugin here already has. A scripted suite cannot guard the aggregation itself, since scriptedDependencies publishLocals the plugin project directly and passes either way, so that check runs in Global/onLoad.

Verified end to end on an isolated Scala Native project wired only with enablePlugins(ScalaNativePlugin, SbtKyoTestPlugin): it resolves the native artifacts, registers NativeFramework alongside the defaults, and runs 4 tests where the report had 0. Each defect was reintroduced in turn and confirmed to fail the new guards.
