### PR TITLE
[build] turn on -Xcheck-macros build-wide and fix what it finds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,6 +133,12 @@ lazy val `kyo-settings` = Seq(
     scalaVersion       := scala3Version,
     crossScalaVersions := List(scala3Version),
     scalacOptions ++= scalacOptionTokens(compilerOptions).value,
+    // Re-check every macro expansion against the compiler's tree invariants. The macros kyo does ship sit
+    // where most programs land (Tag, Frame, Schema derivation, Sql `.run`, `assert`) and read trees that
+    // inline, which is pervasive, fills with the compiler's own bindings and proxies. A malformed
+    // expansion reaches users as a broken build in their code, not ours. The Scala 2.13 cross-builds (the
+    // kyo-scheduler family) do not have the flag.
+    scalacOptions ++= (if (scalaVersion.value.startsWith("3")) Seq("-Xcheck-macros") else Nil),
     Test / scalacOptions --= scalacOptionTokens(Set(ScalacOptions.warnNonUnitStatement)).value,
     // Not in CI: parallel cross-version compilations of one module format the same shared
     // sources concurrently, and the loser logs "scalafmt: failed for 1 sources" on every
@@ -727,8 +733,7 @@ lazy val `kyo-data` =
         .withKyoTest
         .settings(
             `kyo-settings`,
-            libraryDependencies += "com.lihaoyi" %%% "pprint"        % "0.9.6",
-            libraryDependencies += "dev.zio"     %%% "izumi-reflect" % "3.0.9" % Test
+            libraryDependencies += "com.lihaoyi" %%% "pprint" % "0.9.6"
         )
         .jvmSettings(mimaCheck(false))
         .nativeSettings(`native-settings`)

--- a/kyo-data/shared/src/main/scala/kyo/Maybe.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Maybe.scala
@@ -75,7 +75,7 @@ object Maybe:
       *   a Maybe instance containing the value if the condition is true, or Absent otherwise
       */
     inline def when[A](cond: Boolean)(inline v: => A): Maybe[A] =
-        if cond then v else Absent
+        if cond then widen(Present(v)) else Absent
 
     /** Represents a defined value in a Maybe. */
     opaque type Present[+A] = A | PresentAbsent
@@ -217,7 +217,7 @@ object Maybe:
           *   a new Maybe containing the result of the function if defined, or Absent if empty
           */
         inline def map[B](inline f: A => B): Maybe[B] =
-            if isEmpty then Absent else f(get)
+            if isEmpty then Absent else widen(Present(f(get)))
 
         /** Applies a function that returns a Maybe to the contained value if defined.
           *
@@ -326,7 +326,9 @@ object Maybe:
           */
         inline def collect[B](pf: PartialFunction[A, B]): Maybe[B] =
             if isEmpty then Absent
-            else pf.applyOrElse(get, constAbsent)
+            else
+                val v = get
+                if pf.isDefinedAt(v) then widen(Present(pf(v))) else Absent
 
         /** Returns this Maybe if defined, or an alternative Maybe if empty.
           *
@@ -350,7 +352,7 @@ object Maybe:
           *   a new Maybe containing a tuple of both values if both are defined, or Absent if either is empty
           */
         def zip[B](that: Maybe[B]): Maybe[(A, B)] =
-            if isEmpty || that.isEmpty then Absent else (get, that.get)
+            if isEmpty || that.isEmpty then Absent else widen(Present((get, that.get)))
 
         /** Creates an iterator over the contained value.
           *
@@ -444,6 +446,16 @@ object Maybe:
                     new PresentAbsent(depth)
         end PresentAbsent
 
-        val constAbsent: Any => Absent = _ => Absent
+        /** Widens a `Present[A]` built by `Present.apply` to the `Maybe[A]` its constructor returns.
+          *
+          * `Present[A] <: Maybe[A]` holds by construction and needs no cast where the opaque types are
+          * transparent. It needs one where they are not: when an inline body below is expanded into user
+          * code and re-checked under `-Xcheck-macros`, the compiler sees `Present` through one inline
+          * proxy and `Maybe` through another, and does not substitute the proxy across the nesting, so
+          * `Maybe[A]` unfolds to a union naming the un-proxied `Present` and the conformance is rejected.
+          * The cast is erased, both sides being the same representation, and can go once the compiler
+          * expands the proxies of nested opaque types consistently.
+          */
+        inline def widen[A](inline v: Present[A]): Maybe[A] = v.asInstanceOf[Maybe[A]]
     end internal
 end Maybe

--- a/kyo-data/shared/src/main/scala/kyo/OrderedDict.scala
+++ b/kyo-data/shared/src/main/scala/kyo/OrderedDict.scala
@@ -442,7 +442,11 @@ object OrderedDict:
 
         /** Returns a new OrderedDict containing only entries that satisfy the predicate, preserving their relative order. */
         inline def filter(inline fn: (K, V) => Boolean): OrderedDict[K, V] =
-            reduce(
+            // The type argument is pinned rather than inferred: inference runs here, where the opaque
+            // type is transparent, and would settle on the representation. The inlined body would then
+            // carry that representation as its expected type, which the caller, where OrderedDict is
+            // abstract, cannot satisfy.
+            reduce[OrderedDict[K, V]](
                 span =>
                     val n   = Span.size(span) / 2
                     val src = Span.toArrayUnsafe(span)
@@ -487,7 +491,7 @@ object OrderedDict:
 
         /** Returns a new OrderedDict with the same keys and values transformed by the given function. */
         inline def mapValues[V2](inline fn: V => V2): OrderedDict[K, V2] =
-            reduce(
+            reduce[OrderedDict[K, V2]](
                 span =>
                     val n   = Span.size(span) / 2
                     val src = Span.toArrayUnsafe(span)

--- a/kyo-data/shared/src/main/scala/kyo/Result.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Result.scala
@@ -51,6 +51,18 @@ object Result:
 
     import internal.*
 
+    /** Widens a `Success[A]` built by `Success.apply` to the `Result[E, A]` its constructor returns.
+      *
+      * `Success[A] <: Result[E, A]` holds by construction and needs no cast where the opaque types are
+      * transparent. It needs one where they are not: when an inline body below is expanded into user
+      * code and re-checked under `-Xcheck-macros`, the compiler sees `Success` through one inline proxy
+      * and `Result` through another, and does not substitute the proxy across the nesting, so
+      * `Result[E, A]` unfolds to a union naming the un-proxied `Success` and the conformance is
+      * rejected. The cast is erased, both sides being the same representation, and can go once the
+      * compiler expands the proxies of nested opaque types consistently.
+      */
+    private[kyo] inline def widen[E, A](inline v: Success[A]): Result[E, A] = v.asInstanceOf[Result[E, A]]
+
     /** Creates a Result from an expression that might throw an exception.
       *
       * @param expr
@@ -60,7 +72,7 @@ object Result:
       */
     inline def apply[A](inline expr: => A): Result[Nothing, A] =
         try
-            Success(expr)
+            widen(Success(expr))
         catch
             case ex =>
                 Panic(ex)
@@ -158,7 +170,7 @@ object Result:
         using inline ct: ConcreteTag[E]
     )[A](inline expr: => A): Result[E, A] =
         try
-            Success(expr)
+            widen(Success(expr))
         catch
             case ct(ex) => Failure(ex)
             case ex     => Panic(ex)
@@ -498,7 +510,7 @@ object Result:
             self match
                 case self: Error[E] @unchecked => self
                 case self =>
-                    try f(self.asInstanceOf[Success[A]].getOrThrow)
+                    try f(self.asInstanceOf[Result[Nothing, A]].getOrThrow)
                     catch
                         case ex =>
                             Panic(ex)

--- a/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
@@ -41,12 +41,25 @@ private[kyo] object TagMacro:
         // class symbol's definition makes the key structurally unique: two types
         // that are genuinely the same share every symbol, so their keys match;
         // two types that share source names but differ in their definitions carry
-        // different definition positions, so their keys diverge. sym.pos returns
-        // Option[Position]; when absent (synthetic symbols, cross-JAR types)
-        // nothing is appended and the show string alone disambiguates.
+        // different definition positions, so their keys diverge. Only locally defined
+        // symbols need the position: everything else is already disambiguated by the
+        // fully qualified path `show` prints. A symbol read from a class file carries no
+        // source position, and asking one for its position makes the compiler answer with
+        // a defaulted offset 0 and report a spurious "Missing symbol position ... This is
+        // a compiler bug" warning under -Xcheck-macros, so the position is consulted only
+        // for term-owned symbols, the locally defined ones, which are always compiled from
+        // source in the current run.
+        @tailrec def isLocallyDefined(sym: Symbol): Boolean =
+            val owner = sym.maybeOwner
+            if owner.isNoSymbol then false
+            else if owner.isClassDef || owner.isPackageDef then isLocallyDefined(owner)
+            else true
+        end isLocallyDefined
         def symPositions(t: TypeRepr): String =
-            val sym     = t.typeSymbol
-            val symPart = if sym.isNoSymbol then "" else sym.pos.map(p => "@" + p.start).getOrElse("")
+            val sym = t.typeSymbol
+            val symPart =
+                if sym.isNoSymbol || !isLocallyDefined(sym) then ""
+                else sym.pos.map(p => "@" + p.start).getOrElse("")
             val children = t match
                 case AndType(a, b) => List(a, b)
                 case OrType(a, b)  => List(a, b)

--- a/kyo-data/shared/src/test/scala/kyo/MaybeTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/MaybeTest.scala
@@ -264,6 +264,33 @@ class MaybeTest extends kyo.test.Test[Any]:
             assert(Present(Absent).map(_ => Present(2)) == Present(Present(2)))
         }
 
+        "map to an absent value should nest it" in {
+            val nested = Present(1).map(_ => Maybe.empty[Int])
+            assert(nested == Present(Absent))
+            assert(!nested.isEmpty)
+            assert(nested.get == Absent)
+        }
+
+        "collect to an absent value should nest it" in {
+            val nested = Present(1).collect { case _ => Maybe.empty[Int] }
+            assert(nested == Present(Absent))
+            assert(!nested.isEmpty)
+            assert(nested.get == Absent)
+        }
+
+        "when with an absent value should nest it" in {
+            val nested = Maybe.when(true)(Maybe.empty[Int])
+            assert(nested == Present(Absent))
+            assert(!nested.isEmpty)
+            assert(nested.get == Absent)
+        }
+
+        "zip should keep an absent side nested" in {
+            val zipped = Present(Maybe.empty[Int]).zip(Present(1))
+            assert(zipped == Present((Absent, 1)))
+            assert(zipped.get == ((Absent, 1)))
+        }
+
         "filter should apply the predicate to the nested Maybe" in {
             assert(Present(Present(1)).filter(_.contains(1)) == Present(Present(1)))
             assert(Present(Present(1)).filter(_.contains(2)) == Absent)

--- a/kyo-data/shared/src/test/scala/kyo/TagTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TagTest.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import izumi.reflect.Tag as ITag
 import kyo.*
 import kyo.internal.RegisterFunction
 import kyo.internal.TagHash
@@ -218,26 +217,26 @@ class TagTest extends kyo.test.Test[Any]:
 
         "opaque types with explicit bounds" - {
             test[BoundedInt, AnyVal]
-            test[Int, BoundedInt](skipIzumiWarning = true)
+            test[Int, BoundedInt]
             test[BoundedString, AnyRef]
-            test[String, BoundedString](skipIzumiWarning = true)
+            test[String, BoundedString]
         }
 
         "opaque types with bounds different from underlying" - {
             test[BoundedCat, Animal]
-            test[Cat, BoundedCat](skipIzumiWarning = true)
+            test[Cat, BoundedCat]
             test[BoundedCat, Mammal]
         }
 
         "bounded opaque types with union underlying type" - {
             test[UnionWithBounds, Any]
-            test[Int, UnionWithBounds](skipIzumiWarning = true)
+            test[Int, UnionWithBounds]
             test[String, UnionWithBounds]
         }
 
         "bounded opaque types with intersection underlying type" - {
             test[IntersectionWithBounds, Readable]
-            test[FileImpl, IntersectionWithBounds](skipIzumiWarning = true)
+            test[FileImpl, IntersectionWithBounds]
             test[IntersectionWithBounds, Writable]
         }
 
@@ -718,7 +717,7 @@ class TagTest extends kyo.test.Test[Any]:
         }
         "Any" - {
             test[Any, Any]
-            test[Any, AnyRef](skipIzumiWarning = true) // known izumi limitation
+            test[Any, AnyRef]
             test[Any, AnyVal]
             test[List[Any], List[Int]]
         }
@@ -770,7 +769,7 @@ class TagTest extends kyo.test.Test[Any]:
             test[Box[Big.Small], Box[Big.Small]]
 
             class Box2[A]
-            def test2[A: Tag: izumi.reflect.Tag] = test[Box2[A], Box2[A]]
+            def test2[A: Tag] = test[Box2[A], Box2[A]]
             test2[Big.Sub]
         }
     }
@@ -1085,12 +1084,12 @@ class TagTest extends kyo.test.Test[Any]:
 
         "different types with similar string representation" - {
             test[1, 1.0]
-            test[1, 1L](skipIzumiWarning = true)
+            test[1, 1L]
             test['a', "a"]
             test[true, "true"]
-            test[1.0f, 1.0](skipIzumiWarning = true)
+            test[1.0f, 1.0]
             test[0, 0.0]
-            test[0, 0L](skipIzumiWarning = true)
+            test[0, 0L]
             class Box[A]
             test[Box[1], Box[1.0]]
         }

--- a/kyo-data/shared/src/test/scala/kyo/internal/TagTestMacro.scala
+++ b/kyo-data/shared/src/test/scala/kyo/internal/TagTestMacro.scala
@@ -1,7 +1,5 @@
 package kyo.internal
 
-import izumi.reflect.Tag as ITag
-import kyo.Ansi.yellow
 import kyo.Frame
 import kyo.Tag
 import scala.concurrent.Future
@@ -15,23 +13,19 @@ abstract class RegisterFunction:
 object TagTestMacro:
     case class Test(name: String, body: () => Unit)
 
-    inline def test[T1, T2](using k1: Tag[T1], i1: ITag[T1], k2: Tag[T2], i2: ITag[T2], register: RegisterFunction, frame: Frame): Unit =
+    inline def test[T1, T2](using k1: Tag[T1], k2: Tag[T2], register: RegisterFunction, frame: Frame): Unit =
         test[T1, T2]()
 
     inline def test[T1, T2](
-        inline pending: Boolean = false,
-        inline skipIzumiWarning: Boolean = false
-    )(using k1: Tag[T1], i1: ITag[T1], k2: Tag[T2], i2: ITag[T2], register: RegisterFunction, frame: Frame): Unit =
-        ${ testImpl[T1, T2]('k1, 'i1, 'k2, 'i2, 'register, '{ pending }, '{ skipIzumiWarning }, '{ frame }) }
+        inline pending: Boolean = false
+    )(using k1: Tag[T1], k2: Tag[T2], register: RegisterFunction, frame: Frame): Unit =
+        ${ testImpl[T1, T2]('k1, 'k2, 'register, '{ pending }, '{ frame }) }
 
     private def testImpl[T1: Type, T2: Type](
         k1: Expr[Tag[T1]],
-        i1: Expr[ITag[T1]],
         k2: Expr[Tag[T2]],
-        i2: Expr[ITag[T2]],
         register: Expr[RegisterFunction],
         pendingExpr: Expr[Boolean],
-        skipExpr: Expr[Boolean],
         frame: Expr[Frame]
     )(using q: Quotes): Expr[Unit] =
         import q.reflect.*
@@ -43,27 +37,16 @@ object TagTestMacro:
 
         '{
             def show[A](a: Tag[A]) = a.show.replace("kyo.TagTest.", "").replace("_$", "")
-            def failure[A, B](op: String, kyo: Boolean, compiler: Boolean, izumi: Boolean)(a: Tag[A], b: Tag[B]): String =
-                s"${show(a)} $op ${show(b)} returned Kyo: $kyo, Compiler: $compiler, Izumi: $izumi\n"
-
-            def izumiMismatch(op: String, compiler: Boolean, izumi: Boolean)(using frame: Frame): String =
-                s"""
-                |              ------------------------------ WARNING ${frame.position.show} ------------------------------
-                |Izumi's behavior for $op differs from compiler: Izumi: $izumi, Compiler: $compiler (types: ${$k1.show} $op ${$k2.show})
-                |
-                |If this is not a known limitation, report an issue: https://github.com/zio/izumi-reflect/issues/
-                |""".stripMargin.yellow
+            def failure[A, B](op: String, kyo: Boolean, compiler: Boolean)(a: Tag[A], b: Tag[B]): String =
+                s"${show(a)} $op ${show(b)} returned Kyo: $kyo, Compiler: $compiler\n"
 
             val subtypeTest = Test(
                 s"${show($k1)} <:< ${show($k2)}",
                 () =>
                     val kresult = $k1 <:< $k2
-                    val iresult = $i1 <:< $i2
-                    if ! $skipExpr && ${ Expr(compilerSubtype) } != iresult then
-                        println(izumiMismatch("<:<", ${ Expr(compilerSubtype) }, iresult))
                     assert(
                         kresult == ${ Expr(compilerSubtype) },
-                        failure("<:<", kresult, ${ Expr(compilerSubtype) }, iresult)($k1, $k2)
+                        failure("<:<", kresult, ${ Expr(compilerSubtype) })($k1, $k2)
                     )
             )
 
@@ -71,12 +54,9 @@ object TagTestMacro:
                 s"${show($k1)} >:> ${show($k2)}",
                 () =>
                     val kresult = $k1 >:> $k2
-                    val iresult = $i2 <:< $i1
-                    if ! $skipExpr && ${ Expr(compilerSupertype) } != iresult then
-                        println(izumiMismatch(">:>", ${ Expr(compilerSupertype) }, iresult))
                     assert(
                         kresult == ${ Expr(compilerSupertype) },
-                        failure(">:>", kresult, ${ Expr(compilerSupertype) }, iresult)($k1, $k2)
+                        failure(">:>", kresult, ${ Expr(compilerSupertype) })($k1, $k2)
                     )
             )
 
@@ -84,12 +64,9 @@ object TagTestMacro:
                 s"${show($k1)} =:= ${show($k2)}",
                 () =>
                     val kresult = $k1 =:= $k2
-                    val iresult = $i1 =:= $i2
-                    if ! $skipExpr && ${ Expr(compilerEquals) } != iresult then
-                        println(izumiMismatch("=:=", ${ Expr(compilerEquals) }, iresult))
                     assert(
                         kresult == ${ Expr(compilerEquals) },
-                        failure("=:=", kresult, ${ Expr(compilerEquals) }, iresult)($k2, $k1)
+                        failure("=:=", kresult, ${ Expr(compilerEquals) })($k2, $k1)
                     )
             )
 
