### PR TITLE
[kyo-sql] read, render, and compare from the column's own type

### DIFF
--- a/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlColumnToken.scala
+++ b/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlColumnToken.scala
@@ -18,17 +18,36 @@ package kyo.internal.mysql
   */
 private[kyo] object MysqlColumnToken:
 
+    import kyo.Maybe
+    import kyo.internal.mysql.types.MysqlEncoder
+
     /** A column whose server metadata is not available. Every read then falls back to the value's byte width. */
     val Unspecified: Int = 0
 
     private val Specified = 1 << 24
 
+    /** Set when the column's collation is `binary` (id 63), which is the only thing that separates a `BLOB` from a `TEXT`, a `VARBINARY`
+      * from a `VARCHAR`, and a `BINARY` from a `CHAR`: MySQL gives each pair the same type byte.
+      *
+      * One derived bit rather than the collation id, which does not fit: the id is 16 bits and only 7 are free. The id's other values
+      * carry no decode meaning here, since every non-binary collation makes the column text and the codec reads it as UTF-8 either way.
+      *
+      * NOT the `BINARY_FLAG` already in the flags word: MySQL sets that for a `*_bin`-collated TEXT column too, so it would call
+      * `CHAR ... COLLATE utf8mb4_bin` bytes.
+      */
+    private val BinaryCollation = 1 << 25
+
+    /** MySQL's `binary` collation id, `my_charset_bin` in the server. */
+    private val BinaryCollationId = 63
+
     /** Bit 0x20 of `ColumnDefinition41.flags`, `UNSIGNED_FLAG` in MySQL's `mysql_com.h`. */
     private val UnsignedFlag = 0x20
 
-    /** Packs a result column's type byte and flags word into the token the neutral row carries. */
-    def apply(columnType: Int, flags: Int): Int =
-        Specified | (columnType & 0xff) | ((flags & 0xffff) << 8)
+    /** Packs a result column's type byte, flags word, and whether its collation is binary into the token the neutral row carries. */
+    def apply(columnType: Int, flags: Int, charset: Int): Int =
+        val binary = if charset == BinaryCollationId then BinaryCollation else 0
+        Specified | binary | (columnType & 0xff) | ((flags & 0xffff) << 8)
+    end apply
 
     /** Whether `token` carries server metadata at all. */
     def isSpecified(token: Int): Boolean = (token & Specified) != 0
@@ -38,5 +57,40 @@ private[kyo] object MysqlColumnToken:
 
     /** Whether the column's integer values are unsigned. False for an [[Unspecified]] token, which knows nothing either way. */
     def isUnsigned(token: Int): Boolean = (token & (UnsignedFlag << 8)) != 0
+
+    /** The MySQL name of `token`'s column type when it names a type whose bytes a text read would reinterpret rather than render. Absent
+      * for a text column, for a type byte with no known meaning, and for an [[Unspecified]] token.
+      *
+      * Answered by [[MysqlRowCodec.nonTextColumnType]], which derives it from the one type table that also backs
+      * [[kyo.SqlRow.columnKind]] and [[kyo.SqlRow.columnTypeName]], so the three answers cannot drift apart.
+      */
+    def nonTextColumnType(token: Int): Maybe[String] =
+        if !isSpecified(token) then Maybe.empty
+        else MysqlRowCodec.nonTextColumnType(columnType(token), isBinaryString(token))
+
+    /** Whether `token` names a column whose value arrives as its text rendering. False for an [[Unspecified]] token, which knows nothing
+      * either way, and for a type byte the table does not name.
+      */
+    def isTextColumn(token: Int): Boolean =
+        isSpecified(token) && !isBinaryString(token) && MysqlRowCodec.isTextReadableType(columnType(token))
+
+    /** Whether `token` names an `ENUM` column. MySQL reports one as `STRING` and puts `ENUM_FLAG` in the flags word, so the type byte
+      * alone calls it a `CHAR`.
+      */
+    def isEnum(token: Int): Boolean =
+        isSpecified(token) && (token & (MysqlEncoder.ENUM_FLAG << 8)) != 0
+
+    /** Whether `token` names a `SET` column, reported the way [[isEnum]] describes. */
+    def isSet(token: Int): Boolean =
+        isSpecified(token) && (token & (MysqlEncoder.SET_FLAG << 8)) != 0
+
+    /** Whether `token` names a column carrying arbitrary bytes rather than text: one of the string-family type bytes, collated `binary`.
+      *
+      * The two conditions are both required. The type byte alone cannot say, since `BLOB` and `TEXT` share one. The collation alone
+      * cannot either, since MySQL reports a `JSON` column as `binary` too, and a JSON column's bytes genuinely are the document text.
+      * `JSON` has its own type byte (0xf5) outside the string family, which is what keeps it out of this.
+      */
+    def isBinaryString(token: Int): Boolean =
+        isSpecified(token) && (token & BinaryCollation) != 0 && MysqlRowCodec.isStringFamily(columnType(token))
 
 end MysqlColumnToken

--- a/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlNumericDecoder.scala
+++ b/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlNumericDecoder.scala
@@ -81,16 +81,23 @@ private[kyo] object MysqlNumericDecoder:
 
     /** Which representation a numeric column value carries under the binary protocol. */
     private enum Wire derives CanEqual:
-        case Integer, Float4, Float8, Decimal
+        case Integer, Float4, Float8, Decimal, Rendering
 
     /** Resolves a binary-protocol column's representation from its type byte.
       *
-      * `whenUnknown` covers an [[MysqlColumnToken.Unspecified]] token and any type byte outside the numeric set, both of which leave only the
-      * value's byte width to go on. It is deliberately not a rejection: a `BIT` column, and any string-shaped column a numeric schema field is
-      * pointed at, read correctly by width today and would start failing for no gain against the mismatch class this resolution closes.
+      * A string-family column resolves to [[Wire.Rendering]]: a number stored in one is its own text rendering under both protocols, so a
+      * numeric field over one parses the digits. Without that case the digits are read as a little-endian integer of whatever width the value
+      * happens to have, which for `'hello'` is a five-byte value no integer width recognises. It is also what makes the failure one a caller
+      * can act on: parsing reports [[kyo.SqlDecodeNumericException]] naming the offending value, which is what the same read reports on
+      * PostgreSQL.
+      *
+      * `whenUnknown` covers an [[MysqlColumnToken.Unspecified]] token and any type byte in neither set, both of which leave only the value's
+      * byte width to go on. It is deliberately not a rejection: a `BIT` column reads correctly by width today and would start failing for no
+      * gain against the mismatch class this resolution closes.
       */
     private def wireOf(token: Int, whenUnknown: Wire): Wire =
         if !MysqlColumnToken.isSpecified(token) then whenUnknown
+        else if MysqlColumnToken.isTextColumn(token) then Wire.Rendering
         else
             MysqlColumnToken.columnType(token) match
                 case MysqlEncoder.TYPE_TINY | MysqlEncoder.TYPE_SHORT | MysqlEncoder.TYPE_INT24 | MysqlEncoder.TYPE_LONG |
@@ -110,10 +117,11 @@ private[kyo] object MysqlNumericDecoder:
         case Format.Text => wholeOf(parseDecimalText(bytes), scalaType, "text column")
         case Format.Binary =>
             wireOf(token, Wire.Integer) match
-                case Wire.Integer => readIntegerBinary(bytes, token, scalaType)
-                case Wire.Float4  => wholeOf(BigDecimal(readFloat4LE(bytes).toDouble), scalaType, "FLOAT column")
-                case Wire.Float8  => wholeOf(BigDecimal(readFloat8LE(bytes)), scalaType, "DOUBLE column")
-                case Wire.Decimal => wholeOf(parseDecimalText(bytes), scalaType, "DECIMAL column")
+                case Wire.Integer   => readIntegerBinary(bytes, token, scalaType)
+                case Wire.Float4    => wholeOf(BigDecimal(readFloat4LE(bytes).toDouble), scalaType, "FLOAT column")
+                case Wire.Float8    => wholeOf(BigDecimal(readFloat8LE(bytes)), scalaType, "DOUBLE column")
+                case Wire.Decimal   => wholeOf(parseDecimalText(bytes), scalaType, "DECIMAL column")
+                case Wire.Rendering => wholeOf(parseDecimalText(bytes), scalaType, "text column")
 
     /** The approximate value a numeric column carries, for the `Float` and `Double` targets. */
     private def approximateValueOf(bytes: Span[Byte], format: Format, token: Int, whenUnknown: Wire, scalaType: String)(using
@@ -128,10 +136,11 @@ private[kyo] object MysqlNumericDecoder:
         case Format.Text => parseDoubleText(bytes)
         case Format.Binary =>
             wireOf(token, whenUnknown) match
-                case Wire.Integer => unsignedDecimalOf(bytes, token, scalaType).toDouble
-                case Wire.Float4  => readFloat4LE(bytes).toDouble
-                case Wire.Float8  => readFloat8LE(bytes)
-                case Wire.Decimal => parseDecimalText(bytes).toDouble
+                case Wire.Integer   => unsignedDecimalOf(bytes, token, scalaType).toDouble
+                case Wire.Float4    => readFloat4LE(bytes).toDouble
+                case Wire.Float8    => readFloat8LE(bytes)
+                case Wire.Decimal   => parseDecimalText(bytes).toDouble
+                case Wire.Rendering => parseDoubleText(bytes)
 
     /** The exact decimal value a numeric column carries, for the `BigDecimal`, `BigInt` and `Boolean` targets.
       *
@@ -152,10 +161,11 @@ private[kyo] object MysqlNumericDecoder:
             case Format.Text => parseDecimalText(bytes)
             case Format.Binary =>
                 wireOf(token, whenUnknown) match
-                    case Wire.Integer => unsignedDecimalOf(bytes, token, scalaType)
-                    case Wire.Float4  => BigDecimal(readFloat4LE(bytes).toDouble)
-                    case Wire.Float8  => BigDecimal(readFloat8LE(bytes))
-                    case Wire.Decimal => parseDecimalText(bytes)
+                    case Wire.Integer   => unsignedDecimalOf(bytes, token, scalaType)
+                    case Wire.Float4    => BigDecimal(readFloat4LE(bytes).toDouble)
+                    case Wire.Float8    => BigDecimal(readFloat8LE(bytes))
+                    case Wire.Decimal   => parseDecimalText(bytes)
+                    case Wire.Rendering => parseDecimalText(bytes)
 
     // --- BIT, the one column type that is neither an ASCII rendering nor a little-endian integer ---
 

--- a/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlPreparedStmt.scala
+++ b/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlPreparedStmt.scala
@@ -1,15 +1,14 @@
 package kyo.internal.mysql
 
-import kyo.Chunk
-
 /** Cached metadata for a server-side MySQL prepared statement (from [[ComStmtPrepare]] / [[StmtPrepareOk]]).
+  *
+  * The statement id is all of it. The column definitions PREPARE reports are deliberately not kept: the server resends them with every
+  * EXECUTE, and those are the ones that describe the rows that execute carries. Holding the prepare-time set invited reading a row against
+  * a description that was not its own, which is what a re-executed `SELECT *` after an `ALTER TABLE ADD COLUMN` made visible.
   *
   * @param stmtId
   *   the server-assigned statement ID
-  * @param columnDefs
-  *   the column definitions for result columns (empty for DML)
   */
 final private[mysql] case class MysqlPreparedStmt(
-    stmtId: Int,
-    columnDefs: Chunk[ColumnDefinition41]
+    stmtId: Int
 )

--- a/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlRowCodec.scala
+++ b/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlRowCodec.scala
@@ -21,9 +21,136 @@ final private[kyo] case class MysqlRowCodec(format: Format) extends SqlPositiona
     def newReader(sliced: SqlRow, matchesFieldAt: Maybe[(Int, String) => Boolean])(using Frame): SqlCodec.Reader =
         new MysqlRowReader(sliced, format, matchesFieldAt)
 
+    override def columnKind(typeToken: Int): SqlRow.ColumnKind =
+        if !MysqlColumnToken.isSpecified(typeToken) then SqlRow.ColumnKind.Unknown
+        // A binary-collated string-family column carries bytes, not text, and shares its type byte with the text
+        // twin `types` names, so the collation decides before the table is consulted.
+        else if MysqlColumnToken.isBinaryString(typeToken) then SqlRow.ColumnKind.Bytes
+        else MysqlRowCodec.kinds.getOrElse(MysqlColumnToken.columnType(typeToken), SqlRow.ColumnKind.Unknown)
+
+    override def typeName(typeToken: Int): Maybe[String] =
+        if !MysqlColumnToken.isSpecified(typeToken) then Maybe.empty
+        else if MysqlColumnToken.isBinaryString(typeToken) then
+            MysqlRowCodec.binaryTypeName(MysqlColumnToken.columnType(typeToken))
+        // An ENUM and a SET both arrive as STRING, which the table names CHAR; the flags word is the only thing that
+        // says which, so a caller asking what the server reported gets the declared type rather than its carrier.
+        else if MysqlColumnToken.isEnum(typeToken) then Maybe("ENUM")
+        else if MysqlColumnToken.isSet(typeToken) then Maybe("SET")
+        else Maybe.fromOption(MysqlRowCodec.typeNames.get(MysqlColumnToken.columnType(typeToken)))
+
 end MysqlRowCodec
 
 private[kyo] object MysqlRowCodec:
+
+    import kyo.internal.mysql.types.MysqlEncoder.*
+
+    /** Every type byte this backend can name, with the MySQL spelling and the neutral kind it maps to.
+      *
+      * One table rather than two so the two answers a caller gets about a column, [[kyo.SqlRow.columnTypeName]] and
+      * [[kyo.SqlRow.columnKind]], cannot drift apart. A type byte absent from it answers `Absent` and [[kyo.SqlRow.ColumnKind.Unknown]].
+      *
+      * A `TEXT` column and a `BLOB` column share the BLOB type bytes and are told apart only by the column's character set, which the
+      * neutral token has no room for, so those bytes are named for the wider of the two and mapped to
+      * [[kyo.SqlRow.ColumnKind.Text]]: MySQL's text types are the common case, and the values arrive as their text rendering either way.
+      */
+    private val types: Map[Int, (String, SqlRow.ColumnKind)] = Map(
+        TYPE_TINY        -> ("TINYINT", SqlRow.ColumnKind.Integer),
+        TYPE_SHORT       -> ("SMALLINT", SqlRow.ColumnKind.Integer),
+        TYPE_INT24       -> ("MEDIUMINT", SqlRow.ColumnKind.Integer),
+        TYPE_LONG        -> ("INT", SqlRow.ColumnKind.Integer),
+        TYPE_LONGLONG    -> ("BIGINT", SqlRow.ColumnKind.Integer),
+        TYPE_YEAR        -> ("YEAR", SqlRow.ColumnKind.Integer),
+        TYPE_BIT         -> ("BIT", SqlRow.ColumnKind.Integer),
+        TYPE_FLOAT       -> ("FLOAT", SqlRow.ColumnKind.Float),
+        TYPE_DOUBLE      -> ("DOUBLE", SqlRow.ColumnKind.Float),
+        TYPE_DECIMAL     -> ("DECIMAL", SqlRow.ColumnKind.Decimal),
+        TYPE_NEWDECIMAL  -> ("DECIMAL", SqlRow.ColumnKind.Decimal),
+        TYPE_DATE        -> ("DATE", SqlRow.ColumnKind.Date),
+        TYPE_TIME        -> ("TIME", SqlRow.ColumnKind.Time),
+        TYPE_DATETIME    -> ("DATETIME", SqlRow.ColumnKind.DateTime),
+        TYPE_TIMESTAMP   -> ("TIMESTAMP", SqlRow.ColumnKind.Timestamp),
+        TYPE_JSON        -> ("JSON", SqlRow.ColumnKind.Json),
+        TYPE_VARCHAR     -> ("VARCHAR", SqlRow.ColumnKind.Text),
+        TYPE_VAR_STRING  -> ("VARCHAR", SqlRow.ColumnKind.Text),
+        TYPE_STRING      -> ("CHAR", SqlRow.ColumnKind.Text),
+        TYPE_ENUM        -> ("ENUM", SqlRow.ColumnKind.Text),
+        TYPE_SET         -> ("SET", SqlRow.ColumnKind.Text),
+        TYPE_TINY_BLOB   -> ("TINYTEXT", SqlRow.ColumnKind.Text),
+        TYPE_MEDIUM_BLOB -> ("MEDIUMTEXT", SqlRow.ColumnKind.Text),
+        TYPE_LONG_BLOB   -> ("LONGTEXT", SqlRow.ColumnKind.Text),
+        TYPE_BLOB        -> ("TEXT", SqlRow.ColumnKind.Text),
+        // WKB behind a four-byte SRID, so a String read of one answers the geometry's bytes.
+        TYPE_GEOMETRY -> ("GEOMETRY", SqlRow.ColumnKind.Bytes)
+    )
+
+    private val typeNames: Map[Int, String]        = types.view.mapValues(_._1).toMap
+    private val kinds: Map[Int, SqlRow.ColumnKind] = types.view.mapValues(_._2).toMap
+
+    /** The MySQL name of the type `columnType` names when a text read of it would reinterpret its bytes rather than render its value.
+      *
+      * Derived from the one type table above rather than from a second list, so what this refuses and what [[kyo.SqlRow.columnKind]] and
+      * [[kyo.SqlRow.columnTypeName]] report cannot drift apart. A type whose kind is [[kyo.SqlRow.ColumnKind.Text]] or
+      * [[kyo.SqlRow.ColumnKind.Json]] carries its text rendering on the wire under both protocols and is not refused; every other named
+      * kind is. A type byte the table does not name is not refused either, for the reason [[MysqlNumericDecoder]] does not refuse an
+      * unrecognised one: a token with no known meaning is not evidence of a mismatch.
+      *
+      * `DECIMAL` is refused even though its bytes are ASCII digits under both protocols, so nothing would corrupt. What decides it is the
+      * schema: a `DECIMAL` column is a number, and a row type declaring `String` for one is wrong about the column on both engines.
+      * Admitting it here and refusing it on PostgreSQL, where `numeric` binary is a struct, would make the same row type decode against
+      * one engine and fail against the other.
+      */
+    private[mysql] def nonTextColumnType(columnType: Int, isBinaryString: Boolean): Maybe[String] =
+        if isBinaryString then Maybe(binaryNames.getOrElse(columnType, "BINARY"))
+        else
+            types.get(columnType) match
+                case Some((name, kind)) if !isTextReadableKind(kind) => Maybe(name)
+                case _                                               => Maybe.empty
+
+    /** Whether the type `columnType` names carries its value's text rendering on the wire, so a `String` read of it converts rather than
+      * reinterprets. False for a type byte the table does not name, which knows nothing either way.
+      *
+      * Answers for the type byte alone. A string-family byte is text only when its collation is not `binary`, which the caller settles
+      * through [[MysqlColumnToken.isBinaryString]] before asking.
+      */
+    private[mysql] def isTextReadableType(columnType: Int): Boolean =
+        types.get(columnType).exists((_, kind) => isTextReadableKind(kind))
+
+    /** Whether a column of this kind carries its value's text rendering on the wire. */
+    private def isTextReadableKind(kind: SqlRow.ColumnKind): Boolean =
+        kind == SqlRow.ColumnKind.Text || kind == SqlRow.ColumnKind.Json
+
+    /** The type bytes MySQL uses for both a text column and its binary twin, which only the collation separates.
+      *
+      * `JSON` is deliberately not here: it has its own type byte and its bytes are the document text, even though the server reports it
+      * as `binary`-collated.
+      */
+    private val stringFamily: Set[Int] = Set(
+        TYPE_VARCHAR,
+        TYPE_VAR_STRING,
+        TYPE_STRING,
+        TYPE_TINY_BLOB,
+        TYPE_MEDIUM_BLOB,
+        TYPE_LONG_BLOB,
+        TYPE_BLOB
+    )
+
+    /** Whether `columnType` is a type byte MySQL shares between a text column and its binary twin. */
+    private[mysql] def isStringFamily(columnType: Int): Boolean = stringFamily.contains(columnType)
+
+    /** How MySQL spells the binary twin of each string-family type byte, for the column types `types` names on their text side. */
+    private val binaryNames: Map[Int, String] = Map(
+        TYPE_VARCHAR     -> "VARBINARY",
+        TYPE_VAR_STRING  -> "VARBINARY",
+        TYPE_STRING      -> "BINARY",
+        TYPE_TINY_BLOB   -> "TINYBLOB",
+        TYPE_MEDIUM_BLOB -> "MEDIUMBLOB",
+        TYPE_LONG_BLOB   -> "LONGBLOB",
+        TYPE_BLOB        -> "BLOB"
+    )
+
+    /** The MySQL spelling of a binary-collated string-family column, for [[kyo.SqlRow.columnTypeName]]. */
+    private[mysql] def binaryTypeName(columnType: Int): Maybe[String] =
+        Maybe.fromOption(binaryNames.get(columnType))
 
     /** Builds a [[SqlRow]] from a [[MysqlRow]].
       *
@@ -35,7 +162,7 @@ private[kyo] object MysqlRowCodec:
     private[kyo] def row(source: MysqlRow): SqlRow =
         new SqlRow(
             source.values,
-            source.columns.map(column => SqlRow.Column(column.name, MysqlColumnToken(column.columnType, column.flags))),
+            source.columns.map(column => SqlRow.Column(column.name, MysqlColumnToken(column.columnType, column.flags, column.charset))),
             MysqlRowCodec(source.format)
         )
 

--- a/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlRowReader.scala
+++ b/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/MysqlRowReader.scala
@@ -10,6 +10,7 @@ import kyo.Result
 import kyo.Span
 import kyo.SqlCodec
 import kyo.SqlCodec.Format
+import kyo.SqlDecodeColumnTypeMismatchException
 import kyo.SqlDecodeEmptyStringForCharException
 import kyo.SqlDecodeException
 import kyo.SqlDecodeIntervalException
@@ -72,6 +73,27 @@ final class MysqlRowReader(row: SqlRow, format: Format, matchesFieldAt: Maybe[(I
         new String(bytes.toArray, StandardCharsets.UTF_8)
     end readUtf8String
 
+    /** Refuses a text read of a column whose type is not text, naming the Scala type that asked.
+      *
+      * The guard the text reads owe their caller: every other read resolves the wire representation from the column's type byte, and this
+      * is the one whose target type any byte sequence satisfies, so without the guard an `INT` column read as `String` answers the four
+      * little-endian bytes of the value as UTF-8 rather than failing.
+      */
+    private def requireTextColumn(scalaType: String): Unit =
+        val token = currentToken()
+        MysqlColumnToken.nonTextColumnType(token).foreach { columnType =>
+            throw SqlDecodeColumnTypeMismatchException(
+                scalaType,
+                MysqlDialect.id,
+                columnType,
+                MysqlColumnToken.columnType(token).toString,
+                // Named where the reader knows it, so a row type declaring the wrong type for one field of several
+                // says which field rather than only which types disagreed.
+                if idx < row.columns.size then Maybe(row.columns(idx).name) else Maybe.empty
+            )(using frame)
+        }
+    end requireTextColumn
+
     // --- Nil check, consumes the column when it answers true ---
 
     /** True when the column the cursor is on is SQL NULL, consuming that column; false leaves the cursor where it was.
@@ -116,7 +138,9 @@ final class MysqlRowReader(row: SqlRow, format: Format, matchesFieldAt: Maybe[(I
         readNumeric((bytes, token) => MysqlNumericDecoder.double(bytes, format, token)(using frame))
 
     override def string(): String =
+        requireTextColumn("String")
         readUtf8String(nextBytes())
+    end string
 
     override def bytes(): Span[Byte] =
         nextBytes()
@@ -138,6 +162,7 @@ final class MysqlRowReader(row: SqlRow, format: Format, matchesFieldAt: Maybe[(I
         readNumeric((bytes, token) => MysqlNumericDecoder.byte(bytes, format, token)(using frame))
 
     override def char(): Char =
+        requireTextColumn("Char")
         val s = readUtf8String(nextBytes())
         // A longer value is refused rather than truncated to its first character: taking `charAt(0)`
         // would drop the rest with nothing raised, a silent value change and not a decode.

--- a/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/exchange/ExtendedQueryExchange.scala
+++ b/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/exchange/ExtendedQueryExchange.scala
@@ -152,17 +152,15 @@ private[mysql] object ExtendedQueryExchange:
     )(using Frame): MysqlPreparedStmt < (Async & Abort[SqlException]) =
         val numParams  = ok.numParams.toInt & 0xffff
         val numColumns = ok.numColumns.toInt & 0xffff
-        // Read and discard the param column-def packets: they must be consumed off the socket even
-        // though only stmtId and the result column defs are retained.
+        // Both def blocks are read and discarded: they must be consumed off the socket to leave the connection on a
+        // packet boundary, but only the statement id is worth keeping. The result column defs in particular are the
+        // PREPARE-time ones, and every EXECUTE resends its own, which are the ones that describe the rows it carries.
         readColumnDefs(channel, numParams).flatMap { _ =>
             // Skip optional intermediate EOF after param defs (only if numParams > 0 and not deprecate-EOF).
             skipEofIfNeeded(channel, numParams, deprecateEof).flatMap { _ =>
-                readColumnDefs(channel, numColumns).flatMap { columnDefs =>
+                readColumnDefs(channel, numColumns).flatMap { _ =>
                     skipEofIfNeeded(channel, numColumns, deprecateEof).map { _ =>
-                        MysqlPreparedStmt(
-                            stmtId = ok.stmtId,
-                            columnDefs = columnDefs
-                        )
+                        MysqlPreparedStmt(stmtId = ok.stmtId)
                     }
                 }
             }
@@ -260,9 +258,14 @@ private[mysql] object ExtendedQueryExchange:
                         readColumnDefs(channel, columnCount).flatMap { columnDefs =>
                             skipEofIfNeeded(channel, columnCount, deprecateEof).flatMap { _ =>
                                 val colTypes = columnDefs.map(_.columnType)
+                                // The definitions this response resent, never the ones COM_STMT_PREPARE sent: the server
+                                // describes a bare placeholder's column before any parameter is bound and calls it
+                                // VAR_STRING, then sends the value in the bound parameter's own binary form. Carrying the
+                                // prepare-time definitions would announce VAR_STRING over an eight-byte little-endian
+                                // integer, disagreeing with the types the payload was just parsed with, one row apart.
                                 readBinaryRows(
                                     channel,
-                                    stmt.columnDefs,
+                                    columnDefs,
                                     colTypes,
                                     deprecateEof,
                                     Chunk.empty,

--- a/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/types/MysqlEncoder.scala
+++ b/kyo-sql-mysql/shared/src/main/scala/kyo/internal/mysql/types/MysqlEncoder.scala
@@ -59,6 +59,32 @@ object MysqlEncoder:
     val TYPE_BLOB       = 0xfc
     val TYPE_VAR_STRING = 0xfd
 
+    // The remaining string-family type bytes. Nothing encodes as one of these (a `String` parameter goes out as
+    // VAR_STRING), but a result column arrives under whichever one the server chose for the stored column. A decode
+    // that resolves the wire representation from the column type needs all of them to recognise a column whose bytes
+    // are the value's text rendering.
+    //
+    // What a released server actually sends is narrower than the list: CHAR, ENUM and SET all arrive as STRING, with
+    // ENUM_FLAG or SET_FLAG in the flags word saying which; every TEXT and BLOB width arrives as BLOB, since
+    // `Field_blob::type()` answers one byte for all four; and VAR_STRING covers VARCHAR. The others are here because
+    // the protocol defines them and a proxy or a fork may send them, not because MySQL does.
+    val TYPE_VARCHAR     = 0x0f
+    val TYPE_ENUM        = 0xf7
+    val TYPE_SET         = 0xf8
+    val TYPE_TINY_BLOB   = 0xf9
+    val TYPE_MEDIUM_BLOB = 0xfa
+    val TYPE_LONG_BLOB   = 0xfb
+    val TYPE_STRING      = 0xfe
+
+    /** Spatial values, carried as WKB behind a four-byte SRID. Nothing encodes to it; a result column arrives under it. */
+    val TYPE_GEOMETRY = 0xff
+
+    /** Bit 0x100 of `ColumnDefinition41.flags`, `ENUM_FLAG` in MySQL's `mysql_com.h`: a STRING column that is an ENUM. */
+    val ENUM_FLAG = 0x100
+
+    /** Bit 0x800 of `ColumnDefinition41.flags`, `SET_FLAG` in MySQL's `mysql_com.h`: a STRING column that is a SET. */
+    val SET_FLAG = 0x800
+
     // --- Boolean → TINY (1 byte) ---
 
     val boolEncoder: MysqlEncoder[Boolean] = new MysqlEncoder[Boolean]:

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/internal/mysql/MysqlDialectReturningRenderTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/internal/mysql/MysqlDialectReturningRenderTest.scala
@@ -15,7 +15,7 @@ class MysqlDialectReturningRenderTest extends Test:
 
     // RETURNING on MySQL raises SqlUnsupportedException (requires Frame for typed error).
     "RETURNING on MySQL raises Unsupported" in {
-        val s = Sql.insert[Event].values(Event(0L, "boot", "2024-01-01")).returning(_.id)
+        val s = Sql.insert[Event].values(Event(0L, "boot", "2024-01-01")).returning(_.id).statement
         val ex = intercept[SqlUnsupportedException] {
             s.render(MysqlDialect)
         }

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/internal/mysql/MysqlEncoderShortTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/internal/mysql/MysqlEncoderShortTest.scala
@@ -34,7 +34,7 @@ class MysqlEncoderShortTest extends Test:
     private def decode(body: Array[Byte]): Short =
         val row = new SqlRow(
             Chunk(Maybe.Present(Span.from(body))),
-            Chunk(SqlRow.Column("n", MysqlColumnToken(MysqlEncoder.TYPE_SHORT, 0))),
+            Chunk(SqlRow.Column("n", MysqlColumnToken(MysqlEncoder.TYPE_SHORT, 0, charset = 45))),
             MysqlRowCodec(Format.Binary)
         )
         new MysqlRowReader(row, Format.Binary)(using kyo.Frame.derive).short()

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/internal/mysql/MysqlRowReaderTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/internal/mysql/MysqlRowReaderTest.scala
@@ -9,6 +9,7 @@ import kyo.Maybe
 import kyo.Span
 import kyo.SqlCodec.Format
 import kyo.SqlDecodeColumnAbsentException
+import kyo.SqlDecodeColumnTypeMismatchException
 import kyo.SqlDecodeException
 import kyo.SqlDecodeIntervalException
 import kyo.SqlDecodeMultiCharacterForCharException
@@ -691,13 +692,23 @@ class MysqlRowReaderTest extends Test:
     // and the UNSIGNED column flag is honored so an `INT UNSIGNED` near its top range does not read as negative. The
     // text protocol shares no representation with any of it.
 
-    /** Builds a single-column row carrying the server's type byte and flags, the way `MysqlRowCodec.row` does. */
-    private def typedRow(bytes: Span[Byte], columnType: Int, flags: Int, format: Format): SqlRow =
+    /** Builds a single-column row carrying the server's type byte, flags, and collation, the way `MysqlRowCodec.row` does.
+      *
+      * `charset` defaults to a non-binary collation, since every leaf here reads a value at its declared type rather than probing the
+      * BLOB-against-TEXT split; the leaves that do probe it pass 63 explicitly.
+      */
+    private def typedRow(bytes: Span[Byte], columnType: Int, flags: Int, format: Format, charset: Int = Utf8Collation): SqlRow =
         new SqlRow(
             Chunk(Maybe.Present(bytes)),
-            Chunk(SqlRow.Column("column", MysqlColumnToken(columnType, flags))),
+            Chunk(SqlRow.Column("column", MysqlColumnToken(columnType, flags, charset))),
             MysqlRowCodec(format)
         )
+
+    /** `utf8mb4_general_ci`, standing in for any collation that is not `binary`. */
+    private val Utf8Collation = 45
+
+    /** MySQL's `binary` collation id, which is what separates a BLOB from a TEXT. */
+    private val BinaryCollation = 63
 
     private def readerFor(row: SqlRow, format: Format): MysqlRowReader =
         new MysqlRowReader(row, format)
@@ -994,6 +1005,49 @@ class MysqlRowReaderTest extends Test:
         val ex  = intercept[SqlDecodeIntervalException](reader(row).nextCalendarInterval())
         assert(ex.field == "text", s"expected field 'text', got ${ex.field}")
         assert(ex.value == stored, s"expected the raw wire text, got ${ex.value}")
+    }
+
+    // ---- The BLOB against TEXT split, which only the collation carries --------------------------------
+    //
+    // MySQL gives a BLOB and a TEXT the same type byte, a VARBINARY and a VARCHAR the same type byte, and a
+    // BINARY and a CHAR the same type byte. Only the column's collation separates each pair, 63 meaning
+    // binary. Without it a `String` field over a BLOB read the raw bytes as UTF-8 and answered replacement
+    // characters, which is the same defect a text read of an int4 is on PostgreSQL, where `bytea` is refused.
+
+    "a String read of a binary-collated BLOB is refused, naming BLOB rather than TEXT" in {
+        val bytes = Span.from(Array[Byte](0x00, 0xff.toByte, 0x00, 0xff.toByte))
+        val row   = typedRow(bytes, MysqlEncoder.TYPE_BLOB, 0, Format.Binary, BinaryCollation)
+        val ex    = intercept[SqlDecodeColumnTypeMismatchException](reader(row).string())
+        assert(ex.columnType == "BLOB", s"expected the failure to name BLOB, got ${ex.columnType}")
+        assert(ex.scalaType == "String", s"expected the failure to name String, got ${ex.scalaType}")
+    }
+
+    "a String read of a binary-collated VARBINARY and BINARY is refused under each spelling" in {
+        val varbinary = typedRow(Span.from(Array[Byte](1, 2)), MysqlEncoder.TYPE_VAR_STRING, 0, Format.Binary, BinaryCollation)
+        val binary    = typedRow(Span.from(Array[Byte](1, 2)), MysqlEncoder.TYPE_STRING, 0, Format.Binary, BinaryCollation)
+        val varEx     = intercept[SqlDecodeColumnTypeMismatchException](reader(varbinary).string())
+        val binEx     = intercept[SqlDecodeColumnTypeMismatchException](reader(binary).string())
+        assert(varEx.columnType == "VARBINARY", s"expected VARBINARY, got ${varEx.columnType}")
+        assert(binEx.columnType == "BINARY", s"expected BINARY, got ${binEx.columnType}")
+    }
+
+    "a String read of the same type bytes under a text collation still decodes" in {
+        // The other half of the split: the type byte alone must not refuse, or every TEXT and VARCHAR breaks.
+        val text    = typedRow(asciiBytes("hello"), MysqlEncoder.TYPE_BLOB, 0, Format.Binary)
+        val varchar = typedRow(asciiBytes("hello"), MysqlEncoder.TYPE_VAR_STRING, 0, Format.Binary)
+        val char    = typedRow(asciiBytes("hello"), MysqlEncoder.TYPE_STRING, 0, Format.Binary)
+        assert(reader(text).string() == "hello", "a TEXT column must still read as String")
+        assert(reader(varchar).string() == "hello", "a VARCHAR column must still read as String")
+        assert(reader(char).string() == "hello", "a CHAR column must still read as String")
+    }
+
+    "a JSON column reads as String even though the server reports it binary-collated" in {
+        // The carve-out that makes the collation rule safe: MySQL reports JSON as collation 63, but a JSON
+        // column's bytes ARE the document text. JSON has its own type byte outside the string family, which
+        // is what keeps it out of the binary split rather than any special case on the collation.
+        val doc = "{\"a\":1}"
+        val row = typedRow(asciiBytes(doc), MysqlEncoder.TYPE_JSON, 0, Format.Binary, BinaryCollation)
+        assert(reader(row).string() == doc, "a JSON column must read as String despite collation 63")
     }
 
 end MysqlRowReaderTest

--- a/kyo-sql-postgres/shared/src/main/scala/kyo/internal/postgres/PostgresRowCodec.scala
+++ b/kyo-sql-postgres/shared/src/main/scala/kyo/internal/postgres/PostgresRowCodec.scala
@@ -31,9 +31,207 @@ final private[kyo] case class PostgresRowCodec(format: Format) extends SqlPositi
     def newReader(sliced: SqlRow, matchesFieldAt: Maybe[(Int, String) => Boolean])(using Frame): SqlCodec.Reader =
         new PostgresRowReader(sliced, format, matchesFieldAt)
 
+    override def columnKind(typeToken: Int): SqlRow.ColumnKind =
+        PostgresRowCodec.kinds.getOrElse(typeToken, SqlRow.ColumnKind.Unknown)
+
+    override def typeName(typeToken: Int): Maybe[String] =
+        Maybe.fromOption(PostgresRowCodec.typeNames.get(typeToken))
+
+    /** Renders a column as the server renders it, so one stored value reads as one string whichever protocol carried the row.
+      *
+      * The shared codec reads each kind at the widest Scala type in its family and prints the Scala value, which agrees with the server
+      * for some types and not others. It disagrees for whole column types rather than at the edges: PostgreSQL writes a bool `t`, a
+      * timestamp `2026-08-25 10:00:00`, a time `10:00:00`, and a float8 1e10 `10000000000`, where Java writes `true`,
+      * `2026-08-25T10:00`, `10:00`, and `1.0E10`. Under the text protocol the server already sent its rendering and the bytes are handed
+      * back, so every type routed here is one whose binary rendering had to be brought into line with that.
+      *
+      * Two of them have no Scala type to read at all. An `interval` is free to carry both a calendar and a time part, which
+      * `java.time.Duration` and `java.time.Period` each refuse half of, and it is routed under BOTH formats because which of its four
+      * renderings the server writes is a session setting. An `inet` is a wire struct, which the shared fallback would answer as UTF-8.
+      */
+    override def text(row: SqlRow, idx: Int)(using Frame): String < Abort[SqlDecodeException] =
+        import SqlRow.ColumnKind
+        val typeToken = row.columns(idx).typeToken
+        inline def renderWith(decoder: PostgresDecoder[String]) =
+            PostgresRowCodec.columnDecoded[String](row, idx)(using summon[Frame], decoder)
+        // The interval is the one routed under both formats, for the session-setting reason above.
+        if columnKind(typeToken) == ColumnKind.Interval then renderWith(PostgresDecoder.intervalText)
+        else if format == Format.Text then super.text(row, idx)
+        else if typeToken == PostgresRowCodec.inetToken then renderWith(PostgresDecoder.inetText)
+        else
+            columnKind(typeToken) match
+                case ColumnKind.Bool           => renderWith(PostgresDecoder.boolText)
+                case ColumnKind.Date           => renderWith(PostgresDecoder.dateText)
+                case ColumnKind.DateTime       => renderWith(PostgresDecoder.timestampText)
+                case ColumnKind.Timestamp      => renderWith(PostgresDecoder.timestamptzText)
+                case ColumnKind.Time           => renderWith(PostgresDecoder.timeText)
+                case ColumnKind.TimeWithOffset => renderWith(PostgresDecoder.timetzText)
+                case ColumnKind.Decimal        => renderWith(PostgresDecoder.numericText)
+                case ColumnKind.Float          =>
+                    // float4 and float8 share a kind, and reading a float4 at Double widens it before it is rendered:
+                    // 0.1 becomes 0.10000000149011612 where the server writes 0.1.
+                    if typeToken == PostgresRowCodec.float4Token then renderWith(PostgresDecoder.float4Text)
+                    else renderWith(PostgresDecoder.float8Text)
+                case _ => super.text(row, idx)
+        end if
+    end text
+
 end PostgresRowCodec
 
 private[kyo] object PostgresRowCodec:
+
+    import kyo.internal.postgres.types.PostgresEncoder.*
+
+    /** What this backend knows about one column type: how PostgreSQL spells it, the neutral kind it maps to, and whether reading it as
+      * text is a conversion rather than a reinterpretation.
+      *
+      * @param name
+      *   the PostgreSQL spelling, for [[kyo.SqlRow.columnTypeName]]
+      * @param kind
+      *   the neutral kind, for [[kyo.SqlRow.columnKind]]
+      * @param textReadable
+      *   whether the column's bytes are the value's text rendering under every wire format, so a `String` read of it returns the value
+      *   rather than the protocol buffer
+      */
+    final private case class TypeInfo(name: String, kind: SqlRow.ColumnKind, textReadable: Boolean)
+
+    /** Every OID this backend can name.
+      *
+      * One table, so the three answers a caller gets about a column cannot drift apart: [[kyo.SqlRow.columnTypeName]],
+      * [[kyo.SqlRow.columnKind]], and whether a text decode of it is refused. An OID absent from it answers `Absent`,
+      * [[kyo.SqlRow.ColumnKind.Unknown]], and is NOT refused, which is the honest report for the dynamic OIDs (`citext`, an enum type, a
+      * domain) whose values this connection cannot resolve to a type.
+      *
+      * `textReadable` is a per-type fact rather than one derived from `kind`, because the kind does not decide it: `json` and `jsonb`
+      * are both [[kyo.SqlRow.ColumnKind.Json]], and `json` carries the document text on the wire while `jsonb` prefixes it with a version
+      * byte. Deriving the refusal from the kind would silently admit `jsonb`.
+      *
+      * `varchar` (1043) and `bpchar` (1042) are spelled as literals here, as they are in the decoders, because they have no
+      * [[kyo.internal.postgres.types.PostgresEncoder]] constant: nothing encodes to them, since a `String` parameter goes out as `text`.
+      */
+    private val types: Map[Int, TypeInfo] = Map(
+        OID_BOOL        -> TypeInfo("bool", SqlRow.ColumnKind.Bool, textReadable = false),
+        OID_BYTEA       -> TypeInfo("bytea", SqlRow.ColumnKind.Bytes, textReadable = false),
+        OID_INT2        -> TypeInfo("int2", SqlRow.ColumnKind.Integer, textReadable = false),
+        OID_INT4        -> TypeInfo("int4", SqlRow.ColumnKind.Integer, textReadable = false),
+        OID_INT8        -> TypeInfo("int8", SqlRow.ColumnKind.Integer, textReadable = false),
+        OID_FLOAT4      -> TypeInfo("float4", SqlRow.ColumnKind.Float, textReadable = false),
+        OID_FLOAT8      -> TypeInfo("float8", SqlRow.ColumnKind.Float, textReadable = false),
+        OID_NUMERIC     -> TypeInfo("numeric", SqlRow.ColumnKind.Decimal, textReadable = false),
+        OID_TEXT        -> TypeInfo("text", SqlRow.ColumnKind.Text, textReadable = true),
+        1043            -> TypeInfo("varchar", SqlRow.ColumnKind.Text, textReadable = true),
+        1042            -> TypeInfo("bpchar", SqlRow.ColumnKind.Text, textReadable = true),
+        OID_JSON        -> TypeInfo("json", SqlRow.ColumnKind.Json, textReadable = true),
+        OID_JSONB       -> TypeInfo("jsonb", SqlRow.ColumnKind.Json, textReadable = false),
+        OID_UUID        -> TypeInfo("uuid", SqlRow.ColumnKind.Uuid, textReadable = false),
+        OID_DATE        -> TypeInfo("date", SqlRow.ColumnKind.Date, textReadable = false),
+        OID_TIME        -> TypeInfo("time", SqlRow.ColumnKind.Time, textReadable = false),
+        OID_TIMETZ      -> TypeInfo("timetz", SqlRow.ColumnKind.TimeWithOffset, textReadable = false),
+        OID_TIMESTAMP   -> TypeInfo("timestamp", SqlRow.ColumnKind.DateTime, textReadable = false),
+        OID_TIMESTAMPTZ -> TypeInfo("timestamptz", SqlRow.ColumnKind.Timestamp, textReadable = false),
+        OID_INTERVAL    -> TypeInfo("interval", SqlRow.ColumnKind.Interval, textReadable = false),
+        OID_INET        -> TypeInfo("inet", SqlRow.ColumnKind.Unknown, textReadable = false),
+        OID_INT4_ARRAY  -> TypeInfo("int4[]", SqlRow.ColumnKind.Array, textReadable = false),
+        OID_TEXT_ARRAY  -> TypeInfo("text[]", SqlRow.ColumnKind.Array, textReadable = false),
+        OID_JSONB_ARRAY -> TypeInfo("jsonb[]", SqlRow.ColumnKind.Array, textReadable = false),
+
+        // The text-shaped built-ins. Named so a caller reading a catalog query gets a kind and a name for them, and marked readable
+        // because each one's binary form IS its characters: `name` is a fixed-width string, `"char"` is the single byte, `xml` is the
+        // document. Leaving them out would have left them unnamed rather than refused, since an unnamed OID is not refused.
+        19  -> TypeInfo("name", SqlRow.ColumnKind.Text, textReadable = true),
+        18  -> TypeInfo("char", SqlRow.ColumnKind.Text, textReadable = true),
+        142 -> TypeInfo("xml", SqlRow.ColumnKind.Text, textReadable = true),
+
+        // Struct-typed built-ins whose binary form is not their rendering. Each has a fixed OID this module already knows elsewhere:
+        // `PostgresParamWriter` maps `cidr`, `macaddr` and the six ranges by name, so an unknown-token argument never covered them.
+        26  -> TypeInfo("oid", SqlRow.ColumnKind.Integer, textReadable = false),
+        650 -> TypeInfo("cidr", SqlRow.ColumnKind.Unknown, textReadable = false),
+        774 -> TypeInfo("macaddr8", SqlRow.ColumnKind.Unknown, textReadable = false),
+        // Named, but deliberately NOT Decimal: money is an int8 of the smallest currency unit rather than the
+        // numeric struct, so a Decimal kind routed `text` into the numeric renderer, which read the cents as a
+        // numeric header and answered `0E-100` for $1.00. Its own rendering is locale-chosen (`lc_monetary`
+        // supplies the symbol and separators, and the server does not report that setting to the connection), so
+        // there is no kind here whose renderer would be right; Unknown is the honest answer and leaves `text` on
+        // the documented byte fallback, which is the server's own rendering under the text protocol.
+        790  -> TypeInfo("money", SqlRow.ColumnKind.Unknown, textReadable = false),
+        829  -> TypeInfo("macaddr", SqlRow.ColumnKind.Unknown, textReadable = false),
+        1560 -> TypeInfo("bit", SqlRow.ColumnKind.Unknown, textReadable = false),
+        1562 -> TypeInfo("varbit", SqlRow.ColumnKind.Unknown, textReadable = false),
+        3614 -> TypeInfo("tsvector", SqlRow.ColumnKind.Unknown, textReadable = false),
+        3615 -> TypeInfo("tsquery", SqlRow.ColumnKind.Unknown, textReadable = false),
+
+        // The geometric family, all fixed-layout float8 structs.
+        600 -> TypeInfo("point", SqlRow.ColumnKind.Unknown, textReadable = false),
+        601 -> TypeInfo("lseg", SqlRow.ColumnKind.Unknown, textReadable = false),
+        602 -> TypeInfo("path", SqlRow.ColumnKind.Unknown, textReadable = false),
+        603 -> TypeInfo("box", SqlRow.ColumnKind.Unknown, textReadable = false),
+        604 -> TypeInfo("polygon", SqlRow.ColumnKind.Unknown, textReadable = false),
+        628 -> TypeInfo("line", SqlRow.ColumnKind.Unknown, textReadable = false),
+        718 -> TypeInfo("circle", SqlRow.ColumnKind.Unknown, textReadable = false),
+
+        // The ranges, each a flag byte followed by its bounds.
+        3904 -> TypeInfo("int4range", SqlRow.ColumnKind.Unknown, textReadable = false),
+        3906 -> TypeInfo("numrange", SqlRow.ColumnKind.Unknown, textReadable = false),
+        3908 -> TypeInfo("tsrange", SqlRow.ColumnKind.Unknown, textReadable = false),
+        3910 -> TypeInfo("tstzrange", SqlRow.ColumnKind.Unknown, textReadable = false),
+        3912 -> TypeInfo("daterange", SqlRow.ColumnKind.Unknown, textReadable = false),
+        3926 -> TypeInfo("int8range", SqlRow.ColumnKind.Unknown, textReadable = false),
+
+        // The remaining array types. Every array's binary form is the same header-plus-elements struct whatever it holds, so the three
+        // this module can encode were never the only ones a SELECT could return.
+        199  -> TypeInfo("json[]", SqlRow.ColumnKind.Array, textReadable = false),
+        651  -> TypeInfo("cidr[]", SqlRow.ColumnKind.Array, textReadable = false),
+        791  -> TypeInfo("money[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1000 -> TypeInfo("bool[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1001 -> TypeInfo("bytea[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1003 -> TypeInfo("name[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1005 -> TypeInfo("int2[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1014 -> TypeInfo("bpchar[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1015 -> TypeInfo("varchar[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1016 -> TypeInfo("int8[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1021 -> TypeInfo("float4[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1022 -> TypeInfo("float8[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1028 -> TypeInfo("oid[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1040 -> TypeInfo("macaddr[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1041 -> TypeInfo("inet[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1115 -> TypeInfo("timestamp[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1182 -> TypeInfo("date[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1183 -> TypeInfo("time[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1185 -> TypeInfo("timestamptz[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1187 -> TypeInfo("interval[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1231 -> TypeInfo("numeric[]", SqlRow.ColumnKind.Array, textReadable = false),
+        1270 -> TypeInfo("timetz[]", SqlRow.ColumnKind.Array, textReadable = false),
+        2951 -> TypeInfo("uuid[]", SqlRow.ColumnKind.Array, textReadable = false)
+    )
+
+    /** The PostgreSQL name of `columnOid` when a text read of it would reinterpret its bytes rather than render its value.
+      *
+      * Absent for a text-readable type and for an OID this backend cannot name, which are the two cases a text read is allowed to
+      * proceed on. This is what [[kyo.internal.postgres.types.PostgresDecoder.requireTextColumn]] refuses against.
+      */
+    /** The PostgreSQL name of `columnOid`, for any type this backend names. Absent otherwise, which is what says an OID carries no known
+      * meaning and so is not evidence of anything.
+      */
+    private[postgres] def typeNameOf(columnOid: Int): Maybe[String] =
+        Maybe.fromOption(typeNames.get(columnOid))
+
+    private[postgres] def nonTextColumnType(columnOid: Int): Maybe[String] =
+        types.get(columnOid) match
+            case Some(info) if !info.textReadable => Maybe(info.name)
+            case _                                => Maybe.empty
+
+    private val typeNames: Map[Int, String]        = types.view.mapValues(_.name).toMap
+    private val kinds: Map[Int, SqlRow.ColumnKind] = types.view.mapValues(_.kind).toMap
+
+    /** The `inet` OID, which `text` renders specially. Named here because no neutral [[kyo.SqlRow.ColumnKind]] describes an address, so
+      * the type token is what the rendering keys on rather than the kind every other column is dispatched by.
+      */
+    private[postgres] val inetToken: Int = OID_INET
+
+    /** The `float4` OID, which `text` renders apart from `float8` despite the two sharing a neutral kind: the kind says how wide a Scala
+      * type reads them, and reading a `float4` at `Double` widens the value before it is rendered.
+      */
+    private[postgres] val float4Token: Int = OID_FLOAT4
 
     /** Builds a [[SqlRow]] from what a PostgreSQL result-set message carries: the column bytes, the `RowDescription` fields, and the wire
       * format the Bind message asked for.
@@ -83,7 +281,7 @@ private[kyo] object PostgresRowCodec:
     /** Decodes the column named `name` with an explicit [[PostgresDecoder]]. */
     private[kyo] def columnDecoded[A](row: SqlRow, name: String)(using Frame, PostgresDecoder[A]): A < Abort[SqlDecodeException] =
         val idx = row.columnNames.indexWhere(_ == name)
-        if idx < 0 then Abort.fail(SqlDecodeColumnNotFoundException(name))
+        if idx < 0 then Abort.fail(SqlDecodeColumnNotFoundException(name, row.columnNames))
         else columnDecoded[A](row, idx)
     end columnDecoded
 

--- a/kyo-sql-postgres/shared/src/main/scala/kyo/internal/postgres/PostgresRowReader.scala
+++ b/kyo-sql-postgres/shared/src/main/scala/kyo/internal/postgres/PostgresRowReader.scala
@@ -61,54 +61,90 @@ final class PostgresRowReader(row: SqlRow, format: Format, matchesFieldAt: Maybe
     private def currentOid(): Int =
         if idx < row.size then row.columns(idx).typeToken else 0
 
+    /** The name of the column the cursor is on, so a refusal can say which field of a row type disagreed. Absent past the end and for a
+      * row carrying fewer column descriptions than values.
+      */
+    private def currentName(): Maybe[String] =
+        if idx < row.columns.size then Maybe(row.columns(idx).name) else Maybe.empty
+
     /** Reads the current column: hands its bytes and OID to the per-type decoder and advances the cursor. */
     private inline def readPrimitive[A](inline fromColumn: (Span[Byte], Int) => A): A =
         val oid = currentOid()
         fromColumn(nextBytes(), oid)
     end readPrimitive
 
+    /** Reads the current column at a numeric target, refusing a named column outside the numeric and text families.
+      *
+      * Separate from [[readDeclared]] because a numeric read legitimately takes more than one column type: every integral width satisfies
+      * an `Int`, both float widths satisfy a `Double`, and the text family satisfies any of them. What it must not take is a named column
+      * whose layout the decode would misread, which is what
+      * [[kyo.internal.postgres.types.PostgresDecoder.requireNumericColumn]] settles.
+      */
+    private inline def readNumeric[A](scalaType: String, accepts: Set[Int], inline fromColumn: (Span[Byte], Int) => A): A =
+        val oid = currentOid()
+        PostgresDecoder.requireNumericColumn(scalaType, oid, currentName(), accepts)
+        fromColumn(nextBytes(), oid)
+    end readNumeric
+
+    /** Reads the current column with a decoder that resolves its wire layout from the target type rather than from the column.
+      *
+      * Every such read is checked against what the decoder claims, because it cannot fail on its own: handed the wrong column it reads
+      * whatever bytes are there at the layout it expects and answers a plausible value. See
+      * [[kyo.internal.postgres.types.PostgresDecoder.requireAcceptedColumn]] for what it stays silent on.
+      */
+    private inline def readDeclared[A](scalaType: String, decoder: PostgresDecoder[A]): A =
+        val oid = currentOid()
+        PostgresDecoder.requireAcceptedColumn(scalaType, decoder.oids, oid, currentName())
+        decoder.read(format, nextBytes(), oid)
+    end readDeclared
+
     override def boolean(): Boolean =
-        readPrimitive((bytes, oid) => PostgresDecoder.bool.read(format, bytes, oid))
+        // A bool column is the target's own type and outside the numeric family, so it is named here; an int4 or
+        // numeric column reaching a Boolean field is one of the widenings the numeric set already carries.
+        readNumeric("Boolean", PostgresDecoder.numericOrBoolOids, (bytes, oid) => PostgresDecoder.bool.read(format, bytes, oid))
 
     override def short(): Short =
-        readPrimitive((bytes, oid) => PostgresDecoder.int2.read(format, bytes, oid))
+        readNumeric("Short", PostgresDecoder.numericFamilyOids, (bytes, oid) => PostgresDecoder.int2.read(format, bytes, oid))
 
     override def int(): Int =
-        readPrimitive((bytes, oid) => PostgresDecoder.int4.read(format, bytes, oid))
+        readNumeric("Int", PostgresDecoder.numericFamilyOids, (bytes, oid) => PostgresDecoder.int4.read(format, bytes, oid))
 
     override def long(): Long =
-        readPrimitive((bytes, oid) => PostgresDecoder.int8.read(format, bytes, oid))
+        readNumeric("Long", PostgresDecoder.numericFamilyOids, (bytes, oid) => PostgresDecoder.int8.read(format, bytes, oid))
 
     override def float(): Float =
-        readPrimitive((bytes, oid) => PostgresDecoder.float4.read(format, bytes, oid))
+        readNumeric("Float", PostgresDecoder.numericFamilyOids, (bytes, oid) => PostgresDecoder.float4.read(format, bytes, oid))
 
     override def double(): Double =
-        readPrimitive((bytes, oid) => PostgresDecoder.float8.read(format, bytes, oid))
+        readNumeric("Double", PostgresDecoder.numericFamilyOids, (bytes, oid) => PostgresDecoder.float8.read(format, bytes, oid))
 
     override def string(): String =
-        // textDecoder accepts both binary and text format identically (UTF-8 bytes either way).
-        PostgresDecoder.textDecoder.read(format, nextBytes())
+        // The column's OID goes to the decoder: a text read is the one read every wire type's bytes satisfy, so the
+        // decoder refuses a column whose type is not text rather than answering the protocol buffer as UTF-8.
+        readPrimitive((bytes, oid) => PostgresDecoder.textDecoder.read(format, bytes, oid))
 
     override def bytes(): Span[Byte] =
-        PostgresDecoder.bytea.read(format, nextBytes())
+        readDeclared("Span[Byte]", PostgresDecoder.bytea)
 
     override def bigDecimal(): BigDecimal =
         // Use the row's wire format: Binary for extended-protocol results, Text for simple-query results.
-        readPrimitive((bytes, oid) => PostgresDecoder.numeric.read(format, bytes, oid))
+        readNumeric("BigDecimal", PostgresDecoder.numericFamilyOids, (bytes, oid) => PostgresDecoder.numeric.read(format, bytes, oid))
 
     override def instant(): java.time.Instant =
         // timestamptz decoder returns kyo.Instant; convert at the boundary.
-        PostgresDecoder.timestamptz.read(format, nextBytes()).toJava
+        readDeclared("Instant", PostgresDecoder.timestamptz).toJava
 
     override def byte(): Byte =
         // PG has no single-byte integer type, so a Byte field travels as int2 and comes back from a column at least
         // twice as wide as the field. `readByte` range-checks the narrowing instead of wrapping it.
-        readPrimitive((bytes, oid) => PostgresDecoder.readByte(format, bytes, oid))
+        readNumeric("Byte", PostgresDecoder.numericFamilyOids, (bytes, oid) => PostgresDecoder.readByte(format, bytes, oid))
 
     override def char(): Char =
         // char is encoded as a 1-char text string; take the first character. A longer value is refused rather than
         // truncated to its first character: truncating to `s.charAt(0)` would drop the rest silently, a value change
-        // rather than a decode.
+        // rather than a decode. The column-type guard runs first so a non-text column is named against `Char`, the
+        // type that actually asked, rather than against the `String` the text decoder reads on the way there.
+        PostgresDecoder.requireTextColumn("Char", currentOid(), currentName())
         val s = PostgresDecoder.textDecoder.read(format, nextBytes())
         if s.isEmpty then throw SqlDecodeEmptyStringForCharException(Maybe(idx - 1))
         else if s.length > 1 then throw SqlDecodeMultiCharacterForCharException(Maybe(idx - 1), s.length)
@@ -118,10 +154,10 @@ final class PostgresRowReader(row: SqlRow, format: Format, matchesFieldAt: Maybe
     override def bigInt(): BigInt =
         // Use the row's wire format: Binary for extended-protocol results, Text for simple-query results.
         // `readBigInt` rejects a fractional value rather than truncating it, which `.toBigInt` would do silently.
-        readPrimitive((bytes, oid) => PostgresDecoder.readBigInt(format, bytes, oid))
+        readNumeric("BigInt", PostgresDecoder.numericFamilyOids, (bytes, oid) => PostgresDecoder.readBigInt(format, bytes, oid))
 
     override def duration(): java.time.Duration =
-        PostgresDecoder.interval.read(format, nextBytes())
+        readDeclared("Duration", PostgresDecoder.interval)
 
     // --- SQL type vocabulary ---
     //
@@ -131,34 +167,34 @@ final class PostgresRowReader(row: SqlRow, format: Format, matchesFieldAt: Maybe
     // or a JSON document.
 
     override def nextJson(): String =
-        PostgresDecoder.jsonDecoder.read(format, nextBytes())
+        readDeclared("JsonText", PostgresDecoder.jsonDecoder)
 
     override def nextUuid(): java.util.UUID =
-        PostgresDecoder.uuid.read(format, nextBytes())
+        readDeclared("UUID", PostgresDecoder.uuid)
 
     override def nextDate(): java.time.LocalDate =
-        PostgresDecoder.date.read(format, nextBytes())
+        readDeclared("LocalDate", PostgresDecoder.date)
 
     override def nextTime(): java.time.LocalTime =
-        PostgresDecoder.time.read(format, nextBytes())
+        readDeclared("LocalTime", PostgresDecoder.time)
 
     override def nextTimeWithOffset(): java.time.OffsetTime =
-        PostgresDecoder.timetz.read(format, nextBytes())
+        readDeclared("OffsetTime", PostgresDecoder.timetz)
 
     override def nextDateTime(): java.time.LocalDateTime =
-        PostgresDecoder.timestamp.read(format, nextBytes())
+        readDeclared("LocalDateTime", PostgresDecoder.timestamp)
 
     override def nextCalendarInterval(): java.time.Period =
-        PostgresDecoder.intervalPeriod.read(format, nextBytes())
+        readDeclared("Period", PostgresDecoder.intervalPeriod)
 
     override def nextArrayOfInt(): Chunk[Int] =
-        PostgresDecoder.int4Array.read(format, nextBytes())
+        readDeclared("Chunk[Int]", PostgresDecoder.int4Array)
 
     override def nextArrayOfString(): Chunk[String] =
-        PostgresDecoder.textArray.read(format, nextBytes())
+        readDeclared("Chunk[String]", PostgresDecoder.textArray)
 
     override def nextArrayOfJson(): Chunk[String] =
-        PostgresDecoder.jsonbArray.read(format, nextBytes())
+        readDeclared("Chunk[JsonText]", PostgresDecoder.jsonbArray)
 
     /** Returns the next column's bytes for a type PostgreSQL owns, in the PostgreSQL wire form, together with which form that is.
       *

--- a/kyo-sql-postgres/shared/src/main/scala/kyo/internal/postgres/types/PostgresDecoder.scala
+++ b/kyo-sql-postgres/shared/src/main/scala/kyo/internal/postgres/types/PostgresDecoder.scala
@@ -10,6 +10,7 @@ import kyo.Span
 import kyo.SqlCodec.Format
 import kyo.SqlDecodeArrayAbsentElementException
 import kyo.SqlDecodeByteaException
+import kyo.SqlDecodeColumnTypeMismatchException
 import kyo.SqlDecodeException
 import kyo.SqlDecodeInstantException
 import kyo.SqlDecodeIntervalException
@@ -19,6 +20,8 @@ import kyo.SqlDecodeValueRangeException
 import kyo.internal.SqlNumericDecode.parseDecimalText
 import kyo.internal.SqlNumericDecode.wholeOf
 import kyo.internal.postgres.PostgresArrayReader
+import kyo.internal.postgres.PostgresDialect
+import kyo.internal.postgres.PostgresRowCodec
 
 /** Decodes raw PostgreSQL wire bytes into a Scala value.
   *
@@ -44,7 +47,7 @@ import kyo.internal.postgres.PostgresArrayReader
   *   the Scala type this decoder produces
   */
 trait PostgresDecoder[A]:
-    /** OIDs this decoder recognises. */
+    /** OIDs this decoder recognises. Read once per guarded column, so implementations hold it rather than rebuilding it. */
     def oids: Set[Int]
 
     /** Decodes `bytes` from the given `format` into an `A`.
@@ -226,7 +229,7 @@ object PostgresDecoder:
       * `false` would silently misreport a column value the driver has no basis for calling falsy.
       */
     val bool: PostgresDecoder[Boolean] = new PostgresDecoder[Boolean]:
-        def oids: Set[Int] = Set(OID_BOOL)
+        val oids: Set[Int] = Set(OID_BOOL)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): Boolean = format match
             case Format.Binary =>
                 if isBoolBinary(columnOid, bytes) then bytes(0) != 0.toByte
@@ -249,7 +252,7 @@ object PostgresDecoder:
     // --- Short ---
 
     val int2: PostgresDecoder[Short] = new PostgresDecoder[Short]:
-        def oids: Set[Int] = Set(OID_INT2)
+        val oids: Set[Int] = Set(OID_INT2)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): Short = format match
             case Format.Binary => narrowToShort(integralValueOf(bytes, columnOid, "Short"), "numeric column")
             case Format.Text   => narrowToShort(wholeOf(parseDecimalText(text(bytes)), "Short", "text"), "text")
@@ -257,7 +260,7 @@ object PostgresDecoder:
     // --- Int ---
 
     val int4: PostgresDecoder[Int] = new PostgresDecoder[Int]:
-        def oids: Set[Int] = Set(OID_INT4)
+        val oids: Set[Int] = Set(OID_INT4)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): Int = format match
             case Format.Binary => narrowToInt(integralValueOf(bytes, columnOid, "Int"), "numeric column")
             case Format.Text   => narrowToInt(wholeOf(parseDecimalText(text(bytes)), "Int", "text"), "text")
@@ -265,7 +268,7 @@ object PostgresDecoder:
     // --- Long ---
 
     val int8: PostgresDecoder[Long] = new PostgresDecoder[Long]:
-        def oids: Set[Int] = Set(OID_INT8)
+        val oids: Set[Int] = Set(OID_INT8)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): Long = format match
             case Format.Binary => integralValueOf(bytes, columnOid, "Long")
             case Format.Text   => wholeOf(parseDecimalText(text(bytes)), "Long", "text")
@@ -282,7 +285,7 @@ object PostgresDecoder:
     // --- Float4 ---
 
     val float4: PostgresDecoder[Float] = new PostgresDecoder[Float]:
-        def oids: Set[Int] = Set(OID_FLOAT4)
+        val oids: Set[Int] = Set(OID_FLOAT4)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): Float = format match
             case Format.Binary => approximateValueOf(bytes, columnOid, NumericWire.Float4, "Float").toFloat
             case Format.Text   => text(bytes).toFloat
@@ -290,7 +293,7 @@ object PostgresDecoder:
     // --- Float8 ---
 
     val float8: PostgresDecoder[Double] = new PostgresDecoder[Double]:
-        def oids: Set[Int] = Set(OID_FLOAT8)
+        val oids: Set[Int] = Set(OID_FLOAT8)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): Double = format match
             case Format.Binary => approximateValueOf(bytes, columnOid, NumericWire.Float8, "Double")
             case Format.Text   => text(bytes).toDouble
@@ -312,7 +315,7 @@ object PostgresDecoder:
       * Value reconstruction: sum_i(digits[i] * 10000^(weight - i)), then apply dscale.
       */
     val numeric: PostgresDecoder[BigDecimal] = new PostgresDecoder[BigDecimal]:
-        def oids: Set[Int] = Set(OID_NUMERIC)
+        val oids: Set[Int] = Set(OID_NUMERIC)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): BigDecimal = format match
             case Format.Text   => parseDecimalText(text(bytes))
             case Format.Binary => decimalValueOf(bytes, columnOid, NumericWire.Numeric, "BigDecimal")
@@ -393,10 +396,97 @@ object PostgresDecoder:
 
     // --- Text / Varchar ---
 
+    /** The PostgreSQL name of `columnOid` when it names a type whose bytes a text read would reinterpret rather than render.
+      *
+      * A text read of such a column returns the protocol buffer reinterpreted as UTF-8: `int4` 42 is `00 00 00 2A`, `date` is an `int4`
+      * day count, `jsonb` carries a leading version byte. None of that is the value's rendering, and none of it fails on its own, since
+      * every byte sequence is some string.
+      *
+      * The answer comes from [[kyo.internal.postgres.PostgresRowCodec]]'s one type table rather than a second list here, so what this
+      * refuses and what [[kyo.SqlRow.columnKind]] and [[kyo.SqlRow.columnTypeName]] report cannot drift apart. `json` (OID 114) is
+      * text-readable there and so is not refused: its wire form is the document text in both formats. An OID the table does not name is
+      * not refused either, for the reason [[numericWireOf]] does not refuse one: the dynamic OIDs (`citext`, an enum type, a domain over
+      * text) are text-shaped and read correctly today, and a token with no known meaning is not evidence of a mismatch.
+      */
+    private[kyo] def nonTextColumnType(columnOid: Int): Maybe[String] =
+        PostgresRowCodec.nonTextColumnType(columnOid)
+
+    /** Refuses a text read of a column whose type is not text, naming the Scala type that asked.
+      *
+      * The guard the text decode owes its caller: a text read is the one every byte sequence satisfies, so without it the target type
+      * cannot refuse anything.
+      */
+    private[kyo] def requireTextColumn(scalaType: String, columnOid: Int, columnName: Maybe[String] = Maybe.empty)(using Frame): Unit =
+        nonTextColumnType(columnOid).foreach { columnType =>
+            throw SqlDecodeColumnTypeMismatchException(scalaType, PostgresDialect.id, columnType, columnOid.toString, columnName)
+        }
+
+    /** The column types a numeric read may take.
+      *
+      * Wider than one decoder's own OID, deliberately: an `Int` field is satisfied by every integral width, a `Double` by both float
+      * widths, and any of them by the text family, whose values ARE their digits under both wire formats. Those widenings are the reason
+      * the numeric reads are not checked against `decoder.oids` the way the declared reads are.
+      *
+      * `varchar` (1043) and `bpchar` (1042) are spelled as literals for the same reason they are in the decoders: nothing encodes to them,
+      * so they have no [[PostgresEncoder]] constant.
+      */
+    private[kyo] val numericFamilyOids: Set[Int] =
+        Set(OID_INT2, OID_INT4, OID_INT8, OID_FLOAT4, OID_FLOAT8, OID_NUMERIC, OID_TEXT, 1043, 1042)
+
+    /** The same set plus `bool`, for a `Boolean` read: its own column type is the one target outside the numeric family. Held rather
+      * than unioned at the call, which would allocate on every read.
+      */
+    private[kyo] val numericOrBoolOids: Set[Int] = numericFamilyOids + OID_BOOL
+
+    /** Refuses a numeric read of a NAMED column outside the numeric and text families.
+      *
+      * The wire dispatch resolves an OID it does not recognise to the target's own family, which is what keeps the by-width reads
+      * (`oid`, `xid`, `regclass`) working and what the two-argument `read` overload relies on. For a column this backend names, that
+      * fallback is not a widening but a misread: a `date` is four big-endian bytes exactly as an `int4` is, so an `Int` over one answers
+      * the day count since the PostgreSQL epoch rather than failing. Unnamed OIDs stay permissive for the reason
+      * [[requireAcceptedColumn]] documents.
+      *
+      * `accepted` is [[numericFamilyOids]], or [[numericOrBoolOids]] for a `Boolean` read, whose own column type is the one target
+      * outside that family.
+      */
+    private[kyo] def requireNumericColumn(scalaType: String, columnOid: Int, columnName: Maybe[String], accepted: Set[Int])(
+        using Frame
+    ): Unit =
+        requireAcceptedColumn(scalaType, accepted, columnOid, columnName)
+
+    /** Refuses a read whose column is a type this backend names and the decoder does not accept.
+      *
+      * The same guard as [[requireTextColumn]] for every read that is not a text read. Those resolve their wire layout from the target
+      * type rather than from the column, so a `date` decoder handed an `int4` column reads the four bytes as a day count and answers a
+      * well-formed wrong date: 42 becomes 2000-02-12, with nothing for the caller to notice. Checking the column against what the
+      * decoder claims is what turns that into a typed refusal.
+      *
+      * Silent on two inputs, deliberately. `OID_UNSPECIFIED` is what a nested value carries (an array element, a range bound), where the
+      * column's own OID describes the container rather than the element. An OID this backend does not name is not refused either, for the
+      * reason [[numericWireOf]] does not refuse one: a token with no known meaning is not evidence of a mismatch, and the dynamic OIDs
+      * (`citext`, an enum type, a domain) live there.
+      *
+      * NOT used by the numeric reads. Those widen on purpose, an `Int` field over a `sum(int4)` that comes back `int8` being the ordinary
+      * case, and [[numericWireOf]] already resolves their representation from the column.
+      */
+    private[kyo] def requireAcceptedColumn(
+        scalaType: String,
+        accepted: Set[Int],
+        columnOid: Int,
+        columnName: Maybe[String] = Maybe.empty
+    )(using Frame): Unit =
+        if columnOid != PostgresEncoder.OID_UNSPECIFIED && !accepted.contains(columnOid) then
+            PostgresRowCodec.typeNameOf(columnOid).foreach { columnType =>
+                throw SqlDecodeColumnTypeMismatchException(scalaType, PostgresDialect.id, columnType, columnOid.toString, columnName)
+            }
+
     val textDecoder: PostgresDecoder[String] = new PostgresDecoder[String]:
         // Accepts text OID, varchar OID (1043), and bpchar OID (1042).
-        def oids: Set[Int]                                                               = Set(OID_TEXT, 1043, 1042)
-        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): String = text(bytes)
+        val oids: Set[Int] = Set(OID_TEXT, 1043, 1042)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): String =
+            requireTextColumn("String", columnOid)
+            text(bytes)
+        end read
 
     // --- JSON / JSONB ---
     // Handles both json (OID 114) and jsonb (OID 3802).
@@ -409,7 +499,7 @@ object PostgresDecoder:
     // For all Text-format values the full byte span is decoded as UTF-8 (no prefix to strip).
 
     val jsonDecoder: PostgresDecoder[String] = new PostgresDecoder[String]:
-        def oids: Set[Int] = Set(OID_JSON, OID_JSONB)
+        val oids: Set[Int] = Set(OID_JSON, OID_JSONB)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): String =
             format match
                 case Format.Binary if bytes.size > 0 && bytes(0) == 0x01.toByte =>
@@ -428,7 +518,7 @@ object PostgresDecoder:
     //     backslash doubled. Returning those bytes as-is would decode `\001` as four ASCII characters
     //     rather than the one byte 0x01.
     val bytea: PostgresDecoder[Span[Byte]] = new PostgresDecoder[Span[Byte]]:
-        def oids: Set[Int] = Set(OID_BYTEA)
+        val oids: Set[Int] = Set(OID_BYTEA)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): Span[Byte] = format match
             case Format.Binary => bytes
             case Format.Text   =>
@@ -505,7 +595,7 @@ object PostgresDecoder:
     // Uses kyo.Instant (preferred over java.time.Instant).
 
     val timestamptz: PostgresDecoder[kyo.Instant] = new PostgresDecoder[kyo.Instant]:
-        def oids: Set[Int] = Set(OID_TIMESTAMPTZ)
+        val oids: Set[Int] = Set(OID_TIMESTAMPTZ)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): kyo.Instant = format match
             case Format.Binary =>
                 val pgMicros    = readBigEndianLong(bytes, 0)
@@ -533,7 +623,7 @@ object PostgresDecoder:
     // No Kyo equivalent for LocalDate; java.time.LocalDate is used.
 
     val date: PostgresDecoder[java.time.LocalDate] = new PostgresDecoder[java.time.LocalDate]:
-        def oids: Set[Int] = Set(OID_DATE)
+        val oids: Set[Int] = Set(OID_DATE)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): java.time.LocalDate = format match
             case Format.Binary =>
                 val pgDays  = readBigEndianInt(bytes, 0)
@@ -546,7 +636,7 @@ object PostgresDecoder:
     // No Kyo equivalent for LocalDateTime; java.time.LocalDateTime is used.
 
     val timestamp: PostgresDecoder[java.time.LocalDateTime] = new PostgresDecoder[java.time.LocalDateTime]:
-        def oids: Set[Int] = Set(OID_TIMESTAMP)
+        val oids: Set[Int] = Set(OID_TIMESTAMP)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): java.time.LocalDateTime = format match
             case Format.Binary =>
                 val pgMicros = readBigEndianLong(bytes, 0)
@@ -562,7 +652,7 @@ object PostgresDecoder:
     // No Kyo equivalent for LocalTime; java.time.LocalTime is used.
 
     val time: PostgresDecoder[java.time.LocalTime] = new PostgresDecoder[java.time.LocalTime]:
-        def oids: Set[Int] = Set(OID_TIME)
+        val oids: Set[Int] = Set(OID_TIME)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): java.time.LocalTime = format match
             case Format.Binary =>
                 val micros = readBigEndianLong(bytes, 0)
@@ -577,7 +667,7 @@ object PostgresDecoder:
     // Text format: ISO-8601 extended, e.g. "13:45:30.123456+05:30"; parsed via OffsetTime.parse.
 
     val timetz: PostgresDecoder[java.time.OffsetTime] = new PostgresDecoder[java.time.OffsetTime]:
-        def oids: Set[Int] = Set(OID_TIMETZ)
+        val oids: Set[Int] = Set(OID_TIMETZ)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using Frame): java.time.OffsetTime = format match
             case Format.Binary =>
                 val micros        = readBigEndianLong(bytes, 0)
@@ -596,7 +686,7 @@ object PostgresDecoder:
     // months/years raises a SqlDecodeIntervalException directing the caller to cast to ISO-formatted text.
 
     val interval: PostgresDecoder[java.time.Duration] = new PostgresDecoder[java.time.Duration]:
-        def oids: Set[Int] = Set(OID_INTERVAL)
+        val oids: Set[Int] = Set(OID_INTERVAL)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): java.time.Duration = format match
             case Format.Binary =>
                 val micros = readBigEndianLong(bytes, 0)
@@ -825,7 +915,7 @@ object PostgresDecoder:
     // raises the same SqlDecodeIntervalException the binary arm raises for a non-zero microseconds field.
 
     val intervalPeriod: PostgresDecoder[java.time.Period] = new PostgresDecoder[java.time.Period]:
-        def oids: Set[Int] = Set(OID_INTERVAL)
+        val oids: Set[Int] = Set(OID_INTERVAL)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): java.time.Period = format match
             case Format.Binary =>
                 val micros = readBigEndianLong(bytes, 0)
@@ -839,12 +929,371 @@ object PostgresDecoder:
                 val s = text(bytes)
                 periodOf(readIntervalText(s))
 
+    // --- INTERVAL, rendered as ISO-8601 text ---
+    // Wire: the same 16-byte struct the two decoders above read, rendered rather than converted.
+    // Text format: the server already sent a rendering, whichever IntervalStyle it was configured for, so it is the answer.
+
+    /** Any INTERVAL as ISO-8601 text, which is the one reading every interval has.
+      *
+      * [[interval]] reads the value as a `java.time.Duration` and [[intervalPeriod]] as a `java.time.Period`, and each refuses what the
+      * other carries: a `Duration` has no lane for months or calendar days, a `Period` none for a time part, and neither holds an
+      * interval with both, which `interval '1 day 3 hours'` is. Rendering the wire fields is what lets [[kyo.SqlRow.text]] answer for
+      * every interval rather than for two halves of the range, and it is a rendering rather than a decode, so nothing has to be dropped.
+      *
+      * The rendering is the one PostgreSQL's own `iso_8601` IntervalStyle produces: a sign per component, `PT0S` for the zero interval,
+      * and fractional seconds only when there are any.
+      */
+    val intervalText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_INTERVAL)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary =>
+                renderIso(readBigEndianInt(bytes, 12).toLong, readBigEndianInt(bytes, 8).toLong, readBigEndianLong(bytes, 0))
+            case Format.Text =>
+                // The one column whose text rendering is NOT simply handed back. Which of the four renderings the
+                // server sends is a session setting, so passing the bytes through would make the same stored value
+                // read differently under the two protocols, and differently again after someone changes
+                // `IntervalStyle`. Parsing and re-rendering is what keeps one value reading as one string.
+                val fields = readIntervalText(text(bytes))
+                renderIso(fields.months, fields.days, fields.micros)
+
+    /** The ISO-8601 rendering of an INTERVAL's three fields, as PostgreSQL's `iso_8601` IntervalStyle writes them. */
+    private def renderIso(months: Long, days: Long, micros: Long): String =
+        val years     = months / 12
+        val monthPart = months  % 12
+        val hours     = micros / MicrosPerHour
+        val minutes   = (micros % MicrosPerHour) / MicrosPerMinute
+        val subMinute = micros  % MicrosPerMinute
+        val seconds   = subMinute / MicrosPerSecond
+        val fraction  = Math.abs(subMinute % MicrosPerSecond)
+        def unit(value: Long, suffix: Char): String =
+            if value == 0 then "" else s"$value$suffix"
+        val secondsPart =
+            if seconds == 0 && fraction == 0 then ""
+            else
+                // The sign lives on the seconds when they are zero and the fraction is not, since `0.5` and `-0.5`
+                // share a whole part and an interval's fields are negative together.
+                val sign = if seconds == 0 && subMinute < 0 then "-" else ""
+                val frac = if fraction == 0 then "" else "." + f"$fraction%06d".reverse.dropWhile(_ == '0').reverse
+                s"$sign$seconds${frac}S"
+        val date = unit(years, 'Y') + unit(monthPart, 'M') + unit(days, 'D')
+        val time = unit(hours, 'H') + unit(minutes, 'M') + secondsPart
+        if date.isEmpty && time.isEmpty then "PT0S"
+        else if time.isEmpty then s"P$date"
+        else s"P${date}T$time"
+    end renderIso
+
+    // --- INET, rendered as the address it holds ---
+    // Wire: family (2 = IPv4, 3 = IPv6), netmask bits, is_cidr, address length in bytes, then the address.
+    // Text format: the server already sent its own rendering, so it is the answer.
+
+    private val AF_INET = 2
+
+    /** An INET as the address it holds, in PostgreSQL's own output form.
+      *
+      * `inet` has no Scala type in this module, so a caller with no row type reaches it through [[kyo.SqlRow.text]], and a text decode
+      * refuses it because the wire value is a struct rather than characters. Rendering that struct is what makes the column readable at
+      * all: the alternative, handing back its bytes as UTF-8, is mojibake for every address.
+      *
+      * The mask is written only when it is not the full one, and an IPv6 address is compressed at its longest run of zero groups
+      * (leftmost on a tie, and never a run of one), which is RFC 5952 and is what the server's own text rendering of the same value says.
+      */
+    val inetText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_INET)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary => renderInet(bytes)
+            case Format.Text   => text(bytes)
+
+    /** The address an INET's wire struct describes, masked as PostgreSQL writes it. */
+    private def renderInet(bytes: Span[Byte]): String =
+        val family = bytes(0) & 0xff
+        val bits   = bytes(1) & 0xff
+        val length = bytes(3) & 0xff
+        if family == AF_INET then
+            val quad = (0 until length).map(i => (bytes(4 + i) & 0xff).toString).mkString(".")
+            if bits == 32 then quad else s"$quad/$bits"
+        else
+            val groups = (0 until 8).map(g => ((bytes(4 + g * 2) & 0xff) << 8) | (bytes(4 + g * 2 + 1) & 0xff))
+            val text   = compressIpv6(groups)
+            if bits == 128 then text else s"$text/$bits"
+        end if
+    end renderInet
+
+    /** The eight groups of an IPv6 address as RFC 5952 writes them: lowercase, no leading zeros, and the longest run of zero groups
+      * replaced by `::`, leftmost on a tie. A run of ONE is left alone, since `::` is no shorter than `0` and the RFC forbids it.
+      */
+    private def compressIpv6(groups: IndexedSeq[Int]): String =
+        var bestStart = -1
+        var bestLen   = 0
+        var i         = 0
+        while i < 8 do
+            if groups(i) != 0 then i += 1
+            else
+                var end = i
+                while end < 8 && groups(end) == 0 do end += 1
+                if end - i > bestLen then
+                    bestLen = end - i
+                    bestStart = i
+                end if
+                i = end
+        end while
+        def hex(from: Int, until: Int): String =
+            (from until until).map(g => Integer.toHexString(groups(g))).mkString(":")
+        if bestLen < 2 then hex(0, 8)
+        else s"${hex(0, bestStart)}::${hex(bestStart + bestLen, 8)}"
+    end compressIpv6
+
+    // --- Server-shaped text renderings ---
+    //
+    // `SqlRow.text` answers one string for one stored value whichever protocol carried the row. Under the text protocol the server
+    // already sent its own rendering and the bytes are handed back; under the binary protocol the value has to be rendered here, and the
+    // rendering that agrees is the server's own, not the JDK's. They differ for whole column types rather than at the edges: PostgreSQL
+    // writes a bool `t`, a timestamp `2026-08-25 10:00:00`, and a float8 1e10 `10000000000`, where Java writes `true`,
+    // `2026-08-25T10:00`, and `1.0E10`.
+    //
+    // The special values are here for the same reason. `numeric 'NaN'` and `date 'infinity'` have no Scala counterpart, so decoding at a
+    // type either refuses them (numeric) or answers a plausible wrong value (a date near year 5881610, which is what `plusDays` on
+    // Int.MaxValue lands on), while the server renders each as a word.
+
+    /** `t` or `f`, which is what `boolout` writes. */
+    val boolText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_BOOL)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary => if bool.read(format, bytes, columnOid) then "t" else "f"
+            case Format.Text   => text(bytes)
+
+    /** A `date`, with `infinity` and `-infinity` rendered as the server writes them rather than decoded. */
+    val dateText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_DATE)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary =>
+                readBigEndianInt(bytes, 0) match
+                    case Int.MaxValue => "infinity"
+                    case Int.MinValue => "-infinity"
+                    case _            => renderLocalDate(date.read(format, bytes, columnOid))
+            case Format.Text => text(bytes)
+
+    /** A `timestamp`, space-separated with the seconds always written and the fraction trimmed, which is `timestamp_out`. */
+    val timestampText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_TIMESTAMP)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary =>
+                readBigEndianLong(bytes, 0) match
+                    case Long.MaxValue => "infinity"
+                    case Long.MinValue => "-infinity"
+                    case _             => renderLocalDateTime(timestamp.read(format, bytes, columnOid))
+            case Format.Text => text(bytes)
+
+    /** A `timestamptz`, rendered at UTC with the `+00` offset the server writes when its TimeZone is UTC. */
+    val timestamptzText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_TIMESTAMPTZ)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary =>
+                readBigEndianLong(bytes, 0) match
+                    case Long.MaxValue => "infinity"
+                    case Long.MinValue => "-infinity"
+                    case _ =>
+                        val instant = timestamptz.read(format, bytes, columnOid).toJava
+                        val utc     = java.time.LocalDateTime.ofInstant(instant, java.time.ZoneOffset.UTC)
+                        renderLocalDateTime(utc) + "+00"
+            case Format.Text => text(bytes)
+
+    /** A `time`, seconds always written, which is `time_out`. */
+    val timeText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_TIME)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary => renderLocalTime(time.read(format, bytes, columnOid))
+            case Format.Text   => text(bytes)
+
+    /** A `timetz`, whose offset the server writes in hours, and in hours and minutes only when the minutes are not zero. */
+    val timetzText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_TIMETZ)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary =>
+                val value = timetz.read(format, bytes, columnOid)
+                renderLocalTime(value.toLocalTime) + renderOffset(value.getOffset)
+            case Format.Text => text(bytes)
+
+    /** A `numeric`, with the three special values rendered rather than refused. */
+    val numericText: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_NUMERIC)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary =>
+                // The sign field of the wire header carries the special values, so they are read before the digits are.
+                val sign = if bytes.size >= 8 then readBigEndianShort(bytes, 4).toInt & 0xffff else 0
+                sign match
+                    case 0xc000 => "NaN"
+                    case 0xd000 => "Infinity"
+                    case 0xf000 => "-Infinity"
+                    // toPlainString, not toString: BigDecimal takes exponent notation once the adjusted exponent is
+                    // below -6, and `numeric_out` never does, so a numeric holding 0.0000001 rendered `1E-7` under
+                    // the binary protocol against the server's own `0.0000001`.
+                    case _ => numeric.read(format, bytes, columnOid).bigDecimal.toPlainString
+                end match
+            case Format.Text => text(bytes)
+
+    /** A `float4`, read at its own width so the value is not widened before it is rendered. */
+    val float4Text: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_FLOAT4)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary =>
+                val value = float4.read(format, bytes, columnOid)
+                if value.isNaN then "NaN"
+                else if value.isInfinite then (if value > 0 then "Infinity" else "-Infinity")
+                else renderFloating(shortestFloat4(value), isNegative(value.toDouble), Float4Digits)
+            case Format.Text => text(bytes)
+
+    /** A `float8`. */
+    val float8Text: PostgresDecoder[String] = new PostgresDecoder[String]:
+        val oids: Set[Int] = Set(OID_FLOAT8)
+        def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): String = format match
+            case Format.Binary =>
+                val value = float8.read(format, bytes, columnOid)
+                if value.isNaN then "NaN"
+                else if value.isInfinite then (if value > 0 then "Infinity" else "-Infinity")
+                else renderFloating(shortestFloat8(value), isNegative(value), Float8Digits)
+            case Format.Text => text(bytes)
+
+    /** `YYYY-MM-DD HH:MM:SS[.ffffff]`, the shape `timestamp_out` writes: a space rather than `T`, the seconds always present, and the
+      * fraction only when it is not zero, with its trailing zeros trimmed.
+      */
+    private def renderLocalDateTime(value: java.time.LocalDateTime): String =
+        val date = value.toLocalDate
+        val body = f"${renderYmd(date)}%s ${renderLocalTime(value.toLocalTime)}%s"
+        // The era trails the whole value, after the time, which is where `timestamp_out` puts it.
+        if date.getYear <= 0 then s"$body BC" else body
+    end renderLocalDateTime
+
+    /** `YYYY-MM-DD`, with the year counted within its era rather than proleptically: `date_out` spells 1 BC as `0001`, where
+      * `LocalDate` numbers that year 0 and 44 BC as -43.
+      *
+      * `LocalDate.toString` also prefixes a `+` to any year of five digits or more, which the server does not write, so a year-10000
+      * date rendered `+10000-01-01` against the server's `10000-01-01`. Both are legal values: PostgreSQL's date range runs from
+      * 4713 BC to 5874897 AD.
+      */
+    private def renderYmd(value: java.time.LocalDate): String =
+        val year = value.getYear
+        val era  = if year <= 0 then 1 - year else year
+        f"$era%04d-${value.getMonthValue}%02d-${value.getDayOfMonth}%02d"
+    end renderYmd
+
+    /** `YYYY-MM-DD`, with `BC` appended for a year in that era, which is how `date_out` writes one. */
+    private def renderLocalDate(value: java.time.LocalDate): String =
+        if value.getYear <= 0 then s"${renderYmd(value)} BC" else renderYmd(value)
+
+    /** `HH:MM:SS[.ffffff]`. Java omits the seconds when they are zero and pads the fraction to a multiple of three digits; the server
+      * does neither.
+      */
+    private def renderLocalTime(value: java.time.LocalTime): String =
+        val base  = f"${value.getHour}%02d:${value.getMinute}%02d:${value.getSecond}%02d"
+        val nanos = value.getNano
+        if nanos == 0 then base
+        else
+            // The server keeps microsecond resolution, so the fraction is six digits before its trailing zeros go.
+            val micros = f"${nanos / 1000}%06d".reverse.dropWhile(_ == '0').reverse
+            s"$base.$micros"
+        end if
+    end renderLocalTime
+
+    /** `+HH`, widening to `+HH:MM` and then `+HH:MM:SS` as each field turns out to be needed, which is how the server writes a `timetz`
+      * offset.
+      *
+      * The seconds field is not vestigial: PostgreSQL accepts a second-precision zone and `timetz_out` writes it back, so
+      * `12:00:00+05:30:33` is a value a column can hold and dropping its `:33` would render a different instant's offset.
+      */
+    private def renderOffset(offset: java.time.ZoneOffset): String =
+        val total = offset.getTotalSeconds
+        val sign  = if total < 0 then "-" else "+"
+        val abs   = Math.abs(total)
+        val hours = abs / 3600
+        val mins  = (abs % 3600) / 60
+        val secs  = abs  % 60
+        if secs != 0 then f"$sign%s$hours%02d:$mins%02d:$secs%02d"
+        else if mins != 0 then f"$sign%s$hours%02d:$mins%02d"
+        else f"$sign%s$hours%02d"
+        end if
+    end renderOffset
+
+    /** Where the server leaves plain notation for each float width: the type's significant-digit count, `FLT_DIG` and `DBL_DIG`. */
+    private val Float4Digits = 6
+    private val Float8Digits = 15
+
+    /** The precisions a shortest-decimal search walks, allocated once: a `float` needs at most 9 significant digits to round-trip and a
+      * `double` at most 17.
+      */
+    private val precisions: Array[java.math.MathContext] =
+        Array.tabulate(18)(p => new java.math.MathContext(if p == 0 then 1 else p))
+
+    /** Whether a value carries a minus sign, negative zero included, which is the case a comparison against zero misses. */
+    private def isNegative(value: Double): Boolean =
+        value < 0.0 || (value == 0.0 && 1.0 / value < 0.0)
+
+    /** The shortest decimal that reads back as the same `float`.
+      *
+      * `Float.toString` answers this on the JVM but not on every platform this module builds for: Scala.js widens to a double first and
+      * prints that, so 12345.6f arrives as `12345.599609375` and 1e-4f as `9.999999747378752e-05`. Searching upward from one significant
+      * digit for the first that round-trips is the same answer on every platform, and it is the answer the server's own shortest-decimal
+      * output is computed from.
+      */
+    private def shortestFloat4(value: Float): java.math.BigDecimal =
+        val exact = new java.math.BigDecimal(value.toDouble)
+        var p     = 1
+        var found = null: java.math.BigDecimal
+        while found == null && p <= 9 do
+            val candidate = exact.round(precisions(p))
+            if candidate.floatValue == value then found = candidate
+            p += 1
+        end while
+        (if found == null then exact else found).stripTrailingZeros
+    end shortestFloat4
+
+    /** The shortest decimal that reads back as the same `double`, by the same search [[shortestFloat4]] runs. */
+    private def shortestFloat8(value: Double): java.math.BigDecimal =
+        val exact = new java.math.BigDecimal(value)
+        var p     = 1
+        var found = null: java.math.BigDecimal
+        while found == null && p <= 17 do
+            val candidate = exact.round(precisions(p))
+            if candidate.doubleValue == value then found = candidate
+            p += 1
+        end while
+        (if found == null then exact else found).stripTrailingZeros
+    end shortestFloat8
+
+    /** Renders a floating value the way `float4out` and `float8out` do: plain notation while the decimal exponent is at least -4 and
+      * below `digits`, and `d.ddde[+-]NN` outside that band, with the exponent padded to at least two digits.
+      *
+      * `digits` is the type's significant-digit count, which is where the server switches: [[Float4Digits]] for a `float4` and
+      * [[Float8Digits]] for a `float8`. The two widths do not share it, so a `float4` 1e6 renders `1e+06` where a `float8` 1e6 renders
+      * `1000000`.
+      *
+      * `value` carries the shortest round-tripping digits and `negative` its sign, which are taken from the value rather than from a
+      * `toString`: the two platforms this module builds for do not spell a float the same way, and one of them drops the sign of a
+      * negative zero entirely.
+      *
+      * The digits are the shortest that round-trip, and for a handful of values the server writes different ones for the same stored
+      * double: it renders 1e23 as `9.999999999999999e+22` under the default `extra_float_digits`, and as `1e+23` under
+      * `extra_float_digits = 0`. Which of the two it picks is a session setting, and the server does not report that setting to the
+      * connection, so no rendering computed here agrees with it for every session. The values it separates are those whose shortest
+      * decimal form falls on an exact representable midpoint: six of the 5409 `d x 10^e` doubles across the type's whole exponent range.
+      */
+    private def renderFloating(value: java.math.BigDecimal, negative: Boolean, digits: Int): String =
+        if value.signum == 0 then (if negative then "-0" else "0")
+        else
+            // The power of ten of the leading digit, which is what the server compares against `digits`.
+            val exponent = value.precision - value.scale - 1
+            if exponent >= -4 && exponent < digits then value.toPlainString
+            else
+                val sign = if exponent < 0 then "-" else "+"
+                f"${value.movePointLeft(exponent).toPlainString}%se$sign%s${Math.abs(exponent)}%02d"
+            end if
+    end renderFloating
+
     // --- UUID ---
     // Binary: 16 bytes big-endian (mostSignificantBits Int64, leastSignificantBits Int64).
     // Text: canonical 36-character hyphenated form (e.g. "550e8400-e29b-41d4-a716-446655440000").
 
     val uuid: PostgresDecoder[java.util.UUID] = new PostgresDecoder[java.util.UUID]:
-        def oids: Set[Int] = Set(OID_UUID)
+        val oids: Set[Int] = Set(OID_UUID)
         def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): java.util.UUID = format match
             case Format.Binary =>
                 if bytes.size != 16 then
@@ -868,9 +1317,9 @@ object PostgresDecoder:
       * [[PostgresEncoder.arrayEncoder]]. `typeName` names the element type in an absent-element error; `arrayOid` is the OID the decoder
       * claims. The element format and OID both come from the array header the reader parsed, never from `elemDecoder`.
       */
-    private def arrayDecoder[A](elemDecoder: PostgresDecoder[A], typeName: String, arrayOid: Int): PostgresDecoder[Chunk[A]] =
+    private def arrayDecoder[A](elemDecoder: PostgresDecoder[A], typeName: String, arrayOids: Set[Int]): PostgresDecoder[Chunk[A]] =
         new PostgresDecoder[Chunk[A]]:
-            def oids: Set[Int] = Set(arrayOid)
+            val oids: Set[Int] = arrayOids
             def read(format: Format, bytes: Span[Byte], columnOid: Int)(using frame: Frame): Chunk[A] =
                 val arr     = new PostgresArrayReader(bytes, format, frame)
                 val count   = arr.openArray()
@@ -889,14 +1338,27 @@ object PostgresDecoder:
             end read
 
     /** Decodes a PostgreSQL `int4[]` (OID 1007) column into a [[Chunk[Int]]]. */
-    val int4Array: PostgresDecoder[Chunk[Int]] = arrayDecoder(int4, "Int", PostgresEncoder.OID_INT4_ARRAY)
+    val int4Array: PostgresDecoder[Chunk[Int]] =
+        // 1005 `int2[]` and 1016 `int8[]`: the element decode reads each element at the width the array header
+        // names and range-checks it into an Int, so the narrower type is exact and the wider one refuses a value
+        // that does not fit rather than truncating. `array_agg` over a bigint produces an int8[], which no other
+        // read in the vocabulary covers.
+        arrayDecoder(int4, "Int", Set(PostgresEncoder.OID_INT4_ARRAY, 1005, 1016))
 
     /** Decodes a PostgreSQL `text[]` (OID 1009) column into a [[Chunk[String]]]. */
-    val textArray: PostgresDecoder[Chunk[String]] = arrayDecoder(textDecoder, "String", PostgresEncoder.OID_TEXT_ARRAY)
+    val textArray: PostgresDecoder[Chunk[String]] =
+        // 1015 `varchar[]`, 1014 `bpchar[]` and 1003 `name[]`: all three carry their elements as the same UTF-8
+        // bytes a `text` element carries, which is what `textDecoder` reads, so refusing them would refuse a
+        // column that decodes exactly. They are spelled as literals here for the reason `varchar` and `bpchar`
+        // are in the scalar decoders: nothing encodes to them, so they have no PostgresEncoder constant.
+        arrayDecoder(textDecoder, "String", Set(PostgresEncoder.OID_TEXT_ARRAY, 1015, 1014, 1003))
 
     /** Decodes a PostgreSQL `jsonb[]` (OID 3807) column into a [[Chunk[String]]]. Each element is decoded by [[jsonDecoder]], the 1-byte
       * JSONB version prefix (0x01) is stripped and the remainder returned as a UTF-8 JSON-text string.
       */
-    val jsonbArray: PostgresDecoder[Chunk[String]] = arrayDecoder(jsonDecoder, "String", PostgresEncoder.OID_JSONB_ARRAY)
+    val jsonbArray: PostgresDecoder[Chunk[String]] =
+        // 199 `json[]`: `jsonDecoder` strips the JSONB version byte only when the element actually carries one,
+        // and a `json` element is the bare document, so both containers read through it unchanged.
+        arrayDecoder(jsonDecoder, "String", Set(PostgresEncoder.OID_JSONB_ARRAY, 199))
 
 end PostgresDecoder

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/SqlClientLogTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/SqlClientLogTest.scala
@@ -437,9 +437,16 @@ class SqlClientLogTest extends SqlContainerTest:
         }
     }
 
-    // ── server error emits an error-level log with sqlState ───────────────────
+    // ── server error is reported to the caller, and logged below ERROR ────────
 
-    "server error emits an error-level log with sqlState" in {
+    /** A server error the caller is handed as a typed value is not an error the library reports on its own initiative.
+      *
+      * This leaf used to require the ERROR level. What it is really about is the message being available with its sqlState, which DEBUG
+      * carries just as well; the level is what decided whether a tool behaving correctly filled an operator's dashboard. A tool that runs
+      * user-written SQL gets a syntax error back from the server as its ordinary answer, and on a stdio transport anything the library
+      * writes uninvited is a candidate for corrupting the channel.
+      */
+    "server error is logged below ERROR and still carries its sqlState" in {
         Scope.run {
             kyo.internal.FakeServer.listenPort { conn =>
                 pgErrorResponseHandler(conn)
@@ -463,16 +470,20 @@ class SqlClientLogTest extends SqlContainerTest:
                     }
                 }.map { case (sink, _) =>
                     val logs = sink.captured
-                    val errorLogs = logs.filter { case (level, msg) =>
-                        level == Log.Level.error && msg.contains("kyo.sql: server error") && msg.contains("sqlState=")
+                    val serverErrorLogs = logs.filter { case (_, msg) =>
+                        msg.contains("kyo.sql: server error") && msg.contains("sqlState=")
                     }
                     assert(
-                        errorLogs.nonEmpty,
-                        s"Expected 'kyo.sql: server error' error log with 'sqlState='. Captured: ${logs.map(_._2).mkString(", ")}"
+                        serverErrorLogs.nonEmpty,
+                        s"Expected 'kyo.sql: server error' log with 'sqlState='. Captured: ${logs.map(_._2).mkString(", ")}"
                     )
                     assert(
-                        errorLogs.exists { case (_, msg) => msg.contains("42601") },
-                        s"Expected sqlState=42601 in server error log. Got: ${errorLogs.map(_._2).mkString(", ")}"
+                        serverErrorLogs.exists { case (_, msg) => msg.contains("42601") },
+                        s"Expected sqlState=42601 in the server error log. Got: ${serverErrorLogs.map(_._2).mkString(", ")}"
+                    )
+                    assert(
+                        serverErrorLogs.forall { case (level, _) => level == Log.Level.debug },
+                        s"a failure handed back to the caller must not be logged at ERROR. Got: ${serverErrorLogs.mkString(", ")}"
                     )
                 }
             }

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/SqlRunStaticTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/SqlRunStaticTest.scala
@@ -33,6 +33,14 @@ class SqlRunStaticTest extends Test:
     case class Person(id: Long, name: String, age: Int, deptId: Long)
     case class User(id: Long, email: String)
 
+    /** A class carrying its own `copy`, whose parameters are NOT its fields in declaration order.
+      *
+      * Declaring one suppresses the synthetic `copy`. A fold that reads a copy's arguments as the case fields would put this one's single
+      * `hi` argument where `lo` is looked up.
+      */
+    case class Bounds(lo: Int, hi: Int):
+        def copy(hi: Int): Bounds = Bounds(lo, hi)
+
     // ── Leaf H, a row whose field resolves through a PARAMETERIZED column given ─────────────────
     //
     // Most `SqlSchema.Column` givens are parameterless values; `maybe[A](using Column[A])` and
@@ -77,6 +85,23 @@ class SqlRunStaticTest extends Test:
             rendered.sqlFor(PostgresDialect.id).get ==
                 """SELECT "person"."id", "person"."name", "person"."age", "person"."deptId" FROM "person" "person" WHERE ("person"."age" >= $1)""",
             s"the compile-time render changed; got ${rendered.sqlFor(PostgresDialect.id)}"
+        )
+    }
+
+    /** A LIMIT count is the one folded number that reaches the SQL as text rather than as a bind, so a fold that reads the wrong argument
+      * writes the wrong query and nothing fails: the statement is well-formed, the server accepts it, and it returns a different number of
+      * rows forever.
+      *
+      * The fold reads a `copy`'s arguments as the class's case fields in declaration order, which holds for the compiler's own `copy` and
+      * for no other. `Bounds` declares its own, which suppresses the synthetic one and takes only `hi`, so reading position 0 as `lo`
+      * answers the new `hi`. Folding `Bounds(1, 25).copy(20).lo` therefore rendered `LIMIT 20` where the value is 1.
+      */
+    "a field read off a class's own copy is not folded into the statement as another field's value" in {
+        val errors  = typeCheckErrors("""kyo.SqlStaticProbe.render(kyo.Sql.from[Person].limit(Bounds(1, 25).copy(20).lo))""")
+        val message = errors.map(_.message).mkString(" | ")
+        assert(
+            message.contains("cannot be folded"),
+            s"a copy whose arguments are not the case fields must refuse the fold; got: $message"
         )
     }
 
@@ -212,8 +237,8 @@ class SqlRunStaticTest extends Test:
     // the flag choose only between aborting and answering `Absent`. The LIFT cannot differ either: both
     // entries call the same `liftAst(q)`, which takes no flag at all. So the probe rendering and `.run` folding
     // hold under identical conditions, in both directions: if a probe leaf compiles then the statement folds
-    // for `.run` too, and if the probe cannot render then `.run` falls back. That is what makes the Update
-    // leaf below able to assert a fallback positively rather than by omission.
+    // for `.run` too, and if the probe cannot render then `.run` falls back. That is what lets a `.run` leaf
+    // below assert what the fold did rather than only that the call compiled.
     //
     // WHAT IT DOES NOT PROVE is that the `.run` call beside it is still the same statement. The probe reads
     // the expression written inside its own call, so the two copies are tied together by nothing except this
@@ -240,26 +265,112 @@ class SqlRunStaticTest extends Test:
         succeed
     }
 
-    // ── Leaf E, Update.runStatic fails at compile time (sets lambda not liftable) ─
+    // ── Leaf E, Update.runStatic folds, including a chain of `set` calls ──────────
     //
-    // `Update.Builder.set(inline specs: ...)` applies each spec lambda via `specs.map(_(columns))`
-    // which produces a runtime `Chunk`, not reducible by `FromExpr.derived`. `runStatic` calls
-    // report.errorAndAbort when the AST is not liftable.
+    // This leaf used to require the opposite: an UPDATE could not fold, because the builder that
+    // accumulates assignments hands the statement its `sets` as `<what it had> ++ <what this call adds>`
+    // by name, and none of those three shapes (the concatenation, the copy the builder makes of itself,
+    // the named argument) was readable at compile time. All three are now, so every write folds and
+    // "INSERT and UPDATE never fold" is no longer a boundary anyone has to work around.
 
-    "Update.runStatic fails at compile time (set lambda is not statically liftable)" in {
-        val errors = typeCheckErrors(
-            """def shape(using kyo.Frame): Long < (kyo.Async & kyo.Abort[kyo.SqlException] & kyo.DB) =
-  kyo.Sql.update[User].set(_.email := "new@example.com").where(_.id == 1L).runStatic"""
+    "Update.runStatic folds for a static AST" in {
+        def shape(using Frame): Long < (Abort[SqlException] & DB) =
+            Sql.update[User].set(_.email := "new@example.com").where(_.id == 1L).runStatic
+        succeed
+    }
+
+    // Compiling proves the fold happened; it does not prove WHAT it folded to. A second `set` reaches the macro as a
+    // copy of the builder whose assignments are one chunk concatenated onto another, and a fold that read that
+    // concatenation the wrong way round, or dropped a side of it, would still compile and still be a statement. So
+    // this leaf renders as well, and asserts both assignments in the order they were written.
+    "Update.runStatic folds with assignments from more than one set call" in {
+        def shape(using Frame): Long < (Abort[SqlException] & DB) =
+            Sql.update[User].set(_.email := "a@b.c").set(_.id := 2L).where(_.id == 1L).runStatic
+        val rendered = SqlStaticProbe.render(
+            Sql.update[User].set(_.email := "a@b.c").set(_.id := 2L).where(_.id == 1L)
         )
-        // The assertion names the diagnostic rather than counting errors, because the macro must carry the
-        // `.runStatic` / `cannot be folded` message from SqlStaticMacro.impl's report.errorAndAbort and not
-        // silently fail with an unrelated one. The exact wording is in SqlStaticMacro.scala's .impl error
-        // branches (".runStatic: query cannot be folded at compile time ..."). An empty error list makes
-        // mkString "" and "".contains false, so this fails cleanly when nothing was rejected at all.
-        val message = errors.map(_.message).mkString(" ")
         assert(
-            message.contains(".runStatic") || message.contains("cannot be folded"),
-            s"expected the SqlStaticMacro.impl diagnostic in the error message; got: $message"
+            rendered.sqlFor(PostgresDialect.id).get ==
+                """UPDATE "user" SET "email" = $1, "id" = $2 WHERE ("id" = $3)""",
+            s"both assignments must fold, in the order written; got ${rendered.sqlFor(PostgresDialect.id)}"
+        )
+        assert(rendered.params.size == 3, s"two assignments and the predicate must each bind; got ${rendered.params}")
+    }
+
+    "Update.runStatic folds with no where clause" in {
+        def shape(using Frame): Long < (Abort[SqlException] & DB) =
+            Sql.update[User].set(_.email := "everyone@example.com").build.runStatic
+        succeed
+    }
+
+    // ── Leaf E3, a source named by a transparent inline def still folds ───────────
+    //
+    // The recipe the README gives for a table whose name is not its type's name: name the source once with a
+    // `transparent inline def` rather than repeating the override at every call site. It is only worth giving
+    // if it keeps the statement on the static path, so this asserts the fold and the overridden table name in
+    // the folded text, not merely that it compiles.
+
+    "a source named by a transparent inline def folds, keeping its overridden table name" in {
+        def shape(using Frame): Chunk[SqlRunStaticTest.Account] < (Abort[SqlException] & DB) =
+            SqlRunStaticTest.accounts.where(r => r.u.id == 1L).runStatic
+        val rendered = SqlStaticProbe.render(SqlRunStaticTest.accounts.where(r => r.u.id == 1L))
+        assert(
+            rendered.sqlFor(PostgresDialect.id).get ==
+                """SELECT "u"."id", "u"."email" FROM "user_account" "u" WHERE ("u"."id" = $1)""",
+            s"the named source must fold and keep its table name; got ${rendered.sqlFor(PostgresDialect.id)}"
+        )
+        assert(rendered.params.size == 1, s"the predicate value must be bound; got ${rendered.params}")
+    }
+
+    /** A source can be named by an `inline def`; a FILTERED source cannot. This pins that limitation, and why.
+      *
+      * The leaf above names a source and reuses it, which works. Adding a `where` to the definition does not compile, and it fails at the
+      * DEFINITION rather than at any call site: the predicate's parameter is a `Record`, whose field selection resolves through a
+      * `Fields.Have` instance summoned by macro, and inside an un-expanded `inline def` body that instance's `Value` member is not yet
+      * computed. So `r.u.email` is "not a member of ?1.Value", and the static path has no reusable filtered trunk at all.
+      *
+      * Two mechanisms that would resolve the selection without a summoned instance were tried and are ruled out by the compiler, not by
+      * judgement. A match type over the field intersection cannot be written: `case h & rest` is rejected as "the pattern contains an
+      * unaccounted type parameter" (E191). And a given declared at `Fields.Aux[A, T]` cannot be satisfied, because `T` is unconstrained
+      * at implicit search and a `transparent inline` refinement happens only after the declared type is matched. What remains is changing
+      * how `Record` represents its field type, which is the owner's call and is on record as declined.
+      *
+      * The assertion is deliberately on the compiler's refusal: this is a limitation pinned so it is visible and executable, not a
+      * property anyone wants. The day the selection is resolvable, this leaf goes red and is replaced by the positive one.
+      */
+    "a filtered trunk named by a transparent inline def does not compile, and the record type is not why" in {
+        val errors = typeCheckErrors(
+            """transparent inline def live = SqlRunStaticTest.accounts.where(r => r.u.email != ""); ()"""
+        )
+        val message = errors.map(_.message).mkString(" | ")
+        assert(
+            message.contains("is not a member of"),
+            s"expected the field selection to be what fails; got: $message"
+        )
+        assert(
+            message.contains("Have"),
+            s"the failure must be the summoned field-selection evidence, not the record type; got: $message"
+        )
+    }
+
+    // ── Leaf E2, what the refusal says when a statement genuinely cannot fold ─────
+    //
+    // The message used to name a `val` for every refusal, including statements written out at the
+    // terminal, which is where it was provably wrong. It now names the construct it can prove is there.
+
+    "the refusal names a raw fragment rather than blaming a val" in {
+        val errors = typeCheckErrors(
+            """Sql.from[User]("u").where(r => sql"${r.u.id} = 1".as[Boolean]).runStatic"""
+        )
+        val message = errors.map(_.message).mkString(" ")
+        assert(message.contains(".runStatic"), s"expected the fold diagnostic; got: $message")
+        assert(
+            message.contains("raw `sql") || message.contains("fragment"),
+            s"expected the refusal to name the fragment; got: $message"
+        )
+        assert(
+            !message.contains("stored in a `val`"),
+            s"a statement written out at the terminal must not be blamed on a val; got: $message"
         )
     }
 
@@ -293,9 +404,10 @@ class SqlRunStaticTest extends Test:
     }
 
     // ── Leaf G, .run on Insert, Update and Delete ────────────────────────────────
-    // Insert and Delete fold; Update does not, because `set` applies its spec lambdas through
-    // `specs.map(_(columns))` and produces a runtime Chunk. Each is asserted rather than assumed, by the
-    // probe reasoning in Leaf C above. All three keep the STATIC-SQL-INLINE-ONLY duplication constraint.
+    // All three fold. Update did not until the macro learned to read the accumulating builder's `copy` and
+    // the `Chunk` concatenation `set` produces, which is what left every UPDATE on the runtime renderer.
+    // Each is asserted rather than assumed, by the probe reasoning in Leaf C above. All three keep the
+    // STATIC-SQL-INLINE-ONLY duplication constraint.
 
     "Insert.run's statement folds at compile time, binding every column including the auto-key" in {
         def shape(using Frame): SqlClient.InsertOutcome < (Abort[SqlException] & DB) =
@@ -310,21 +422,18 @@ class SqlRunStaticTest extends Test:
         assert(rendered.params.size == 2, s"both columns must be bound; got ${rendered.params}")
     }
 
-    "Update.run falls back to runtime, and the set lambda is why" in {
+    "Update.run's statement folds at compile time, binding the assignment and the predicate" in {
         def shape(using Frame): Long < (Abort[SqlException] & DB) =
             Sql.update[User].set(_.email := "y").where(_.id == 2L).run
-        // A POSITIVE assertion of the fallback rather than the absence of one. The probe aborts on exactly
-        // the predicates that make `.run` answer `Absent`, so a refusal here IS the evidence that `.run`
-        // takes the runtime path. Asserting the diagnostic rather than an error count, as Leaf E does, so a
-        // rejection for some unrelated reason cannot pass as this one.
-        val errors = typeCheckErrors(
-            """kyo.SqlStaticProbe.render(kyo.Sql.update[User].set(_.email := "y").where(_.id == 2L))"""
-        )
-        val message = errors.map(_.message).mkString(" ")
+        // This leaf used to assert the fallback and name the set lambda as the reason for it. The reason is
+        // gone: the builder's accumulated assignments are readable at compile time now, so an UPDATE folds
+        // like every other statement and the rendered text is what this pins.
+        val rendered = SqlStaticProbe.render(Sql.update[User].set(_.email := "y").where(_.id == 2L))
         assert(
-            message.contains(".runStatic") || message.contains("cannot be folded"),
-            s"expected the SqlStaticMacro.impl diagnostic for a statement that cannot fold; got: $message"
+            rendered.sqlFor(PostgresDialect.id).get == """UPDATE "user" SET "email" = $1 WHERE ("id" = $2)""",
+            s"the compile-time render changed; got ${rendered.sqlFor(PostgresDialect.id)}"
         )
+        assert(rendered.params.size == 2, s"the assignment and the predicate must both bind; got ${rendered.params}")
     }
 
     "Delete.run's statement folds at compile time, binding the predicate value" in {
@@ -499,5 +608,44 @@ class SqlRunStaticTest extends Test:
             "a missing given must fail the compile; answering None is what made a real regression unreadable"
         )
     }
+
+    // ── Leaf I, the builder terminals that are a `copy` ──────────────────────────
+    //
+    // A builder method that answers a copy of its own node reaches the macro as `receiver.copy(field = v)`,
+    // which the fold could not read: it recognised a construction only as `apply` or `new`. Every statement
+    // ending in one therefore refused, and said so with the message for a value known only at run time, which
+    // is not what happened. The compiler's own `copy` takes the case fields in declaration order, which is
+    // exactly what the argument list is read as, so it is a construction as much as `apply` is.
+
+    "a statement ending in .distinct folds at compile time" in {
+        def shape(using Frame): Chunk[String] < (Abort[SqlException] & DB) =
+            Sql.from[User]("u").select(r => r.u.email).distinct.runStatic
+        val rendered = SqlStaticProbe.render(Sql.from[User]("u").select(r => r.u.email).distinct)
+        assert(
+            rendered.sqlFor(PostgresDialect.id).get == """SELECT DISTINCT "u"."email" FROM "user" "u"""",
+            s"the compile-time render changed; got ${rendered.sqlFor(PostgresDialect.id)}"
+        )
+    }
+
+    "a class's own copy is still refused, which is what keeps the field reading honest" in {
+        // The guard the leaf above rests on. Only the compiler's `copy` takes the case fields in declaration
+        // order; a hand-written one is free to take a subset, and reading its arguments as fields would fold a
+        // neighbouring field to the wrong constant. Pinned here as well as at the LIMIT leaf, because that one
+        // reads a field OFF a copy and this one would have the copy AS the construction.
+        val errors  = typeCheckErrors("""kyo.SqlStaticProbe.render(kyo.Sql.from[Person].limit(Bounds(1, 25).copy(20).lo))""")
+        val message = errors.map(_.message).mkString(" | ")
+        assert(message.contains("cannot be folded"), s"a hand-written copy must refuse the fold; got: $message")
+    }
+
+end SqlRunStaticTest
+
+object SqlRunStaticTest:
+    case class Account(id: Long, email: String)
+
+    /** The README's recipe for a table whose name is not its type's name: the source is named once, here, and every query starts from it.
+      *
+      * `transparent` is what makes it usable: without it the record type widens and the lambdas at the call sites cannot name a column.
+      */
+    transparent inline def accounts = Sql.from[Account]("u", "user_account")
 
 end SqlRunStaticTest

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/PostgresDialectDslRenderTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/PostgresDialectDslRenderTest.scala
@@ -17,11 +17,17 @@ class PostgresDialectDslRenderTest extends Test:
     case class Order(id: Long, userId: Long, total: BigDecimal, createdAt: Instant)
     case class NameAge(name: String, age: Int)
     case class Customer(id: Long, name: String, email: Maybe[String], suspended: Boolean)
+    // A foreign key that permits NULL, which is the ordinary shape of one: `customerId` is optional while `Customer.id` is not.
+    case class Ticket(id: Long, customerId: Maybe[Long], subject: String)
+    // `quantity` is the smallint every schema has one of, and the column an aggregate is first asked for.
+    case class OrderLine(orderId: Long, productId: Short, quantity: Short)
 
     val people      = Sql.from[Person]("p")
     val departments = Sql.from[Department]("d")
     val orders      = Sql.from[Order]("o")
     val customers   = Sql.from[Customer]("c")
+    val tickets     = Sql.from[Ticket]("t")
+    val orderLines  = Sql.from[OrderLine]("l")
 
     def sqlOf(q: Query[?]): String      = q.render(PostgresDialect).onlySql.get
     def sqlOf(s: Executable[?]): String = s.render(PostgresDialect).onlySql.get
@@ -130,6 +136,88 @@ class PostgresDialectDslRenderTest extends Test:
         val f = people.fullOuterJoin(orders).on(j => j.p.id == j.o.userId)
         assert(sqlOf(r) == """SELECT * FROM "person" "p" RIGHT JOIN "order" "o" ON ("p"."id" = "o"."userId")""")
         assert(sqlOf(f) == """SELECT * FROM "person" "p" FULL OUTER JOIN "order" "o" ON ("p"."id" = "o"."userId")""")
+    }
+
+    // A nullable foreign key joined to a non-null primary key: the first join anyone writes against a schema that permits NULL there.
+    // Nullability is a property of the Scala type on each side and not of the SQL, which compares the two columns the same way either
+    // way, so the two sides compare and the rendered predicate is the ordinary one.
+    "join a nullable foreign key to a non-null primary key" in {
+        val q = tickets.innerJoin(customers).on(j => j.t.customerId == j.c.id).select(j => (j.t.subject, j.c.name))
+        assert(
+            sqlOf(q) == """SELECT "t"."subject", "c"."name" FROM "ticket" "t" INNER JOIN "customer" "c" ON ("t"."customerId" = "c"."id")"""
+        )
+        assert(paramsOf(q) == 0)
+    }
+
+    "join a non-null primary key to a nullable foreign key" in {
+        val q = customers.innerJoin(tickets).on(j => j.c.id == j.t.customerId).select(j => (j.c.name, j.t.subject))
+        assert(
+            sqlOf(q) == """SELECT "c"."name", "t"."subject" FROM "customer" "c" INNER JOIN "ticket" "t" ON ("c"."id" = "t"."customerId")"""
+        )
+    }
+
+    "an ordering comparison also spans nullability" in {
+        val q = tickets.innerJoin(customers).on(j => j.t.customerId >= j.c.id)
+        assert(sqlOf(q) == """SELECT * FROM "ticket" "t" INNER JOIN "customer" "c" ON ("t"."customerId" >= "c"."id")""")
+    }
+
+    // A column permitting NULL compares against a plain literal. `Present(...)` still works and is what an explicitly optional value is
+    // spelled as; what this asserts is that a caller who has a value in hand does not have to wrap it to ask the ordinary question.
+    "a nullable column compares against a raw literal" in {
+        val q = customers.where(c => c.c.email == "a@b.c")
+        assert(sqlOf(q) == """SELECT "c"."id", "c"."name", "c"."email", "c"."suspended" FROM "customer" "c" WHERE ("c"."email" = $1)""")
+        assert(paramsOf(q) == 1)
+    }
+
+    "a nullable column still compares against Present and Absent" in {
+        val present = customers.where(c => c.c.email == Present("a@b.c"))
+        val absent  = customers.where(c => c.c.email == Absent)
+        assert(sqlOf(present).endsWith("""WHERE ("c"."email" = $1)"""), sqlOf(present))
+        assert(sqlOf(absent).endsWith("""WHERE ("c"."email" IS NULL)"""), sqlOf(absent))
+    }
+
+    "an ordering comparison takes a raw literal against a nullable column" in {
+        val q = people.leftJoin(orders).on(j => j.p.id == j.o.userId).where(j => j.o.total > BigDecimal(100))
+        assert(sqlOf(q).endsWith("""WHERE ("o"."total" > $1)"""), sqlOf(q))
+    }
+
+    // A smallint column is a number: it sums, averages, and takes arithmetic like any other, and a grouped view has no cast to widen
+    // through, so the aggregate has to be reachable from the column type itself.
+    "a smallint column aggregates" in {
+        val summed   = orderLines.groupBy(_.l.orderId).select(view => (view.orderId, view.quantity.sum))
+        val averaged = orderLines.groupBy(_.l.orderId).select(view => (view.orderId, view.quantity.avg))
+        val filtered = orderLines.groupBy(_.l.orderId).having(view => view.quantity.sum >= 200L).select(view => view.orderId)
+        assert(
+            sqlOf(summed) == """SELECT "l"."orderId", SUM("l"."quantity") FROM "orderline" "l" GROUP BY "l"."orderId"""",
+            sqlOf(summed)
+        )
+        assert(sqlOf(averaged).contains("""AVG("l"."quantity")"""), sqlOf(averaged))
+        assert(sqlOf(filtered).contains("""HAVING (SUM("l"."quantity") >= $1)"""), sqlOf(filtered))
+    }
+
+    "a smallint column takes arithmetic" in {
+        val q = orderLines.select(l => l.l.quantity + 1.toShort)
+        assert(sqlOf(q).contains("""("l"."quantity" + $1)"""), sqlOf(q))
+    }
+
+    "a bare column orders ascending" in {
+        val bare     = customers.orderBy(c => c.c.id)
+        val explicit = customers.orderBy(c => c.c.id.asc)
+        assert(sqlOf(bare).endsWith("""ORDER BY "c"."id" ASC"""), sqlOf(bare))
+        assert(sqlOf(bare) == sqlOf(explicit), s"a bare column must order as `.asc` does: ${sqlOf(bare)}")
+    }
+
+    "a tuple mixes bare columns and explicit specs" in {
+        val q = customers.orderBy(c => (c.c.name, c.c.id.desc))
+        assert(sqlOf(q).endsWith("""ORDER BY "c"."name" ASC, "c"."id" DESC"""), sqlOf(q))
+    }
+
+    // `.to[B]` survives the combinators that follow a projection, so the order they are written in is not load-bearing.
+    "to[B] applies after orderBy and after limit" in {
+        val afterOrderBy = people.select(p => (p.p.name, p.p.age)).orderBy(p => p.p.age.desc).to[NameAge]
+        val afterLimit   = people.select(p => (p.p.name, p.p.age)).orderBy(p => p.p.age.desc).limit(3).to[NameAge]
+        assert(sqlOf(afterOrderBy).endsWith("""ORDER BY "p"."age" DESC"""), sqlOf(afterOrderBy))
+        assert(sqlOf(afterLimit).endsWith("""ORDER BY "p"."age" DESC LIMIT 3"""), sqlOf(afterLimit))
     }
 
     "cross join + where" in {

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/PostgresDialectReturningRenderTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/PostgresDialectReturningRenderTest.scala
@@ -17,7 +17,7 @@ class PostgresDialectReturningRenderTest extends Test:
 
     // Leaf 1: INSERT.returning(id, createdAt) on PG, both columns appear in RETURNING list.
     "INSERT.returning(id, createdAt) emits both columns on PG" in {
-        val s = Sql.insert[Event].values(Event(0L, "boot", "2024-01-01")).returning(_.id, _.createdAt)
+        val s = Sql.insert[Event].values(Event(0L, "boot", "2024-01-01")).returning(r => (r.id, r.createdAt)).statement
         val r = s.render(PostgresDialect)
         assert(r.onlySql.get.contains("RETURNING"))
         assert(r.onlySql.get.contains(""""id""""))
@@ -30,8 +30,10 @@ class PostgresDialectReturningRenderTest extends Test:
     }
 
     // Leaf 2: UPDATE.returning(version) on PG, column appears after RETURNING.
+    // `.statement` because a returning write is typed by the rows it answers; the statement it renders is the
+    // ordinary UPDATE inside that wrapper.
     "UPDATE.returning(version) emits on PG" in {
-        val s = Sql.update[Versioned].set(_.value := "x").returning(_.version).where(_.id == 1L)
+        val s = Sql.update[Versioned].set(_.value := "x").returning(_.version).where(_.id == 1L).statement
         val r = s.render(PostgresDialect)
         assert(r.onlySql.get.contains("UPDATE"))
         assert(r.onlySql.get.contains("RETURNING"))
@@ -42,7 +44,7 @@ class PostgresDialectReturningRenderTest extends Test:
 
     // Leaf 3: DELETE.returning(id) on PG, id appears after RETURNING.
     "DELETE.returning(id) emits on PG" in {
-        val s = Sql.delete[Event].returning(_.id).where(_.name == "boot")
+        val s = Sql.delete[Event].returning(_.id).where(_.name == "boot").statement
         val r = s.render(PostgresDialect)
         assert(r.onlySql.get.startsWith("DELETE FROM"))
         assert(r.onlySql.get.contains("RETURNING"))

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/PostgresRowCodecTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/PostgresRowCodecTest.scala
@@ -16,6 +16,10 @@ import kyo.internal.postgres.types.PostgresDecoder
   */
 class PostgresRowCodecTest extends Test:
 
+    // `java.time.LocalDate` is a JDK type with no `CanEqual` instance in scope; its `equals` compares the date
+    // fields, which is the comparison the guarded-read assertions below rely on.
+    given CanEqual[java.time.LocalDate, java.time.LocalDate] = CanEqual.canEqualAny
+
     private val column = SqlRow.Column("id", 23)
     private val codec  = PostgresRowCodec(Format.Text)
 
@@ -92,12 +96,242 @@ class PostgresRowCodecTest extends Test:
         end match
     }
 
+    // An INTERVAL is the one column kind no Scala type spans: `java.time.Duration` carries the time part and
+    // `java.time.Period` the calendar part, and a value is free to carry both. Rendering it at either type refused
+    // ordinary values, so `interval '3 days'` and `interval '1 mon'` aborted a call documented to render whatever the
+    // column holds, and `interval '1 day 3 hours'` had no reading at all. The rendering is over the wire fields, so
+    // there is nothing to drop and nothing to refuse.
+    "an interval renders as text whatever mix of calendar and time components it carries" - {
+        // Wire: Int64 microseconds, Int32 days, Int32 months, all big-endian.
+        def intervalRow(months: Int, days: Int, micros: Long): SqlRow =
+            val out = new Array[Byte](16)
+            var i   = 0
+            while i < 8 do
+                out(i) = ((micros >>> ((7 - i) * 8)) & 0xffL).toByte
+                i += 1
+            while i < 12 do
+                out(i) = ((days >>> ((11 - i) * 8)) & 0xff).toByte
+                i += 1
+            while i < 16 do
+                out(i) = ((months >>> ((15 - i) * 8)) & 0xff).toByte
+                i += 1
+            new SqlRow(
+                Chunk(Maybe.Present(Span.from(out))),
+                Chunk(SqlRow.Column("span", 1186)),
+                PostgresRowCodec(Format.Binary)
+            )
+        end intervalRow
+
+        def rendered(months: Int, days: Int, micros: Long)(using kyo.test.AssertScope): Maybe[String] =
+            Abort.run[SqlDecodeException](intervalRow(months, days, micros).text(0)).eval match
+                case Result.Success(v) => v
+                case other             => fail(s"expected a rendering, got $other")
+
+        "a time-only interval" in {
+            assert(rendered(0, 0, 3_600_000_000L) == Present("PT1H"))
+            assert(rendered(0, 0, 14_706_000_000L) == Present("PT4H5M6S"))
+        }
+
+        "a calendar-only interval, which a Duration cannot hold" in {
+            assert(rendered(0, 3, 0L) == Present("P3D"))
+            assert(rendered(1, 0, 0L) == Present("P1M"))
+            assert(rendered(14, 0, 0L) == Present("P1Y2M"))
+        }
+
+        "an interval carrying both, which neither type holds" in {
+            assert(rendered(14, 3, 14_706_000_000L) == Present("P1Y2M3DT4H5M6S"))
+            assert(rendered(0, 1, 10_800_000_000L) == Present("P1DT3H"))
+        }
+
+        "the zero interval" in {
+            assert(rendered(0, 0, 0L) == Present("PT0S"))
+        }
+
+        "a negative interval carries the sign on every component, as the server's own rendering does" in {
+            assert(rendered(-14, -3, -14_706_000_000L) == Present("P-1Y-2M-3DT-4H-5M-6S"))
+        }
+
+        "fractional seconds, and only when there are any" in {
+            assert(rendered(0, 0, 1_500_000L) == Present("PT1.5S"))
+            assert(rendered(0, 0, 500_000L) == Present("PT0.5S"))
+            assert(rendered(0, 0, -500_000L) == Present("PT-0.5S"))
+            assert(rendered(0, 0, 2_000_000L) == Present("PT2S"))
+            assert(rendered(0, 0, 1_000_001L) == Present("PT1.000001S"))
+        }
+    }
+
+    // An `inet` is a binary struct on the wire, so rendering it as UTF-8 answers the struct's bytes as mojibake. The
+    // column is one this backend names, and `decode[String]` refuses it precisely because those bytes are not text,
+    // which leaves `text` as the route a caller with no row type has: it has to render what the column holds.
+    "an inet renders as the address it holds, not as its wire struct" - {
+        // Wire: family (2 = IPv4, 3 = IPv6), netmask bits, is_cidr, address length, then the address bytes.
+        def inetRow(family: Int, bits: Int, addr: Array[Int]): SqlRow =
+            val out = new Array[Byte](4 + addr.length)
+            out(0) = family.toByte
+            out(1) = bits.toByte
+            out(2) = 0
+            out(3) = addr.length.toByte
+            var i = 0
+            while i < addr.length do
+                out(4 + i) = (addr(i) & 0xff).toByte
+                i += 1
+            new SqlRow(
+                Chunk(Maybe.Present(Span.from(out))),
+                Chunk(SqlRow.Column("addr", 869)),
+                PostgresRowCodec(Format.Binary)
+            )
+        end inetRow
+
+        def rendered(family: Int, bits: Int, addr: Array[Int])(using kyo.test.AssertScope): Maybe[String] =
+            Abort.run[SqlDecodeException](inetRow(family, bits, addr).text(0)).eval match
+                case Result.Success(v) => v
+                case other             => fail(s"expected a rendering, got $other")
+
+        def v6(groups: Int*): Array[Int] =
+            groups.flatMap(g => Seq((g >> 8) & 0xff, g & 0xff)).toArray
+
+        "an IPv4 host address carries no mask" in {
+            assert(rendered(2, 32, Array(192, 168, 1, 1)) == Present("192.168.1.1"))
+        }
+
+        "an IPv4 network keeps the mask it was given" in {
+            assert(rendered(2, 24, Array(192, 168, 1, 0)) == Present("192.168.1.0/24"))
+            assert(rendered(2, 0, Array(0, 0, 0, 0)) == Present("0.0.0.0/0"))
+        }
+
+        "an IPv6 address is compressed at its longest run of zero groups" in {
+            assert(rendered(3, 128, v6(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)) == Present("2001:db8::1"))
+            assert(rendered(3, 128, v6(0, 0, 0, 0, 0, 0, 0, 1)) == Present("::1"))
+            assert(rendered(3, 128, v6(0, 0, 0, 0, 0, 0, 0, 0)) == Present("::"))
+            assert(rendered(3, 64, v6(0x2001, 0x0db8, 0, 0, 0, 0, 0, 0)) == Present("2001:db8::/64"))
+        }
+
+        // A single zero group is written out: `::` for one group is not shorter, and RFC 5952 forbids it, so a
+        // renderer that compressed every run would disagree with the server's own text for the same value.
+        "a single zero group is not compressed, and the leftmost longest run wins" in {
+            assert(rendered(3, 128, v6(0x2001, 0, 0x2001, 1, 1, 1, 1, 1)) == Present("2001:0:2001:1:1:1:1:1"))
+            assert(rendered(3, 128, v6(1, 0, 0, 1, 0, 0, 0, 1)) == Present("1:0:0:1::1"))
+        }
+    }
+
     "a decoder that throws a decode leaf surfaces the leaf, not a wrapper" in {
         val leaf                   = SqlDecodeNumericException("boom", SqlDecodeNumericException.Subtype.Parse)
         given PostgresDecoder[Int] = throwing(leaf)
         Abort.run[SqlDecodeException](PostgresRowCodec.columnDecoded[Int](oneColumnRow, 0)).eval match
             case Result.Failure(e) => assert(e eq leaf, s"expected the leaf itself, got $e")
             case other             => fail(s"expected the decode leaf unwrapped, got $other")
+    }
+
+    // ---- The struct-typed built-ins the refusal list did not name ------------------------------------
+    //
+    // The refusal was curated from the types this module can encode, which is not the set a SELECT can
+    // return. Every OID below is a fixed built-in whose binary form is a struct, so a String read of one
+    // answered the protocol buffer as UTF-8. `cidr` is the sharpest of them: it shares its wire struct with
+    // `inet`, the one type this change went out of its way to render field by field.
+
+    "a String read of a struct-typed built-in is refused, naming the type" - {
+        val cases = Seq(
+            650  -> "cidr",
+            829  -> "macaddr",
+            790  -> "money",
+            1560 -> "bit",
+            3904 -> "int4range",
+            600  -> "point",
+            3614 -> "tsvector"
+        )
+        cases.foreach { (oid, name) =>
+            s"$name (OID $oid)" in {
+                val ex = intercept[SqlDecodeColumnTypeMismatchException](
+                    PostgresDecoder.requireTextColumn("String", oid)
+                )
+                assert(ex.columnType == name, s"expected the failure to name $name, got ${ex.columnType}")
+                assert(ex.typeToken == oid.toString, s"expected the token $oid, got ${ex.typeToken}")
+            }
+        }
+    }
+
+    "a String read of any array column is refused, not only the three this module encodes" - {
+        // Every array shares one binary layout, a header then the elements, so the element type cannot make
+        // one readable. text[] was refused and varchar[] was not, which is the same struct either way.
+        val cases = Seq(1016 -> "int8[]", 1015 -> "varchar[]", 1000 -> "bool[]", 2951 -> "uuid[]", 1185 -> "timestamptz[]")
+        cases.foreach { (oid, name) =>
+            s"$name (OID $oid)" in {
+                val ex = intercept[SqlDecodeColumnTypeMismatchException](
+                    PostgresDecoder.requireTextColumn("String", oid)
+                )
+                assert(ex.columnType == name, s"expected the failure to name $name, got ${ex.columnType}")
+            }
+        }
+    }
+
+    "the text-shaped built-ins are still read as text" in {
+        // The other half: `name`, `"char"` and `xml` carry their characters on the wire, so naming them in the
+        // table must not refuse them. A catalog query selecting relname is the ordinary case.
+        Seq(19, 18, 142).foreach { oid =>
+            PostgresDecoder.requireTextColumn("String", oid)
+        }
+        succeed
+    }
+
+    "an OID the backend cannot name is still not refused" in {
+        // The dynamic range: citext, an enum type, a domain. A token with no known meaning is not evidence of
+        // a mismatch, and refusing it would break every extension type.
+        PostgresDecoder.requireTextColumn("String", 16384)
+        PostgresDecoder.requireTextColumn("String", 999999)
+        succeed
+    }
+
+    // ---- A typed read of the wrong column, which cannot fail on its own -------------------------------
+    //
+    // The text guard closed one direction: a String field over an int4. The other direction is the same
+    // defect and answers something worse than mojibake. `date` binary is an int4 day count from 2000-01-01,
+    // so a LocalDate field over an int4 column holding 42 read the four bytes at the layout it expected and
+    // answered 2000-02-12, a well-formed date with nothing to notice. `time` and `timestamptz` are int64s
+    // and do the same. These decoders resolve their layout from the target type, never from the column, so
+    // the column has to be checked against what the decoder claims.
+
+    private def readerOn(oid: Int, bytes: Array[Byte], format: Format): PostgresRowReader =
+        val row = new SqlRow(Chunk(Maybe.Present(Span.from(bytes))), Chunk(SqlRow.Column("c", oid)), PostgresRowCodec(format))
+        new PostgresRowReader(row, format, Maybe.empty)
+    end readerOn
+
+    /** 42 as PostgreSQL sends an int4: four bytes, big-endian. */
+    private val int4Of42 = Array[Byte](0, 0, 0, 42)
+
+    "a LocalDate read of an int4 column is refused rather than answering a day count" in {
+        val ex = intercept[SqlDecodeColumnTypeMismatchException](readerOn(23, int4Of42, Format.Binary).nextDate())
+        assert(ex.columnType == "int4", s"expected the failure to name int4, got ${ex.columnType}")
+        assert(ex.scalaType == "LocalDate", s"expected the failure to name LocalDate, got ${ex.scalaType}")
+    }
+
+    "a LocalTime and an Instant read of an int8 column are refused" in {
+        val int8 = Array[Byte](0, 0, 0, 0, 0, 0, 0, 1)
+        assert(intercept[SqlDecodeColumnTypeMismatchException](readerOn(20, int8, Format.Binary).nextTime()).columnType == "int8")
+        assert(intercept[SqlDecodeColumnTypeMismatchException](readerOn(20, int8, Format.Binary).instant()).columnType == "int8")
+    }
+
+    "a UUID read of a bytea column is refused, and bytes of a uuid column" in {
+        val sixteen = Array.fill[Byte](16)(0)
+        assert(intercept[SqlDecodeColumnTypeMismatchException](readerOn(17, sixteen, Format.Binary).nextUuid()).columnType == "bytea")
+        assert(intercept[SqlDecodeColumnTypeMismatchException](readerOn(2950, sixteen, Format.Binary).bytes()).columnType == "uuid")
+    }
+
+    "each guarded read still accepts the column it is for" in {
+        // The negative control. A guard that refuses everything would pass every leaf above.
+        assert(readerOn(1082, int4Of42, Format.Binary).nextDate() == java.time.LocalDate.of(2000, 2, 12), "a date column must still decode")
+        assert(readerOn(17, Array[Byte](1, 2), Format.Binary).bytes().size == 2, "a bytea column must still decode")
+        succeed
+    }
+
+    "a nested value carries no column OID and is not refused" in {
+        // An array element or a range bound reaches a decoder with OID_UNSPECIFIED, because the column's own
+        // OID describes the container. Refusing on it would break every array read.
+        assert(readerOn(0, int4Of42, Format.Binary).nextDate() == java.time.LocalDate.of(2000, 2, 12), "an unspecified OID must not refuse")
+    }
+
+    "an OID the backend cannot name is not refused by the typed guard either" in {
+        // A domain or an extension type, which this connection cannot resolve. Same rule as the text guard.
+        assert(readerOn(16384, int4Of42, Format.Binary).nextDate() == java.time.LocalDate.of(2000, 2, 12), "an unnamed OID must not refuse")
     }
 
 end PostgresRowCodecTest

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/PostgresRowReaderTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/PostgresRowReaderTest.scala
@@ -367,18 +367,32 @@ class PostgresRowReaderTest extends Test:
         assert(ex.columnIndex == Maybe(0), s"expected column 0 reported, got: ${ex.columnIndex}")
     }
 
-    "an array read over a scalar column raises a decode failure, not an unsupported-operation one" in {
-        // A four-byte int4 payload cannot hold the twenty-byte array header, and the refusal has to be a decode
-        // failure: an Unsupported leaf would say the backend cannot read arrays at all, which is the opposite of
-        // what happened.
+    "an array read over a named scalar column is refused by column type, before its payload is examined" in {
+        // Previously this reported that a four-byte payload cannot hold the twenty-byte array header, which is a
+        // symptom rather than the cause: the column is an int4 and no payload of one would have been an array. The
+        // refusal still has to be a decode failure, since an Unsupported leaf would say the backend cannot read
+        // arrays at all, and SqlDecodeColumnTypeMismatchException is one.
         val fdInt4 = SqlRow.Column("column", 23)
         val row    = pgRow(Chunk(Maybe.Present(encode(1, PostgresEncoder.int4Binary))), Chunk(fdInt4), Format.Binary)
         val r      = reader(row)
-        val ex = intercept[kyo.SqlDecodeArrayFormatException] {
+        val ex = intercept[kyo.SqlDecodeColumnTypeMismatchException] {
             val _ = r.nextArrayOfInt()
         }
-        // The intercepted type IS the assertion: SqlDecodeArrayFormatException is a decode leaf, and an
-        // Unsupported one could not be thrown at it.
+        assert(ex.columnType == "int4", s"the refusal names the column's type, got ${ex.columnType}")
+        assert(ex.scalaType == "Chunk[Int]", s"the refusal names the type that asked, got ${ex.scalaType}")
+        val _: kyo.SqlDecodeException = ex // a decode leaf, not an Unsupported one
+        succeed
+    }
+
+    "an array read whose column type is unknown still reports the payload it could not parse" in {
+        // The column guard is silent on an OID this backend does not name, which is where the array reader's own
+        // format check is still what refuses. Keeps that leaf covered now that a named scalar column is caught
+        // earlier.
+        val fdUnknown = SqlRow.Column("column", 999999)
+        val row       = pgRow(Chunk(Maybe.Present(encode(1, PostgresEncoder.int4Binary))), Chunk(fdUnknown), Format.Binary)
+        val ex = intercept[kyo.SqlDecodeArrayFormatException] {
+            val _ = reader(row).nextArrayOfInt()
+        }
         assert(ex.length == 4, s"the refusal reports the payload length it was handed, got ${ex.length}")
     }
 
@@ -495,6 +509,35 @@ class PostgresRowReaderTest extends Test:
         Span.from(buf.toByteArray)
     end pgTextArrayBytes
 
+    /** Build PG binary array bytes carrying `elemOid` in the header, for the layout-compatible element types. */
+    private def pgArrayBytesOfOid(elemOid: Int, payloads: Array[Byte]*): Span[Byte] =
+        val buf = new java.io.ByteArrayOutputStream
+        def writeInt32BE(v: Int): Unit =
+            buf.write((v >> 24) & 0xff)
+            buf.write((v >> 16) & 0xff)
+            buf.write((v >> 8) & 0xff)
+            buf.write(v & 0xff)
+        end writeInt32BE
+        writeInt32BE(1)             // ndim
+        writeInt32BE(0)             // hasNulls
+        writeInt32BE(elemOid)       // elemOID
+        writeInt32BE(payloads.size) // dim_size
+        writeInt32BE(1)             // lbound
+        for pl <- payloads do
+            writeInt32BE(pl.length)
+            buf.write(pl)
+        end for
+        Span.from(buf.toByteArray)
+    end pgArrayBytesOfOid
+
+    private def utf8(s: String): Array[Byte] = s.getBytes(StandardCharsets.UTF_8)
+
+    private def int8BE(v: Long): Array[Byte] =
+        Array.tabulate(8)(i => ((v >>> (56 - i * 8)) & 0xff).toByte)
+
+    private def int2BE(v: Short): Array[Byte] =
+        Array(((v >> 8) & 0xff).toByte, (v & 0xff).toByte)
+
     "container columns" - {
 
         // A container column is a whole-column read through the vocabulary: `nextArrayOfInt` hands its bytes to
@@ -511,6 +554,48 @@ class PostgresRowReaderTest extends Test:
         "nextArrayOfString reads a binary text[] column" in {
             val row = pgRowCols(("arr", pgTextArrayBytes("a", "b"), PostgresEncoder.OID_TEXT_ARRAY))
             assert(reader(row).nextArrayOfString() == Chunk("a", "b"))
+        }
+
+        // The column guard refuses a NAMED OID the decoder does not claim, and each array decoder claims exactly
+        // one. The array element types below are layout-compatible with the decoder's own: the reader takes the
+        // element OID and format from the array header rather than from the decoder, `textDecoder` reads a
+        // varchar or bpchar element as it reads a text one, and the integral element decode widens per value.
+        // So refusing the container is refusing a column that decodes correctly, and for int8[] and int2[] there
+        // is no other read in the vocabulary to fall back to: the column becomes undecodable outright.
+
+        "nextArrayOfString reads a varchar[] column, whose elements are text-compatible" in {
+            val row = pgRowCols(("arr", pgArrayBytesOfOid(1043, utf8("a"), utf8("b")), 1015))
+            assert(reader(row).nextArrayOfString() == Chunk("a", "b"))
+        }
+
+        "nextArrayOfString reads a bpchar[] column" in {
+            val row = pgRowCols(("arr", pgArrayBytesOfOid(1042, utf8("a"), utf8("b")), 1014))
+            assert(reader(row).nextArrayOfString() == Chunk("a", "b"))
+        }
+
+        "nextArrayOfInt reads an int8[] column, which array_agg over a bigint produces" in {
+            val row = pgRowCols(("arr", pgArrayBytesOfOid(20, int8BE(7L), int8BE(8L)), 1016))
+            assert(reader(row).nextArrayOfInt() == Chunk(7, 8))
+        }
+
+        "nextArrayOfInt reads an int2[] column" in {
+            val row = pgRowCols(("arr", pgArrayBytesOfOid(21, int2BE(7), int2BE(8)), 1005))
+            assert(reader(row).nextArrayOfInt() == Chunk(7, 8))
+        }
+
+        // Accepting int8[] is only correct because the element decode range-checks: a bigint that does not fit an
+        // Int has to refuse rather than truncate, or widening the claim would trade a loud refusal for a silently
+        // wrong number.
+        "an int8[] element that does not fit an Int is refused rather than truncated" in {
+            val tooBig = 1L << 40
+            val row    = pgRowCols(("arr", pgArrayBytesOfOid(20, int8BE(1L), int8BE(tooBig)), 1016))
+            val ex = intercept[kyo.SqlDecodeException] {
+                val _ = reader(row).nextArrayOfInt()
+            }
+            assert(
+                !ex.getMessage.contains("cannot be read as"),
+                s"the refusal must be about the value's range, not the column's type, got: ${ex.getMessage}"
+            )
         }
 
         "an array column hands the row cursor back to the column after it" in {
@@ -826,6 +911,41 @@ class PostgresRowReaderTest extends Test:
         kyo.Abort.run[SqlDecodeException](row.decode[Int]).eval match
             case kyo.Result.Failure(e: kyo.SqlDecodeValueRangeException) => assert(e.scalaType == "Int")
             case other => fail(s"Expected Failure(SqlDecodeValueRangeException) but got $other")
+    }
+
+    // The same table's other half: a column this backend NAMES whose layout a numeric decode has no business
+    // reading. The wire dispatch resolves an OID it does not recognise to the target's own family, and a `date` is
+    // four big-endian bytes exactly as an `int4` is, so the read succeeds and answers the day count since the
+    // PostgreSQL epoch. That is the plausible wrong value this suite exists to rule out, reached from the
+    // opposite direction to the int8 case above.
+
+    "Int over a date column is refused rather than answering the day count" in {
+        val row = pgRowCols(("d", encode(java.time.LocalDate.of(2026, 8, 25), PostgresEncoder.dateBinary), PostgresEncoder.OID_DATE))
+        val ex = intercept[kyo.SqlDecodeColumnTypeMismatchException] {
+            val _ = reader(row).int()
+        }
+        assert(ex.columnType == "date", s"the refusal names the column's type, got ${ex.columnType}")
+        assert(ex.scalaType == "Int", s"the refusal names the type that asked, got ${ex.scalaType}")
+    }
+
+    "Boolean over a date column is refused rather than answering the day count's sign" in {
+        val row = pgRowCols(("d", encode(java.time.LocalDate.of(2026, 8, 25), PostgresEncoder.dateBinary), PostgresEncoder.OID_DATE))
+        val ex = intercept[kyo.SqlDecodeColumnTypeMismatchException] {
+            val _ = reader(row).boolean()
+        }
+        assert(ex.columnType == "date", s"the refusal names the column's type, got ${ex.columnType}")
+    }
+
+    "Double over a uuid column is refused rather than reading the first eight bytes as a double" in {
+        val row = pgRowCols((
+            "u",
+            encode(java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000"), PostgresEncoder.uuidBinary),
+            PostgresEncoder.OID_UUID
+        ))
+        val ex = intercept[kyo.SqlDecodeColumnTypeMismatchException] {
+            val _ = reader(row).double()
+        }
+        assert(ex.columnType == "uuid", s"the refusal names the column's type, got ${ex.columnType}")
     }
 
     "Int over a text column parses the rendering rather than reading the UTF-8 bytes as an integer" in {

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/types/PostgresDecoderTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/internal/postgres/types/PostgresDecoderTest.scala
@@ -247,4 +247,201 @@ class PostgresDecoderTest extends Test:
         assert(PostgresDecoder.int4Array.read(Format.Binary, Span.from(buf.toByteArray)) == kyo.Chunk(7, 8))
     }
 
+    // ── float4 and float8 rendered as the server renders them ───────────────────────
+    //
+    // `float4Text` and `float8Text` re-render a binary-protocol float so it reads as the string the text
+    // protocol would have carried for the same stored value. Every expectation below is what PostgreSQL 16
+    // writes for that value at the default `extra_float_digits`, read off the server rather than derived
+    // from Java, because Java's own rendering is what these decoders exist to correct.
+    //
+    // The two widths do NOT share a threshold. The server stays in plain notation while the decimal exponent
+    // is below the type's significant-digit count and switches after: FLT_DIG (6) for a float4, DBL_DIG (15)
+    // for a float8. So a float4 1e6 is `1e+06` where a float8 1e6 is `1000000`.
+
+    private def binaryFloat4(value: Float): Span[Byte] =
+        val bits = java.lang.Float.floatToIntBits(value)
+        Span.from(Array.tabulate(4)(i => (bits >>> (24 - i * 8)).toByte))
+
+    private def binaryFloat8(value: Double): Span[Byte] =
+        val bits = java.lang.Double.doubleToLongBits(value)
+        Span.from(Array.tabulate(8)(i => (bits >>> (56 - i * 8)).toByte))
+
+    private def renderFloat4(value: Float): String =
+        PostgresDecoder.float4Text.read(Format.Binary, binaryFloat4(value))
+
+    private def renderFloat8(value: Double): String =
+        PostgresDecoder.float8Text.read(Format.Binary, binaryFloat8(value))
+
+    "float8 drops the .0 Java appends to a whole value" in {
+        assert(renderFloat8(1.0) == "1", s"1.0: expected 1, got ${renderFloat8(1.0)}")
+        assert(renderFloat8(100.0) == "100", s"100.0: expected 100, got ${renderFloat8(100.0)}")
+        assert(renderFloat8(1e6) == "1000000", s"1e6: expected 1000000, got ${renderFloat8(1e6)}")
+    }
+
+    "float8 stays plain below DBL_DIG and takes the exponent after it" in {
+        assert(renderFloat8(1e14) == "100000000000000", s"1e14: expected 100000000000000, got ${renderFloat8(1e14)}")
+        assert(renderFloat8(1e15) == "1e+15", s"1e15: expected 1e+15, got ${renderFloat8(1e15)}")
+        assert(
+            renderFloat8(1.234567890123456e15) == "1.234567890123456e+15",
+            s"1.234567890123456e15: expected 1.234567890123456e+15, got ${renderFloat8(1.234567890123456e15)}"
+        )
+    }
+
+    "float8 pads the exponent to two digits, as the server does" in {
+        assert(renderFloat8(1e-5) == "1e-05", s"1e-5: expected 1e-05, got ${renderFloat8(1e-5)}")
+        assert(renderFloat8(-1.5e-7) == "-1.5e-07", s"-1.5e-7: expected -1.5e-07, got ${renderFloat8(-1.5e-7)}")
+        assert(renderFloat8(6.02e23) == "6.02e+23", s"6.02e23: expected 6.02e+23, got ${renderFloat8(6.02e23)}")
+    }
+
+    // `BigDecimal("1.0E-4").toPlainString` is "0.00010", and trimming only a trailing ".0" leaves that last
+    // zero standing. -4 is the one negative exponent reaching the plain branch at all, since Java writes
+    // plain from 1e-3 up, so every d x 10^-4 came out one digit wider than the server writes it.
+    "float8 leaves no trailing zero at the plain boundary" in {
+        assert(renderFloat8(1e-4) == "0.0001", s"1e-4: expected 0.0001, got ${renderFloat8(1e-4)}")
+        assert(renderFloat8(2e-4) == "0.0002", s"2e-4: expected 0.0002, got ${renderFloat8(2e-4)}")
+        assert(renderFloat8(9e-4) == "0.0009", s"9e-4: expected 0.0009, got ${renderFloat8(9e-4)}")
+        assert(renderFloat8(1.2345e-4) == "0.00012345", s"1.2345e-4: expected 0.00012345, got ${renderFloat8(1.2345e-4)}")
+    }
+
+    "float8 keeps the sign of a negative zero" in {
+        assert(renderFloat8(-0.0) == "-0", s"-0.0: expected -0, got ${renderFloat8(-0.0)}")
+        assert(renderFloat8(0.0) == "0", s"0.0: expected 0, got ${renderFloat8(0.0)}")
+    }
+
+    "float8 spells the non-finite values as the server spells them" in {
+        assert(
+            renderFloat8(Double.PositiveInfinity) == "Infinity",
+            s"Double.PositiveInfinity: expected Infinity, got ${renderFloat8(Double.PositiveInfinity)}"
+        )
+        assert(
+            renderFloat8(Double.NegativeInfinity) == "-Infinity",
+            s"Double.NegativeInfinity: expected -Infinity, got ${renderFloat8(Double.NegativeInfinity)}"
+        )
+        assert(renderFloat8(Double.NaN) == "NaN", s"Double.NaN: expected NaN, got ${renderFloat8(Double.NaN)}")
+    }
+
+    // Rendering a float4 at the float8 threshold keeps plain notation across nine exponents the server has
+    // already left, which is most of a float4's usable range: everything from 1e6 up read back in the wrong
+    // notation.
+    "float4 takes the exponent at FLT_DIG, not at DBL_DIG" in {
+        assert(renderFloat4(1e6f) == "1e+06", s"1e6f: expected 1e+06, got ${renderFloat4(1e6f)}")
+        assert(renderFloat4(1.5e6f) == "1.5e+06", s"1.5e6f: expected 1.5e+06, got ${renderFloat4(1.5e6f)}")
+        assert(renderFloat4(1234567f) == "1.234567e+06", s"1234567f: expected 1.234567e+06, got ${renderFloat4(1234567f)}")
+        assert(renderFloat4(1e7f) == "1e+07", s"1e7f: expected 1e+07, got ${renderFloat4(1e7f)}")
+        assert(renderFloat4(3.4e38f) == "3.4e+38", s"3.4e38f: expected 3.4e+38, got ${renderFloat4(3.4e38f)}")
+    }
+
+    "float4 stays plain below FLT_DIG" in {
+        assert(renderFloat4(1f) == "1", s"1f: expected 1, got ${renderFloat4(1f)}")
+        assert(renderFloat4(100f) == "100", s"100f: expected 100, got ${renderFloat4(100f)}")
+        assert(renderFloat4(100000f) == "100000", s"100000f: expected 100000, got ${renderFloat4(100000f)}")
+        assert(renderFloat4(123456f) == "123456", s"123456f: expected 123456, got ${renderFloat4(123456f)}")
+        assert(renderFloat4(12345.6f) == "12345.6", s"12345.6f: expected 12345.6, got ${renderFloat4(12345.6f)}")
+        assert(renderFloat4(1.2345f) == "1.2345", s"1.2345f: expected 1.2345, got ${renderFloat4(1.2345f)}")
+    }
+
+    "float4 leaves no trailing zero at the plain boundary" in {
+        assert(renderFloat4(1e-4f) == "0.0001", s"1e-4f: expected 0.0001, got ${renderFloat4(1e-4f)}")
+        assert(renderFloat4(2e-4f) == "0.0002", s"2e-4f: expected 0.0002, got ${renderFloat4(2e-4f)}")
+    }
+
+    "float4 spells the non-finite values as the server spells them" in {
+        assert(
+            renderFloat4(Float.PositiveInfinity) == "Infinity",
+            s"Float.PositiveInfinity: expected Infinity, got ${renderFloat4(Float.PositiveInfinity)}"
+        )
+        assert(
+            renderFloat4(Float.NegativeInfinity) == "-Infinity",
+            s"Float.NegativeInfinity: expected -Infinity, got ${renderFloat4(Float.NegativeInfinity)}"
+        )
+        assert(renderFloat4(Float.NaN) == "NaN", s"Float.NaN: expected NaN, got ${renderFloat4(Float.NaN)}")
+    }
+
+    // ── numeric rendered as `numeric_out` writes it ─────────────────────────────────
+    //
+    // A numeric's scale rides the wire, so the rendering keeps the trailing zeros it names. What it never takes is
+    // exponent notation: `numeric_out` writes 0.0000001 plainly, while BigDecimal.toString switches to it once the
+    // adjusted exponent is below -6. Expectations read off PostgreSQL 16.
+
+    private def numericBinaryBytes(digits: Seq[Int], weight: Int, sign: Int, dscale: Int): Span[Byte] =
+        val buf = new java.io.ByteArrayOutputStream
+        def writeInt16BE(v: Int): Unit =
+            buf.write((v >> 8) & 0xff)
+            buf.write(v & 0xff)
+        writeInt16BE(digits.size)
+        writeInt16BE(weight)
+        writeInt16BE(sign)
+        writeInt16BE(dscale)
+        digits.foreach(writeInt16BE)
+        Span.from(buf.toByteArray)
+    end numericBinaryBytes
+
+    "numeric renders a small value plainly, as numeric_out does" in {
+        // 0.0000001: one base-10000 digit of 10, at weight -2, with dscale 7 (10 * 10000^-2 = 1e-7).
+        val bytes = numericBinaryBytes(Seq(10), weight = -2, sign = 0, dscale = 7)
+        assert(PostgresDecoder.numericText.read(Format.Binary, bytes) == "0.0000001")
+    }
+
+    "numeric keeps the trailing zeros its scale carries" in {
+        // 2.50: digits 2 and 5000 at weight 0, with dscale 2.
+        val bytes = numericBinaryBytes(Seq(2, 5000), weight = 0, sign = 0, dscale = 2)
+        assert(PostgresDecoder.numericText.read(Format.Binary, bytes) == "2.50")
+    }
+
+    // ── the era, the wide years, and a second-precision zone ────────────────────────
+    //
+    // Three legal PostgreSQL values whose Java counterpart spells them differently. Expectations read off
+    // PostgreSQL 16: a date's range runs from 4713 BC to 5874897 AD, and `timetz` accepts a zone to the second.
+
+    private def binaryInt32(value: Int): Span[Byte] =
+        Span.from(Array.tabulate(4)(i => ((value >>> (24 - i * 8)) & 0xff).toByte))
+
+    private def binaryInt64(value: Long): Span[Byte] =
+        Span.from(Array.tabulate(8)(i => ((value >>> (56 - i * 8)) & 0xff).toByte))
+
+    /** A `date` column's binary payload: days from the PostgreSQL epoch, 2000-01-01. */
+    private def dateBytes(date: java.time.LocalDate): Span[Byte] =
+        binaryInt32(java.time.temporal.ChronoUnit.DAYS.between(java.time.LocalDate.of(2000, 1, 1), date).toInt)
+
+    /** A `timetz` column's binary payload: microseconds since midnight, then the zone's seconds WEST of UTC. */
+    private def timetzBytes(time: java.time.LocalTime, offsetSeconds: Int): Span[Byte] =
+        val micros = binaryInt64(time.toNanoOfDay / 1000L)
+        val zone   = binaryInt32(-offsetSeconds)
+        Span.from(micros.toArray ++ zone.toArray)
+    end timetzBytes
+
+    "a date in the BC era is written with its era's year, not the proleptic one" in {
+        // 1 BC is proleptic year 0, and 44 BC is -43.
+        val one = PostgresDecoder.dateText.read(Format.Binary, dateBytes(java.time.LocalDate.of(0, 1, 1)))
+        assert(one == "0001-01-01 BC", s"expected 0001-01-01 BC, got $one")
+        val ides = PostgresDecoder.dateText.read(Format.Binary, dateBytes(java.time.LocalDate.of(-43, 3, 15)))
+        assert(ides == "0044-03-15 BC", s"expected 0044-03-15 BC, got $ides")
+    }
+
+    "a date past four digits is written without the + LocalDate prefixes" in {
+        val wide = PostgresDecoder.dateText.read(Format.Binary, dateBytes(java.time.LocalDate.of(10000, 1, 1)))
+        assert(wide == "10000-01-01", s"expected 10000-01-01, got $wide")
+    }
+
+    "an ordinary date still pads its year to four digits" in {
+        val padded = PostgresDecoder.dateText.read(Format.Binary, dateBytes(java.time.LocalDate.of(100, 2, 3)))
+        assert(padded == "0100-02-03", s"expected 0100-02-03, got $padded")
+        val plain = PostgresDecoder.dateText.read(Format.Binary, dateBytes(java.time.LocalDate.of(2026, 8, 25)))
+        assert(plain == "2026-08-25", s"expected 2026-08-25, got $plain")
+    }
+
+    "a timetz zone keeps its seconds" in {
+        // '12:00:00+05:30:33', which the server accepts and writes back whole.
+        val offset   = 5 * 3600 + 30 * 60 + 33
+        val rendered = PostgresDecoder.timetzText.read(Format.Binary, timetzBytes(java.time.LocalTime.NOON, offset))
+        assert(rendered == "12:00:00+05:30:33", s"expected 12:00:00+05:30:33, got $rendered")
+    }
+
+    "a timetz zone on the hour or the minute stays short" in {
+        val onHour = PostgresDecoder.timetzText.read(Format.Binary, timetzBytes(java.time.LocalTime.of(10, 0), 2 * 3600))
+        assert(onHour == "10:00:00+02", s"expected 10:00:00+02, got $onHour")
+        val onMinute = PostgresDecoder.timetzText.read(Format.Binary, timetzBytes(java.time.LocalTime.NOON, 5 * 3600 + 30 * 60))
+        assert(onMinute == "12:00:00+05:30", s"expected 12:00:00+05:30, got $onMinute")
+    }
+
 end PostgresDecoderTest

--- a/kyo-sql-tests/shared/src/test/scala/kyo/SqlCodecTypeMismatchConformanceTest.scala
+++ b/kyo-sql-tests/shared/src/test/scala/kyo/SqlCodecTypeMismatchConformanceTest.scala
@@ -1,0 +1,239 @@
+package kyo
+
+import kyo.Sql.*
+import kyo.internal.SqlTestBackend
+
+/** Cross-backend battery for the column-type check every decode owes its caller: a column whose wire type cannot become the requested Scala
+  * type aborts [[SqlDecodeException]] rather than answering a value.
+  *
+  * The `String` codec is the one this suite exists for. Every other codec resolves the wire representation from the column's type token, so
+  * a numeric field over a wider column widens or aborts; the text codec read whatever bytes arrived as UTF-8, which every wire type
+  * satisfies, so an `int4`, `int8`, `float8`, `date` or `bool` column read as `String` answered the raw protocol buffer reinterpreted as
+  * text. The per-engine byte order is what proves it was the raw buffer: PostgreSQL sends `int4` 42 as `00 00 00 2A` and MySQL sends it as
+  * `2A 00 00 00`, so the two engines corrupted the same column into two different strings.
+  *
+  * Three lanes reach that codec and all three are covered here, because the defect is one codec's and reaches every tier built on it:
+  *   - the dynamic lane, [[SqlRow.decode]] by column name;
+  *   - the raw typed lane, `sql"...".as[String]`;
+  *   - the typed SQL-mirror DSL, where the `String` is a field of a row type (also the schema declaration) or a projected column.
+  *
+  * Both wire formats are covered too. The check is on the column's type token, not on the format, so the simple/text protocol refuses the
+  * same read the extended/binary protocol refuses: a row type declaring `String` for a `date` column is wrong about the column, and which
+  * protocol carried the row is not part of that. `SELECT CAST(x AS <text>)` is the spelling for a text rendering of a non-text column, and
+  * the last group proves it still works.
+  *
+  * The final group is the negative control that bounds the check. Text into a numeric field must keep failing with the typed
+  * [[SqlDecodeNumericException]] that names the value, and the two width conversions that already convert correctly (`float32` into
+  * `Double`, `smallint` into `Long`) must keep converting. A check that over-reached into either would pass every group above and still be
+  * wrong.
+  */
+class SqlCodecTypeMismatchConformanceTest extends SqlBackendTest:
+
+    /** The row every group reads: one column per wire family, holding values whose corrupt renderings are recorded in the finding. */
+    private def createProbe(backend: SqlTestBackend, client: SqlClient)(using Frame): Unit < (Async & Abort[SqlException]) =
+        val ddl =
+            s"""CREATE TABLE probe (
+               |  i  ${backend.columnType(SqlTestBackend.ColumnType.Int)},
+               |  b  ${backend.columnType(SqlTestBackend.ColumnType.BigInt)},
+               |  s  ${backend.textColumnType},
+               |  f  ${backend.columnType(SqlTestBackend.ColumnType.Float64)},
+               |  d  ${backend.columnType(SqlTestBackend.ColumnType.Date)},
+               |  t  ${backend.columnType(SqlTestBackend.ColumnType.Boolean)},
+               |  r  ${backend.columnType(SqlTestBackend.ColumnType.Float32)},
+               |  sm ${backend.columnType(SqlTestBackend.ColumnType.SmallInt)}
+               |)""".stripMargin
+        client.executeRaw(ddl).andThen(
+            client.executeRaw("INSERT INTO probe VALUES (42, 9001, 'hello', 1.5, '2026-08-04', true, 18.0, 3)")
+        ).unit
+    end createProbe
+
+    /** Runs `read` and requires it to abort a [[SqlDecodeException]], naming the value it answered instead when it did not.
+      *
+      * The value is rendered as its UTF-16 code units: a corrupt decode carries NULs and replacement characters, and printing those raw is
+      * what killed the log forwarder mid-run when the defect was first probed.
+      */
+    private def assertDecodeRefused[A](label: String, columnType: String)(read: A < (Async & Abort[SqlException] & DB))(using
+        Frame,
+        kyo.test.AssertScope
+    ): Unit < (Async & DB) =
+        Abort.run[SqlException](read).map {
+            case Result.Success(value) =>
+                val text  = String.valueOf(value)
+                val units = text.map(c => f"${c.toInt}%04x").mkString(" ")
+                assert(false, s"$label: expected a type-mismatch abort, got Success with utf16 [$units] (length ${text.length})")
+            case Result.Failure(e: SqlDecodeColumnTypeMismatchException) =>
+                assert(
+                    e.getMessage.contains(columnType),
+                    s"$label: expected the failure to name the column type '$columnType', got: ${e.getMessage}"
+                )
+                assert(
+                    e.getMessage.contains(e.scalaType),
+                    s"$label: expected the failure to name the Scala type that asked, got: ${e.getMessage}"
+                )
+            case Result.Failure(e) =>
+                assert(
+                    false,
+                    s"$label: expected SqlDecodeColumnTypeMismatchException, got ${e.getClass.getSimpleName}: ${e.getMessage}"
+                )
+            case Result.Panic(t) =>
+                assert(false, s"$label: expected a type-mismatch abort, got a panic ${t.getClass.getSimpleName}: ${t.getMessage}")
+        }
+    end assertDecodeRefused
+
+    /** How each engine names the probe table's non-text column types in a decode-mismatch report, by probe column.
+      *
+      * Asserted on rather than ignored: a report that does not name the column's own type leaves the reader with a failure and no way to
+      * tell which of a row type's fields is the wrong one.
+      */
+    private def columnTypeName(backend: SqlTestBackend, column: String): String =
+        val names =
+            if backend.id == "mysql" then
+                Map("i"  -> "INT", "b"  -> "BIGINT", "f" -> "DOUBLE", "d" -> "DATE", "t" -> "TINYINT")
+            else Map("i" -> "int4", "b" -> "int8", "f"   -> "float8", "d" -> "date", "t" -> "bool")
+        names(column)
+    end columnTypeName
+
+    // ── The dynamic lane: SqlRow.decode[String] by name ───────────────────────
+
+    "a non-text column decoded as String aborts, extended/binary protocol" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _    <- createProbe(backend, client)
+                rows <- client.query("SELECT i, b, f, d, t FROM probe")
+                row = rows.head
+                _ <- assertDecodeRefused("int as String", columnTypeName(backend, "i"))(row.decode[String]("i"))
+                _ <- assertDecodeRefused("bigint as String", columnTypeName(backend, "b"))(row.decode[String]("b"))
+                _ <- assertDecodeRefused("float64 as String", columnTypeName(backend, "f"))(row.decode[String]("f"))
+                _ <- assertDecodeRefused("date as String", columnTypeName(backend, "d"))(row.decode[String]("d"))
+                _ <- assertDecodeRefused("bool as String", columnTypeName(backend, "t"))(row.decode[String]("t"))
+            yield ()
+        }
+    }
+
+    "a non-text column decoded as String aborts, simple/text protocol" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _    <- createProbe(backend, client)
+                rows <- client.simpleQuery("SELECT i, b, f, d, t FROM probe")
+                row = rows.head
+                _ <- assertDecodeRefused("int as String", columnTypeName(backend, "i"))(row.decode[String]("i"))
+                _ <- assertDecodeRefused("bigint as String", columnTypeName(backend, "b"))(row.decode[String]("b"))
+                _ <- assertDecodeRefused("float64 as String", columnTypeName(backend, "f"))(row.decode[String]("f"))
+                _ <- assertDecodeRefused("date as String", columnTypeName(backend, "d"))(row.decode[String]("d"))
+                _ <- assertDecodeRefused("bool as String", columnTypeName(backend, "t"))(row.decode[String]("t"))
+            yield ()
+        }
+    }
+
+    // ── The raw typed lane: sql"...".as[String] ───────────────────────────────
+
+    "the raw typed lane refuses a non-text column as String" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _ <- createProbe(backend, client)
+                _ <- assertDecodeRefused("as[String] over int", columnTypeName(backend, "i"))(sql"SELECT i FROM probe".as[String].run)
+                _ <- assertDecodeRefused("as[String] over bigint", columnTypeName(backend, "b"))(sql"SELECT b FROM probe".as[String].run)
+                _ <- assertDecodeRefused("as[String] over float64", columnTypeName(backend, "f"))(sql"SELECT f FROM probe".as[String].run)
+                _ <- assertDecodeRefused("as[String] over date", columnTypeName(backend, "d"))(sql"SELECT d FROM probe".as[String].run)
+                _ <- assertDecodeRefused("as[String] over bool", columnTypeName(backend, "t"))(sql"SELECT t FROM probe".as[String].run)
+            yield ()
+        }
+    }
+
+    // ── The typed DSL: the String is a row-type field, and a projection ───────
+
+    "the typed DSL refuses a row type declaring String for a non-text column" - {
+        case class BadIntText(i: String) derives CanEqual
+        case class BadDateText(d: String) derives CanEqual
+
+        forEachBackend() { (backend, client, _) =>
+            for
+                _ <- createProbe(backend, client)
+                _ <- assertDecodeRefused("row type over int", columnTypeName(backend, "i"))(Sql.from[BadIntText]("p", "probe").run)
+                _ <- assertDecodeRefused("row type over date", columnTypeName(backend, "d"))(Sql.from[BadDateText]("p", "probe").run)
+            yield ()
+        }
+    }
+
+    "the typed DSL refuses a projected non-text column read as String" - {
+        case class BadIntText(i: String) derives CanEqual
+
+        forEachBackend() { (backend, client, _) =>
+            for
+                _ <- createProbe(backend, client)
+                _ <- assertDecodeRefused("projection over int", columnTypeName(backend, "i"))(Sql.from[BadIntText]("p", "probe").select(r =>
+                    r.p.i
+                ).run)
+            yield ()
+        }
+    }
+
+    // ── A text column is still a String, in both protocols ────────────────────
+
+    "a text column still decodes as String in both protocols" - {
+        case class GoodText(s: String) derives CanEqual
+
+        forEachBackend() { (backend, client, _) =>
+            for
+                _        <- createProbe(backend, client)
+                extended <- client.query("SELECT s FROM probe")
+                binary   <- extended.head.decode[String]("s")
+                simple   <- client.simpleQuery("SELECT s FROM probe")
+                text     <- simple.head.decode[String]("s")
+                typed    <- sql"SELECT s FROM probe".as[String].run
+                dsl      <- Sql.from[GoodText]("p", "probe").run
+            yield
+                assert(binary == "hello", s"extended protocol: expected 'hello', got '$binary'")
+                assert(text == "hello", s"simple protocol: expected 'hello', got '$text'")
+                assert(typed.head == "hello", s"raw typed lane: expected 'hello', got '${typed.head}'")
+                assert(dsl.head == GoodText("hello"), s"typed DSL: expected GoodText(hello), got ${dsl.head}")
+        }
+    }
+
+    "a SQL cast is the spelling for a text rendering of a non-text column" - {
+        case class ProbeInt(i: Int) derives CanEqual
+
+        forEachBackend() { (backend, client, _) =>
+            for
+                _    <- createProbe(backend, client)
+                cast <- Sql.from[ProbeInt]("p", "probe").select(r => r.p.i.cast[String]).run
+            yield assert(cast.head == "42", s"an int column cast to text: expected '42', got '${cast.head}'")
+        }
+    }
+
+    // ── The negative control: what the check must NOT disturb ─────────────────
+
+    "text into a numeric field still fails with the typed numeric error" - {
+        case class BadTextNumeric(s: Long) derives CanEqual
+
+        forEachBackend() { (backend, client, _) =>
+            for
+                _      <- createProbe(backend, client)
+                result <- Abort.run[SqlException](Sql.from[BadTextNumeric]("p", "probe").run)
+            yield result match
+                case Result.Failure(e: SqlDecodeNumericException) =>
+                    assert(
+                        e.getMessage.contains("hello"),
+                        s"expected the numeric error to name the value 'hello', got: ${e.getMessage}"
+                    )
+                case other =>
+                    assert(false, s"expected SqlDecodeNumericException, got $other")
+        }
+    }
+
+    "width conversions still convert" - {
+        case class WidenedFloat(r: Double) derives CanEqual
+        case class WidenedInt(sm: Long) derives CanEqual
+
+        forEachBackend() { (backend, client, _) =>
+            for
+                _     <- createProbe(backend, client)
+                float <- Sql.from[WidenedFloat]("p", "probe").run
+                int   <- Sql.from[WidenedInt]("p", "probe").run
+            yield
+                assert(float.head == WidenedFloat(18.0), s"float32 into Double: expected 18.0, got ${float.head}")
+                assert(int.head == WidenedInt(3L), s"smallint into Long: expected 3, got ${int.head}")
+        }
+    }
+
+end SqlCodecTypeMismatchConformanceTest

--- a/kyo-sql-tests/shared/src/test/scala/kyo/SqlConfigUrlOptionsTest.scala
+++ b/kyo-sql-tests/shared/src/test/scala/kyo/SqlConfigUrlOptionsTest.scala
@@ -90,6 +90,17 @@ class SqlConfigUrlOptionsTest extends SqlContainerTest:
                                     s"establishment must be bounded by the URL's connectTimeout, was bounded by ${e.timeout}"
                                 )
                                 assert(e.port == listener.port)
+                                // The failure names the knob that supplied the budget, which is the URL's here, and says
+                                // that authentication shares it: this server answers the TCP connect and then nothing, so
+                                // a message pointing only at reachability would send a reader to the wrong place.
+                                assert(
+                                    e.budgetSource == SqlConnectionEstablishTimeoutException.fromConnectTimeout,
+                                    s"the URL's connectTimeout supplied the budget, message said: ${e.budgetSource}"
+                                )
+                                assert(
+                                    e.message.contains("authentication handshake"),
+                                    s"the failure must say the budget covers authentication too, got: ${e.message}"
+                                )
                             case other =>
                                 fail(s"expected establishment to time out, got $other")
                         }

--- a/kyo-sql-tests/shared/src/test/scala/kyo/SqlNamingScopeConformanceTest.scala
+++ b/kyo-sql-tests/shared/src/test/scala/kyo/SqlNamingScopeConformanceTest.scala
@@ -1,0 +1,62 @@
+package kyo
+
+import kyo.internal.SqlTestBackend
+
+/** Both arms of where a [[SqlNaming]] given has to be declared to reach a query, against a live server.
+  *
+  * A casing given is found by ordinary implicit search at the call site of the run, so declaring it somewhere the run is not (a companion
+  * object, another method) leaves the decode asking for the verbatim Scala field names against snake_case columns. That is not detectable
+  * while compiling: whether the columns are cased is a fact about the database, so both arms below run the same query against the same
+  * table and differ only in whether the given is in scope.
+  *
+  * The failing arm is the one this exists for. It used to report only that a column was missing, which named neither the columns the row
+  * did have nor the reason they looked different, and the same failure reached the caller from inside a workflow store where it presented
+  * as a silent engine stall. It now lists the row's own columns and says that a casing given is resolved at the call site.
+  */
+class SqlNamingScopeConformanceTest extends SqlBackendTest:
+
+    case class ExecutionRow(executionId: String, flowId: String) derives CanEqual
+
+    private def createExecutions(backend: SqlTestBackend, client: SqlClient)(using Frame): Unit < (Async & Abort[SqlException]) =
+        client.executeRaw(
+            s"CREATE TABLE flow_execution (execution_id ${backend.textColumnType}, flow_id ${backend.textColumnType})"
+        ).andThen(
+            client.executeRaw("INSERT INTO flow_execution VALUES ('exec-1', 'fulfillment')")
+        ).unit
+
+    "a casing given in scope at the run site is applied" - {
+        forEachBackend() { (backend, client, _) =>
+            given SqlNaming = SqlNaming.SnakeCase
+            for
+                _    <- createExecutions(backend, client)
+                rows <- sql"SELECT execution_id, flow_id FROM flow_execution".as[ExecutionRow].run
+            yield assert(
+                rows == Chunk(ExecutionRow("exec-1", "fulfillment")),
+                s"the given is in scope here, so the cased columns must decode, got $rows"
+            )
+            end for
+        }
+    }
+
+    "a casing given that does not reach the run site fails naming the row's columns and the casing" - {
+        forEachBackend() { (backend, client, _) =>
+            // No `given SqlNaming` in scope at this run, which is what a given declared in a companion object of some
+            // other class looks like from here.
+            for
+                _      <- createExecutions(backend, client)
+                result <- Abort.run[SqlException](sql"SELECT execution_id, flow_id FROM flow_execution".as[ExecutionRow].run)
+            yield result match
+                case Result.Failure(e: SqlDecodeColumnNotFoundException) =>
+                    assert(e.columnName == "executionId", s"the lookup asks for the verbatim field name, got ${e.columnName}")
+                    assert(
+                        e.availableColumns.contains("execution_id"),
+                        s"the failure must list the row's own columns, got ${e.availableColumns}"
+                    )
+                    assert(e.message.contains("only in casing"), s"the failure must name the casing, got: ${e.message}")
+                    assert(e.message.contains("SqlNaming"), s"the failure must name the given, got: ${e.message}")
+                case other =>
+                    assert(false, s"expected the decode to fail naming the missing column, got $other")
+        }
+    }
+
+end SqlNamingScopeConformanceTest

--- a/kyo-sql-tests/shared/src/test/scala/kyo/SqlRowColumnMetadataConformanceTest.scala
+++ b/kyo-sql-tests/shared/src/test/scala/kyo/SqlRowColumnMetadataConformanceTest.scala
@@ -1,0 +1,255 @@
+package kyo
+
+import kyo.internal.SqlTestBackend
+
+/** Cross-backend battery for what a caller learns about a result set it did not type: the kind of value each column carries, the engine's
+  * own name for that type, and the column's value rendered as text.
+  *
+  * The tool this exists for runs SQL nobody typed. It has no row type to decode into, so the reachable surface used to be a column name and
+  * bytes it could not interpret, and the only reader that never failed was `decode[String]`, which answered those bytes as UTF-8 whatever
+  * they were. That reader now refuses a column that is not text, which is correct and leaves the generic caller with nothing, so the two
+  * halves are one change: [[SqlRow.columnKind]] and [[SqlRow.columnTypeName]] say what a column is, and [[SqlRow.text]] renders the value
+  * the column actually holds.
+  *
+  * Both wire formats are covered. A text-protocol row already carries every value as its rendering; a binary-protocol row carries wire
+  * representations that have to be decoded at the column's own type first, which is where a renderer that reinterpreted bytes would answer
+  * mojibake. The two must agree, so each group asserts the same rendering under both.
+  */
+class SqlRowColumnMetadataConformanceTest extends SqlBackendTest:
+
+    private def createProbe(backend: SqlTestBackend, client: SqlClient)(using Frame): Unit < (Async & Abort[SqlException]) =
+        val ddl =
+            s"""CREATE TABLE probe (
+               |  i ${backend.columnType(SqlTestBackend.ColumnType.Int)},
+               |  b ${backend.columnType(SqlTestBackend.ColumnType.BigInt)},
+               |  s ${backend.textColumnType},
+               |  f ${backend.columnType(SqlTestBackend.ColumnType.Float64)},
+               |  d ${backend.columnType(SqlTestBackend.ColumnType.Date)},
+               |  t ${backend.columnType(SqlTestBackend.ColumnType.Boolean)},
+               |  n ${backend.columnType(SqlTestBackend.ColumnType.Numeric)}
+               |)""".stripMargin
+        client.executeRaw(ddl).andThen(
+            client.executeRaw("INSERT INTO probe VALUES (42, 9001, 'hello', 1.5, '2026-08-04', true, 2.50)")
+        ).unit
+    end createProbe
+
+    private val select = "SELECT i, b, s, f, d, t, n FROM probe"
+
+    "a column reports the kind of value it carries" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _    <- createProbe(backend, client)
+                rows <- client.query(select)
+                row = rows.head
+            yield
+                assert(row.columnKind("i") == SqlRow.ColumnKind.Integer, s"i: got ${row.columnKind("i")}")
+                assert(row.columnKind("b") == SqlRow.ColumnKind.Integer, s"b: got ${row.columnKind("b")}")
+                assert(row.columnKind("s") == SqlRow.ColumnKind.Text, s"s: got ${row.columnKind("s")}")
+                assert(row.columnKind("f") == SqlRow.ColumnKind.Float, s"f: got ${row.columnKind("f")}")
+                assert(row.columnKind("d") == SqlRow.ColumnKind.Date, s"d: got ${row.columnKind("d")}")
+                assert(row.columnKind("n") == SqlRow.ColumnKind.Decimal, s"n: got ${row.columnKind("n")}")
+                // MySQL stores a BOOLEAN as TINYINT and reports it as one, so the neutral kind is the integer it is.
+                // Pinned per engine rather than as a disjunction: this is the accessor a generic caller acts on, and a
+                // regression mapping PostgreSQL's bool to Integer would satisfy an either-answer assertion.
+                val expectedBoolKind =
+                    if backend.id == "mysql" then SqlRow.ColumnKind.Integer else SqlRow.ColumnKind.Bool
+                assert(row.columnKind("t") == expectedBoolKind, s"t: expected $expectedBoolKind, got ${row.columnKind("t")}")
+                assert(row.columnKind("nosuch") == SqlRow.ColumnKind.Unknown, "an absent column has no kind")
+        }
+    }
+
+    "a column reports the engine's own name for its type" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _    <- createProbe(backend, client)
+                rows <- client.query(select)
+                row = rows.head
+            yield
+                val expected =
+                    if backend.id == "mysql" then Map("i" -> "INT", "b"  -> "BIGINT", "f" -> "DOUBLE", "d" -> "DATE")
+                    else Map("i"                          -> "int4", "b" -> "int8", "f"   -> "float8", "d" -> "date")
+                expected.foreach { (column, name) =>
+                    assert(
+                        row.columnTypeName(column) == Present(name),
+                        s"$column: expected Present($name), got ${row.columnTypeName(column)}"
+                    )
+                }
+                assert(row.columnTypeName("nosuch") == Absent, "an absent column has no type name")
+        }
+    }
+
+    /** The types whose two renderings coincide, kept as the base case.
+      *
+      * `t` and `n` are deliberately not here: a bool renders `t` against the server and `true` through the JDK, which is the divergence
+      * the leaf below covers over the full set. This one says the ordinary columns were not disturbed.
+      */
+    "a column renders as text under both wire formats" - {
+        forEachBackend() { (backend, client, _) =>
+            val expected = Map("i" -> "42", "b" -> "9001", "s" -> "hello", "f" -> "1.5", "d" -> "2026-08-04")
+            for
+                _        <- createProbe(backend, client)
+                extended <- client.query(select)
+                simple   <- client.simpleQuery(select)
+                binary   <- Kyo.foreach(Chunk.from(expected.keys))(name => extended.head.text(name).map(name -> _))
+                textual  <- Kyo.foreach(Chunk.from(expected.keys))(name => simple.head.text(name).map(name -> _))
+            yield
+                binary.foreach { (name, rendered) =>
+                    assert(rendered == Present(expected(name)), s"binary protocol, $name: expected ${expected(name)}, got $rendered")
+                }
+                textual.foreach { (name, rendered) =>
+                    assert(rendered == Present(expected(name)), s"text protocol, $name: expected ${expected(name)}, got $rendered")
+                }
+            end for
+        }
+    }
+
+    /** The two column types whose text rendering the backend produces itself, checked against the server that stores them.
+      *
+      * Both are PostgreSQL's. Neither has a Scala type that spans it, so neither can be rendered by decoding at a type and printing the
+      * value: an interval carries calendar and time parts that `java.time.Duration` and `java.time.Period` each refuse half of, and an
+      * `inet` is a wire struct with no Scala type here at all. The renderings are written against the wire layout, which makes this leaf
+      * the one that says the layout was read right, over values a real server encoded.
+      *
+      * The interval is deliberately one carrying every component at once, which is exactly what the two typed readings cannot hold.
+      */
+    "an interval and an inet render as text, and agree across both wire formats" - {
+        forEachBackend() { (backend, client, _) =>
+            if backend.id != "postgres" then succeed(s"${backend.label} has neither an interval nor an inet type")
+            else
+                // Three rows, chosen for where a hand-written rendering and the server's own are most likely to
+                // disagree: every component at once, which is the value neither typed reading holds; a negative
+                // interval, where the sign convention is per-component rather than leading; and an IPv6 address,
+                // whose zero-run compression is a rule rather than a formatting choice.
+                val select = "SELECT id, span, addr FROM netprobe ORDER BY id"
+                for
+                    _ <- client.executeRaw("CREATE TABLE netprobe (id int, span interval, addr inet)")
+                    _ <- client.executeRaw(
+                        """INSERT INTO netprobe VALUES
+                          |  (1, interval '1 year 2 mons 3 days 04:05:06', '192.168.1.0/24'),
+                          |  (2, interval '-1 year -2 mons -3 days -04:05:06', '2001:db8::1'),
+                          |  (3, interval '90 minutes', '::1')""".stripMargin
+                    )
+                    extended <- client.query(select)
+                    simple   <- client.simpleQuery(select)
+                    binSpans <- Kyo.foreach(extended)(_.text("span"))
+                    binAddrs <- Kyo.foreach(extended)(_.text("addr"))
+                    txtSpans <- Kyo.foreach(simple)(_.text("span"))
+                    txtAddrs <- Kyo.foreach(simple)(_.text("addr"))
+                yield
+                    val spans = Chunk(Present("P1Y2M3DT4H5M6S"), Present("P-1Y-2M-3DT-4H-5M-6S"), Present("PT1H30M"))
+                    val addrs = Chunk(Present("192.168.1.0/24"), Present("2001:db8::1"), Present("::1"))
+                    assert(binSpans == spans, s"binary protocol, spans: got $binSpans")
+                    assert(txtSpans == spans, s"text protocol, spans: got $txtSpans")
+                    assert(binAddrs == addrs, s"binary protocol, addrs: got $binAddrs")
+                    assert(txtAddrs == addrs, s"text protocol, addrs: got $txtAddrs")
+                end for
+        }
+    }
+
+    "a NULL column renders as absent, and an unknown column name aborts" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _      <- createProbe(backend, client)
+                _      <- client.executeRaw("INSERT INTO probe (i) VALUES (7)")
+                rows   <- client.query("SELECT s FROM probe WHERE i = 7")
+                value  <- rows.head.text(0)
+                missed <- Abort.run[SqlException](rows.head.text("nosuch"))
+            yield
+                assert(value == Absent, s"a NULL column renders as Absent, got $value")
+                missed match
+                    case Result.Failure(e: SqlDecodeColumnNotFoundException) =>
+                        assert(e.columnName == "nosuch", s"the failure must name the column asked for, got ${e.columnName}")
+                        assert(e.availableColumns.nonEmpty, "the failure must list the row's own columns")
+                    case other => assert(false, s"expected SqlDecodeColumnNotFoundException, got $other")
+                end match
+        }
+    }
+
+    /** Every column type whose text rendering the two wire protocols used to disagree on, checked against the server that stores them.
+      *
+      * `SqlRow.text` answers the server's own rendering. Under the text protocol that is what arrived; under the binary protocol the
+      * value is decoded and re-rendered here, so the two agreeing is a property of this backend rather than of the wire. They did not
+      * agree before: a bool read `true` against the server's `t`, a timestamptz read `2026-08-25T10:00:00Z` against
+      * `2026-08-25 10:00:00+00`, a time read `10:00` against `10:00:00`, and a float4 0.1 read `0.10000000149011612`, having been
+      * widened to a Double before it was printed.
+      *
+      * The assertion is against the server's answer for the same row read through the simple protocol, not against a literal written
+      * here, so the leaf cannot drift from what PostgreSQL actually writes.
+      */
+    "every rendered column agrees with the server under both wire formats" - {
+        forEachBackend() { (backend, client, _) =>
+            if backend.id != "postgres" then succeed(s"${backend.label} renders its own types")
+            else
+                val select = "SELECT b, ts, tsn, t, tz, d, f4, f8, n FROM rendering ORDER BY id"
+                for
+                    _ <- client.executeRaw(
+                        """CREATE TABLE rendering (
+                          |  id int, b bool, ts timestamptz, tsn timestamp, t time,
+                          |  tz timetz, d date, f4 float4, f8 float8, n numeric
+                          |)""".stripMargin
+                    )
+                    _ <- client.executeRaw(
+                        """INSERT INTO rendering VALUES
+                          |  (1, true,  '2026-08-25 10:00:00+00',        '2026-08-25 10:00:00',   '10:00:00',
+                          |      '10:00:00+02', '2026-08-25',   0.1,    1e10,  2.50),
+                          |  (2, false, '2026-08-25 10:00:00.123456+00', '2026-08-25 10:00:00.5', '10:00:00.25',
+                          |      '23:59:59-05', '0001-01-01', 3.4e38,   1.5,   0.000001)""".stripMargin
+                    )
+                    extended <- client.query(select)
+                    simple   <- client.simpleQuery(select)
+                    names = Chunk("b", "ts", "tsn", "t", "tz", "d", "f4", "f8", "n")
+                    binary  <- Kyo.foreach(extended)(row => Kyo.foreach(names)(n => row.text(n)))
+                    textual <- Kyo.foreach(simple)(row => Kyo.foreach(names)(n => row.text(n)))
+                yield
+                    assert(binary == textual, s"the two protocols must render one value one way:\nbinary $binary\ntext   $textual")
+                    // Pinned outright as well, so the leaf fails if BOTH paths drift together.
+                    assert(
+                        textual.head == Chunk(
+                            Present("t"),
+                            Present("2026-08-25 10:00:00+00"),
+                            Present("2026-08-25 10:00:00"),
+                            Present("10:00:00"),
+                            Present("10:00:00+02"),
+                            Present("2026-08-25"),
+                            Present("0.1"),
+                            Present("10000000000"),
+                            Present("2.50")
+                        ),
+                        s"row 1: got ${textual.head}"
+                    )
+                end for
+        }
+    }
+
+    /** The values with no Scala counterpart, which decoding at a type either refuses or answers wrongly. */
+    "a special value renders as the server writes it rather than refusing or guessing" - {
+        forEachBackend() { (backend, client, _) =>
+            if backend.id != "postgres" then succeed(s"${backend.label} has no such values")
+            else
+                val select = "SELECT n, d, ts FROM specials ORDER BY id"
+                for
+                    _ <- client.executeRaw("CREATE TABLE specials (id int, n numeric, d date, ts timestamptz)")
+                    _ <- client.executeRaw(
+                        """INSERT INTO specials VALUES
+                          |  (1, 'NaN', 'infinity', 'infinity'),
+                          |  (2, 'Infinity', '-infinity', '-infinity')""".stripMargin
+                    )
+                    extended <- client.query(select)
+                    simple   <- client.simpleQuery(select)
+                    names = Chunk("n", "d", "ts")
+                    binary  <- Kyo.foreach(extended)(row => Kyo.foreach(names)(n => row.text(n)))
+                    textual <- Kyo.foreach(simple)(row => Kyo.foreach(names)(n => row.text(n)))
+                yield
+                    assert(binary == textual, s"a special value must read one way:\nbinary $binary\ntext   $textual")
+                    assert(
+                        binary == Chunk(
+                            Chunk(Present("NaN"), Present("infinity"), Present("infinity")),
+                            Chunk(Present("Infinity"), Present("-infinity"), Present("-infinity"))
+                        ),
+                        s"got $binary"
+                    )
+                end for
+        }
+    }
+
+end SqlRowColumnMetadataConformanceTest

--- a/kyo-sql-tests/shared/src/test/scala/kyo/SqlWriteReturningConformanceTest.scala
+++ b/kyo-sql-tests/shared/src/test/scala/kyo/SqlWriteReturningConformanceTest.scala
@@ -1,0 +1,173 @@
+package kyo
+
+import kyo.Sql.*
+import kyo.internal.SqlTestBackend
+
+/** Cross-backend battery for a write that answers the rows it changed.
+  *
+  * `returning` on an UPDATE or a DELETE was accepted by the builder, rendered into the statement, and then thrown away: the only terminals
+  * answered a row count, so the rows the server had already sent back were unreachable. The raw tier could read them from the same
+  * statement in the same run, which is what made it a hole rather than a missing feature.
+  *
+  * The rows are typed by what was asked for, so a single column decodes as that column's value and several decode as the tuple. Each group
+  * asserts the typed result against the raw spelling of the same statement, so the two tiers are held to the same answer.
+  *
+  * A flavor with no `RETURNING` clause refuses the statement rather than answering nothing, which is the other half of the contract: the
+  * request is not silently dropped. The suite branches on the descriptor's own capability flag rather than on an engine name.
+  */
+class SqlWriteReturningConformanceTest extends SqlBackendTest:
+
+    case class Widget(id: Long, name: String, price: BigDecimal) derives CanEqual
+
+    private def createWidgets(backend: SqlTestBackend, client: SqlClient)(using Frame): Unit < (Async & Abort[SqlException]) =
+        val ddl =
+            s"""CREATE TABLE widget (
+               |  id ${backend.columnType(SqlTestBackend.ColumnType.BigInt)},
+               |  name ${backend.textColumnType},
+               |  price ${backend.columnType(SqlTestBackend.ColumnType.Numeric)}
+               |)""".stripMargin
+        client.executeRaw(ddl).andThen(
+            client.executeRaw("INSERT INTO widget VALUES (1, 'bolt', 2.00), (2, 'nut', 3.00), (3, 'washer', 4.00)")
+        ).unit
+    end createWidgets
+
+    "an UPDATE answers the rows it changed" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _ <- createWidgets(backend, client)
+                result <- Abort.run[SqlException](
+                    Sql.update[Widget]("widget")
+                        .set(_.price := BigDecimal(9))
+                        .returning(r => (r.id, r.price))
+                        .where(_.id == 2L)
+                        .run
+                )
+            yield
+                if backend.supportsReturning then
+                    result match
+                        case Result.Success(rows) =>
+                            assert(rows == Chunk((2L, BigDecimal(9))), s"expected the changed row back, got $rows")
+                        case other => assert(false, s"expected the changed row, got $other")
+                else
+                    result match
+                        case Result.Failure(e: SqlUnsupportedException) =>
+                            assert(e.getMessage.contains("RETURNING"), s"the refusal must name RETURNING, got ${e.getMessage}")
+                        case other =>
+                            assert(false, s"a flavor with no RETURNING must refuse the statement, got $other")
+        }
+    }
+
+    "an UPDATE answers a single returned column at that column's own type" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _ <- createWidgets(backend, client)
+                result <- Abort.run[SqlException](
+                    Sql.update[Widget]("widget").set(_.name := "hex nut").returning(_.name).where(_.id == 2L).run
+                )
+            yield
+                if backend.supportsReturning then
+                    assert(result == Result.Success(Chunk("hex nut")), s"expected the new name back, got $result")
+                else
+                    result match
+                        case Result.Failure(e: SqlUnsupportedException) =>
+                            assert(e.getMessage.contains("RETURNING"), s"the refusal must name RETURNING, got ${e.getMessage}")
+                        case other =>
+                            assert(false, s"a flavor with no RETURNING must refuse the statement as unsupported, got $other")
+        }
+    }
+
+    "a DELETE answers the rows it removed" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _ <- createWidgets(backend, client)
+                result <- Abort.run[SqlException](
+                    Sql.delete[Widget]("widget").returning(r => (r.id, r.name)).where(_.id == 3L).run
+                )
+                left <- client.query("SELECT id FROM widget")
+            yield
+                if backend.supportsReturning then
+                    assert(result == Result.Success(Chunk((3L, "washer"))), s"expected the removed row back, got $result")
+                    assert(left.size == 2, s"the row must actually be gone, ${left.size} left")
+                else
+                    result match
+                        case Result.Failure(_: SqlUnsupportedException) =>
+                            assert(left.size == 3, s"a refused DELETE must remove nothing, ${left.size} left")
+                        case other =>
+                            assert(false, s"a flavor with no RETURNING must refuse the statement as unsupported, got $other")
+        }
+    }
+
+    "the typed tier answers what the raw tier answers for the same statement" - {
+        forEachBackend() { (backend, client, _) =>
+            // The comparison is only askable where the flavor has the clause; the leaf above is what covers a flavor
+            // that does not, so this one says why it did nothing rather than passing silently.
+            if !backend.supportsReturning then succeed(s"${backend.label} has no RETURNING clause")
+            else
+                for
+                    _ <- createWidgets(backend, client)
+                    typed <- Sql.update[Widget]("widget")
+                        .set(_.price := BigDecimal(7))
+                        .returning(r => (r.id, r.price))
+                        .where(_.id == 1L)
+                        .run
+                    raw <- sql"UPDATE widget SET price = ${BigDecimal(8)} WHERE id = ${1L} RETURNING id, price"
+                        .as[(Long, BigDecimal)].run
+                yield
+                    assert(typed == Chunk((1L, BigDecimal(7))), s"the typed tier must answer the changed row, got $typed")
+                    assert(raw == Chunk((1L, BigDecimal(8))), s"the raw tier must answer the same shape, got $raw")
+        }
+    }
+
+    /** An INSERT that names its returning columns answers the rows it wrote, not how many.
+      *
+      * INSERT is the statement RETURNING exists for, and it was the one left answering a count while the server sent the rows. It also
+      * carries the case the other two do not: the renderer appends `RETURNING <autoKey>` on its own for a detected auto-key, so an
+      * explicit clause has to replace that one rather than emit beside it.
+      */
+    "an INSERT answers the rows it wrote" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _ <- createWidgets(backend, client)
+                result <- Abort.run[SqlException](
+                    Sql.insert[Widget]("widget")
+                        .values(Widget(4L, "screw", BigDecimal(5)))
+                        .returning(r => (r.id, r.name))
+                        .run
+                )
+            yield
+                if backend.supportsReturning then
+                    result match
+                        case Result.Success(rows) =>
+                            assert(rows == Chunk((4L, "screw")), s"expected the written row back, got $rows")
+                        case other => assert(false, s"expected the written row, got $other")
+                else
+                    result match
+                        case Result.Failure(e: SqlUnsupportedException) =>
+                            assert(e.getMessage.contains("RETURNING"), s"the refusal must name RETURNING, got ${e.getMessage}")
+                        case other =>
+                            assert(false, s"a flavor with no RETURNING must refuse the statement, got $other")
+        }
+    }
+
+    "an INSERT answers a single returned column at that column's own type" - {
+        forEachBackend() { (backend, client, _) =>
+            for
+                _ <- createWidgets(backend, client)
+                result <- Abort.run[SqlException](
+                    Sql.insert[Widget]("widget").values(Widget(5L, "rivet", BigDecimal(6))).returning(_.name).run
+                )
+            yield
+                if backend.supportsReturning then
+                    result match
+                        case Result.Success(rows) => assert(rows == Chunk("rivet"), s"expected the name back, got $rows")
+                        case other                => assert(false, s"expected the name, got $other")
+                else
+                    result match
+                        case Result.Failure(e: SqlUnsupportedException) =>
+                            assert(e.getMessage.contains("RETURNING"), s"the refusal must name RETURNING, got ${e.getMessage}")
+                        case other =>
+                            assert(false, s"a flavor with no RETURNING must refuse the statement, got $other")
+        }
+    }
+
+end SqlWriteReturningConformanceTest

--- a/kyo-sql-tests/shared/src/test/scala/kyo/internal/mysql/exchange/MysqlExtendedProtocolIntegrationTest.scala
+++ b/kyo-sql-tests/shared/src/test/scala/kyo/internal/mysql/exchange/MysqlExtendedProtocolIntegrationTest.scala
@@ -3,6 +3,7 @@ package kyo.internal.mysql.exchange
 import kyo.*
 import kyo.internal.SqlSharedContainers
 import kyo.internal.mysql.BoundMysqlParam
+import kyo.internal.mysql.MysqlColumnToken
 import kyo.internal.mysql.MysqlConnection
 import kyo.internal.mysql.MysqlRowCodec
 import kyo.internal.mysql.types.MysqlEncoder
@@ -116,6 +117,47 @@ class MysqlExtendedProtocolIntegrationTest extends SqlContainerTest:
                         assert(rows.size == 1)
                         decode[Int](rows(0), 0).map { decoded =>
                             assert(decoded == v, s"Expected $v, got $decoded")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── the column definitions a row carries ──────────────────────────────────
+
+    /** A row must carry the column definitions the EXECUTE response sent, not the ones COM_STMT_PREPARE sent.
+      *
+      * MySQL describes the result column of a bare placeholder at prepare time, before any parameter is bound, and reports `VAR_STRING`
+      * for it. At execute time it resends the definitions and sends the value in the bound parameter's own binary form: an `Int` parameter
+      * comes back as the eight little-endian bytes `2a 00 00 00 00 00 00 00` under a `LONGLONG` definition. A row built from the
+      * prepare-time definitions therefore announces `VAR_STRING` over a binary integer, and every decoder that resolves the wire
+      * representation from the column's type resolves it from a type the value does not have. The row payload was already parsed with the
+      * execute-time types, so the two disagreed inside one row.
+      */
+    "ExtendedQueryExchange rows carry the execute-time column definitions" in {
+        Scope.run {
+            SqlSharedContainers.withFreshSchema(SqlSharedContainers.Backend.MySQL) { ctx =>
+                withConn(ctx) { conn =>
+                    val params = Chunk(BoundMysqlParam(42, MysqlEncoder.intEncoder))
+                    conn.extendedQuery("SELECT ? AS declared", params).flatMap { rows =>
+                        val neutral   = MysqlRowCodec.row(rows(0))
+                        val typeByte  = MysqlColumnToken.columnType(neutral.columns(0).typeToken)
+                        val byteCount = neutral.column(0).fold(0)(_.size)
+                        assert(
+                            typeByte != MysqlEncoder.TYPE_VAR_STRING,
+                            s"the column announced VAR_STRING over a $byteCount-byte binary payload, which is the prepare-time definition"
+                        )
+                        assert(
+                            typeByte == MysqlEncoder.TYPE_LONGLONG,
+                            s"expected the execute-time LONGLONG definition, got type byte 0x${typeByte.toHexString}"
+                        )
+                        // The consequence a caller sees: an integer column read as text is refused rather than answering its bytes.
+                        Abort.run[SqlException](neutral.decode[String](0)).map {
+                            case Result.Failure(e: SqlDecodeColumnTypeMismatchException) =>
+                                assert(e.scalaType == "String", s"the failure must name the type that asked, got ${e.scalaType}")
+                                assert(e.columnType == "BIGINT", s"the failure must name the column's type, got ${e.columnType}")
+                            case other => assert(false, s"expected a type-mismatch abort reading the integer column as String, got $other")
                         }
                     }
                 }

--- a/kyo-sql-tests/shared/src/test/scala/sqlproof/SqlRowDownstreamProofTest.scala
+++ b/kyo-sql-tests/shared/src/test/scala/sqlproof/SqlRowDownstreamProofTest.scala
@@ -1,0 +1,37 @@
+package sqlproof
+
+import kyo.*
+
+/** Proves the per-column metadata of a result row is reachable from outside the `kyo` package.
+  *
+  * A tool that runs SQL nobody typed needs, per column, a name and enough type information to render the value. The name was always
+  * reachable and the type information was not: [[kyo.SqlRow.Column.typeToken]] existed, and the accessor that reached it was
+  * `private[kyo]`, so a caller outside the package saw a name and bytes it could not interpret. This compiles from the public surface
+  * alone, so a member creeping back behind `private[kyo]` would fail this compile.
+  */
+class SqlRowDownstreamProofTest extends kyo.Test:
+
+    "a downstream caller reads a row's column metadata" in {
+        val row = new SqlRow(
+            Chunk(Maybe.Present(Span.from("hello".getBytes("UTF-8")))),
+            Chunk(SqlRow.Column("greeting", 25)),
+            new StubCodec
+        )
+        val described = row.columns.map(column => s"${column.name}/${column.typeToken}")
+        assert(described == Chunk("greeting/25"))
+        assert(row.columnKind(0) == SqlRow.ColumnKind.Unknown)
+        assert(row.columnTypeName(0) == Absent)
+        Abort.run[SqlDecodeException](row.text("greeting")).map { rendered =>
+            assert(rendered == Result.Success(Maybe.Present("hello")))
+        }
+    }
+
+    /** The smallest codec a downstream engine can supply: the metadata hooks carry defaults, so a codec that has none still compiles. */
+    final class StubCodec extends SqlRow.Codec:
+        def read[A](schema: SqlSchema[A], row: SqlRow, offset: Int, naming: Maybe[SqlNaming], fieldMatch: SqlRow.FieldMatch)(using
+            Frame
+        ): A < Abort[SqlDecodeException] =
+            Abort.fail(SqlDecodeColumnNotFoundException("the stub codec decodes nothing"))
+    end StubCodec
+
+end SqlRowDownstreamProofTest

--- a/kyo-sql/README.md
+++ b/kyo-sql/README.md
@@ -223,6 +223,20 @@ defaults do not fit. `Sql.from[Invoice]("i")` sets the alias, which re-keys the 
 how a self-join tells its two sides apart, and `Sql.from[Invoice]("i", "invoice_ledger")` names the table
 outright beside it.
 
+The override is per call site, which is a repetition where a schema's table names differ from its type names
+throughout, plural tables being the common case. Name the source once instead:
+
+```scala
+transparent inline def invoices = Sql.from[Invoice]("i", "invoice_ledger")
+
+val pending    = invoices.where(r => r.i.status == InvoiceStatus.Pending)
+val topByTotal = invoices.orderBy(r => r.i.total.desc).limit(10)
+```
+
+Every query then starts from `invoices` and the table name is written once. `transparent` is what makes it
+work: without it the record type widens and the lambdas cannot name a column, and with it the source still
+folds at compile time (see [Static queries](#static-queries)).
+
 In a self-join both sides need their own key, so the predicate can name one against the other, pairing distinct
 invoices billed to the same customer:
 
@@ -305,11 +319,15 @@ falling back silently:
 ```text
 9 |    page.runStatic
   |         ^
-  |    .runStatic: query cannot be folded at compile time. Ensure the query and its DSL fragments are
-  |    constructed at the call site (a query stored in a `val` reaches this macro as a variable
-  |    reference, without the construction behind it). Use .run for opportunistic static folding with
-  |    runtime fallback, or .runDynamic to skip static folding entirely.
+  |    .runStatic: this statement cannot be folded at compile time. The statement reaches this macro
+  |    as a variable reference rather than as its construction, which is what a query stored in a
+  |    `val` looks like here. Construct it at the call site, or name it with a `transparent inline
+  |    def`. Use .run for opportunistic static folding with runtime fallback, or .runDynamic to skip
+  |    static folding entirely.
 ```
+
+The refusal names the construct it found rather than guessing, so a statement carrying a raw `sql"..."`
+fragment or a `having` clause says so instead of blaming a `val`.
 
 ### Static queries
 
@@ -360,12 +378,54 @@ outside the rendered set fails with `SqlStaticRenderMissingDialectException`, na
 and the dialects that were rendered. Putting the driver on the compile classpath is what extends `.run` and
 `.runStatic` to it.
 
-Keeping a statement on the static path takes two habits beyond constructing at the terminal: keep
-`SqlNaming` givens at a top level or in a companion, because a casing given local to a method cannot be
-resolved statically and sends the render to run time, and write `.runStatic` where the build should fail
-if a refactor breaks the compile-time render, because `.run` falls back silently and reports nothing. The text is also inspectable without
-executing anything: `ast.render(dialect)` is pure and needs no client, and `client.render(ast)` targets a
-live client's flavor and server version.
+Keeping a statement on the static path takes two habits beyond constructing at the terminal: declare
+`SqlNaming` givens at the top level of the file that runs the queries, because a casing given local to a
+method cannot be resolved statically and sends the render to run time, and write `.runStatic` where the
+build should fail if a refactor breaks the compile-time render, because `.run` falls back silently and
+reports nothing.
+
+A `SqlNaming` given is found by ordinary implicit search **where the statement is constructed**, so where it
+is declared decides which queries it reaches. Top level of the file, or an object the queries are written
+inside of, both work. A companion object does not reach the class beside it: a given in `object Store` is
+not in scope inside `class Store`, so a query written there runs uncased and asks for the verbatim Scala
+field names.
+
+What that failure looks like depends on the tier. The typed DSL names its columns in the projection, so the
+statement goes out as `SELECT "signedUpAt" …` and the server rejects it before a row exists, arriving as a
+`SqlServerException` carrying SQLSTATE 42703. A raw `sql"…"` decoded by name gets as far as the decode and
+fails with `SqlDecodeColumnNotFoundException`, which lists the columns the row does have and says a casing
+given is resolved elsewhere. Import it (`import Store.given`) or declare it where the queries are.
+
+Note the construction site is not always the run site. A statement built at the terminal, and one named by a
+`transparent inline def`, are constructed where they run; a shared trunk held in a `val` fixed its casing
+where the `val` is defined, so moving a given next to the `.run` will not reach it.
+
+### What the static path cannot fold
+
+Two constructs are rendered at run time, so a statement carrying either one folds no further: an embedded
+raw `sql"..."` fragment, and a `having` clause. Spelling the predicate with the typed operators is what keeps
+it static.
+
+Two more shapes refuse for a different reason, both about what the macro can read rather than what it can
+render. A statement reaching the macro as a variable reference cannot be folded, which is what a query held
+in a `val` looks like from there. And a statement embedding a value known only at run time, a `limit` count
+read from configuration being the usual one, has nothing to fold that value to.
+
+On `.runStatic` each of the four is a compile error naming which one it found; on `.run` the statement falls
+back to the runtime renderer, which is the same SQL either way.
+
+Reuse and the static path meet at the source. A source named by a `transparent inline def` folds, and
+`transparent` is required, so the table-name override has a home rather than being repeated at every call
+site (see [Names derive from the type](#names-derive-from-the-type)).
+
+A source is as far as that goes: a `transparent inline def` naming a source **with a filter already on it**
+does not compile, at the definition rather than at the use site. The record the predicate lambda reads is
+typed through the `Fields` evidence summoned for the row type, and inside an inline def that evidence is not
+resolved yet, so the lambda cannot name a column. Reuse a filtered trunk as a `val` and run it with `.run`,
+which renders it at run time.
+
+Whichever path a statement takes, its text is inspectable without executing anything: `ast.render(dialect)`
+is pure and needs no client, and `client.render(ast)` targets a live client's flavor and server version.
 
 ### What the types are doing
 

--- a/kyo-sql/shared/src/main/scala/kyo/Sql.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/Sql.scala
@@ -2,6 +2,7 @@ package kyo
 
 import kyo.Record.~
 import kyo.db.Idiom
+import scala.annotation.implicitNotFound
 import scala.annotation.publicInBinary
 import scala.annotation.targetName
 import scala.compiletime.constValue
@@ -9,6 +10,7 @@ import scala.compiletime.erasedValue
 import scala.compiletime.summonFrom
 import scala.compiletime.summonInline
 import scala.deriving.Mirror
+import scala.util.NotGiven
 
 // --- Sql, root of the AST hierarchy ---
 
@@ -134,14 +136,14 @@ object Sql:
     /** UPDATE entry point, table name derived from `T`'s case-class label. */
     transparent inline def update[T](using f: Fields[T]) =
         val cols = kyo.internal.SqlAstInternal.buildRowColumns[T]
-        Update.Builder[T, Sql.RecordF[cols.type]](cols, kyo.internal.SqlMacros.tableName[T])
+        Update.Builder[T, Sql.RecordF[cols.type]](cols, kyo.internal.SqlMacros.tableName[T], Chunk.empty)
 
     /** UPDATE into an explicitly named table, overriding the `T`-derived default (a copy, not a delegation: transparent inline overloads
       * cannot delegate).
       */
     transparent inline def update[T](inline tableName: String)(using f: Fields[T]) =
         val cols = kyo.internal.SqlAstInternal.buildRowColumns[T]
-        Update.Builder[T, Sql.RecordF[cols.type]](cols, tableName)
+        Update.Builder[T, Sql.RecordF[cols.type]](cols, tableName, Chunk.empty)
 
     /** DELETE entry point, table name derived from `T`'s case-class label. */
     transparent inline def delete[T](using f: Fields[T]) =
@@ -216,7 +218,7 @@ object Sql:
       * @param c
       *   the single-column SQL evidence for `A`; its carried schema controls encode/decode; implicit-resolved
       */
-    inline def literal[A](inline value: A)(using c: SqlSchema.Column[A]): Term[A] = lit(value, c)
+    inline def literal[A](inline value: A)(using c: SqlSchema.Column[A]): Literal[A] = lit(value, c)
 
     /** A single-column SQL codec that stores `T` as a JSON document (`jsonb` on PostgreSQL, `JSON` on MySQL), with the document text
       * produced and consumed through the type's [[Schema]].
@@ -354,46 +356,127 @@ object Sql:
 
         // -- Comparison ------------------------------------------------------
 
-        final inline def ==(inline other: Term[A]): Term[Boolean] =
+        // Each comparison takes a right side whose type need only agree with the left one up to nullability, which is what
+        // [[Sql.SqlComparable]] states. SQL compares two columns the same way whether or not either permits NULL, so requiring the two Scala
+        // types to be equal would reject the ordinary join between a nullable foreign key and the non-null primary key it references, and
+        // there is no lift from `Term[A]` to `Term[Maybe[A]]` that does not change the SQL.
+        //
+        // Each operator has three forms: against another term, against a raw value of the column's own type, and against a raw value
+        // whose type differs from the column's by nullability. The third is what lets a column permitting NULL be compared to a plain
+        // literal, `country == "Germany"` rather than `country == Present("Germany")`. The second stays because it is the one that
+        // accepts a `Present(...)` written out: `Present[A]` is its own type rather than an `A`, so it reaches the column's type through
+        // the parameter's expected type and not through inference.
+        //
+        // The third form carries [[Sql.SqlComparableLiteral]] and not the evidence the first one does, because a raw value may cross
+        // nullability in one direction only: a value that may be absent, compared against a column that cannot be NULL, is a comparison
+        // no row satisfies. See that trait for why it is rejected rather than rendered.
+
+        final inline def ==[B](inline other: Term[B])(using SqlComparable[this.type, A, B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Eq, other)
+
+        /** Compares against a value lifted by [[Sql.literal]], which follows the raw-value rule rather than the column one.
+          * More specific than the `Term[B]` form above, so a lifted value picks this and a column picks that.
+          */
+        @targetName("eqLifted")
+        final inline def ==[B](inline other: Literal[B])(using SqlComparableLifted[this.type, A, B]): Term[Boolean] =
             Comparison(this, Comparison.Op.Eq, other)
 
         @targetName("eqRaw")
         final inline def ==(inline other: A)(using c: SqlSchema.Column[A]): Term[Boolean] =
             Comparison(this, Comparison.Op.Eq, lit(other, c))
 
-        final inline def !=(inline other: Term[A]): Term[Boolean] =
+        @targetName("eqRawOptional")
+        final inline def ==[B](inline other: B)(using ev: SqlComparableLiteral[this.type, A, B], c: SqlSchema.Column[B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Eq, lit(other, c))
+
+        final inline def !=[B](inline other: Term[B])(using SqlComparable[this.type, A, B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.NotEq, other)
+
+        /** Compares against a value lifted by [[Sql.literal]], which follows the raw-value rule rather than the column one.
+          * More specific than the `Term[B]` form above, so a lifted value picks this and a column picks that.
+          */
+        @targetName("neLifted")
+        final inline def !=[B](inline other: Literal[B])(using SqlComparableLifted[this.type, A, B]): Term[Boolean] =
             Comparison(this, Comparison.Op.NotEq, other)
 
         @targetName("neqRaw")
         final inline def !=(inline other: A)(using c: SqlSchema.Column[A]): Term[Boolean] =
             Comparison(this, Comparison.Op.NotEq, lit(other, c))
 
-        final inline def <(inline other: Term[A]): Term[Boolean] =
+        @targetName("neqRawOptional")
+        final inline def !=[B](inline other: B)(using ev: SqlComparableLiteral[this.type, A, B], c: SqlSchema.Column[B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.NotEq, lit(other, c))
+
+        final inline def <[B](inline other: Term[B])(using SqlComparable[this.type, A, B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Lt, other)
+
+        /** Compares against a value lifted by [[Sql.literal]], which follows the raw-value rule rather than the column one.
+          * More specific than the `Term[B]` form above, so a lifted value picks this and a column picks that.
+          */
+        @targetName("ltLifted")
+        final inline def <[B](inline other: Literal[B])(using SqlComparableLifted[this.type, A, B]): Term[Boolean] =
             Comparison(this, Comparison.Op.Lt, other)
 
         @targetName("ltRaw")
         final inline def <(inline other: A)(using c: SqlSchema.Column[A]): Term[Boolean] =
             Comparison(this, Comparison.Op.Lt, lit(other, c))
 
-        final inline def <=(inline other: Term[A]): Term[Boolean] =
+        @targetName("ltRawOptional")
+        final inline def <[B](inline other: B)(using ev: SqlComparableLiteral[this.type, A, B], c: SqlSchema.Column[B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Lt, lit(other, c))
+
+        final inline def <=[B](inline other: Term[B])(using SqlComparable[this.type, A, B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Lte, other)
+
+        /** Compares against a value lifted by [[Sql.literal]], which follows the raw-value rule rather than the column one.
+          * More specific than the `Term[B]` form above, so a lifted value picks this and a column picks that.
+          */
+        @targetName("lteLifted")
+        final inline def <=[B](inline other: Literal[B])(using SqlComparableLifted[this.type, A, B]): Term[Boolean] =
             Comparison(this, Comparison.Op.Lte, other)
 
         @targetName("lteRaw")
         final inline def <=(inline other: A)(using c: SqlSchema.Column[A]): Term[Boolean] =
             Comparison(this, Comparison.Op.Lte, lit(other, c))
 
-        final inline def >(inline other: Term[A]): Term[Boolean] =
+        @targetName("lteRawOptional")
+        final inline def <=[B](inline other: B)(using ev: SqlComparableLiteral[this.type, A, B], c: SqlSchema.Column[B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Lte, lit(other, c))
+
+        final inline def >[B](inline other: Term[B])(using SqlComparable[this.type, A, B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Gt, other)
+
+        /** Compares against a value lifted by [[Sql.literal]], which follows the raw-value rule rather than the column one.
+          * More specific than the `Term[B]` form above, so a lifted value picks this and a column picks that.
+          */
+        @targetName("gtLifted")
+        final inline def >[B](inline other: Literal[B])(using SqlComparableLifted[this.type, A, B]): Term[Boolean] =
             Comparison(this, Comparison.Op.Gt, other)
 
         @targetName("gtRaw")
         final inline def >(inline other: A)(using c: SqlSchema.Column[A]): Term[Boolean] =
             Comparison(this, Comparison.Op.Gt, lit(other, c))
 
-        final inline def >=(inline other: Term[A]): Term[Boolean] =
+        @targetName("gtRawOptional")
+        final inline def >[B](inline other: B)(using ev: SqlComparableLiteral[this.type, A, B], c: SqlSchema.Column[B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Gt, lit(other, c))
+
+        final inline def >=[B](inline other: Term[B])(using SqlComparable[this.type, A, B]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Gte, other)
+
+        /** Compares against a value lifted by [[Sql.literal]], which follows the raw-value rule rather than the column one.
+          * More specific than the `Term[B]` form above, so a lifted value picks this and a column picks that.
+          */
+        @targetName("gteLifted")
+        final inline def >=[B](inline other: Literal[B])(using SqlComparableLifted[this.type, A, B]): Term[Boolean] =
             Comparison(this, Comparison.Op.Gte, other)
 
         @targetName("gteRaw")
         final inline def >=(inline other: A)(using c: SqlSchema.Column[A]): Term[Boolean] =
+            Comparison(this, Comparison.Op.Gte, lit(other, c))
+
+        @targetName("gteRawOptional")
+        final inline def >=[B](inline other: B)(using ev: SqlComparableLiteral[this.type, A, B], c: SqlSchema.Column[B]): Term[Boolean] =
             Comparison(this, Comparison.Op.Gte, lit(other, c))
 
         // -- Absence ---------------------------------------------------------
@@ -428,6 +511,20 @@ object Sql:
         final inline def in(inline values: A*)(using c: SqlSchema.Column[A]): Term[Boolean] =
             InValues(this, Chunk.from(values).map(v => lit(v, c)))
 
+        /** Membership over raw values that differ from the column by nullability, on the rule `==` follows.
+          *
+          * The lifted values are cast to the column's parameter because the node holds `Term[A]` and the evidence has already
+          * decided the two denote the same SQL type with one of them optional. The cast is erasure-only: a `Term` is a pure
+          * description that nothing reads the parameter of at run time, and what is rendered is one bind either way.
+          *
+          * A nullable column against plain values is the ordinary case: `status.in("open", "held")` on a column that
+          * permits NULL. The reverse is refused for the reason the equality form gives, since `IN` renders a chain of
+          * equalities and one against NULL is UNKNOWN in both polarities.
+          */
+        @targetName("inRawOptional")
+        final inline def in[B](inline values: B*)(using ev: SqlComparableLiteral[this.type, A, B], c: SqlSchema.Column[B]): Term[Boolean] =
+            InValues(this, Chunk.from(values).map(v => lit(v, c).asInstanceOf[Term[A]]))
+
         final inline def in(inline query: Query[A]): Term[Boolean] = InSubquery(this, query)
 
         final inline def notIn(inline values: Term[A]*): Term[Boolean] = NotInValues(this, Chunk.from(values))
@@ -435,6 +532,14 @@ object Sql:
         @targetName("notInRaw")
         final inline def notIn(inline values: A*)(using c: SqlSchema.Column[A]): Term[Boolean] =
             NotInValues(this, Chunk.from(values).map(v => lit(v, c)))
+
+        /** Non-membership over raw values that differ from the column by nullability. See [[in]]. */
+        @targetName("notInRawOptional")
+        final inline def notIn[B](inline values: B*)(using
+            ev: SqlComparableLiteral[this.type, A, B],
+            c: SqlSchema.Column[B]
+        ): Term[Boolean] =
+            NotInValues(this, Chunk.from(values).map(v => lit(v, c).asInstanceOf[Term[A]]))
 
         final inline def notIn(inline query: Query[A]): Term[Boolean] = NotInSubquery(this, query)
 
@@ -445,6 +550,14 @@ object Sql:
         @targetName("betweenRaw")
         final inline def between(inline low: A, inline high: A)(using c: SqlSchema.Column[A]): Term[Boolean] =
             Between(this, lit(low, c), lit(high, c))
+
+        /** Range over raw bounds that differ from the column by nullability, on the rule `==` follows. */
+        @targetName("betweenRawOptional")
+        final inline def between[B](inline low: B, inline high: B)(using
+            ev: SqlComparableLiteral[this.type, A, B],
+            c: SqlSchema.Column[B]
+        ): Term[Boolean] =
+            Between(this, lit(low, c).asInstanceOf[Term[A]], lit(high, c).asInstanceOf[Term[A]])
 
         // -- Coalesce / absentIf ----------------------------------------------
         final def coalesce(others: Term[A]*): Term[A] = Coalesce(this +: Chunk.from(others))
@@ -569,7 +682,17 @@ object Sql:
 
         // -- String-only ops (gated by A =:= String) ------------------------
         // asStr must remain inline so that callers used in staticSql expressions are macro-liftable.
-        private inline def asStr(using ev: A =:= String): Term[String]                    = ev.substituteCo[[T] =>> Term[T]](this)
+        private inline def asStr(using ev: A =:= String): Term[String] = ev.substituteCo[[T] =>> Term[T]](this)
+
+        /** The same term seen as text, for a column whose type is `String` or `Maybe[String]`.
+          *
+          * The pattern operators answer `Term[Boolean]` whatever the operand's nullability, because a NULL operand makes
+          * the predicate UNKNOWN and a WHERE drops the row, which is what a caller asking `LIKE` on a column that permits
+          * NULL means. The node carries `Term[String]` and the cast is erasure-only: `Term` is a pure description and
+          * nothing reads the parameter at run time. `asStr` above stays for the operators that RETURN text, where the
+          * operand's nullability belongs in the result type and this substitution would lose it.
+          */
+        private inline def asTextual: Term[String]                                        = this.asInstanceOf[Term[String]]
         final def upper(using A =:= String): Term[String]                                 = StringFn(asStr, StringFn.Op.Upper)
         final def lower(using A =:= String): Term[String]                                 = StringFn(asStr, StringFn.Op.Lower)
         final def length(using A =:= String): Term[Int]                                   = StringLength(asStr)
@@ -580,33 +703,33 @@ object Sql:
         final inline def ++(inline other: String)(using A =:= String): Term[String] =
             Concat(Chunk(asStr, lit(other, SqlSchema.string)))
 
-        final inline def like(inline pattern: Term[String])(using A =:= String): Term[Boolean] =
-            StringMatch(asStr, StringMatch.Op.Like, pattern)
+        final inline def like(inline pattern: Term[String])(using SqlTextual[this.type, A]): Term[Boolean] =
+            StringMatch(asTextual, StringMatch.Op.Like, pattern)
 
         @targetName("likeRaw")
-        final inline def like(inline pattern: String)(using A =:= String): Term[Boolean] =
-            StringMatch(asStr, StringMatch.Op.Like, lit(pattern, SqlSchema.string))
+        final inline def like(inline pattern: String)(using SqlTextual[this.type, A]): Term[Boolean] =
+            StringMatch(asTextual, StringMatch.Op.Like, lit(pattern, SqlSchema.string))
 
-        final inline def notLike(inline pattern: Term[String])(using A =:= String): Term[Boolean] =
-            StringMatch(asStr, StringMatch.Op.NotLike, pattern)
+        final inline def notLike(inline pattern: Term[String])(using SqlTextual[this.type, A]): Term[Boolean] =
+            StringMatch(asTextual, StringMatch.Op.NotLike, pattern)
 
         @targetName("notLikeRaw")
-        final inline def notLike(inline pattern: String)(using A =:= String): Term[Boolean] =
-            StringMatch(asStr, StringMatch.Op.NotLike, lit(pattern, SqlSchema.string))
+        final inline def notLike(inline pattern: String)(using SqlTextual[this.type, A]): Term[Boolean] =
+            StringMatch(asTextual, StringMatch.Op.NotLike, lit(pattern, SqlSchema.string))
 
-        final inline def ilike(inline pattern: Term[String])(using A =:= String): Term[Boolean] =
-            StringMatch(asStr, StringMatch.Op.ILike, pattern)
+        final inline def ilike(inline pattern: Term[String])(using SqlTextual[this.type, A]): Term[Boolean] =
+            StringMatch(asTextual, StringMatch.Op.ILike, pattern)
 
         @targetName("ilikeRaw")
-        final inline def ilike(inline pattern: String)(using A =:= String): Term[Boolean] =
-            StringMatch(asStr, StringMatch.Op.ILike, lit(pattern, SqlSchema.string))
+        final inline def ilike(inline pattern: String)(using SqlTextual[this.type, A]): Term[Boolean] =
+            StringMatch(asTextual, StringMatch.Op.ILike, lit(pattern, SqlSchema.string))
 
-        final inline def notIlike(inline pattern: Term[String])(using A =:= String): Term[Boolean] =
-            StringMatch(asStr, StringMatch.Op.NotILike, pattern)
+        final inline def notIlike(inline pattern: Term[String])(using SqlTextual[this.type, A]): Term[Boolean] =
+            StringMatch(asTextual, StringMatch.Op.NotILike, pattern)
 
         @targetName("notIlikeRaw")
-        final inline def notIlike(inline pattern: String)(using A =:= String): Term[Boolean] =
-            StringMatch(asStr, StringMatch.Op.NotILike, lit(pattern, SqlSchema.string))
+        final inline def notIlike(inline pattern: String)(using SqlTextual[this.type, A]): Term[Boolean] =
+            StringMatch(asTextual, StringMatch.Op.NotILike, lit(pattern, SqlSchema.string))
 
         final inline def substring(inline start: Term[Int])(using A =:= String): Term[String] = Substring(asStr, start, Maybe.empty)
 
@@ -713,7 +836,160 @@ object Sql:
       */
     final case class LabelledTerm[N <: String & Singleton, A](label: N, term: Term[A]) extends Term[A] derives CanEqual
 
-    final case class Comparison[A](left: Term[A], op: Comparison.Op, right: Term[A]) extends Term[Boolean] derives CanEqual
+    /** Evidence that a `Term[A]` and a `Term[B]` may be compared: the two denote the same SQL type, with either side optional.
+      *
+      * Nullability is a property of the Scala type, not of the comparison: SQL compares a column that permits NULL to one that does not
+      * exactly as it compares two of the same kind. Requiring both sides to be the same Scala type would reject the ordinary join between
+      * a nullable foreign key and the non-null primary key it references, which is the first join written against most schemas, and the
+      * DSL has no lift from `Term[A]` to `Term[Maybe[A]]` that leaves the SQL alone: `coalesce` stays inside `Maybe`, and `cast` emits a
+      * SQL CAST, which is a different query and can cost an index.
+      *
+      * The three instances are the three shapes: both total, the left optional, the right optional. Two optional sides are the first
+      * instance, since the types are then equal.
+      */
+    @implicitNotFound(
+        "Cannot compare a SQL expression of type ${A} with one of type ${B}.\n" +
+            "The two sides of a comparison must denote the same SQL type; one of them may be optional (kyo.Maybe), which is what a\n" +
+            "column permitting NULL is, so a nullable foreign key compares against the non-null key it references. Two different SQL\n" +
+            "types do not compare: spell the conversion with `.cast`."
+    )
+    sealed trait SqlComparable[S, A, B]
+
+    object SqlComparable:
+        private val evidence: SqlComparable[Any, Any, Any] = new SqlComparable[Any, Any, Any] {}
+
+        /** Both sides are the same Scala type, optional or not. */
+        given same[S, A](using NotGiven[S <:< Literal[?]]): SqlComparable[S, A, A] =
+            evidence.asInstanceOf[SqlComparable[S, A, A]]
+
+        /** The left side permits NULL and the right does not. Guarded off a lifted receiver: that side is then a value rather than a
+          * column, and the argument keeping this instance does not reach it.
+          */
+        given leftOptional[S, A](using NotGiven[S <:< Literal[?]]): SqlComparable[S, Maybe[A], A] =
+            evidence.asInstanceOf[SqlComparable[S, Maybe[A], A]]
+
+        /** The right side permits NULL and the left does not. */
+        given rightOptional[S, A](using NotGiven[S <:< Literal[?]]): SqlComparable[S, A, Maybe[A]] =
+            evidence.asInstanceOf[SqlComparable[S, A, Maybe[A]]]
+
+        /** A lifted receiver against a term of its own type. */
+        given liftedSame[S <: Literal[?], A]: SqlComparable[S, A, A] =
+            evidence.asInstanceOf[SqlComparable[S, A, A]]
+
+        /** A lifted receiver against a term that permits NULL where the lifted value does not, which is the one direction a value may
+          * cross. The reverse has no instance, which is what refuses `Sql.literal(absent) == notNullColumn`.
+          */
+        given liftedArgOptional[S <: Literal[?], A]: SqlComparable[S, A, Maybe[A]] =
+            evidence.asInstanceOf[SqlComparable[S, A, Maybe[A]]]
+    end SqlComparable
+
+    /** Evidence that a column of type `A` may be compared against a RAW value of type `B` that differs from it by nullability.
+      *
+      * One instance, in one direction: the column permits NULL and the value does not. That is the case the raw form exists for,
+      * `country == "Germany"` on a nullable column rather than `country == Present("Germany")`.
+      *
+      * The other direction is deliberately absent, and this is why [[SqlComparable]] cannot serve here. A column that cannot be NULL
+      * compared against a value that may be is a question no row can answer: `= NULL` is unknown for every row, so the comparison matches
+      * nothing, and so does its negation: `x = NULL` is UNKNOWN for every row, `NOT UNKNOWN` is UNKNOWN too, and a WHERE keeps neither.
+      * A predicate no row can satisfy in either polarity is one the author cannot have meant, and it fails silently and at runtime.
+      * Deciding between `= ?` and `IS NULL` by looking at the value
+      * is not available either, for the reason the absence operators below give: the static path lifts the bind as the call site's own
+      * expression, so there is no value to look at. Rejecting it is the only answer that reports anything.
+      *
+      * A `Term[A]` against a `Term[Maybe[A]]` stays allowed, on [[SqlComparable]]: comparing two columns says nothing about whether
+      * either is NULL, and the join between a non-null key and the nullable foreign key referencing it is written that way round as often
+      * as the other.
+      */
+    @implicitNotFound(
+        "Cannot compare a SQL column of type ${A} with a raw value of type ${B}.\n" +
+            "Either the two are different SQL types, in which case the value's type is the thing to fix; or they differ only by\n" +
+            "nullability, which a raw value may do in one direction only: the column permits NULL and the value does not, as in\n" +
+            "`country == \"Germany\"` on a nullable column. The other way round matches no row, and neither does its negation, because\n" +
+            "nothing compares equal to NULL. To ask whether the column is absent, compare against `Absent`."
+    )
+    sealed trait SqlComparableLiteral[S, A, B]
+
+    object SqlComparableLiteral:
+        private val evidence: SqlComparableLiteral[Any, Any, Any] = new SqlComparableLiteral[Any, Any, Any] {}
+
+        /** The column permits NULL and the raw value does not.
+          *
+          * No instance exists for a lifted receiver: a lifted value against a raw value is two values, and the one that may be absent
+          * makes the comparison the `= NULL` no row satisfies, exactly as it does against a column.
+          */
+        given optionalColumn[S, A](using NotGiven[S <:< Literal[?]]): SqlComparableLiteral[S, Maybe[A], A] =
+            evidence.asInstanceOf[SqlComparableLiteral[S, Maybe[A], A]]
+    end SqlComparableLiteral
+
+    /** Evidence that a column of type `A` may be compared against a value LIFTED into a term by [[Sql.literal]].
+      *
+      * The same rule [[SqlComparableLiteral]] states, and for the same reason: a lifted value is a value, not a column, so the argument
+      * that keeps [[SqlComparable.rightOptional]] does not reach it. Comparing two columns says nothing about whether either is NULL,
+      * which is why the join between a non-null key and the nullable foreign key referencing it is allowed; a lifted `Maybe` against a
+      * NOT NULL column is the `= NULL` no row satisfies in either polarity, spelled through a different door.
+      *
+      * Carries the same-type case as well, which [[SqlComparableLiteral]] does not need: a raw value of the column's own type is served by
+      * the overload taking `A` exactly, and a lifted one arrives as a `Literal[A]` that overload cannot match.
+      */
+    @implicitNotFound(
+        "Cannot compare a SQL column of type ${A} with a lifted value of type ${B}.\n" +
+            "A lifted value follows the rule a raw one does: it may differ from the column by nullability only in the direction\n" +
+            "where the column permits NULL and the value does not. The other way round matches no row, and neither does its\n" +
+            "negation, because nothing compares equal to NULL. To ask whether the column is absent, compare against `Absent`."
+    )
+    sealed trait SqlComparableLifted[S, A, B]
+
+    /** Evidence that a column of type `A` holds text, whether or not it permits NULL.
+      *
+      * The pattern operators (`like`, `ilike` and their negations) need this rather than `A =:= String`, which admits only a column that
+      * cannot be NULL. `name LIKE 'a%'` on a nullable column is ordinary SQL, and it answers UNKNOWN for the rows where the column is
+      * absent, which a WHERE drops. Before this the operators simply did not exist on a `Maybe[String]` column, in either form.
+      *
+      * Only the operators answering `Term[Boolean]` take it. The ones that RETURN text keep `A =:= String`, because there the operand's
+      * nullability belongs in the result type: `upper` on a column that may be absent may itself be absent.
+      */
+    sealed trait SqlTextual[S, A]
+
+    object SqlTextual:
+        private val evidence: SqlTextual[Any, Any] = new SqlTextual[Any, Any] {}
+
+        /** A text column that cannot be NULL. */
+        given text[S](using NotGiven[S <:< Literal[?]]): SqlTextual[S, String] =
+            evidence.asInstanceOf[SqlTextual[S, String]]
+
+        /** A text column that permits NULL. */
+        given optionalText[S](using NotGiven[S <:< Literal[?]]): SqlTextual[S, Maybe[String]] =
+            evidence.asInstanceOf[SqlTextual[S, Maybe[String]]]
+
+        /** A lifted text value, which is present by construction. A lifted value that may be absent has no instance: `? LIKE '%'` with a
+          * NULL bind is UNKNOWN for every row, the same never-matching predicate the comparisons refuse.
+          */
+        given liftedText[S <: Literal[?]]: SqlTextual[S, String] =
+            evidence.asInstanceOf[SqlTextual[S, String]]
+    end SqlTextual
+
+    object SqlComparableLifted:
+        private val evidence: SqlComparableLifted[Any, Any, Any] = new SqlComparableLifted[Any, Any, Any] {}
+
+        /** The lifted value has the column's own type. */
+        given same[S, A](using NotGiven[S <:< Literal[?]]): SqlComparableLifted[S, A, A] =
+            evidence.asInstanceOf[SqlComparableLifted[S, A, A]]
+
+        /** The column permits NULL and the lifted value does not. */
+        given optionalColumn[S, A](using NotGiven[S <:< Literal[?]]): SqlComparableLifted[S, Maybe[A], A] =
+            evidence.asInstanceOf[SqlComparableLifted[S, Maybe[A], A]]
+
+        /** Both sides lifted, which is two values rather than a value and a column: equal types only, so a lifted absent value is
+          * refused against a lifted present one in either order.
+          */
+        given liftedSame[S <: Literal[?], A]: SqlComparableLifted[S, A, A] =
+            evidence.asInstanceOf[SqlComparableLifted[S, A, A]]
+    end SqlComparableLifted
+
+    /** A binary comparison. The operands carry no shared type parameter: [[Sql.SqlComparable]] has already decided at the call site that
+      * the two sides denote the same SQL type, and what is rendered is the same either way.
+      */
+    final case class Comparison(left: Term[?], op: Comparison.Op, right: Term[?]) extends Term[Boolean] derives CanEqual
     object Comparison:
         enum Op derives CanEqual:
             case Eq, NotEq, Lt, Lte, Gt, Gte
@@ -1766,7 +2042,19 @@ object Sql:
         inline def limit(inline n: Int): Limit[A]                     = limit(n, 0)
         inline def limit(inline n: Int, inline offset: Int): Limit[A] = Limit(this, n, offset)
 
-    final case class Limit[A](sql: Query[A], n: Int, offset: Int) extends Query[A] derives CanEqual
+        /** Coerces the row type to a case class, as [[Select.to]] does. Carried through here so the combinator order stops being
+          * load-bearing: `.select(...).orderBy(...).to[Row]` reads the way it is written, rather than compiling only when `.to` sits
+          * immediately after `.select`.
+          */
+        inline def to[B2](using m: Mirror.ProductOf[B2] { type MirroredElemTypes = A & Tuple }): OrderBy[B2] =
+            OrderBy[B2](sql.asInstanceOf[Query[B2]], specs)
+    end OrderBy
+
+    final case class Limit[A](sql: Query[A], n: Int, offset: Int) extends Query[A] derives CanEqual:
+        /** Coerces the row type to a case class, as [[Select.to]] does. See [[OrderBy.to]]. */
+        inline def to[B2](using m: Mirror.ProductOf[B2] { type MirroredElemTypes = A & Tuple }): Limit[B2] =
+            Limit[B2](sql.asInstanceOf[Query[B2]], n, offset)
+    end Limit
 
     final case class Lock[A](
         sql: Query[A],
@@ -1880,8 +2168,23 @@ object Sql:
             )
         inline def onConflictDoUpdate(inline targets: (Record[F] => Column[? <: String, ?])*): Insert.OnConflict.DoUpdateBuilder[T, F] =
             Insert.OnConflict.DoUpdateBuilder(this, Chunk.from(targets.map(_(columns))), Maybe.empty)
-        inline def returning(inline cols: (Record[F] => Column[? <: String, ?])*): Insert[T, F] =
-            copy(returning = Maybe(Chunk.from(cols.map(_(columns)))))
+
+        /** Ask for a column of the rows this INSERT wrote, typed as that column.
+          *
+          * The rows are what the statement then answers, in place of the affected-row count and generated key an INSERT reports
+          * otherwise. Asking for the key column is how a caller reads a server-assigned key as a value rather than through
+          * [[kyo.SqlClient.InsertOutcome]], and the renderer already prefers an explicit RETURNING over the one it appends for a detected
+          * auto-key, so the two do not both emit.
+          */
+        inline def returning[N <: String & Singleton, V](inline col: Record[F] => Column[N, V]): Insert.Returning[T, F, V] =
+            Insert.Returning[T, F, V](copy(returning = Maybe(Chunk(col(columns)))))
+
+        /** Ask for several columns of the rows this INSERT wrote, typed as the tuple they were asked for. */
+        @targetName("returningTuple")
+        inline def returning[Tup <: Tuple, Vs <: Tuple](inline cols: Record[F] => Tup)(using
+            ev: IsTupleOfReturned.Aux[Tup, Vs]
+        ): Insert.Returning[T, F, Vs] =
+            Insert.Returning[T, F, Vs](copy(returning = Maybe(ev.toChunk(cols(columns)))))
     end Insert
 
     object Insert:
@@ -2005,6 +2308,39 @@ object Sql:
                     Maybe.empty
                 )
         end Builder
+
+        /** An INSERT that answers the rows it wrote rather than how many.
+          *
+          * The same wrapper [[Sql.Update.Returning]] is, for the same reason: the RETURNING clause lives on the statement and the
+          * renderers already emit it, so what this adds is the type of what comes back. It replaces the [[kyo.SqlClient.InsertOutcome]]
+          * an INSERT answers otherwise, because a caller who named the columns has said what they want back, and the count of a values
+          * list is one the caller already holds.
+          */
+        final case class Returning[T, F, A](statement: Insert[T, F]) derives CanEqual
+
+        object Returning:
+            extension [T, F, A](inline ret: Returning[T, F, A])
+                /** Try the static-emission path; fall back to the runtime renderer if the AST is not reducible at compile time. */
+                inline def run(using SqlSchema[A], Frame): Chunk[A] < (Abort[SqlException] & DB) =
+                    ${ kyo.internal.SqlRunMacro.runInsertReturningImpl[T, F, A]('ret) }
+
+                /** Requires compile-time AST reduction; produces a compile error if the AST is not reducible. */
+                inline def runStatic(using SqlSchema[A], Frame): Chunk[A] < (Abort[SqlException] & DB) =
+                    ${ kyo.internal.SqlRunMacro.runInsertReturningStaticImpl[T, F, A]('ret) }
+            end extension
+
+            extension [T, F, A](ret: Returning[T, F, A])
+                /** Skip the static path entirely and always use the runtime renderer. */
+                def runDynamic(using frame: Frame, evidence: SqlSchema[A]): Chunk[A] < (Abort[SqlException] & DB) =
+                    DB.state.map { state =>
+                        state.client.render(ret.statement).map(r =>
+                            r.sqlForOrFail(state.client.dialect.id).map(sql =>
+                                state.client.internalExecuteQuery[A](sql, r.params, state.config)
+                            )
+                        )
+                    }
+            end extension
+        end Returning
     end Insert
 
     final case class Update[T, F](
@@ -2040,31 +2376,82 @@ object Sql:
                 }
         end extension
 
+        /** The accumulating half of an UPDATE: the table's columns, its name, and the assignments named so far.
+          *
+          * `sets` has no default value on purpose. A default reaches the compile-time render as a call to the synthetic accessor the
+          * compiler generates for it, whose body that render cannot see, and one unreadable field is enough to make the whole statement
+          * unfoldable. Written at the two construction sites instead.
+          */
         final case class Builder[T, F](
             columns: Record[F],
             tableName: String,
-            sets: Chunk[SetSpec[?, ?]] = Chunk.empty
+            sets: Chunk[SetSpec[?, ?]]
         ):
             inline def set(inline specs: (Record[F] => SetSpec[? <: String, ?])*): Builder[T, F] =
                 copy(sets = sets ++ Chunk.from(specs.map(_(columns))))
             inline def where(inline predicate: Record[F] => Term[Boolean]): Update[T, F] =
                 Update[T, F](columns, tableName, sets, Maybe(predicate(columns)), Maybe.empty)
             inline def build: Update[T, F] = Update[T, F](columns, tableName, sets, Maybe.empty, Maybe.empty)
-            inline def returning(inline cols: (Record[F] => Column[? <: String, ?])*): ReturningBuilder[T, F] =
-                ReturningBuilder(columns, tableName, sets, Chunk.from(cols.map(_(columns))))
+
+            /** Ask for the rows the statement changed, one column.
+              *
+              * The result is typed by what was asked for, so `.run` answers those rows rather than a count: a builder method whose result
+              * a caller cannot reach is worse than not having the method.
+              */
+            inline def returning[N <: String & Singleton, V](inline col: Record[F] => Column[N, V]): ReturningBuilder[T, F, V] =
+                ReturningBuilder(columns, tableName, sets, Chunk(col(columns)))
+
+            /** Ask for the rows the statement changed, several columns, typed as the tuple they were asked for. */
+            @targetName("returningTuple")
+            inline def returning[Tup <: Tuple, Vs <: Tuple](inline cols: Record[F] => Tup)(using
+                ev: IsTupleOfReturned.Aux[Tup, Vs]
+            ): ReturningBuilder[T, F, Vs] =
+                ReturningBuilder(columns, tableName, sets, ev.toChunk(cols(columns)))
         end Builder
 
-        final case class ReturningBuilder[T, F](
+        final case class ReturningBuilder[T, F, A](
             columns: Record[F],
             tableName: String,
             sets: Chunk[SetSpec[?, ?]],
             returningCols: Chunk[Column[?, ?]]
         ):
-            inline def where(inline predicate: Record[F] => Term[Boolean]): Update[T, F] =
-                Update[T, F](columns, tableName, sets, Maybe(predicate(columns)), Maybe(returningCols))
-            inline def build: Update[T, F] =
-                Update[T, F](columns, tableName, sets, Maybe.empty, Maybe(returningCols))
+            inline def where(inline predicate: Record[F] => Term[Boolean]): Returning[T, F, A] =
+                Returning[T, F, A](Update[T, F](columns, tableName, sets, Maybe(predicate(columns)), Maybe(returningCols)))
+            inline def build: Returning[T, F, A] =
+                Returning[T, F, A](Update[T, F](columns, tableName, sets, Maybe.empty, Maybe(returningCols)))
         end ReturningBuilder
+
+        /** An UPDATE that answers the rows it changed rather than how many.
+          *
+          * A thin wrapper over the statement, not a node of its own: the RETURNING clause lives on the statement and the renderers already
+          * emit it, so what this adds is the type of what comes back, which is what the terminals need in order to decode. A flavor with
+          * no RETURNING clause refuses the statement when it is rendered, rather than answering an empty result.
+          */
+        final case class Returning[T, F, A](statement: Update[T, F]) derives CanEqual
+
+        object Returning:
+            extension [T, F, A](inline ret: Returning[T, F, A])
+                /** Try the static-emission path; fall back to the runtime renderer if the AST is not reducible at compile time. */
+                inline def run(using SqlSchema[A], Frame): Chunk[A] < (Abort[SqlException] & DB) =
+                    ${ kyo.internal.SqlRunMacro.runReturningImpl[T, F, A]('ret) }
+
+                /** Requires compile-time AST reduction; produces a compile error if the AST is not reducible. */
+                inline def runStatic(using SqlSchema[A], Frame): Chunk[A] < (Abort[SqlException] & DB) =
+                    ${ kyo.internal.SqlRunMacro.runReturningStaticImpl[T, F, A]('ret) }
+            end extension
+
+            extension [T, F, A](ret: Returning[T, F, A])
+                /** Skip the static path entirely and always use the runtime renderer. */
+                def runDynamic(using frame: Frame, evidence: SqlSchema[A]): Chunk[A] < (Abort[SqlException] & DB) =
+                    DB.state.map { state =>
+                        state.client.render(ret.statement).map(r =>
+                            r.sqlForOrFail(state.client.dialect.id).map(sql =>
+                                state.client.internalExecuteQuery[A](sql, r.params, state.config)
+                            )
+                        )
+                    }
+            end extension
+        end Returning
     end Update
 
     final case class Delete[T, F](
@@ -2106,20 +2493,53 @@ object Sql:
             inline def where(inline predicate: Record[F] => Term[Boolean]): Delete[T, F] =
                 Delete[T, F](columns, tableName, Maybe(predicate(columns)), Maybe.empty)
             inline def build: Delete[T, F] = Delete[T, F](columns, tableName, Maybe.empty, Maybe.empty)
-            inline def returning(inline cols: (Record[F] => Column[? <: String, ?])*): ReturningBuilder[T, F] =
-                ReturningBuilder(columns, tableName, Chunk.from(cols.map(_(columns))))
+
+            /** Ask for the rows the statement removed, one column. See [[Update.Builder.returning]]. */
+            inline def returning[N <: String & Singleton, V](inline col: Record[F] => Column[N, V]): ReturningBuilder[T, F, V] =
+                ReturningBuilder(columns, tableName, Chunk(col(columns)))
+
+            /** Ask for the rows the statement removed, several columns, typed as the tuple they were asked for. */
+            @targetName("returningTuple")
+            inline def returning[Tup <: Tuple, Vs <: Tuple](inline cols: Record[F] => Tup)(using
+                ev: IsTupleOfReturned.Aux[Tup, Vs]
+            ): ReturningBuilder[T, F, Vs] =
+                ReturningBuilder(columns, tableName, ev.toChunk(cols(columns)))
         end Builder
 
-        final case class ReturningBuilder[T, F](
+        final case class ReturningBuilder[T, F, A](
             columns: Record[F],
             tableName: String,
             returningCols: Chunk[Column[?, ?]]
         ):
-            inline def where(inline predicate: Record[F] => Term[Boolean]): Delete[T, F] =
-                Delete[T, F](columns, tableName, Maybe(predicate(columns)), Maybe(returningCols))
-            inline def build: Delete[T, F] =
-                Delete[T, F](columns, tableName, Maybe.empty, Maybe(returningCols))
+            inline def where(inline predicate: Record[F] => Term[Boolean]): Returning[T, F, A] =
+                Returning[T, F, A](Delete[T, F](columns, tableName, Maybe(predicate(columns)), Maybe(returningCols)))
+            inline def build: Returning[T, F, A] =
+                Returning[T, F, A](Delete[T, F](columns, tableName, Maybe.empty, Maybe(returningCols)))
         end ReturningBuilder
+
+        /** A DELETE that answers the rows it removed rather than how many. See [[Update.Returning]]. */
+        final case class Returning[T, F, A](statement: Delete[T, F]) derives CanEqual
+
+        object Returning:
+            extension [T, F, A](inline ret: Returning[T, F, A])
+                inline def run(using SqlSchema[A], Frame): Chunk[A] < (Abort[SqlException] & DB) =
+                    ${ kyo.internal.SqlRunMacro.runDeleteReturningImpl[T, F, A]('ret) }
+
+                inline def runStatic(using SqlSchema[A], Frame): Chunk[A] < (Abort[SqlException] & DB) =
+                    ${ kyo.internal.SqlRunMacro.runDeleteReturningStaticImpl[T, F, A]('ret) }
+            end extension
+
+            extension [T, F, A](ret: Returning[T, F, A])
+                def runDynamic(using frame: Frame, evidence: SqlSchema[A]): Chunk[A] < (Abort[SqlException] & DB) =
+                    DB.state.map { state =>
+                        state.client.render(ret.statement).map(r =>
+                            r.sqlForOrFail(state.client.dialect.id).map(sql =>
+                                state.client.internalExecuteQuery[A](sql, r.params, state.config)
+                            )
+                        )
+                    }
+            end extension
+        end Returning
     end Delete
 
     /** What a column can be assigned: an expression, or the column's own declared default.
@@ -2221,10 +2641,17 @@ object Sql:
                 type Avg = V
                 type Div = D
 
+        // Every type a single column can carry as a number, which is what makes an aggregate reachable from any of them. `Short` and
+        // `Byte` are stored as a two-byte integer and widen to `Long` under SUM exactly as `Int` does; `BigInt` is stored as an exact
+        // decimal and aggregates as one, like `BigDecimal`. Leaving them out is what made "total units per order" unreachable on a
+        // `smallint` column, since a grouped view has no `cast` to widen through either.
         given int: Aux[Int, Long, BigDecimal, BigDecimal]                     = instance
         given long: Aux[Long, BigDecimal, BigDecimal, BigDecimal]             = instance
+        given short: Aux[Short, Long, BigDecimal, BigDecimal]                 = instance
+        given byte: Aux[Byte, Long, BigDecimal, BigDecimal]                   = instance
         given float: Aux[Float, Double, Double, Double]                       = instance
         given double: Aux[Double, Double, Double, Double]                     = instance
+        given bigInt: Aux[BigInt, BigDecimal, BigDecimal, BigDecimal]         = instance
         given bigDecimal: Aux[BigDecimal, BigDecimal, BigDecimal, BigDecimal] = instance
 
         given maybe[A, S, V, D](using Aux[A, S, V, D]): Aux[Maybe[A], Maybe[S], Maybe[V], Maybe[D]] = instance
@@ -2236,13 +2663,15 @@ object Sql:
       * `int4 / int4` truncates there while `numeric / numeric` and `float8 / float8` do not, so only an integral `/` needs the cast that
       * reaches the fractional quotient the DSL types.
       *
-      * The instance list is the integral subset of [[SqlNumeric]]'s. There is deliberately no `Short` or `Byte` here, because there is none
-      * there either: no column the DSL can build carries one.
+      * The instance list is the integral subset of [[SqlNumeric]]'s: the four types stored as a SQL integer. `BigInt` is not one of them
+      * even though it is exact, because it is stored as a decimal, whose division does not truncate on either flavor.
       */
     sealed trait SqlIntegral[A]
     object SqlIntegral:
         given int: SqlIntegral[Int]                                 = new SqlIntegral[Int] {}
         given long: SqlIntegral[Long]                               = new SqlIntegral[Long] {}
+        given short: SqlIntegral[Short]                             = new SqlIntegral[Short] {}
+        given byte: SqlIntegral[Byte]                               = new SqlIntegral[Byte] {}
         given maybe[A](using SqlIntegral[A]): SqlIntegral[Maybe[A]] = new SqlIntegral[Maybe[A]] {}
     end SqlIntegral
 
@@ -2368,6 +2797,30 @@ object Sql:
             def toChunk(t: TermH *: Tail): Chunk[Term[?]] = t.head +: rest.toChunk(t.tail)
     end IsTupleOfTerms
 
+    /** Inductive proof that `Tup` is a tuple of [[Column]]s, exposing the tuple of their value types.
+      *
+      * What a `RETURNING` clause needs from a projection: the clause itself names columns, which every flavor that has one renders as bare
+      * identifiers, and the rows that come back decode at those columns' value types. [[Values]] is that decode type, so asking for two
+      * columns produces rows of the pair.
+      */
+    sealed trait IsTupleOfReturned[Tup <: Tuple]:
+        type Values <: Tuple
+        def toChunk(t: Tup): Chunk[Column[?, ?]]
+
+    object IsTupleOfReturned:
+        type Aux[Tup <: Tuple, Vs <: Tuple] = IsTupleOfReturned[Tup] { type Values = Vs }
+
+        given empty: Aux[EmptyTuple, EmptyTuple] = new IsTupleOfReturned[EmptyTuple]:
+            type Values = EmptyTuple
+            def toChunk(t: EmptyTuple): Chunk[Column[?, ?]] = Chunk.empty
+
+        given cons[N <: String & Singleton, V, Tail <: Tuple, VTail <: Tuple](
+            using rest: Aux[Tail, VTail]
+        ): Aux[Column[N, V] *: Tail, V *: VTail] = new IsTupleOfReturned[Column[N, V] *: Tail]:
+            type Values = V *: VTail
+            def toChunk(t: Column[N, V] *: Tail): Chunk[Column[?, ?]] = t.head +: rest.toChunk(t.tail)
+    end IsTupleOfReturned
+
     /** Inductive proof that `Tup` is a tuple of [[Column]]s, exposing as [[MaybeFields]] the `Name ~ Value` field tuple those columns
       * form with every value type lifted through [[AsMaybe]].
       *
@@ -2408,10 +2861,23 @@ object Sql:
     object OrderArg:
         given single: OrderArg[OrderSpec] with
             def toChunk(a: OrderSpec): Chunk[OrderSpec] = Chunk(a)
+
+        /** A bare term orders ascending, which is what SQL does with a bare column and what `.asc` spells explicitly.
+          *
+          * Without this the DSL was stricter than the language it mirrors: `orderBy(r => r.customers.id)` did not compile, and the error
+          * named `OrderArg` rather than the `.asc` it wanted. The explicit spellings stay, and the absent-placement ones
+          * (`ascAbsentFirst` and its siblings) are the reason to reach for them.
+          */
+        given term[A <: Term[?]]: OrderArg[A] with
+            def toChunk(a: A): Chunk[OrderSpec] =
+                Chunk(OrderSpec(a, OrderSpec.Direction.Asc, OrderSpec.AbsentPlacement.Default))
+
         given empty: OrderArg[EmptyTuple] with
             def toChunk(a: EmptyTuple): Chunk[OrderSpec] = Chunk.empty
-        given cons[T <: Tuple](using rest: OrderArg[T]): OrderArg[OrderSpec *: T] with
-            def toChunk(a: OrderSpec *: T): Chunk[OrderSpec] = a.head +: rest.toChunk(a.tail)
+
+        // The head is whatever the element itself is an OrderArg for, so a tuple mixes bare terms and explicit specs.
+        given cons[H, T <: Tuple](using head: OrderArg[H], rest: OrderArg[T]): OrderArg[H *: T] with
+            def toChunk(a: H *: T): Chunk[OrderSpec] = head.toChunk(a.head) ++ rest.toChunk(a.tail)
     end OrderArg
 
     // --- Internal type machinery and helpers ---

--- a/kyo-sql/shared/src/main/scala/kyo/SqlException.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/SqlException.scala
@@ -201,11 +201,35 @@ final case class SqlConnectionAcquireTimeoutException(acquireTimeout: Duration)(
         s"Acquiring a connection from the pool timed out after ${acquireTimeout.show}"
     ) with SqlRetryable
 
-/** Establishing a new physical connection exceeded the configured connect timeout. */
-final case class SqlConnectionEstablishTimeoutException(timeout: Duration, host: String, port: Int)(using Frame)
+/** Opening a new physical connection exceeded its budget.
+  *
+  * The budget covers the whole opening, the TCP connect and the authentication handshake alike, so a timeout here does not mean the server
+  * was unreachable: an authentication that did not finish in time reports exactly the same way, and SCRAM is deliberately iterated key
+  * stretching whose cost is the server's own iteration count. The message says so rather than pointing only at the network, and names the
+  * knob that supplied the budget, since the two come from different places.
+  *
+  * @param timeout
+  *   the budget that expired
+  * @param host
+  *   the server the connection was being opened to
+  * @param port
+  *   its port
+  * @param budgetSource
+  *   where the budget came from: the URL's `connectTimeout`, or the config's `acquireTimeout` standing in for it
+  */
+final case class SqlConnectionEstablishTimeoutException(timeout: Duration, host: String, port: Int, budgetSource: String)(using Frame)
     extends SqlConnectionException(
-        s"Establishing a connection to $host:$port timed out after ${timeout.show}"
+        s"Opening a connection to $host:$port timed out after ${timeout.show}. The budget covers the TCP connect and the " +
+            s"authentication handshake together, so this does not by itself mean the server was unreachable. Raise it with $budgetSource."
     ) with SqlRetryable
+
+object SqlConnectionEstablishTimeoutException:
+    /** The budget came from the config's `acquireTimeout`, which stands in when the URL declares no `connectTimeout`. */
+    val fromAcquireTimeout: String = "`acquireTimeout` on SqlConfig (or `connectTimeout` in the URL, which takes precedence)"
+
+    /** The budget came from the URL's own `connectTimeout`. */
+    val fromConnectTimeout: String = "`connectTimeout` in the URL"
+end SqlConnectionEstablishTimeoutException
 
 /** A query exceeded the configured per-query timeout. */
 final case class SqlConnectionQueryTimeoutException(queryTimeout: Duration)(using Frame)
@@ -736,11 +760,49 @@ final case class SqlDecodeColumnOutOfBoundsException(columnIndex: Int, columnCou
 final case class SqlDecodeInvalidTextException(typeName: String, text: String)(using Frame)
     extends SqlDecodeException(s"invalid $typeName text '$text'")
 
-/** A column looked up by name is not present in the row. */
-final case class SqlDecodeColumnNotFoundException(columnName: String)(using Frame)
+/** A column looked up by name is not present in the row.
+  *
+  * `availableColumns` is what the row actually carries, because the reason this is raised is almost never that the column is missing from
+  * the database: it is that the name being looked for is not the name the server reported. A [[kyo.SqlNaming]] casing is resolved at the
+  * call site of the run, so one declared where the run is not (another object, another method) leaves the lookup asking for the verbatim
+  * Scala field name against snake_case columns. Listing the row's own columns is what makes that visible at the point of failure, and the
+  * message says so outright when a row column matches the requested name up to casing and underscores.
+  *
+  * @param columnName
+  *   the name that was looked up
+  * @param availableColumns
+  *   the columns the row carries, empty where the caller had none to report
+  */
+final case class SqlDecodeColumnNotFoundException(columnName: String, availableColumns: Chunk[String])(using Frame)
     extends SqlDecodeException(
-        s"Column '$columnName' not found in row"
+        SqlDecodeColumnNotFoundException.format(columnName, availableColumns)
     )
+
+object SqlDecodeColumnNotFoundException:
+
+    /** The lookup with no row to report, for a caller that has only the name. */
+    def apply(columnName: String)(using Frame): SqlDecodeColumnNotFoundException =
+        new SqlDecodeColumnNotFoundException(columnName, Chunk.empty)
+
+    private def format(columnName: String, availableColumns: Chunk[String]): String =
+        if availableColumns.isEmpty then s"Column '$columnName' not found in row"
+        else
+            val hint = Maybe.fromOption(availableColumns.find(c => normalize(c) == normalize(columnName))).fold("") { actual =>
+                s". The row has '$actual', which differs from '$columnName' only in casing: a SqlNaming given is resolved at the " +
+                    "call site of the run, so one declared elsewhere (another object, another method) does not reach this query"
+            }
+            s"Column '$columnName' not found in row; the row has ${availableColumns.mkString(", ")}$hint"
+
+    /** Two names are the same up to the casing a [[kyo.SqlNaming]] applies.
+      *
+      * Lowercased per character rather than through `String.toLowerCase`, which uses the default locale: on a tr or az locale JVM that
+      * maps `I` to a dotless `ı`, so `executionId` and `execution_id` would stop matching and the hint below would go missing on exactly
+      * the failure it was written for. `SqlMacros.tableNameImpl` avoids the same trap for the same reason.
+      */
+    private def normalize(name: String): String =
+        name.filter(_ != '_').map(_.toLower)
+
+end SqlDecodeColumnNotFoundException
 
 /** No codec on the active backend covers the column's wire type token. */
 final case class SqlDecodeUnknownTypeException(dialect: Idiom.Id, typeToken: String)(using Frame)
@@ -758,6 +820,59 @@ final case class SqlDecodeCodecMismatchException(
     extends SqlDecodeException(
         s"Codec on dialect '${dialect.value}' for type token '$typeToken' produced a $decodedClass, expected $expectedClass"
     )
+
+/** A column's wire type cannot become the Scala type the schema asked for.
+  *
+  * Raised where the target type's codec would otherwise reinterpret the column's bytes rather than convert its value. The `String` codec is
+  * the case this exists for: a column's binary wire form is the value's representation, not its rendering, so any wire type's bytes satisfy
+  * a UTF-8 read and what comes back is the protocol buffer as text, per engine byte order and all.
+  *
+  * The check is on the column's type token, not on the wire format, so the simple/text protocol refuses the same read the extended/binary
+  * protocol refuses: a schema declaring `String` for a `date` column is wrong about the column, and which protocol carried the row is not
+  * part of that.
+  *
+  * A conversion a codec can carry out is not this: a narrower integer over a wider column widens (or reports
+  * [[kyo.SqlDecodeValueRangeException]]), and a numeric column's text rendering parses (or reports
+  * [[kyo.SqlDecodeNumericException]]). A column type the backend does not recognise is not this either, since a token with no known
+  * meaning is not evidence of a mismatch.
+  *
+  * @param scalaType
+  *   the Scala type the schema asked for
+  * @param dialect
+  *   the backend that reported the column's type
+  * @param columnType
+  *   the column type the backend reported, named the way that backend spells it
+  * @param typeToken
+  *   the backend's own tag for that type: a PostgreSQL OID, a MySQL type byte
+  */
+final case class SqlDecodeColumnTypeMismatchException(
+    scalaType: String,
+    dialect: Idiom.Id,
+    columnType: String,
+    typeToken: String,
+    columnName: Maybe[String] = Maybe.empty
+)(using Frame)
+    extends SqlDecodeException(
+        SqlDecodeColumnTypeMismatchException.format(scalaType, dialect, columnType, typeToken, columnName)
+    )
+
+object SqlDecodeColumnTypeMismatchException:
+
+    private def format(
+        scalaType: String,
+        dialect: Idiom.Id,
+        columnType: String,
+        typeToken: String,
+        columnName: Maybe[String]
+    ): String =
+        // The column is named where the reader knew it. A row type declaring the wrong type for one field of several
+        // otherwise reports which types disagreed and leaves finding the field to the reader.
+        val which = columnName.fold("A")(name => s"Column '$name': a")
+        s"$which $columnType column cannot be read as $scalaType on dialect '${dialect.value}' (type token '$typeToken'). " +
+            "The column's bytes are the value's wire representation, not its text rendering: read the column at its own type, " +
+            "render it as text in SQL with a CAST, or reach for SqlRow.text, which renders a column at whatever it holds."
+    end format
+end SqlDecodeColumnTypeMismatchException
 
 /** A custom column decoder raised an exception while converting the wire value.
   *

--- a/kyo-sql/shared/src/main/scala/kyo/SqlRow.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/SqlRow.scala
@@ -21,7 +21,7 @@ import scala.util.control.NonFatal
   */
 final class SqlRow(
     val values: Chunk[Maybe[Span[Byte]]],
-    private[kyo] val columns: Chunk[SqlRow.Column],
+    val columns: Chunk[SqlRow.Column],
     private[kyo] val codec: SqlRow.Codec
 ):
 
@@ -30,6 +30,74 @@ final class SqlRow(
 
     /** The column names, in order. */
     def columnNames: Chunk[String] = columns.map(_.name)
+
+    /** What kind of value the column at `idx` carries, in the neutral vocabulary both backends map their own types onto.
+      *
+      * The reader for a result set nobody typed: a tool running user-written SQL knows a column's name and its bytes, and this is what
+      * says whether those bytes are a number, an instant, or text, without the caller learning either backend's type tags.
+      * [[SqlRow.ColumnKind.Unknown]] for a type the backend has no neutral kind for and for a row assembled without server metadata.
+      */
+    def columnKind(idx: Int): SqlRow.ColumnKind =
+        if idx < 0 || idx >= columns.size then SqlRow.ColumnKind.Unknown
+        else codec.columnKind(columns(idx).typeToken)
+
+    /** What kind of value the column named `name` carries. [[SqlRow.ColumnKind.Unknown]] when the row has no such column. */
+    def columnKind(name: String): SqlRow.ColumnKind =
+        columnKind(columns.indexWhere(_.name == name))
+
+    /** The backend's own name for the type of the column at `idx`: `int4` and `timestamptz` on PostgreSQL, `BIGINT` and `DATETIME` on
+      * MySQL. Absent for a type token the backend does not recognise, which is what a row assembled without server metadata carries.
+      *
+      * For a decision a caller acts on, prefer [[columnKind]], which is the same fact in a vocabulary that does not change with the engine.
+      * This is for showing a human which type the server reported.
+      */
+    def columnTypeName(idx: Int): Maybe[String] =
+        if idx < 0 || idx >= columns.size then Maybe.empty
+        else codec.typeName(columns(idx).typeToken)
+
+    /** The backend's own name for the type of the column named `name`. */
+    def columnTypeName(name: String): Maybe[String] =
+        columnTypeName(columns.indexWhere(_.name == name))
+
+    /** The column at `idx` rendered as text, whatever its wire type, or [[Absent]] for SQL NULL.
+      *
+      * The reader a generic tool needs, and the one operation `decode[String]` deliberately is not: `decode[String]` asks for a column that
+      * IS text and aborts [[SqlDecodeColumnTypeMismatchException]] on one that is not, because a schema declaring `String` for a `date`
+      * column is wrong about the column. This renders the value the column actually holds, decoding it at its own type first, so an `int4`
+      * answers `"42"` and a `date` answers `"2026-08-04"` under either wire format.
+      *
+      * The rendering is the SERVER's, and the same one under either wire format. That is the whole contract: a text-protocol row already
+      * carries the server's rendering and it is handed back, and a binary-protocol row is decoded and re-rendered to match it, so one
+      * stored value reads as one string whichever protocol carried the row. The two do not agree on their own, and not only at the edges:
+      * PostgreSQL writes a bool `t` where Java writes `true`, a timestamp `2026-08-25 10:00:00` where Java writes `2026-08-25T10:00`, and
+      * a float8 1e10 `10000000000` where Java writes `1.0E10`.
+      *
+      * A backend renders the types it names; one it does not name falls back to reading the column's bytes as UTF-8, which is a rendering
+      * of last resort rather than a decode. [[columnKind]] says which case a column is in.
+      *
+      * @throws SqlDecodeException
+      *   if the column is out of bounds, or the value cannot be decoded at the type its column reports
+      */
+    def text(idx: Int)(using Frame): Maybe[String] < Abort[SqlDecodeException] =
+        // Bounded against BOTH, unlike the value reads: a backend's `text` dispatches on the column's type before it
+        // touches the value, so a row carrying fewer column descriptions than values would index past `columns` from
+        // inside the codec, where the raised IndexOutOfBounds is outside the declared Abort. `columnKind` and
+        // `columnTypeName` already guard the same way.
+        if idx < 0 || idx >= values.size || idx >= columns.size then
+            Abort.fail(SqlDecodeColumnOutOfBoundsException(idx, values.size))
+        else if values(idx).isEmpty then Maybe.empty
+        else codec.text(this, idx).map(Maybe(_))
+
+    /** The column named `name` rendered as text, or [[Absent]] for SQL NULL.
+      *
+      * @throws SqlDecodeException
+      *   if the column is not found, or the value cannot be decoded at the type its column reports
+      */
+    def text(name: String)(using Frame): Maybe[String] < Abort[SqlDecodeException] =
+        val idx = columns.indexWhere(_.name == name)
+        if idx < 0 then Abort.fail(SqlDecodeColumnNotFoundException(name, columnNames))
+        else text(idx)
+    end text
 
     /** Returns the raw bytes for the column at `idx`, or [[Absent]] for SQL NULL. */
     def column(idx: Int): Maybe[Span[Byte]] =
@@ -90,7 +158,7 @@ final class SqlRow(
       */
     def decode[A](name: String)(using frame: Frame, evidence: SqlSchema[A]): A < Abort[SqlDecodeException] =
         val idx = columns.indexWhere(_.name == name)
-        if idx < 0 then Abort.fail(SqlDecodeColumnNotFoundException(name))
+        if idx < 0 then Abort.fail(SqlDecodeColumnNotFoundException(name, columnNames))
         else decode[A](idx)
     end decode
 
@@ -168,7 +236,9 @@ object SqlRow:
     /** Neutral column metadata.
       *
       * `typeToken` is the backend's own tag for the column's type (a PostgreSQL OID, a MySQL type byte). Core never interprets it; it exists so
-      * a backend codec can dispatch on the type the server reported.
+      * a backend codec can dispatch on the type the server reported. A caller reading a result set it did not type wants
+      * [[SqlRow.columnKind]] or [[SqlRow.columnTypeName]] rather than the token itself, both of which are this token put through the row's
+      * own backend.
       *
       * @param name
       *   the column name the server reported
@@ -176,6 +246,24 @@ object SqlRow:
       *   the backend's type tag for the column
       */
     final case class Column(val name: String, val typeToken: Int) derives CanEqual
+
+    /** What kind of value a result column carries, in a vocabulary neither backend owns.
+      *
+      * The type information a caller running user-written SQL can act on: which reader to reach for, how to align a value in a table,
+      * whether a filter makes sense. It is deliberately coarser than either engine's type list, since the distinctions it drops (`int2`
+      * against `int8`, `varchar` against `text`) are ones the codecs already handle and a generic caller does not choose between.
+      * [[SqlRow.columnTypeName]] is the engine's own spelling for the same column, for showing a human.
+      *
+      *   - [[Integer]], [[Decimal]], [[Float]]: exact integral, exact scaled decimal, and approximate binary floating point.
+      *   - [[Bool]], [[Text]], [[Json]], [[Uuid]], [[Bytes]]: the non-numeric scalars.
+      *   - [[Date]], [[Time]], [[TimeWithOffset]], [[DateTime]], [[Timestamp]], [[Interval]]: the temporal family, split the way the SQL
+      *     types are.
+      *   - [[Array]]: a one-dimensional array column.
+      *   - [[Unknown]]: a type the backend has no neutral kind for, and a row assembled without server metadata.
+      */
+    enum ColumnKind derives CanEqual:
+        case Integer, Decimal, Float, Bool, Text, Json, Uuid, Bytes, Date, Time, TimeWithOffset, DateTime, Timestamp, Interval, Array,
+            Unknown
 
     /** A backend's decoder for the rows it produced.
       *
@@ -190,6 +278,28 @@ object SqlRow:
         def read[A](schema: SqlSchema[A], row: SqlRow, offset: Int, naming: Maybe[SqlNaming], fieldMatch: SqlRow.FieldMatch)(using
             Frame
         ): A < Abort[SqlDecodeException]
+
+        /** The neutral kind of the type `typeToken` names, backing [[SqlRow.columnKind]].
+          *
+          * Defaults to [[SqlRow.ColumnKind.Unknown]], which is the honest answer for a codec that carries no server type metadata; a
+          * backend that receives it maps its own type tags here.
+          */
+        def columnKind(typeToken: Int): SqlRow.ColumnKind = SqlRow.ColumnKind.Unknown
+
+        /** The backend's own name for the type `typeToken` names, backing [[SqlRow.columnTypeName]]. Absent for a token the backend does
+          * not recognise.
+          */
+        def typeName(typeToken: Int): Maybe[String] = Maybe.empty
+
+        /** Renders the non-NULL column at `idx` as text, backing [[SqlRow.text]]. NULL and bounds are settled by the caller.
+          *
+          * Defaults to reading the column's bytes as UTF-8, which is what a value already in its text rendering needs and all a codec with
+          * no type metadata can do. A backend whose result sets carry binary values decodes the value at its column's own type first.
+          */
+        def text(row: SqlRow, idx: Int)(using Frame): String < Abort[SqlDecodeException] =
+            row.column(idx) match
+                case Maybe.Present(bytes) => new String(bytes.toArray, java.nio.charset.StandardCharsets.UTF_8)
+                case Maybe.Absent         => Abort.fail(SqlDecodeColumnAbsentException(idx))
     end Codec
 
     object Codec:

--- a/kyo-sql/shared/src/main/scala/kyo/db/Idiom.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/db/Idiom.scala
@@ -256,7 +256,7 @@ abstract class Idiom:
             case lit: Sql.Literal[a]         => ctx.appendBind(Sql.BoundValue(lit.value, lit.schema, lit.typeName))
             case lt: Sql.LabelledTerm[?, ?]  => term(ctx, lt.term)
             case gc: Sql.GroupedColumn[?, ?] => term(ctx, gc.column)
-            case c: Sql.Comparison[?]        => binary(ctx, c.left, comparisonOp(c.op), c.right)
+            case c: Sql.Comparison           => binary(ctx, c.left, comparisonOp(c.op), c.right)
             case lg: Sql.Logical             => binary(ctx, lg.left, logicalOp(lg.op), lg.right)
             case ar: Sql.Arithmetic[?]       => arithmetic(ctx, ar)
             case sm: Sql.StringMatch         => stringMatch(ctx, sm)

--- a/kyo-sql/shared/src/main/scala/kyo/internal/FromExprDerived.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/FromExprDerived.scala
@@ -245,6 +245,10 @@ object FromExprDerived:
                 case Block(Nil, inner)    => unwrap(inner, args)
                 case Typed(inner, _)      => unwrap(inner, args)
                 case TypeApply(inner, _)  => unwrap(inner, args)
+                // `f(name = value)`: the name is how the argument was written and says nothing about the value, which is
+                // what the fold reads. A `copy` replacing one field passes it by name, so without this the argument is
+                // not recognised at all.
+                case NamedArg(_, inner) => unwrap(inner, args)
                 // Prepend, so a curried application keeps its arguments in declaration order.
                 case Apply(fun, as) => unwrap(fun, as ::: args)
                 case other          => (other, args)
@@ -433,6 +437,11 @@ object FromExprDerived:
         // Recognises a case-class constructor application `Companion.apply(args)` / `new C(args…)`
         // (including curried / multi-parameter-list `<init>` forms) and returns
         // `(caseClassSymbol, flattenedArgs)`.
+        // Reading a flag off a symbol that has none is a reflection failure rather than a `false`, so every read here
+        // goes through this: an expression that cannot answer is one this fold declines, never one it guesses at.
+        def isSynthetic(s: Symbol): Boolean =
+            try s != Symbol.noSymbol && s.flags.is(Flags.Synthetic)
+            catch case _: Throwable => false
         def asConstruction(t: Term): Option[(Symbol, List[Term])] =
             // Collect every value-argument list down a (possibly nested) `Apply` chain, left-to-right.
             def collect(cur: Term, acc: List[Term]): (Term, List[Term]) =
@@ -444,7 +453,22 @@ object FromExprDerived:
             head match
                 case Select(qual, "apply")      => Some((qual.symbol, args))
                 case Select(New(tpt), "<init>") => Some((tpt.tpe.typeSymbol, args))
-                case _                          => None
+                // `receiver.copy(args)` builds the same case class the receiver is one of, and its arguments are
+                // that class's fields in declaration order, so it is a construction as much as `apply` is. This is
+                // the shape every builder that accumulates produces: `Update.Builder.set` answers a copy of itself
+                // with one more assignment, and a statement built through it reached this macro as a copy whose
+                // fields could not be read, which is what kept every UPDATE off the static path.
+                // Only the compiler's own `copy`, which is the one whose parameters ARE the case fields in
+                // declaration order. A class is free to declare its own, and declaring one suppresses the synthetic
+                // one, so a `copy` that takes a subset of the fields (or something else entirely) would have its
+                // arguments read as fields here and fold a neighbouring field to the wrong constant, silently and at
+                // compile time. Refusing to recognise it leaves the statement on the dynamic path, which is correct.
+                case sel @ Select(qual, "copy") if isSynthetic(sel.symbol) =>
+                    val cls =
+                        try qual.tpe.widen.typeSymbol
+                        catch case _: Throwable => Symbol.noSymbol
+                    if cls == Symbol.noSymbol then None else Some((cls, args))
+                case _ => None
             end match
         end asConstruction
         // Pass 2, substitute `Ident` references to bound symbols with their rhs, AND fold
@@ -492,6 +516,23 @@ object FromExprDerived:
                     // field matchers expect the constructor head, and the whole statement silently fails to fold.
                     case TypeApply(Select(inner, "asInstanceOf" | "$asInstanceOf$"), _) =>
                         transformTerm(inner)(owner)
+                    // An omitted `copy` argument is spelled `receiver.copy$default$N`, N being 1-based over the case
+                    // fields. Rewriting it to the field selection it stands for lets the fold below read it like any
+                    // other field, which is what makes a `copy` that omits arguments resolvable at all.
+                    // The polymorphic form: `receiver.copy$default$N[T, F]`. The type arguments belong to the
+                    // defaulted method and mean nothing to the field selection it stands for, so they go with it.
+                    case TypeApply(sel @ Select(_, name), _) if name.startsWith("copy$default$") =>
+                        transformTerm(sel)(owner)
+                    case sel @ Select(receiver, name) if name.startsWith("copy$default$") =>
+                        val fields =
+                            try transformTerm(receiver)(owner).tpe.widen.typeSymbol.caseFields
+                            catch case _: Throwable => Nil
+                        val index =
+                            try name.stripPrefix("copy$default$").toInt - 1
+                            catch case _: Throwable => -1
+                        if index >= 0 && index < fields.length then
+                            transformTerm(Select(receiver, fields(index)))(owner)
+                        else Select.copy(sel)(transformTerm(receiver)(owner), name)
                     case sel @ Select(receiver, fieldName) =>
                         val resolvedReceiver = transformTerm(receiver)(owner)
                         // Peel `Inlined` / `Block` / `Typed` wrappers off the resolved receiver before
@@ -1167,12 +1208,19 @@ object FromExprDerived:
                 // The constructor head must name THIS case class, otherwise a 0-arg case class
                 // (`Default()`) would match any term reducing to a non-`Apply` head, and an n-arg
                 // case class would match any unrelated n-arg `Apply`.
+                def isSyntheticCopy(sym: Symbol): Boolean =
+                    try sym.flags.is(Flags.Synthetic)
+                    catch case _: Throwable => false
                 def headMatches(head: Term): Boolean =
                     head match
                         case Select(New(tpt), "<init>") => tpt.tpe.typeSymbol.name == caseClassName
                         case Select(qual, "apply") =>
                             val n = qual.symbol.name
                             n == caseClassName || n == caseClassName + "$"
+                        // See the sibling site: only the compiler's own `copy`, whose parameters ARE the case fields.
+                        case sel @ Select(qual, "copy") if isSyntheticCopy(sel.symbol) =>
+                            (try qual.tpe.widen.typeSymbol.name
+                            catch case _: Throwable => "") == caseClassName
                         case Ident("apply") => false
                         case _              => false
                 collectArgs(term, Nil) match
@@ -1801,7 +1849,12 @@ object FromExprDerived:
                                             case Inlined(_, _, inner) => unwrap(inner)
                                             case Block(_, inner)      => unwrap(inner)
                                             case Typed(inner, _)      => unwrap(inner)
-                                            case other                => other
+                                            // `f(name = value)`: the name is how the argument was written and says nothing about
+                                            // the value, which is what this matches on. A builder that copies itself with one
+                                            // field replaced passes that field by name, so without this the chunk it passes is
+                                            // not recognised as a chunk at all.
+                                            case NamedArg(_, inner) => unwrap(inner)
+                                            case other              => other
                                     // Resolve inline-expansion `Block` `val` bindings so element matchers
                                     // receive binding-free trees (see `deriveProduct` / `resolveBindings`).
                                     val term = unwrap(kyo.internal.FromExprDerived.resolveBindings(x.asTerm))
@@ -1875,19 +1928,45 @@ object FromExprDerived:
                                                 case single                                                      => List(single)
                                             end match
                                         end tupleOrSingle
-                                        val elemsOpt: Option[List[Term]] =
-                                            term match
+                                        // The symbol behind a term, normalised the way `norm` is, so the shapes below can be
+                                        // recognised at any depth rather than only at the term this derivation started from.
+                                        def symbolOf(t: Term): String =
+                                            val n =
+                                                try t.symbol.fullName
+                                                catch case _: Throwable => ""
+                                            n.replace("$package", "").replace("$", "")
+                                        end symbolOf
+                                        // Every shape a chunk of pure data reaches this macro as. `++` is the one a builder that
+                                        // accumulates produces: `Update.Builder.set` appends to the specs it already holds, so an
+                                        // UPDATE arrives as `Chunk.empty ++ Chunk.from(...)` rather than as one literal chunk, and
+                                        // not recognising the concatenation is what kept every UPDATE off the static path. Both
+                                        // sides are themselves shapes recognised here, so the concatenation is as much data as
+                                        // either half.
+                                        def elemsOf(t: Term): Option[List[Term]] =
+                                            unwrap(t) match
+                                                case Apply(Select(left, "++"), List(right)) =>
+                                                    for
+                                                        l <- elemsOf(left)
+                                                        r <- elemsOf(right)
+                                                    yield l ++ r
+                                                case Apply(TypeApply(Select(left, "++"), _), List(right)) =>
+                                                    for
+                                                        l <- elemsOf(left)
+                                                        r <- elemsOf(right)
+                                                    yield l ++ r
+                                                case inner if endsWith(symbolOf(inner), "Chunk.empty") => Some(Nil)
                                                 case Apply(fun, List(reps))
                                                     if isChunkRef(fun) &&
-                                                        (endsWith(norm, "Chunk.apply") ||
-                                                            endsWith(norm, "IterableFactory.apply") ||
+                                                        (endsWith(symbolOf(fun), "Chunk.apply") ||
+                                                            endsWith(symbolOf(fun), "IterableFactory.apply") ||
                                                             // `Chunk.from(varargs)`, produced by inline-def varargs forwarding
                                                             // such as `Insert.Builder.values(rows: T*)` → `Chunk.from(rows)`.
-                                                            endsWith(norm, "Chunk.from")) =>
+                                                            endsWith(symbolOf(fun), "Chunk.from")) =>
                                                     extractElems(reps)
                                                 case Apply(Select(_, "toChunk"), List(arg)) =>
                                                     Some(tupleOrSingle(arg))
                                                 case _ => None
+                                        val elemsOpt: Option[List[Term]] = elemsOf(term)
                                         elemsOpt.flatMap { elems =>
                                             val lifted: List[Option[Any]] =
                                                 elems.map(e => innerFE.unapply(e.asExprOf[Any]))
@@ -2059,12 +2138,23 @@ object FromExprDerived:
                     // The constructor head must name THIS case class, otherwise a 0-arg case class
                     // (`Default()`) matches any non-`Apply` head and an n-arg case class matches any
                     // unrelated n-arg `Apply`.
+                    def isSyntheticCopy(sym: Symbol): Boolean =
+                        try sym.flags.is(Flags.Synthetic)
+                        catch case _: Throwable => false
                     def headMatches(head: Term): Boolean =
                         head match
                             case Select(New(tpt), "<init>") => tpt.tpe.typeSymbol.name == expectedCaseClassName
                             case Select(qual, "apply") =>
                                 val n = qual.symbol.name
                                 n == expectedCaseClassName || n == expectedCaseClassName + "$"
+                            // `receiver.copy(args)` rebuilds the same case class, and the compiler's own `copy` takes the
+                            // case fields in declaration order, which is exactly what the argument list below is read as.
+                            // Only the synthetic one: a class declaring its own suppresses it and is free to take a subset
+                            // or something else entirely, which would fold a neighbouring field to the wrong constant. A
+                            // refusal leaves the statement on the dynamic path, which renders the same SQL.
+                            case sel @ Select(qual, "copy") if isSyntheticCopy(sel.symbol) =>
+                                (try qual.tpe.widen.typeSymbol.name
+                                catch case _: Throwable => "") == expectedCaseClassName
                             case _ => false
                     // Resolve inline-expansion `Block` `val` bindings (see resolveBindings).
                     val term = kyo.internal.FromExprDerived.resolveBindings(x.asTerm)

--- a/kyo-sql/shared/src/main/scala/kyo/internal/SqlPositionalRowCodec.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/SqlPositionalRowCodec.scala
@@ -3,6 +3,7 @@ package kyo.internal
 import kyo.<
 import kyo.Abort
 import kyo.Frame
+import kyo.JsonText
 import kyo.Maybe
 import kyo.SqlCodec
 import kyo.SqlCodec.Format
@@ -30,6 +31,52 @@ abstract class SqlPositionalRowCodec extends SqlRow.Codec:
       */
     def newReader(sliced: SqlRow, matchesFieldAt: Maybe[(Int, String) => Boolean])(using Frame): SqlCodec.Reader
 
+    /** Renders one column as text by decoding it at the type its own column reports, then rendering that value.
+      *
+      * Under [[kyo.SqlCodec.Format.Text]] every value is already its rendering, so the bytes are the answer and no decode happens. Under
+      * [[kyo.SqlCodec.Format.Binary]] the value is a wire representation that has to be read before it can be rendered, and what reads it
+      * is the [[kyo.SqlSchema.Column]] for the Scala type the column's [[kyo.SqlRow.ColumnKind]] names. Each kind maps to the widest Scala
+      * type in its family, so one integral read covers `int2` through `int8` and one float read covers both binary float widths.
+      *
+      * A kind with no lossless Scala rendering falls back to the bytes as UTF-8: [[kyo.SqlRow.ColumnKind.Unknown]] is a type the backend
+      * did not recognise, and an [[kyo.SqlRow.ColumnKind.Array]] or [[kyo.SqlRow.ColumnKind.Bytes]] column has no single scalar reading.
+      * That fallback is a rendering of last resort and can answer mojibake for a binary value, which is exactly why it is not what
+      * `decode[String]` does.
+      *
+      * [[kyo.SqlRow.ColumnKind.Interval]] falls there too, for the same reason read the other way round: `java.time.Duration` carries an
+      * interval's time part and `java.time.Period` its calendar part, and an interval may carry both, so neither type spans the kind. A
+      * backend that reports it renders it from its own wire fields by overriding this method, which is where the layout is known.
+      */
+    override def text(row: SqlRow, idx: Int)(using Frame): String < Abort[SqlDecodeException] =
+        import SqlRow.ColumnKind
+        def read[A](using SqlSchema[A]): A < Abort[SqlDecodeException] =
+            val sliced = row.slice(idx, idx + 1)
+            SqlRow.Codec.catchingColumn(Maybe(idx))(summon[SqlSchema[A]].read(newReader(sliced, Maybe.empty)))
+        end read
+        format match
+            case Format.Text => super.text(row, idx)
+            case Format.Binary =>
+                columnKind(row.columns(idx).typeToken) match
+                    case ColumnKind.Integer => read[Long].map(_.toString)
+                    // toPlainString: a fixed-point column's rendering never takes exponent notation, and
+                    // BigDecimal.toString does once the adjusted exponent is below -6, so a DECIMAL(10,7) holding
+                    // 0.0000001 rendered `1E-7` under the binary protocol against the server's `0.0000001`.
+                    case ColumnKind.Decimal        => read[BigDecimal].map(_.bigDecimal.toPlainString)
+                    case ColumnKind.Float          => read[Double].map(_.toString)
+                    case ColumnKind.Bool           => read[Boolean].map(_.toString)
+                    case ColumnKind.Text           => read[String]
+                    case ColumnKind.Json           => read[JsonText].map(_.text)
+                    case ColumnKind.Uuid           => read[java.util.UUID].map(_.toString)
+                    case ColumnKind.Date           => read[java.time.LocalDate].map(_.toString)
+                    case ColumnKind.Time           => read[java.time.LocalTime].map(_.toString)
+                    case ColumnKind.TimeWithOffset => read[java.time.OffsetTime].map(_.toString)
+                    case ColumnKind.DateTime       => read[java.time.LocalDateTime].map(_.toString)
+                    case ColumnKind.Timestamp      => read[java.time.Instant].map(_.toString)
+                    case ColumnKind.Interval | ColumnKind.Array | ColumnKind.Bytes | ColumnKind.Unknown =>
+                        super.text(row, idx)
+        end match
+    end text
+
     /** Decodes `schema` from the row's columns starting at `offset`.
       *
       * The reader is handed a field matcher built from the codec's field names and the sliced row together, because which field a column
@@ -47,7 +94,7 @@ abstract class SqlPositionalRowCodec extends SqlRow.Codec:
                 case SqlRow.FieldMatch.ByName => SqlFieldMatcher.missingByName(schema.fieldNames, sliced.columnNames, naming)
                 case _                        => Maybe.empty[String]
         missing match
-            case Maybe.Present(name) => Abort.fail(SqlDecodeColumnNotFoundException(name))
+            case Maybe.Present(name) => Abort.fail(SqlDecodeColumnNotFoundException(name, sliced.columnNames))
             case Maybe.Absent =>
                 SqlRow.Codec.catching(
                     schema.read(newReader(sliced, Maybe(SqlFieldMatcher.of(schema.fieldNames, sliced.columnNames, naming, fieldMatch))))

--- a/kyo-sql/shared/src/main/scala/kyo/internal/SqlRunMacro.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/SqlRunMacro.scala
@@ -63,6 +63,60 @@ object SqlRunMacro:
     ): Expr[Long < (Abort[SqlException] & DB)] =
         emitUpdate(SqlStaticMacro.impl(widenStatement(upd)))
 
+    // --- Update.Returning[T, F, A] / Delete.Returning[T, F, A] ---
+    //
+    // A returning write answers rows, so it emits the row-returning dispatch rather than the count one. The
+    // statement it renders is the ordinary write it wraps, whose RETURNING clause the renderers already emit;
+    // what the wrapper adds is the type those rows decode at.
+
+    def runReturningImpl[T: Type, F: Type, A: Type](ret: Expr[Update.Returning[T, F, A]])(using
+        Quotes
+    ): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
+        val ev = summonEvidence[A](ret)
+        SqlStaticMacro.tryImpl(widenStatement('{ $ret.statement })) match
+            case Present(rendered) => emitQuery[A](rendered, ev)
+            case Absent            => '{ $ret.runDynamic(using summon[Frame], $ev) }
+    end runReturningImpl
+
+    def runReturningStaticImpl[T: Type, F: Type, A: Type](ret: Expr[Update.Returning[T, F, A]])(using
+        Quotes
+    ): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
+        emitQuery[A](SqlStaticMacro.impl(widenStatement('{ $ret.statement })), summonEvidence[A](ret))
+
+    def runDeleteReturningImpl[T: Type, F: Type, A: Type](ret: Expr[Delete.Returning[T, F, A]])(using
+        Quotes
+    ): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
+        val ev = summonEvidence[A](ret)
+        SqlStaticMacro.tryImpl(widenStatement('{ $ret.statement })) match
+            case Present(rendered) => emitQuery[A](rendered, ev)
+            case Absent            => '{ $ret.runDynamic(using summon[Frame], $ev) }
+    end runDeleteReturningImpl
+
+    def runDeleteReturningStaticImpl[T: Type, F: Type, A: Type](ret: Expr[Delete.Returning[T, F, A]])(using
+        Quotes
+    ): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
+        emitQuery[A](SqlStaticMacro.impl(widenStatement('{ $ret.statement })), summonEvidence[A](ret))
+
+    // --- Insert.Returning[T, F, A] ---
+    //
+    // An INSERT that names its returning columns answers rows, so it emits the row-returning dispatch rather than the
+    // insert-outcome one. The renderer already prefers an explicit RETURNING over the auto-key clause it appends, so
+    // there is one clause either way and the rows this decodes are the ones the caller asked for.
+
+    def runInsertReturningImpl[T: Type, F: Type, A: Type](ret: Expr[Insert.Returning[T, F, A]])(using
+        Quotes
+    ): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
+        val ev = summonEvidence[A](ret)
+        SqlStaticMacro.tryImpl(widenStatement('{ $ret.statement })) match
+            case Present(rendered) => emitQuery[A](rendered, ev)
+            case Absent            => '{ $ret.runDynamic(using summon[Frame], $ev) }
+    end runInsertReturningImpl
+
+    def runInsertReturningStaticImpl[T: Type, F: Type, A: Type](ret: Expr[Insert.Returning[T, F, A]])(using
+        Quotes
+    ): Expr[Chunk[A] < (Abort[SqlException] & DB)] =
+        emitQuery[A](SqlStaticMacro.impl(widenStatement('{ $ret.statement })), summonEvidence[A](ret))
+
     // --- Delete[T, F] ---
 
     def runDeleteImpl[T: Type, F: Type](del: Expr[Delete[T, F]])(using Quotes): Expr[Long < (Abort[SqlException] & DB)] =

--- a/kyo-sql/shared/src/main/scala/kyo/internal/SqlStaticMacro.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/SqlStaticMacro.scala
@@ -62,14 +62,66 @@ private[kyo] object SqlStaticMacro:
                 // expansion stops without a second diagnostic, which is the documented use of StopMacroExpansion.
                 if containsErrorTree(q.asTerm) then throw new scala.quoted.runtime.StopMacroExpansion
                 report.errorAndAbort(
-                    ".runStatic: query cannot be folded at compile time. " +
-                        "Ensure the query and its DSL fragments are constructed at the call site (a query stored in a `val` reaches " +
-                        "this macro as a variable reference, without the construction behind it). " +
+                    s".runStatic: this statement cannot be folded at compile time. ${blockingConstruct(q.asTerm)} " +
                         "Use .run for opportunistic static folding with runtime fallback, or .runDynamic to skip static folding entirely.",
                     q.asTerm.pos
                 )
         end match
     end impl
+
+    /** Names the construct that stopped the fold, for the message the caller reads.
+      *
+      * The lift answers yes or no and carries no reason with it, so the reason is recovered from the statement's own tree by looking for
+      * the constructs known to block a fold. This exists because the alternative, one fixed sentence for every refusal, was wrong more
+      * often than right: it blamed a `val` for statements written out at the terminal, which sent the reader looking for a variable that
+      * was not there while the raw fragment or the `having` in front of them went unmentioned.
+      *
+      * Reports what it can prove and nothing more: with no known construct present, it says the fold failed without inventing a cause.
+      */
+    private def blockingConstruct(using Quotes)(root: quotes.reflect.Term): String =
+        import quotes.reflect.*
+        given CanEqual[String, String] = CanEqual.derived
+        var sawFragment                = false
+        var sawHaving                  = false
+        // A statement WRITTEN OUT at the terminal arrives as a construction; one read from a `val` arrives as the
+        // reference, which is the case the old message assumed for every refusal.
+        def isReference(t: Term): Boolean =
+            t match
+                case Inlined(_, _, inner) => isReference(inner)
+                case Typed(inner, _)      => isReference(inner)
+                case Block(_, inner)      => isReference(inner)
+                case _: Ident             => true
+                case _                    => false
+        val walker = new TreeAccumulator[Unit]:
+            def foldTree(u: Unit, tree: Tree)(owner: Symbol): Unit =
+                tree match
+                    case t: Term =>
+                        val shown =
+                            try t.tpe.dealias.show
+                            catch case _: Throwable => ""
+                        if shown.contains("Sql.Fragment") then sawFragment = true
+                        t match
+                            case Apply(Select(_, "having"), _)               => sawHaving = true
+                            case Apply(TypeApply(Select(_, "having"), _), _) => sawHaving = true
+                            case _                                           => ()
+                        end match
+                    case _ => ()
+                end match
+                foldOverTree(u, tree)(owner)
+            end foldTree
+        walker.foldTree((), root)(Symbol.spliceOwner)
+        if sawFragment then
+            "A raw `sql\"...\"` fragment embedded in a typed statement is rendered at run time, so a statement carrying one cannot be " +
+                "folded. Spell the same predicate with the typed operators to keep it on the static path."
+        else if sawHaving then
+            "A `having` clause is rendered at run time, so a statement carrying one cannot be folded."
+        else if isReference(root) then
+            "The statement reaches this macro as a variable reference rather than as its construction, which is what a query stored in " +
+                "a `val` looks like here. Construct it at the call site, or name it with a `transparent inline def`."
+        else
+            "The construction could not be read at compile time. If it embeds a value that is only known at run time, that value is why."
+        end if
+    end blockingConstruct
 
     /** True when `root` contains a subtree the compiler has already marked erroneous, meaning an error for this
       * statement is already reported at a more precise position.

--- a/kyo-sql/shared/src/main/scala/kyo/internal/auth/PureHash.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/auth/PureHash.scala
@@ -241,28 +241,68 @@ private[kyo] object PureHash:
     /** PBKDF2-HMAC-SHA-256 per RFC 2898 §5.2.
       *
       * DK = T1 || T2 || … where Ti = U1 XOR U2 XOR … XOR Uc U1 = HMAC(P, S || INT(i)); Uc = HMAC(P, Uc-1)
+      *
+      * The password is the HMAC key for every one of the thousands of iterations, so the two padded key blocks it produces are derived
+      * once here and reused, and the three message buffers are allocated once and refilled: one for the outer hash, one for the first
+      * iteration's salt-and-block-index message, and one for the digest-sized message every iteration after it. Calling [[hmacSha256]]
+      * per iteration instead re-derives both pads and allocates five arrays each time, which is the shape of work that decides what this
+      * costs: key stretching is deliberately iterated, so anything per-iteration is multiplied by the server's iteration count.
       */
     def pbkdf2HmacSha256(password: Array[Byte], salt: Array[Byte], iterations: Int, keyLength: Int): Array[Byte] =
         val hLen   = 32 // SHA-256 output length
         val blocks = (keyLength + hLen - 1) / hLen
         val result = new Array[Byte](keyLength)
-        var pos    = 0
-        var block  = 1
+
+        // The key schedule, derived once: ipad and opad are functions of the password alone.
+        val normalizedKey =
+            if password.length > SHA256_BLOCK_SIZE then sha256(password)
+            else password
+        val ipad = new Array[Byte](SHA256_BLOCK_SIZE)
+        val opad = new Array[Byte](SHA256_BLOCK_SIZE)
+        var k    = 0
+        while k < SHA256_BLOCK_SIZE do
+            val kb = if k < normalizedKey.length then normalizedKey(k) else 0.toByte
+            ipad(k) = (kb ^ 0x36).toByte
+            opad(k) = (kb ^ 0x5c).toByte
+            k += 1
+        end while
+
+        // The outer message is always opad plus a digest. The inner message has two shapes, the salt block on the
+        // first iteration of each output block and a digest on every one after it, so each gets its own buffer sized
+        // exactly for it: sizing one at the larger and filling part of it would hash the unused tail as well.
+        val outerBuf = new Array[Byte](SHA256_BLOCK_SIZE + hLen)
+        java.lang.System.arraycopy(opad, 0, outerBuf, 0, SHA256_BLOCK_SIZE)
+        val firstInner = new Array[Byte](SHA256_BLOCK_SIZE + salt.length + 4)
+        java.lang.System.arraycopy(ipad, 0, firstInner, 0, SHA256_BLOCK_SIZE)
+        java.lang.System.arraycopy(salt, 0, firstInner, SHA256_BLOCK_SIZE, salt.length)
+        val innerBuf = new Array[Byte](SHA256_BLOCK_SIZE + hLen)
+        java.lang.System.arraycopy(ipad, 0, innerBuf, 0, SHA256_BLOCK_SIZE)
+
+        /** One HMAC round over a digest-sized message already sitting in `innerBuf` after the ipad block. */
+        def hmacOverInner(): Array[Byte] =
+            val innerHash = sha256(innerBuf)
+            java.lang.System.arraycopy(innerHash, 0, outerBuf, SHA256_BLOCK_SIZE, hLen)
+            sha256(outerBuf)
+        end hmacOverInner
+
+        var pos   = 0
+        var block = 1
         while block <= blocks do
             // U1 = HMAC(password, salt || INT(block))
-            val saltBlock = new Array[Byte](salt.length + 4)
-            java.lang.System.arraycopy(salt, 0, saltBlock, 0, salt.length)
-            saltBlock(salt.length) = ((block >>> 24) & 0xff).toByte
-            saltBlock(salt.length + 1) = ((block >>> 16) & 0xff).toByte
-            saltBlock(salt.length + 2) = ((block >>> 8) & 0xff).toByte
-            saltBlock(salt.length + 3) = (block & 0xff).toByte
-
-            var u = hmacSha256(password, saltBlock)
+            val blockIdx = SHA256_BLOCK_SIZE + salt.length
+            firstInner(blockIdx) = ((block >>> 24) & 0xff).toByte
+            firstInner(blockIdx + 1) = ((block >>> 16) & 0xff).toByte
+            firstInner(blockIdx + 2) = ((block >>> 8) & 0xff).toByte
+            firstInner(blockIdx + 3) = (block & 0xff).toByte
+            val firstHash = sha256(firstInner)
+            java.lang.System.arraycopy(firstHash, 0, outerBuf, SHA256_BLOCK_SIZE, hLen)
+            var u = sha256(outerBuf)
             val t = u.clone()
 
             var c = 1
             while c < iterations do
-                u = hmacSha256(password, u)
+                java.lang.System.arraycopy(u, 0, innerBuf, SHA256_BLOCK_SIZE, hLen)
+                u = hmacOverInner()
                 var i = 0
                 while i < hLen do
                     t(i) = (t(i) ^ u(i)).toByte

--- a/kyo-sql/shared/src/main/scala/kyo/internal/client/SqlConnectionPool.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/client/SqlConnectionPool.scala
@@ -386,9 +386,15 @@ final private[kyo] class SqlConnectionPool[C <: Connection](
                                 }
                             }.andThen {
                                 Abort.run[SqlException](body).flatMap {
-                                    case Result.Success(a) => a
+                                    case Result.Success(a)                     => a
                                     case Result.Failure(e: SqlServerException) =>
-                                        Log.error(s"kyo.sql: server error sqlState=${e.sqlState} msg=${e.serverMessage}")
+                                        // DEBUG, not ERROR. The caller is handed the same failure as a typed value and
+                                        // decides what it is: a tool running user-written SQL gets a syntax error back
+                                        // from the server as its ordinary answer. Writing it at ERROR filled an
+                                        // operator's dashboard with entries for a program behaving correctly, and on a
+                                        // stdio transport anything the library writes on its own initiative is a
+                                        // candidate for corrupting the channel. The typed Abort is the report.
+                                        Log.debug(s"kyo.sql: server error sqlState=${e.sqlState} msg=${e.serverMessage}")
                                             .andThen(Abort.fail[SqlException](e))
                                     case Result.Failure(e) => Abort.fail[SqlException](e)
                                     case Result.Panic(t)   => Abort.error(Result.Panic(t))
@@ -637,11 +643,14 @@ final private[kyo] class SqlConnectionPool[C <: Connection](
             Abort.fail(SqlConnectionTlsNotConfiguredException(config.tlsMode))
         else
             val budget = connectTimeout.getOrElse(config.acquireTimeout)
+            val source =
+                if connectTimeout.isEmpty then SqlConnectionEstablishTimeoutException.fromAcquireTimeout
+                else SqlConnectionEstablishTimeoutException.fromConnectTimeout
             if budget == Duration.Infinity then factory.open(address, password, config)
             else
                 Async.timeoutWithError(
                     budget,
-                    Result.Failure(SqlConnectionEstablishTimeoutException(budget, address.host, address.port))
+                    Result.Failure(SqlConnectionEstablishTimeoutException(budget, address.host, address.port, source))
                 )(factory.open(address, password, config))
             end if
     end connect
@@ -824,16 +833,22 @@ final private[kyo] class SqlConnectionPool[C <: Connection](
     private def releaseToPool(netKey: SqlConnectionPool.Endpoint, conn: C, logger: Log)(using Frame, AllowUnsafe): Unit =
         if pool.isClosed then destroyAndFreeSlot(conn, logger)
         else
-            pool.release(netKey, conn)
+            // The counter goes up before the connection moves, so that anything which can observe the move can already
+            // see the count. The reverse order leaves a window in which a waiter woken by the connection's own
+            // handover reads a counter that has not caught up yet, and a metric that lags what it counts is one a
+            // caller cannot act on the moment it learns the thing happened.
             discard(Sync.Unsafe.evalOrThrow(metrics.recordRelease))
+            pool.release(netKey, conn)
             // Not "closed": this connection is going back into the ring alive. The sibling in destroyAndFreeSlot is
             // the one that closes.
             logger.unsafe.debug(s"kyo.sql: pooled connection id=${conn.id}")
 
     /** Closes a connection instead of pooling it, freeing the place it held. */
     private def destroyAndFreeSlot(conn: C, logger: Log)(using Frame, AllowUnsafe): Unit =
-        pool.discard(conn)
+        // Counted before the close, for the reason releaseToPool spells out: the close is observable, so anything that
+        // sees it must already see the count.
         discard(Sync.Unsafe.evalOrThrow(metrics.recordDiscard))
+        pool.discard(conn)
         logger.unsafe.debug(s"kyo.sql: closed connection id=${conn.id} reason=discarded")
     end destroyAndFreeSlot
 

--- a/kyo-sql/shared/src/test/scala/kyo/SqlExceptionTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/SqlExceptionTest.scala
@@ -186,6 +186,40 @@ class SqlExceptionTest extends Test:
         assert(ex.getMessage.contains("id"))
     }
 
+    "SqlDecodeColumnNotFoundException names the row's own columns" in {
+        val ex = SqlDecodeColumnNotFoundException("executionId", Chunk("execution_id", "flow_id", "status"))
+        assert(ex.columnName == "executionId")
+        assert(ex.availableColumns == Chunk("execution_id", "flow_id", "status"))
+        assert(ex.message.contains("execution_id, flow_id, status"), ex.message)
+    }
+
+    /** A field name that matches a column up to casing is the shape a SqlNaming that did not reach the query leaves behind.
+      *
+      * The given is resolved at the call site of the run, so one declared in an object the run is not inside of (a companion, another
+      * method) is not applied, and every field then looks for its verbatim Scala name against snake_case columns. The failure is a
+      * column-not-found at the first decode, which said only that the column was missing.
+      */
+    "SqlDecodeColumnNotFoundException points at the casing when only the casing differs" in {
+        val ex = SqlDecodeColumnNotFoundException("executionId", Chunk("execution_id", "flow_id"))
+        assert(ex.message.contains("differs from 'executionId' only in casing"), ex.message)
+        assert(ex.message.contains("SqlNaming"), ex.message)
+        assert(ex.message.contains("call site of the run"), ex.message)
+    }
+
+    "SqlDecodeColumnNotFoundException says nothing about casing when nothing matches" in {
+        val ex = SqlDecodeColumnNotFoundException("total", Chunk("execution_id", "flow_id"))
+        // The rendered message carries the raising frame's source context, so the absence is asserted on the hint's own
+        // words rather than on "casing", which the enclosing leaf name would put in the frame regardless.
+        assert(!ex.message.contains("only in casing"), ex.message)
+        assert(ex.message.contains("the row has execution_id, flow_id"), ex.message)
+    }
+
+    "SqlDecodeColumnNotFoundException with no row to report keeps its original message" in {
+        val ex = SqlDecodeColumnNotFoundException("id")
+        assert(ex.message.contains("Column 'id' not found in row"), ex.message)
+        assert(!ex.message.contains("the row has"), ex.message)
+    }
+
     "SqlRequestMysqlLocalInfileRequiresLoadApiException names the dedicated API" in {
         val ex = SqlRequestMysqlLocalInfileRequiresLoadApiException()
         assert(ex.getMessage.contains("LOAD DATA LOCAL INFILE"))

--- a/kyo-sql/shared/src/test/scala/kyo/SqlTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/SqlTest.scala
@@ -23,6 +23,7 @@ class SqlTest extends Test:
     case class Survey(id: Long, opinion: Maybe[Boolean]) derives SqlSchema
     case class Reading(id: Long, celsius: Maybe[Int], ratio: Double) derives SqlSchema
     case class Sale(region: String, product: Maybe[String], amount: Int) derives SqlSchema
+    case class Tally(id: Long, small: Byte, mid: Short, huge: BigInt) derives SqlSchema
 
     val people      = Sql.from[Person]("p")
     val departments = Sql.from[Department]("d")
@@ -316,6 +317,222 @@ class SqlTest extends Test:
 
         assert(!typeChecks("Sql.from[Person](\"p\").where(c => c.p.age == Absent)"))
         assert(!typeChecks("Sql.from[Person](\"p\").where(c => c.p.name != Absent)"))
+    }
+
+    // The raw-value comparison that crosses nullability goes one way only: a column permitting NULL against a plain
+    // literal. The other way round is a column that cannot be NULL against a value that may be, and no row can
+    // satisfy it in either polarity: `= NULL` is UNKNOWN for every row, `NOT UNKNOWN` is UNKNOWN too, and a WHERE
+    // keeps neither, so the query answers nothing and so does its negation. A predicate no row can satisfy either way
+    // is not a question worth asking, and it reports nothing at runtime, so it is a compile error. The `Term` forms
+    // keep the other direction, because a join between a nullable foreign key and the non-null key it references is
+    // written that way round as often as not.
+    "a raw value that may be absent is only compared against a column that may be" in {
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email == \"a@b\")"))
+        assert(typeChecks("val e: Maybe[String] = Present(\"a@b\"); Sql.from[Customer](\"c\").where(c => c.c.email == e)"))
+        assert(typeChecks(
+            "Sql.from[Person](\"p\").innerJoin(Sql.from[Customer](\"c\")).on(j => j.p.name == j.c.email)"
+        ))
+        assert(typeChecks(
+            "Sql.from[Customer](\"c\").innerJoin(Sql.from[Person](\"p\")).on(j => j.c.email == j.p.name)"
+        ))
+
+        assert(!typeChecks("val n: Maybe[String] = Present(\"x\"); Sql.from[Person](\"p\").where(c => c.p.name == n)"))
+        assert(!typeChecks("val n: Maybe[String] = Present(\"x\"); Sql.from[Person](\"p\").where(c => c.p.name != n)"))
+        assert(!typeChecks("val a: Maybe[Int] = Present(1); Sql.from[Person](\"p\").where(c => c.p.age > a)"))
+        assert(!typeChecks("val a: Maybe[Int] = Present(1); Sql.from[Person](\"p\").where(c => c.p.age <= a)"))
+    }
+
+    // Lifting a value with `Sql.literal` is the other door into the same comparison, and it used to be open: the
+    // lifted term is a `Term[Maybe[A]]`, which the column-to-column evidence admits against a NOT NULL column
+    // because comparing two COLUMNS across nullability is the ordinary join. A lifted value is not a column, so it
+    // follows the raw-value rule instead.
+    "a lifted value that may be absent is only compared against a column that may be" in {
+        // Allowed: the lifted value has the column's own type.
+        assert(typeChecks("Sql.from[Person](\"p\").where(c => c.p.age > Sql.literal(18))"))
+        assert(typeChecks("Sql.from[Person](\"p\").where(c => c.p.name == Sql.literal(\"ada\"))"))
+        // Allowed: the column permits NULL and the lifted value does not.
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email == Sql.literal(\"a@b\"))"))
+
+        // Refused: a lifted value that may be absent against a column that may not. This renders `= ?` with a NULL
+        // bind, which is the statement the raw form is refused for.
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(c => c.p.name == Sql.literal(e))"
+        ))
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(c => c.p.name != Sql.literal(e))"
+        ))
+        assert(!typeChecks(
+            "val a: Maybe[Int] = Absent; Sql.from[Person](\"p\").where(c => c.p.age >= Sql.literal(a))"
+        ))
+
+        // The join keeps working, which is what the column-to-column evidence exists for and what a blanket
+        // tightening would have broken.
+        assert(typeChecks(
+            "Sql.from[Person](\"p\").innerJoin(Sql.from[Customer](\"c\")).on(j => j.p.name == j.c.email)"
+        ))
+
+        // The control the negations above need. Lifting a `Maybe` is legal on its own and compiles against a column
+        // that permits NULL, so the refusals are about the direction of the comparison rather than about
+        // `Sql.literal` rejecting a `Maybe` outright. Without this, a missing `SqlSchema.Column[Maybe[String]]`
+        // would satisfy every negation for a reason unrelated to the property under test.
+        assert(typeChecks("val e: Maybe[String] = Absent; val t: Term[Maybe[String]] = Sql.literal(e)"))
+        assert(typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Customer](\"c\").where(c => c.c.email == Sql.literal(e))"
+        ))
+    }
+
+    // The same rule approached from the other side. `Sql.literal(e) == column` puts the lifted value on the
+    // receiver, so the ARGUMENT is a plain column rather than a `Literal` and the lifted evidence is never
+    // consulted; the column-to-column rule admits it through `SqlComparable.leftOptional`, and the statement
+    // renders `? = "name"` with a NULL bind. That is the same never-matching predicate the form above is refused
+    // for, written the other way round.
+    "a lifted value that may be absent is refused on the left of the comparison too" in {
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(c => Sql.literal(e) == c.p.name)"
+        ))
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(c => Sql.literal(e) != c.p.name)"
+        ))
+        assert(!typeChecks(
+            "val a: Maybe[Int] = Absent; Sql.from[Person](\"p\").where(c => Sql.literal(a) <= c.p.age)"
+        ))
+
+        // The control the negations need: the same shape against a column that DOES permit NULL still compiles,
+        // so the refusals are about the direction rather than about a lifted `Maybe` failing to be a term at all.
+        assert(typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Customer](\"c\").where(c => Sql.literal(e) == c.c.email)"
+        ))
+        assert(typeChecks(
+            "Sql.from[Person](\"p\").where(c => Sql.literal(\"ada\") == c.p.name)"
+        ))
+    }
+
+    // Two more doors into the same never-matching predicate, both closed by the receiver-aware evidence.
+    //
+    // Lifted against lifted is two VALUES, so the argument that keeps a nullability crossing for a column does not
+    // reach it in either order: `? = ?` with one NULL bind matches nothing exactly as `? = "col"` does.
+    "two lifted values compare only at the same type, in both orders" in {
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(_ => Sql.literal(e) == Sql.literal(\"ada\"))"
+        ))
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(_ => Sql.literal(\"ada\") == Sql.literal(e))"
+        ))
+        // Controls: equal types compare, whether or not they permit NULL.
+        assert(typeChecks("Sql.from[Person](\"p\").where(_ => Sql.literal(\"ada\") == Sql.literal(\"bob\"))"))
+        assert(typeChecks(
+            "val e: Maybe[String] = Absent; val f: Maybe[String] = Absent; Sql.from[Person](\"p\").where(_ => Sql.literal(e) == Sql.literal(f))"
+        ))
+    }
+
+    // The raw-value and pattern doors, on a lifted receiver.
+    "a lifted value that may be absent takes neither a raw comparison nor a pattern test" in {
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(_ => Sql.literal(e) == \"ada\")"
+        ))
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(_ => Sql.literal(e).like(\"a%\"))"
+        ))
+        // Controls: a lifted PRESENT value takes both, and a nullable COLUMN still takes both.
+        assert(typeChecks("Sql.from[Person](\"p\").where(_ => Sql.literal(\"ada\").like(\"a%\"))"))
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.like(\"a%\"))"))
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email == \"a@b\")"))
+    }
+
+    // The lifted spelling reached the six comparison operators but not membership or range, so a value that could
+    // be compared could not be tested for membership: the allowed direction did not compile at all. These pin both
+    // halves, so the lifted form cannot be added in one direction only.
+    // Membership and range against a LIFTED value, which the six comparison operators grew a dedicated form for and
+    // these did not. The safety property still holds here without one, because it falls out of the element type
+    // rather than out of evidence: `in` takes `Term[A]*`, and a lifted value that may be absent is a
+    // `Term[Maybe[A]]`, which is not the `Term[A]` a NOT NULL column's form accepts.
+    "membership and range refuse a lifted value that may be absent" in {
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(c => c.p.name.in(Sql.literal(e)))"
+        ))
+        assert(!typeChecks(
+            "val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(c => c.p.name.notIn(Sql.literal(e)))"
+        ))
+        assert(!typeChecks(
+            "val a: Maybe[Int] = Absent; Sql.from[Person](\"p\").where(c => c.p.age.between(Sql.literal(a), Sql.literal(a)))"
+        ))
+
+        // A lifted value of the column's own type is accepted by the `Term[A]*` form, so the lifted spelling works
+        // here without a dedicated overload.
+        assert(typeChecks("Sql.from[Person](\"p\").where(c => c.p.name.in(Sql.literal(\"ada\")))"))
+        assert(typeChecks("Sql.from[Person](\"p\").where(c => c.p.age.between(Sql.literal(1), Sql.literal(9)))"))
+
+        // Crossing nullability with a lifted value has no form: `Term[A]*` wants the column's own type, and adding a
+        // `Literal[B]*` overload beside it is ambiguous against exactly that form, which the same shape at a single
+        // argument is not. The raw form is the spelling for this case and it carries the same one-way rule.
+        assert(!typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.in(Sql.literal(\"a@b\")))"))
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.in(\"a@b\"))"))
+    }
+
+    // The rule `==` follows reached six operators of the fifteen a column has. The rest still took the column's own
+    // type exactly, so a nullable column could be compared to a plain value but not tested for membership in one,
+    // and the pattern operators were gated on `A =:= String`, which left a nullable text column without `like` at
+    // all, in either form.
+    "membership and range over raw values cross nullability the way equality does" in {
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.in(\"a@b\", \"c@d\"))"))
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.notIn(\"a@b\"))"))
+        assert(typeChecks("Sql.from[Reading](\"r\").where(c => c.r.celsius.between(0, 100))"))
+
+        // The column's own type still works, which is the overload that was already there.
+        assert(typeChecks("Sql.from[Person](\"p\").where(c => c.p.age.in(1, 2))"))
+        assert(typeChecks("Sql.from[Person](\"p\").where(c => c.p.age.between(0, 100))"))
+
+        // And the direction that renders a comparison against NULL is still refused.
+        assert(!typeChecks("val e: Maybe[String] = Absent; Sql.from[Person](\"p\").where(c => c.p.name.in(e))"))
+        assert(!typeChecks("val a: Maybe[Int] = Absent; Sql.from[Person](\"p\").where(c => c.p.age.between(a, a))"))
+    }
+
+    // The `SqlNumeric` and `SqlIntegral` givens added for Short, Byte and BigInt shipped with only Short
+    // exercised. These pin the result types the servers actually return, in both directions: the type that is
+    // right typechecks, and the operand's own type does not, so a given typed as its operand cannot satisfy them.
+    "sum over a Byte column widens to Long, as it does over Short and Int" in {
+        assert(typeChecks("""val q: Query[Maybe[Long]] = Sql.from[Tally]("t").sum(_.t.small)"""))
+        assert(!typeChecks("""val q: Query[Maybe[Byte]] = Sql.from[Tally]("t").sum(_.t.small)"""))
+        assert(!typeChecks("""val q: Query[Maybe[Int]] = Sql.from[Tally]("t").sum(_.t.small)"""))
+    }
+
+    "sum over a BigInt column widens to BigDecimal, which is what an exact aggregate returns" in {
+        assert(typeChecks("""val q: Query[Maybe[BigDecimal]] = Sql.from[Tally]("t").sum(_.t.huge)"""))
+        assert(!typeChecks("""val q: Query[Maybe[BigInt]] = Sql.from[Tally]("t").sum(_.t.huge)"""))
+    }
+
+    "avg over Byte and BigInt is BigDecimal, as over any exact operand" in {
+        assert(typeChecks("""val q: Query[Maybe[BigDecimal]] = Sql.from[Tally]("t").avg(_.t.small)"""))
+        assert(typeChecks("""val q: Query[Maybe[BigDecimal]] = Sql.from[Tally]("t").avg(_.t.huge)"""))
+        assert(!typeChecks("""val q: Query[Maybe[Double]] = Sql.from[Tally]("t").avg(_.t.small)"""))
+    }
+
+    "division over an integral column answers BigDecimal, which is what the truncation-avoiding cast returns" in {
+        // The one with non-obvious behavior: an integral `/` renders a cast so the server does not truncate, so
+        // the result is not the operand's type. Pinned for each integral width the givens now cover.
+        assert(typeChecks("""val q: Select[?, BigDecimal, ?] = Sql.from[Tally]("t").select(r => r.t.small / 2.toByte)"""))
+        assert(typeChecks("""val q: Select[?, BigDecimal, ?] = Sql.from[Tally]("t").select(r => r.t.mid / 2.toShort)"""))
+        assert(!typeChecks("""val q: Select[?, Byte, ?] = Sql.from[Tally]("t").select(r => r.t.small / 2.toByte)"""))
+        assert(!typeChecks("""val q: Select[?, Short, ?] = Sql.from[Tally]("t").select(r => r.t.mid / 2.toShort)"""))
+    }
+
+    "a text column that permits NULL has the pattern operators" in {
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.like(\"a%\"))"))
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.ilike(\"A%\"))"))
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.notLike(\"a%\"))"))
+        assert(typeChecks("Sql.from[Customer](\"c\").where(c => c.c.email.notIlike(\"A%\"))"))
+
+        // The non-null column keeps them.
+        assert(typeChecks("Sql.from[Person](\"p\").where(c => c.p.name.like(\"a%\"))"))
+
+        // A column that holds neither String nor Maybe[String] still has none of them, which is what says the
+        // evidence widened the text case rather than admitting anything.
+        assert(!typeChecks("Sql.from[Person](\"p\").where(c => c.p.age.like(\"a%\"))"))
+        assert(!typeChecks("Sql.from[Reading](\"r\").where(c => c.r.celsius.like(\"a%\"))"))
+
+        // The operators that RETURN text keep the stricter gate, since a nullable operand's result is nullable and
+        // this substitution would lose that.
+        assert(!typeChecks("Sql.from[Customer](\"c\").select(c => c.c.email.upper)"))
     }
 
     // `Sql.default` is the `DEFAULT` keyword, which every server accepts in an assignment and nowhere else. It is

--- a/kyo-sql/shared/src/test/scala/kyo/db/IdiomTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/db/IdiomTest.scala
@@ -808,14 +808,16 @@ class IdiomTest extends Test:
         assert(withIt.substring(withIt.indexOf("RETURNING")).contains(q("id")))
         assert(!sqlText(stub, ins).contains("RETURNING"))
         // When the caller names columns, the clause carries those and not the auto-key.
-        val explicit = sqlText(returningIdiom, ins.returning(_.name))
+        val explicit = sqlText(returningIdiom, ins.returning(_.name).statement)
         val tail     = explicit.substring(explicit.indexOf("RETURNING"))
         assert(tail.contains(q("name")))
         assert(!tail.contains(q("id")))
     }
 
     "an explicit returning request fails typed where the flavor lacks the clause" in {
-        val upd = Sql.update[Person].set(_.name := "x").returning(_.id).build
+        // `.statement` because a returning write is typed by what it answers: the wrapper carries the row type and
+        // the statement it renders is the ordinary UPDATE inside it.
+        val upd = Sql.update[Person].set(_.name := "x").returning(_.id).build.statement
         val ex  = intercept[SqlUnsupportedDialectFeatureException](rendered(stub, upd))
         // Not version-gated: the flavor either has RETURNING or never had it, so no floor is named.
         assert(ex.requiredVersion.isEmpty)

--- a/kyo-sql/shared/src/test/scala/kyo/internal/SqlConnectionCancelTest.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/SqlConnectionCancelTest.scala
@@ -279,11 +279,51 @@ class SqlConnectionCancelTest extends kyo.Test:
             }
         }
 
-    /** Reads exactly `n` reported events, in order. */
+    /** How long [[report]] waits for the events it was told to expect before it reports a shortfall instead.
+      *
+      * Far longer than the reclaim chain takes (the whole suite runs in a third of a second), so it never trips on a slow machine. Its
+      * only job is to be shorter than the suite's own limit, so a shortfall arrives as this file's assertion rather than as that.
+      */
+    private val reportLimit = 30.seconds
+
+    /** Reads exactly `n` reported events, in order, or says how few arrived.
+      *
+      * The bound is the point. `Channel.take` waits forever, so a leaf expecting one event more than the reclaim actually reports used to
+      * hang until the suite's own limit expired, and the failure read as an unattributed two-minute timeout naming neither the leaf's
+      * assertion nor the missing event. That is exactly the shape a regression here takes: a reclaim that pools instead of destroying
+      * reports one event fewer. [[drained]] below already solved it for the leaves whose regression IS a missing event; this closes the
+      * same hole for the leaves that run on the real clock, including the case where an event is merely very late because the machine is
+      * saturated.
+      *
+      * NOT for the two leaves that run under `Clock.withTimeControl`. There the bound is registered on the virtual clock, which only moves
+      * when a leaf advances it, and neither advances anywhere near this far, so the timeout never fires and those two still hang to the
+      * suite's own limit. Bounding them would mean advancing the virtual clock from inside this helper, which would fire the timers the
+      * leaf is controlling.
+      *
+      * The events taken so far are accumulated as they arrive rather than collected at the end, so the shortfall message can name what DID
+      * arrive, which is what says whether the reclaim stopped early or never started.
+      */
     private def report(events: Channel[String], n: Int)(using Frame): Chunk[String] < (Async & Abort[SqlException]) =
-        Abort.run[Closed](Kyo.foreach(Chunk.from(0 until n))(_ => events.take)).flatMap {
-            case Result.Success(seen) => seen
-            case other                => Abort.panic(new AssertionError(s"probe event channel closed early: $other"))
+        AtomicRef.init(Chunk.empty[String]).flatMap { seenRef =>
+            val takeAll =
+                Loop(0) { taken =>
+                    if taken == n then Loop.done(())
+                    else
+                        Abort.run[Closed](events.take).flatMap {
+                            case Result.Success(event) => seenRef.getAndUpdate(_ :+ event).andThen(Loop.continue(taken + 1))
+                            case other                 => Abort.panic(new AssertionError(s"probe event channel closed early: $other"))
+                        }
+                }
+            Abort.run[Timeout](Async.timeout(reportLimit)(takeAll)).flatMap { outcome =>
+                seenRef.get.map { seen =>
+                    outcome match
+                        case Result.Success(_) => seen
+                        case _ =>
+                            Abort.panic(new AssertionError(
+                                s"expected $n reclaim events within ${reportLimit.show}, saw ${seen.size}: $seen"
+                            ))
+                }
+            }
         }
 
     /** Every event reported so far, without waiting for one that may never arrive.


### PR DESCRIPTION
### Problem

A read that cannot detect a mismatch on its own answered a plausible wrong value instead of failing. An `Int` read from a `date` column returned `9733`, the day count since the PostgreSQL epoch, since both are four big-endian bytes; a `money` column answered `0E-100` for $1.00, its cents parsed as a numeric header. Neither raised.

The DSL had the same shape: `Sql.literal(absent) == column` compiled and rendered `? = "col"` with a NULL bind, a predicate no row satisfies and neither does its negation.

`SqlRow.text` promised one string per stored value under either wire protocol and did not keep it, spelling a float by the platform's `toString`, so a `float4` holding `12345.6` read back `12345.599609375` on Scala.js.

### Solution

Three moves. The column's reported type now decides how its bytes are read, so a decoder that would misread one refuses, with the numeric family kept permissive where widening is genuine (an `int8` into an `Int`, a text column's digits). A rendering is computed from the decoded value rather than from a JDK `toString`, which is also what makes it identical on every platform. A lifted value follows its nullability rule on either side of a comparison, enforced by making the evidence receiver-aware rather than by adding an overload, which collided with the existing raw form.

### Notes

The float digits are the shortest that round-trip. For a few values landing on an exact representable midpoint, PostgreSQL writes different ones under its default `extra_float_digits`, which it never reports to the connection, so no computed rendering agrees with every session.

Membership and range have no lifted form for a nullability crossing: a `Literal[B]*` overload is ambiguous against the existing `Term[A]*`, which the same shape at a single argument is not. The raw form covers it under the same rule.

The connection-pool counter reordering carries no regression test; the property is an interleaving and `Metrics` has no injection seam.