@@ -97,12 +74,9 @@ object TagTestMacro:
                 s"${show($k1)} =!= ${show($k2)}",
                 () =>
                     val kresult = $k1 =!= $k2
-                    val iresult = !($i1 =:= $i2)
-                    if ! $skipExpr && !${ Expr(compilerEquals) } != iresult then
-                        println(izumiMismatch("=!=", !${ Expr(compilerEquals) }, iresult))
                     assert(
                         kresult != ${ Expr(compilerEquals) },
-                        failure("=!=", kresult, !${ Expr(compilerEquals) }, iresult)($k2, $k1)
+                        failure("=!=", kresult, !${ Expr(compilerEquals) })($k2, $k1)
                     )
             )
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -410,7 +410,12 @@ object `<`:
                         if kyo.tag =:= Tag[Defer] =>
                         evalLoop(kyo((), Context.empty))
                     case kyo: KyoSuspend[?, ?, ?, ?, A, Any] @unchecked =>
-                        bug.failTag(kyo, Tag[Any])
+                        // A KyoSuspend is a member of the union `<` expands to, so the cast states a
+                        // conformance that holds by construction. It is needed because this body is
+                        // inline: expanded into user code and re-checked under -Xcheck-macros, `<` is
+                        // seen through an inline proxy the compiler does not substitute into the union,
+                        // leaving the un-proxied KyoSuspend nothing to conform to. Erased.
+                        bug.failTag(kyo.asInstanceOf[A < Any], Tag[Any])
                     case v =>
                         v.unsafeGet
                 end match

--- a/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
@@ -23,6 +23,36 @@ import scala.quoted.*
   */
 @publicInBinary private[kyo] object FocusMacro:
 
+    /** Builds `Schema.init`'s `writeFn` with the lambda's parameters as ordinary terms of this scope.
+      *
+      * The natural spelling, `'{ (v, w) => ${ writeBody('v, 'w) } }`, creates the parameters inside a
+      * splice and hands them to a helper that quotes with the enclosing method's `Quotes`, so a
+      * parameter is used outside the splice that created it. That is a scope violation, it compiles
+      * only because the body happens to land back where the parameter is in scope, and
+      * `-Xcheck-macros` rejects it. Building the lambda through `Lambda` keeps the parameters and the
+      * body in a single scope, so nothing crosses a splice boundary.
+      */
+    private def writeFnExpr[A: Type](using Quotes)(body: (Expr[A], Expr[Writer]) => Expr[Unit]): Expr[(A, Writer) => Unit] =
+        import quotes.reflect.*
+        Lambda(
+            Symbol.spliceOwner,
+            MethodType(List("v", "w"))(_ => List(TypeRepr.of[A], TypeRepr.of[Writer]), _ => TypeRepr.of[Unit]),
+            (owner, params) =>
+                val List(v, w) = params.map(_.asInstanceOf[Term])
+                body(v.asExprOf[A], w.asExprOf[Writer]).asTerm.changeOwner(owner)
+        ).asExprOf[(A, Writer) => Unit]
+    end writeFnExpr
+
+    /** Builds `Schema.init`'s `readFn` the same way `writeFnExpr` builds `writeFn`. */
+    private def readFnExpr[A: Type](using Quotes)(body: Expr[Reader] => Expr[A]): Expr[Reader => A] =
+        import quotes.reflect.*
+        Lambda(
+            Symbol.spliceOwner,
+            MethodType(List("r"))(_ => List(TypeRepr.of[Reader]), _ => TypeRepr.of[A]),
+            (owner, params) => body(params.head.asInstanceOf[Term].asExprOf[Reader]).asTerm.changeOwner(owner)
+        ).asExprOf[Reader => A]
+    end readFnExpr
+
     // ==========================================================================
     // Focus navigation (Focus.Select.selectDynamic, Schema.focus / focusChain / foreachChain)
     // ==========================================================================
@@ -1519,10 +1549,12 @@ import scala.quoted.*
         end structureExpr
 
         val selfRefExpr: Expr[Schema[A]] = selfRef.asExprOf[Schema[A]]
+        val writeFn                      = writeFnExpr[A](writeBody)
+        val readFn                       = readFnExpr[A](readBody)
         val selfRhs: Expr[Schema[A]] = '{
             Schema.init[A](
-                writeFn = (v, w) => ${ writeBody('v, 'w) },
-                readFn = r => ${ readBody('r) },
+                writeFn = $writeFn,
+                readFn = $readFn,
                 variantDecoders = $variantDecodersExpr,
                 representation = Schema.UnionRepresentation.Untagged,
                 structure = ${ structureExpr }
@@ -2020,12 +2052,14 @@ import scala.quoted.*
 
         // Build the Schema.init term first so every fieldSchemaExprTyped / structure call has
         // populated `hoistedSchemas`, then prepend the hoisted lazy vals as a wrapping block.
-        val cfg = desugarProductConfig[A](sym, tpe)
+        val cfg     = desugarProductConfig[A](sym, tpe)
+        val writeFn = writeFnExpr[A](writeBody)
+        val readFn  = readFnExpr[A](readBody)
         val schemaInitTerm: Term =
             '{
                 Schema.init[A](
-                    writeFn = (v, w) => ${ writeBody('v, 'w) },
-                    readFn = r => ${ readBody('r) },
+                    writeFn = $writeFn,
+                    readFn = $readFn,
                     sourceFields = $sourceFields,
                     renamedFields = ${ cfg.renamedFields },
                     droppedFields = ${ cfg.droppedFields },
@@ -2293,11 +2327,13 @@ import scala.quoted.*
             }
             '{ kyo.Chunk.from[kyo.Codec.Reader => Any](Array[kyo.Codec.Reader => Any](${ Varargs(perVariant) }*)) }
         end variantDecodersExpr
-        val cfg = desugarSumConfig(sym, tpe, children)
+        val cfg     = desugarSumConfig(sym, tpe, children)
+        val writeFn = writeFnExpr[A](writeBody)
+        val readFn  = readFnExpr[A](readBody)
         val selfRhs: Expr[Schema[A]] = '{
             Schema.init[A](
-                writeFn = (v, w) => ${ writeBody('v, 'w) },
-                readFn = r => ${ readBody('r) },
+                writeFn = $writeFn,
+                readFn = $readFn,
                 sourceFields = $sourceFields,
                 variantDecoders = $variantDecodersExpr,
                 discriminatorField = ${ cfg.discriminatorField },

--- a/kyo-sql/shared/src/main/scala/kyo/Sql.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/Sql.scala
@@ -1138,12 +1138,12 @@ object Sql:
               *     that the backend does not yet implement. Re-derive the schema without the unsupported structural type, or supply a
               *     custom decoder via [[SqlCodec.of]].
               */
-            inline def run(using SqlSchema[A], Frame): Chunk[A] < (Abort[SqlException] & DB) =
-                ${ kyo.internal.SqlRunMacro.runQueryImpl[A]('q) }
+            inline def run(using ev: SqlSchema[A], frame: Frame): Chunk[A] < (Abort[SqlException] & DB) =
+                ${ kyo.internal.SqlRunMacro.runQueryImpl[A]('q, 'ev, 'frame) }
 
             /** Requires compile-time AST reduction; produces a compile error if the AST is not reducible. */
-            inline def runStatic(using SqlSchema[A], Frame): Chunk[A] < (Abort[SqlException] & DB) =
-                ${ kyo.internal.SqlRunMacro.runQueryStaticImpl[A]('q) }
+            inline def runStatic(using ev: SqlSchema[A], frame: Frame): Chunk[A] < (Abort[SqlException] & DB) =
+                ${ kyo.internal.SqlRunMacro.runQueryStaticImpl[A]('q, 'ev, 'frame) }
         end extension
 
         extension [A](q: Query[A])
@@ -1221,11 +1221,17 @@ object Sql:
         inline def groupBy[N <: String & Singleton, V, FT <: Tuple](inline key: Record[F] => Column[N, V])(using
             Fields.Aux[T, FT]
         ): GroupBy[T, RewriteGrouped[FT, (N ~ Unit) *: EmptyTuple]] =
-            val ks = Chunk(key(columns))
+            // The key chunk is built at each use rather than bound to a val: a binding in an inline body is a
+            // definition, and the inline chain moves it without re-owning it, which fails the tree check when
+            // the static-SQL lift reads this query back. `key` is a column selection, so building it twice
+            // costs one extra chunk at query-construction time.
             new GroupBy[T, RewriteGrouped[FT, (N ~ Unit) *: EmptyTuple]](
                 this,
-                ks,
-                kyo.internal.SqlGroupedView.buildGroupedView[RewriteGrouped[FT, (N ~ Unit) *: EmptyTuple]](this, ks),
+                Chunk(key(columns)),
+                kyo.internal.SqlGroupedView.buildGroupedView[RewriteGrouped[FT, (N ~ Unit) *: EmptyTuple]](
+                    this,
+                    Chunk(key(columns))
+                ),
                 Maybe.empty,
                 GroupBy.Kind.Plain
             )
@@ -1535,11 +1541,17 @@ object Sql:
         inline def groupBy[N <: String & Singleton, V, FT <: Tuple](inline key: Record[F] => Column[N, V])(using
             Fields.Aux[T, FT]
         ): GroupBy[T, RewriteGrouped[FT, (N ~ Unit) *: EmptyTuple]] =
-            val ks = Chunk(key(columns))
+            // The key chunk is built at each use rather than bound to a val: a binding in an inline body is a
+            // definition, and the inline chain moves it without re-owning it, which fails the tree check when
+            // the static-SQL lift reads this query back. `key` is a column selection, so building it twice
+            // costs one extra chunk at query-construction time.
             new GroupBy[T, RewriteGrouped[FT, (N ~ Unit) *: EmptyTuple]](
                 this,
-                ks,
-                kyo.internal.SqlGroupedView.buildGroupedView[RewriteGrouped[FT, (N ~ Unit) *: EmptyTuple]](this, ks),
+                Chunk(key(columns)),
+                kyo.internal.SqlGroupedView.buildGroupedView[RewriteGrouped[FT, (N ~ Unit) *: EmptyTuple]](
+                    this,
+                    Chunk(key(columns))
+                ),
                 Maybe.empty,
                 GroupBy.Kind.Plain
             )
@@ -1929,8 +1941,8 @@ object Sql:
         extension [T, F](inline ins: Insert[T, F])
 
             /** Try the static-emission path; fall back to the runtime renderer if the AST is not reducible at compile time. */
-            inline def run(using Frame): SqlClient.InsertOutcome < (Abort[SqlException] & DB) =
-                ${ kyo.internal.SqlRunMacro.runInsertImpl[T, F]('ins) }
+            inline def run(using frame: Frame): SqlClient.InsertOutcome < (Abort[SqlException] & DB) =
+                ${ kyo.internal.SqlRunMacro.runInsertImpl[T, F]('ins, 'frame) }
 
             /** Requires compile-time AST reduction; produces a compile error if the AST is not reducible. */
             inline def runStatic(using Frame): SqlClient.InsertOutcome < (Abort[SqlException] & DB) =
@@ -2021,8 +2033,8 @@ object Sql:
         extension [T, F](inline upd: Update[T, F])
 
             /** Try the static-emission path; fall back to the runtime renderer if the AST is not reducible at compile time. */
-            inline def run(using Frame): Long < (Abort[SqlException] & DB) =
-                ${ kyo.internal.SqlRunMacro.runUpdateImpl[T, F]('upd) }
+            inline def run(using frame: Frame): Long < (Abort[SqlException] & DB) =
+                ${ kyo.internal.SqlRunMacro.runUpdateImpl[T, F]('upd, 'frame) }
 
             /** Requires compile-time AST reduction; produces a compile error if the AST is not reducible. */
             inline def runStatic(using Frame): Long < (Abort[SqlException] & DB) =
@@ -2080,8 +2092,8 @@ object Sql:
         extension [T, F](inline del: Delete[T, F])
 
             /** Try the static-emission path; fall back to the runtime renderer if the AST is not reducible at compile time. */
-            inline def run(using Frame): Long < (Abort[SqlException] & DB) =
-                ${ kyo.internal.SqlRunMacro.runDeleteImpl[T, F]('del) }
+            inline def run(using frame: Frame): Long < (Abort[SqlException] & DB) =
+                ${ kyo.internal.SqlRunMacro.runDeleteImpl[T, F]('del, 'frame) }
 
             /** Requires compile-time AST reduction; produces a compile error if the AST is not reducible. */
             inline def runStatic(using Frame): Long < (Abort[SqlException] & DB) =

--- a/kyo-sql/shared/src/main/scala/kyo/internal/FromExprDerived.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/FromExprDerived.scala
@@ -461,6 +461,14 @@ object FromExprDerived:
         // recomputation when the same Ident is referenced from N sites). termMemo caches per-input-
         // Term substitution result (preserves referential sharing in the output, so the next
         // iteration's collector, which is visited-set guarded, walks the shared subtree once).
+        // A closure literal is `Block(List(<anonfun DefDef>), Closure(<ref to it>, _))`: the wrapper is the value
+        // itself rather than something wrapping a value, and `Closure.meth` refers to the def beside it, so the
+        // statements cannot be dropped and the term is passed through whole. Any other statement list belongs to a
+        // wrapper and is dead once substitution has run.
+        def isClosureLiteral(expr: Term): Boolean =
+            expr match
+                case _: Closure => true
+                case _          => false
         val identMemo = scala.collection.mutable.Map.empty[Symbol, Term]
         val termMemo  = new java.util.IdentityHashMap[Term, Term]()
         val Fuel      = 1000000
@@ -545,6 +553,29 @@ object FromExprDerived:
                                     case _                        => Select.copy(sel)(resolvedReceiver, fieldName)
                             case _ => Select.copy(sel)(resolvedReceiver, fieldName)
                         end match
+                    // `Inlined` and `Block` are the only terms carrying a statement list, so they are the
+                    // only ones whose rebuild runs a definition through a checked constructor: the default
+                    // `TreeMap` transforms the statements, and `ValDef.copy` / `Block.copy` assert that each
+                    // definition's owner matches where it now sits (`-Xcheck-macros`). The compiler relocates
+                    // its own inline bindings without re-owning them, so those assertions fire on definitions
+                    // this rewriter only passes through and never reads. Both wrappers are dropped instead:
+                    // pass 1 has already collected every binding, and the statement lists are dead once the
+                    // `Ident`s referencing them are substituted, which is the same reason `peel` and the
+                    // walkers' `unwrap` strip them.
+                    //
+                    // A closure literal is the exception: its statements are part of the value rather than a
+                    // wrapper around one, so it keeps the default traversal. Dropping them would strand
+                    // `Closure.meth` and destroy the redex `betaReduceFully` looks for, and skipping the body
+                    // would leave the bindings a projection inside it reads unresolved, which stops the
+                    // statement folding. That traversal rebuilds the `DefDef`, so its own check still applies,
+                    // but only to what a closure body actually holds rather than to every wrapper passed
+                    // through on the way.
+                    case in @ Inlined(_, _, expansion) =>
+                        if isClosureLiteral(expansion) then super.transformTerm(in)(owner)
+                        else transformTerm(expansion)(owner)
+                    case bl @ Block(_, expr) =>
+                        if isClosureLiteral(expr) then super.transformTerm(bl)(owner)
+                        else transformTerm(expr)(owner)
                     case other => super.transformTerm(other)(owner)
                 termMemo.put(t, result)
                 result

--- a/kyo-sql/shared/src/main/scala/kyo/internal/SqlAstInternal.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/SqlAstInternal.scala
@@ -2,6 +2,8 @@ package kyo.internal
 
 import kyo.*
 import kyo.Sql.*
+import scala.compiletime.constValue
+import scala.compiletime.erasedValue
 import scala.compiletime.summonFrom
 
 /** Macro-facing helpers for [[kyo.Sql]].
@@ -40,18 +42,37 @@ private[kyo] object SqlAstInternal:
         )
     end resolveSqlName
 
-    transparent inline def buildColumns[T, N <: String & Singleton](alias: N)(using Fields[T]) =
-        alias ~ Record.stageNamed[T] {
-            [n <: String & Singleton, v] =>
-                (g: Field[n, v]) =>
-                    Column[n & String, v](alias, g.name, resolveSqlName[T](g.name))
-        }
+    /** Builds the per-field column dictionary the two entry points below wrap in a `Record`.
+      *
+      * Written as an inline recursion over the field tuple rather than through `Record.stageNamed`, whose
+      * API is a staging function. The compiler reduces the per-field application of such a function by
+      * binding its type parameters and its argument, and the inline chain above then moves those bindings
+      * without re-owning them. Every `.run` on a query reads this tree back through `FromExprDerived`, and
+      * reading a tree with a mis-owned definition in it fails under `-Xcheck-macros`. Constructing the
+      * columns directly leaves no definitions in the tree to be moved, and the static-SQL lift reads
+      * `Column.apply` straight off it rather than beta-reducing a closure first.
+      */
+    private[kyo] inline def columnsDict[T, Fs <: Tuple](alias: String): Dict[String, Any] =
+        inline erasedValue[Fs] match
+            case _: EmptyTuple        => Dict.empty[String, Any]
+            case _: ((n ~ v) *: rest) =>
+                // The name is spelled out at each use rather than bound to a val: `constValue` folds to the
+                // same literal at each, and a binding here is a definition the inline chain above would
+                // move without re-owning, which is the whole point of building the columns this way.
+                columnsDict[T, rest](alias) ++
+                    Dict[String, Any](
+                        constValue[n & String & Singleton] ->
+                            Column[n & String & Singleton, v](
+                                alias,
+                                constValue[n & String & Singleton],
+                                resolveSqlName[T](constValue[n & String & Singleton])
+                            )
+                    )
 
-    transparent inline def buildRowColumns[T](using Fields[T]) =
-        Record.stageNamed[T] {
-            [n <: String & Singleton, v] =>
-                (g: Field[n, v]) =>
-                    Column[n & String, v]("", g.name, resolveSqlName[T](g.name))
-        }
+    transparent inline def buildColumns[T, N <: String & Singleton](alias: N)(using f: Fields[T]) =
+        alias ~ new Record(columnsDict[T, f.AsTuple](alias)).asInstanceOf[Record[f.MapNamed[Column]]]
+
+    transparent inline def buildRowColumns[T](using f: Fields[T]) =
+        new Record(columnsDict[T, f.AsTuple]("")).asInstanceOf[Record[f.MapNamed[Column]]]
 
 end SqlAstInternal

--- a/kyo-sql/shared/src/main/scala/kyo/internal/SqlRunMacro.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/SqlRunMacro.scala
@@ -20,31 +20,34 @@ import scala.quoted.*
   */
 object SqlRunMacro:
 
-    def runQueryImpl[A: Type](q: Expr[Query[A]])(using Quotes): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
-        val ev = summonEvidence[A](q)
+    def runQueryImpl[A: Type](q: Expr[Query[A]], ev: Expr[SqlSchema[A]], frame: Expr[Frame])(using
+        Quotes
+    ): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
         SqlStaticMacro.tryImpl(widenStatement(q)) match
-            case Present(rendered) => emitQuery[A](rendered, ev)
-            // The using args are supplied explicitly because `A` is abstract in this macro, so the quote cannot resolve the evidence
-            // itself; `Frame` resolves at the splice site. No naming is threaded: the decode is positional by construction on both
-            // the static path and this fallback.
-            case Absent => '{ $q.runDynamic(using summon[Frame], $ev) }
+            case Present(rendered) => emitQuery[A](rendered, ev, frame)
+            // The using args are supplied explicitly rather than summoned in the quote: `A` is abstract in this macro, so the quote
+            // cannot resolve the evidence itself, and re-summoning the `Frame` would discard the one the caller already threaded and
+            // derive a fresh one at the splice site. No naming is threaded: the decode is positional by construction on both the
+            // static path and this fallback.
+            case Absent => '{ $q.runDynamic(using $frame, $ev) }
         end match
     end runQueryImpl
 
-    def runQueryStaticImpl[A: Type](q: Expr[Query[A]])(using Quotes): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
+    def runQueryStaticImpl[A: Type](q: Expr[Query[A]], ev: Expr[SqlSchema[A]], frame: Expr[Frame])(using
+        Quotes
+    ): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
         // SqlStaticMacro.impl reports the precise position and message when the AST cannot be folded.
-        val ev = summonEvidence[A](q)
-        emitQuery[A](SqlStaticMacro.impl(widenStatement(q)), ev)
+        emitQuery[A](SqlStaticMacro.impl(widenStatement(q)), ev, frame)
     end runQueryStaticImpl
 
     // --- Insert[T, F] ---
 
-    def runInsertImpl[T: Type, F: Type](ins: Expr[Insert[T, F]])(using
+    def runInsertImpl[T: Type, F: Type](ins: Expr[Insert[T, F]], frame: Expr[Frame])(using
         Quotes
     ): Expr[SqlClient.InsertOutcome < (Abort[SqlException] & DB)] =
         SqlStaticMacro.tryImpl(widenStatement(ins)) match
             case Present(rendered) => emitInsert(rendered)
-            case Absent            => '{ $ins.runDynamic(using summon[Frame]) }
+            case Absent            => '{ $ins.runDynamic(using $frame) }
 
     def runInsertStaticImpl[T: Type, F: Type](ins: Expr[Insert[T, F]])(using
         Quotes
@@ -53,10 +56,12 @@ object SqlRunMacro:
 
     // --- Update[T, F] ---
 
-    def runUpdateImpl[T: Type, F: Type](upd: Expr[Update[T, F]])(using Quotes): Expr[Long < (Abort[SqlException] & DB)] =
+    def runUpdateImpl[T: Type, F: Type](upd: Expr[Update[T, F]], frame: Expr[Frame])(using
+        Quotes
+    ): Expr[Long < (Abort[SqlException] & DB)] =
         SqlStaticMacro.tryImpl(widenStatement(upd)) match
             case Present(rendered) => emitUpdate(rendered)
-            case Absent            => '{ $upd.runDynamic(using summon[Frame]) }
+            case Absent            => '{ $upd.runDynamic(using $frame) }
 
     def runUpdateStaticImpl[T: Type, F: Type](upd: Expr[Update[T, F]])(using
         Quotes
@@ -65,10 +70,12 @@ object SqlRunMacro:
 
     // --- Delete[T, F] ---
 
-    def runDeleteImpl[T: Type, F: Type](del: Expr[Delete[T, F]])(using Quotes): Expr[Long < (Abort[SqlException] & DB)] =
+    def runDeleteImpl[T: Type, F: Type](del: Expr[Delete[T, F]], frame: Expr[Frame])(using
+        Quotes
+    ): Expr[Long < (Abort[SqlException] & DB)] =
         SqlStaticMacro.tryImpl(widenStatement(del)) match
             case Present(rendered) => emitUpdate(rendered)
-            case Absent            => '{ $del.runDynamic(using summon[Frame]) }
+            case Absent            => '{ $del.runDynamic(using $frame) }
 
     def runDeleteStaticImpl[T: Type, F: Type](del: Expr[Delete[T, F]])(using
         Quotes
@@ -95,13 +102,14 @@ object SqlRunMacro:
       */
     private def emitQuery[A: Type](
         rendered: Expr[Sql.Rendered],
-        schemaExpr: Expr[SqlSchema[A]]
+        schemaExpr: Expr[SqlSchema[A]],
+        frame: Expr[Frame]
     )(using Quotes): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
         '{
             DB.state.map { state =>
                 val r = $rendered
                 r.sqlForOrFail(state.client.dialect.id).map(sql =>
-                    state.client.internalExecuteQuery[A](sql, r.params, state.config)(using summon[Frame], $schemaExpr)
+                    state.client.internalExecuteQuery[A](sql, r.params, state.config)(using $frame, $schemaExpr)
                 )
             }
         }
@@ -125,20 +133,5 @@ object SqlRunMacro:
                 r.sqlForOrFail(state.client.dialect.id).map(sql => state.client.internalExecuteInsert(sql, r.params, state.config))
             }
         }
-
-    /** The [[kyo.SqlSchema]] evidence that proves `A` is SQL-storable, or a compile error at the call site telling the caller how to make it
-      * one. The evidence is what admits `A` to a run; its carried schema (`.schema`) is the codec the decode runs through.
-      */
-    private def summonEvidence[A: Type](q: Expr[?])(using Quotes): Expr[SqlSchema[A]] =
-        import quotes.reflect.*
-        Expr.summon[SqlSchema[A]].getOrElse(
-            report.errorAndAbort(
-                s"${Type.show[A]} is not a SQL-storable result type. Add `derives SqlSchema` to ${Type.show[A]} (its fields must all be " +
-                    s"single-column SQL types), or install a `given SqlSchema.Column[${Type.show[A]}]` (Sql.jsonColumn, Sql.enumText, " +
-                    s"SqlSchema.of) for a custom single-column codec.",
-                q.asTerm.pos
-            )
-        )
-    end summonEvidence
 
 end SqlRunMacro

--- a/kyo-sql/shared/src/test/scala/kyo/SqlRunMacroTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/SqlRunMacroTest.scala
@@ -1,0 +1,73 @@
+package kyo
+
+import kyo.Sql.*
+import scala.compiletime.testing.typeCheckErrors
+
+/** Pins the shape of what [[kyo.internal.SqlRunMacro]] emits, on both of `.run`'s paths.
+  *
+  * `.run` folds the statement when it can and emits `.runDynamic` when it cannot, and the two differ in what reaches the compiler
+  * afterwards. The folded path emits SQL string constants and drops the query tree entirely. The fallback splices the query tree back into
+  * the expansion, and an expansion is re-checked against the compiler's tree invariants under `-Xcheck-macros`, which every module in this
+  * build compiles with. That check does not run over ordinary inlined code, so it is only ever the macro re-emitting the tree that exposes
+  * it.
+  *
+  * This module is the only place the fallback can be pinned: `SqlStaticMacro` reads the compile classpath for dialects, `kyo-sql` declares
+  * none (the engine modules depend on it rather than the reverse), so every `.run` here renders at run time. In every other module the same
+  * calls fold and the branch is never taken.
+  *
+  * The queries are chained rather than bare because chaining is what makes the tree hard: each inline combinator applied to a value leaves
+  * the compiler a receiver binding and a proxy for its `using` parameters, and those are the definitions whose owners the check reads.
+  */
+class SqlRunMacroTest extends Test:
+
+    case class Person(id: Long, name: String, age: Int, deptId: Long) derives SqlSchema
+
+    "the fallback expansion is well-formed" - {
+
+        "for a chained select" in {
+            val errors = typeCheckErrors(
+                """def probe(using f: Frame): Chunk[String] < (Abort[SqlException] & DB) =
+    Sql.from[Person]("p").where(c => c.p.age >= 18).select(c => c.p.name).run"""
+            )
+            assert(errors.isEmpty, errors.map(_.message).mkString("\n"))
+        }
+
+        "for a deeper chain" in {
+            val errors = typeCheckErrors(
+                """def probe(using f: Frame): Chunk[String] < (Abort[SqlException] & DB) =
+    Sql.from[Person]("p").where(c => c.p.age >= 18).select(c => c.p.name).limit(10).run"""
+            )
+            assert(errors.isEmpty, errors.map(_.message).mkString("\n"))
+        }
+
+        "for an update" in {
+            val errors = typeCheckErrors(
+                """def probe(using f: Frame): Long < (Abort[SqlException] & DB) =
+    Sql.update[Person].set(_.name := "x").where(_.id == 1L).run"""
+            )
+            assert(errors.isEmpty, errors.map(_.message).mkString("\n"))
+        }
+
+        "for a delete" in {
+            val errors = typeCheckErrors(
+                """def probe(using f: Frame): Long < (Abort[SqlException] & DB) =
+    Sql.delete[Person].where(_.id == 1L).run"""
+            )
+            assert(errors.isEmpty, errors.map(_.message).mkString("\n"))
+        }
+    }
+
+    "the run evidence is the one the call site supplies" in {
+        // `.run` takes `using SqlSchema[A]`, and what it decodes through has to be that argument rather than whatever a fresh implicit
+        // search would find. The two coincide wherever only the derived given is in scope, so the difference is only observable with a
+        // second instance the call site names explicitly.
+        val explicit = summon[SqlSchema[Person]]
+        val errors = typeCheckErrors(
+            """def probe(using f: Frame): Chunk[String] < (Abort[SqlException] & DB) =
+    Sql.from[Person]("p").select(c => c.p.name).run(using summon[SqlSchema[String]], f)"""
+        )
+        assert(errors.isEmpty, errors.map(_.message).mkString("\n"))
+        assert(explicit.width == 4)
+    }
+
+end SqlRunMacroTest

--- a/kyo-test/api/shared/src/main/scala/kyo/test/internal/AssertMacro.scala
+++ b/kyo-test/api/shared/src/main/scala/kyo/test/internal/AssertMacro.scala
@@ -31,6 +31,57 @@ object AssertMacro:
         sys.props.get("kyo.test.powerAssert").orElse(sys.env.get("KYO_TEST_POWER_ASSERT")).exists(truthy)
     end powerAssertEnabled
 
+    /** The same flag as a compile-time constant, so `assert` can branch on it with an `inline if`.
+      *
+      * The branch matters beyond instrumentation: only the power-assert path needs to take the condition
+      * apart, and only that path puts the caller's expression inside a macro expansion. Off the power
+      * path the condition is left in the inline body untouched, so `-Xcheck-macros` never re-checks user
+      * code that it did not already check where the user wrote it. That re-checking is not free: the
+      * compiler mis-substitutes its inline proxies for nested opaque types, so re-checking an ordinary
+      * `A < S1 < S2` or a staged `Record` rejects it, and every assert over such a value would fail to
+      * compile for anyone running with the flag.
+      */
+    inline def powerAssertCompiledIn: Boolean = ${ powerAssertCompiledInImpl }
+
+    private def powerAssertCompiledInImpl(using Quotes): Expr[Boolean] = Expr(powerAssertEnabled)
+
+    /** Records that the leaf evaluated an assertion.
+      *
+      * Called from the inline `assert` body rather than spliced, so the `private[kyo]` access happens
+      * here rather than at the call site, which can be any user package.
+      */
+    def evaluated(scope: AssertScope): Unit = scope.recordEvaluated()
+
+    /** Builds the failure from an assert whose condition was false, records it into the leaf, and throws.
+      *
+      * Recording before the throw is what lets a failure raised by a detached or leaked fiber reach the
+      * leaf sink even when its throw never returns to the joined body.
+      *
+      * The source text comes from the frame the assert already carries, so the path that does not compile
+      * in the power-assert instrumentation needs no macro of its own. The frame's marker sits at the end
+      * of the `assert(...)` call it was taken at, so the text before it, last line, is that call.
+      */
+    def raise(msg: Maybe[String], frame: Frame, scope: AssertScope): Nothing =
+        val sourceText =
+            frame.snippet.split("📍")(0).linesIterator.toList.lastOption.getOrElse("").trim
+        val diagram =
+            msg match
+                case Maybe.Present(m) if m.nonEmpty => s"$sourceText\n// message: $m"
+                case _                              => sourceText
+        val failure = new kyo.test.AssertionFailed(diagram, frame, msg, Maybe.empty[Throwable])
+        scope.record(failure)
+        throw failure
+    end raise
+
+    // A splice has to be the whole right-hand side of its inline def, so each of the two power-assert
+    // entry points gets one of its own.
+
+    inline def power(inline cond: Boolean, inline f: Frame, inline as: AssertScope): Unit =
+        ${ assertImpl('cond, 'f, 'as) }
+
+    inline def powerWithMsg(inline cond: Boolean, inline msg: String, inline f: Frame, inline as: AssertScope): Unit =
+        ${ assertWithMsgImpl('cond, 'msg, 'f, 'as) }
+
     /** Macro implementation for `assert(cond: Boolean)`, scope-threaded (the leaf evidence value). */
     def assertImpl(cond: Expr[Boolean], frame: Expr[Frame], scope: Expr[AssertScope])(using Quotes): Expr[Unit] =
         instrumentAndCheck(cond, frame, '{ Maybe.empty[String] }, scope)
@@ -58,6 +109,23 @@ object AssertMacro:
     def cancelImpl(msg: Expr[String], frame: Expr[Frame])(using Quotes): Expr[Nothing] =
         '{ throw new kyo.test.TestCancelled($msg)(using $frame) }
 
+    // Extract the source line for the diagram header at compile time.
+    //
+    // Off the power path the condition reaches this through `assert`'s inline body, so its position can
+    // land in TestBase.scala, whose source is a jar for every module but kyo-test itself and so reads
+    // back empty. The macro-expansion position is the caller's own `assert(...)`, which always has
+    // source, so it stands in when the condition's own position yields nothing.
+    private def sourceText(cond: Expr[Boolean])(using Quotes): String =
+        import quotes.reflect.*
+        def textOf(pos: Position): Option[String] =
+            pos.sourceCode.orElse {
+                pos.sourceFile.content
+                    .flatMap(_.linesIterator.drop(pos.startLine).nextOption())
+                    .map(_.drop(math.max(0, pos.startColumn)))
+            }.filter(_.nonEmpty)
+        textOf(cond.asTerm.pos).orElse(textOf(Position.ofMacroExpansion)).getOrElse("")
+    end sourceText
+
     private def instrumentAndCheck(
         cond: Expr[Boolean],
         frame: Expr[Frame],
@@ -75,21 +143,9 @@ object AssertMacro:
         // relative to `baseCol` (see `instrument`). When `sourceCode` is absent we fall back
         // to the raw file line, which still carries the leading indentation, so we drop
         // `baseCol` leading characters to de-indent it to the same column 0 base.
-        val condTerm  = cond.asTerm
-        val sourcePos = condTerm.pos
-        val baseCol   = sourcePos.startColumn
-        val sourceLine: String =
-            sourcePos.sourceCode.getOrElse(
-                sourcePos.sourceFile.content
-                    .getOrElse("")
-                    .linesIterator
-                    .drop(sourcePos.startLine)
-                    .nextOption()
-                    .getOrElse("")
-                    .drop(math.max(0, baseCol))
-            )
+        val baseCol = cond.asTerm.pos.startColumn
 
-        val sourceLineExpr: Expr[String] = Expr(sourceLine)
+        val sourceLineExpr: Expr[String] = Expr(sourceText(cond))
 
         if powerAssertEnabled then
             '{

--- a/kyo-test/api/shared/src/main/scala/kyo/test/internal/TestBase.scala
+++ b/kyo-test/api/shared/src/main/scala/kyo/test/internal/TestBase.scala
@@ -344,11 +344,21 @@ abstract class TestBase[S] extends KyoTestReflect with TypeCheck:
 
     /** Power-assert that throws `AssertionFailed` on `cond == false`, including a diagram of subexpression values to aid diagnosis. */
     protected inline def assert(inline cond: Boolean)(using inline f: Frame, inline as: kyo.test.AssertScope): Unit =
-        ${ kyo.test.internal.AssertMacro.assertImpl('cond, 'f, 'as) }
+        inline if kyo.test.internal.AssertMacro.powerAssertCompiledIn then
+            kyo.test.internal.AssertMacro.power(cond, f, as)
+        else
+            kyo.test.internal.AssertMacro.evaluated(as)
+            if !cond then kyo.test.internal.AssertMacro.raise(kyo.Maybe.empty[String], f, as)
+            end if
 
     /** Power-assert with an explicit user message appended to the diagram on failure. */
     protected inline def assert(inline cond: Boolean, inline msg: String)(using inline f: Frame, inline as: kyo.test.AssertScope): Unit =
-        ${ kyo.test.internal.AssertMacro.assertWithMsgImpl('cond, 'msg, 'f, 'as) }
+        inline if kyo.test.internal.AssertMacro.powerAssertCompiledIn then
+            kyo.test.internal.AssertMacro.powerWithMsg(cond, msg, f, as)
+        else
+            kyo.test.internal.AssertMacro.evaluated(as)
+            if !cond then kyo.test.internal.AssertMacro.raise(kyo.Maybe(msg), f, as)
+            end if
 
     /** Marks a leaf as intentionally asserting no runtime value: its verification is structural (it compiles,
       * runs without error, or matched an expected case) rather than a checked value. Records an evaluation so the


### PR DESCRIPTION
Fixes #1733

### Problem

Issue #1733 reports `Abort.fail` printing "Missing symbol position" and "This is a compiler bug" under `-Xcheck-macros`. It is ours, not the compiler's: `TagMacro` asks every type symbol for a source position, and a symbol read from a class file has none.

The flag was off everywhere, so that class of defect had no coverage. It matters more here than the macro count suggests. The macros kyo ships are few and deliberate, but they sit where most programs land (`Tag`, `Frame`, `Schema` derivation, `.run`, `assert`) and they read trees that `inline`, which is pervasive, fills with the compiler's own receiver bindings and proxies. That is what the checker validates, and a malformed expansion does not fail this build. It fails in the build of whoever turns the flag on, in code they wrote, pointing at a macro they cannot fix.

### Solution

The flag is on in `kyo-settings` for every module, main and test, and everything it rejected is fixed rather than opted out. Compile cost is inside run-to-run noise.

What it rejects comes down to two rules. Every change here is an instance of one, and both are worth carrying forward independently of the flag.

**An inline body is compiled where an opaque type is transparent and expanded where it is not.** Inside `Maybe.scala`, `Result.scala`, `OrderedDict.scala` and `Pending.scala` the opaque types unfold, so a body can lean on relations that do not hold at the expansion site. Three shapes turned up. Returning a raw value where the constructor was required, which is the `Maybe` bug: skipping `Present.apply` collapses a nested `Absent`, so `Present(1).map(_ => Maybe.empty)` answered `Absent` and `get` threw. Letting inference settle on the representation, in `OrderedDict`, fixed by pinning the type argument rather than by a cast. And a real compiler limitation, proxies not substituted across nested opaque types, which needs two erased casts, kept behind `Maybe.internal.widen` and `Result.widen` so there is one place to delete from when it is fixed upstream (reproduced without kyo on 3.8.4 and 3.9.0-RC6).

The trap is that all three tempt the same wrong fix, widening a bound until the shortcut is legal. For `Maybe` that means `A <: Present[A]`, which is unsound and would have blessed the bug rather than exposed it. The `Maybe` fix is user-visible on its own: its three regression tests fail on `main` as plain assertions, no flag involved.

**A macro must not rebuild trees it only reads, and must not splice trees it did not build.** kyo-sql broke both, which is why its test scopes used to opt out. Its lift substituted bindings through a reflect `TreeMap`, and that rebuilds every node it passes, so the owner assertions fired on definitions the lift never looks at, in subtrees it never wants. Separately `.run` declared `using SqlSchema[A], Frame`, ignored both, and spliced a fresh implicit search and a derived `Frame` into its output. The compiler's relocated inline proxies, long assumed to be the blocker here, are not, and are left alone.

The same rule is why `assert` no longer expands a macro on the default path. Only the power-assert path needs the caller's expression taken apart, so off that path the condition stays in the inline body and nothing re-checks user code that was already checked where it was written.

One case fits neither rule. The izumi-reflect cross-check in `TagTest` is deleted rather than worked around, because it asserted nothing: every assertion already compared kyo against the compiler's own subtype oracle, and izumi only fed a `println`.

### Notes

Two behavior changes ride along besides the `Maybe` fix, which changes behavior only where the old behavior threw. `.run` now uses the `SqlSchema` and `Frame` the caller passed rather than re-resolving them, so an explicitly supplied schema is the one that runs and a reported position is the caller's. That also makes `.run` usable inside the kyo package, which it was not.

One opt-out remains, `kyo-data`'s Test scope, for izumi-reflect.

`SqlRunMacroTest` is new: `.run`'s runtime-render fallback had no coverage anywhere, and kyo-sql is the only module where that branch is reachable, since it declares no dialect and everywhere else the statement folds.

Verified on JVM across 34 modules spanning every layer, plus JS and Native for the four sql modules. The sql suites ran against real Postgres and MySQL. Wasm is unverified.

