### PR TITLE
[kyo-schema] recursive transform propagation, Protobuf collection handling, and a differential oracle (#1887, #1747)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -862,8 +862,8 @@ lazy val `kyo-schema-tests` =
             doctestSources := Seq((ThisBuild / baseDirectory).value / "kyo-schema" / "README.md"),
             // Differential-oracle deps (ProtobufDifferentialTest): protobuf-java is the wire
             // oracle, Proteus the code-first schema-mapping oracle. JVM test scope only.
-            libraryDependencies += "com.google.protobuf"   % "protobuf-java" % "4.35.0" % Test,
-            libraryDependencies += "com.github.ghostdogpr" %% "proteus-core" % "0.6.0"  % Test
+            libraryDependencies += "com.google.protobuf"    % "protobuf-java" % "4.35.0" % Test,
+            libraryDependencies += "com.github.ghostdogpr" %% "proteus-core"  % "0.6.0"  % Test
         ))
         .nativeSettings(`native-settings`)
         .jsSettings(`js-settings`, Test / scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))

--- a/build.sbt
+++ b/build.sbt
@@ -859,7 +859,11 @@ lazy val `kyo-schema-tests` =
         // The shared kyo-schema README exercises every format; only this project's Test
         // classpath sees the core plus all six format modules, so it hosts the validation.
         .jvmConfigure(_.settings(
-            doctestSources := Seq((ThisBuild / baseDirectory).value / "kyo-schema" / "README.md")
+            doctestSources := Seq((ThisBuild / baseDirectory).value / "kyo-schema" / "README.md"),
+            // Differential-oracle deps (ProtobufDifferentialTest): protobuf-java is the wire
+            // oracle, Proteus the code-first schema-mapping oracle. JVM test scope only.
+            libraryDependencies += "com.google.protobuf"   % "protobuf-java" % "4.35.0" % Test,
+            libraryDependencies += "com.github.ghostdogpr" %% "proteus-core" % "0.6.0"  % Test
         ))
         .nativeSettings(`native-settings`)
         .jsSettings(`js-settings`, Test / scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))

--- a/kyo-schema-json/shared/src/test/scala/externalschema/SchemaRecursiveTransformTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/externalschema/SchemaRecursiveTransformTest.scala
@@ -1,0 +1,81 @@
+package externalschema
+
+import kyo.*
+
+// Regression fixtures for issue #1887: configuration applied through the fluent
+// API (discriminator, variant renames, field renames) must reach recursive
+// occurrences of the type. The givens are TOP-LEVEL and declared AFTER the
+// containers on purpose: with an object-scoped given the derivation macro ties
+// recursive references to the configured given, but a top-level given is not
+// found by the self-summon inside its own right-hand side, so nested
+// occurrences silently bound to an unconfigured derived schema.
+
+sealed trait RTNode
+case class RTParent(ref: String, children: Seq[RTNode]) extends RTNode
+case class RTChild(ref: String)                         extends RTNode
+
+final case class RTContainer(items: Seq[RTNode]) derives Schema
+
+given Schema[RTNode] = Schema[RTNode]
+    .discriminator("type")
+    .renameAllVariants(Schema.NameCase.KebabCase)
+
+enum RTTree:
+    case Branch(label: String, limbs: Seq[RTTree])
+    case Leaf(label: String)
+
+given Schema[RTTree] = Schema[RTTree]
+    .discriminator("kind")
+    .renameAllVariants(Schema.NameCase.KebabCase)
+
+final case class RTDoc(fullName: String, parts: Seq[RTDoc])
+
+given Schema[RTDoc] = Schema[RTDoc].renameAllFields(Schema.NameCase.SnakeCase)
+
+class SchemaRecursiveTransformTest extends kyo.test.Test[Any]:
+
+    given CanEqual[Any, Any] = CanEqual.derived
+
+    "sealed trait, top-level given" - {
+        "encode uses the discriminator at every depth" in {
+            val json = Json.encode(RTContainer(Seq(RTParent("p1", Seq(RTChild("c1"))))))
+            assert(json == """{"items":[{"type":"rt-parent","ref":"p1","children":[{"type":"rt-child","ref":"c1"}]}]}""")
+        }
+        "decode reads the discriminator at every depth" in {
+            val json   = """{"items":[{"type":"rt-parent","ref":"p1","children":[{"type":"rt-child","ref":"c1"}]}]}"""
+            val result = Json.decode[RTContainer](json, 32, Int.MaxValue)
+            assert(result == Result.succeed(RTContainer(Seq(RTParent("p1", Seq(RTChild("c1")))))))
+        }
+        "decode ignores extra fields in nested variants" in {
+            val json   = """{"items":[{"type":"rt-parent","ref":"p1","children":[{"extra":"val","type":"rt-child","ref":"c1"}]}]}"""
+            val result = Json.decode[RTContainer](json, 32, Int.MaxValue)
+            assert(result == Result.succeed(RTContainer(Seq(RTParent("p1", Seq(RTChild("c1")))))))
+        }
+        "round-trip at depth three" in {
+            val value = RTContainer(Seq(RTParent("p1", Seq(RTChild("c1"), RTParent("p2", Seq(RTChild("c2")))))))
+            assert(Json.decode[RTContainer](Json.encode(value)) == Result.succeed(value))
+        }
+    }
+
+    "enum, top-level given" - {
+        "encode uses the discriminator at every depth" in {
+            val json = Json.encode(RTTree.Branch("a", Seq(RTTree.Leaf("b"))): RTTree)
+            assert(json == """{"kind":"branch","label":"a","limbs":[{"kind":"leaf","label":"b"}]}""")
+        }
+        "round-trip" in {
+            val value: RTTree = RTTree.Branch("a", Seq(RTTree.Leaf("b"), RTTree.Branch("c", Seq.empty)))
+            assert(Json.decode[RTTree](Json.encode(value)) == Result.succeed(value))
+        }
+    }
+
+    "recursive product with renameAllFields, top-level given" - {
+        "encode renames fields at every depth" in {
+            val json = Json.encode(RTDoc("root", Seq(RTDoc("kid", Seq.empty))))
+            assert(json == """{"full_name":"root","parts":[{"full_name":"kid","parts":[]}]}""")
+        }
+        "round-trip" in {
+            val value = RTDoc("root", Seq(RTDoc("kid", Seq.empty)))
+            assert(Json.decode[RTDoc](Json.encode(value)) == Result.succeed(value))
+        }
+    }
+end SchemaRecursiveTransformTest

--- a/kyo-schema-protobuf/shared/src/main/scala/kyo/Protobuf.scala
+++ b/kyo-schema-protobuf/shared/src/main/scala/kyo/Protobuf.scala
@@ -110,11 +110,15 @@ object Protobuf:
             case _ => false
     end isProto3MapKey
 
-    /** Walks a schema structure under [[Conformance.Strict]] and rejects any shape proto3 cannot
-      * encode canonically. The only non-canonical shape this codec can produce is a map whose key is
-      * not a proto3-native scalar (the entry-message key form), so that is the entire rejection set.
-      * Product / Sum recursion is cycle-guarded by name; every container is reached so a map nested
-      * anywhere is validated.
+    /** Walks a schema structure under [[Conformance.Strict]] and rejects any shape this codec
+      * cannot round-trip. The rejection set is measured, not assumed: the only losing shape is a
+      * map whose key is not a proto3-native scalar (the entry-message key form). Shapes proto3
+      * cannot DECLARE but this codec round-trips losslessly are accepted: an empty repeated or
+      * empty map value decodes back from its key-only entry via the value schema's absent
+      * default, and a nested repeated is one length-delimited record per inner collection (a
+      * non-canonical extension; [[protoSchema]] still rejects it in `.proto` text generation,
+      * where the shape genuinely has no declaration). Product / Sum recursion is cycle-guarded by
+      * name; every container is reached so a map nested anywhere is validated.
       */
     private def validateCanonical(structure: Structure.Type)(using Frame): Unit =
         // Explicit work-stack loop (tail-recursive): a Structure walk has multiple children per node

--- a/kyo-schema-protobuf/shared/src/main/scala/kyo/internal/ProtobufReader.scala
+++ b/kyo-schema-protobuf/shared/src/main/scala/kyo/internal/ProtobufReader.scala
@@ -183,43 +183,51 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
 
     def hasNextElement(): Boolean =
         repeatedFrames match
+            case Nil => hasNextField()
             case frame :: _ =>
-                if frame.bare then
-                    if pos < frame.bareLimit then
-                        // Bare elements: length-prefixed blobs (messages, strings, deeper
-                        // collections) consume their own length, which is what LengthDelimited
-                        // signals; bare scalars never consult the wire type.
-                        currentWireType = LengthDelimited
-                        true
-                    else false
-                else
-                    if frame.packed && pos >= frame.packedLimit then
-                        frame.packed = false // packed run exhausted; a mixed producer may continue
-                    hasNextElementUnpacked(frame)
-            case Nil =>
-                hasNextField()
+                if frame.packed && pos >= frame.packedLimit then
+                    frame.packed = false // packed run exhausted; a mixed producer may continue
+                if frame.bare then nextBareElement(frame)
+                else if frame.packed then true // still inside the current packed run, no tag to peek
+                else if frame.firstPending then firstElement(frame)
+                else peekNextElementTag(frame)
+                end if
     end hasNextElement
 
-    private def hasNextElementUnpacked(frame: RepeatedFrame): Boolean =
-        if frame.packed then
-            true // still inside the current packed run, no tag to peek
-        else if frame.firstPending then
-            frame.firstPending = false
-            if frame.fieldNumber == 0 && limits.size == 1 then
-                // Top-level collection: no enclosing field consumed the first tag; read it
-                // now to learn the real field number (empty input is an empty collection).
-                if pos >= limits.head then false
-                else
-                    val tag = readVarint().toInt
-                    frame.fieldNumber = tag >>> 3
-                    currentFieldNumber = tag >>> 3
-                    currentWireType = tag & 0x7
-                    true
-            else true
-            end if
+    /** Bare elements of a nested-collection record are bounded by the record limit, with no tags
+      * to peek. Length-prefixed blobs (messages, strings, deeper collections) consume their own
+      * length, which is what LengthDelimited signals; bare scalars never consult the wire type.
+      */
+    private def nextBareElement(frame: RepeatedFrame): Boolean =
+        val more = pos < frame.bareLimit
+        if more then currentWireType = LengthDelimited
+        more
+    end nextBareElement
+
+    /** First hasNextElement of a frame. The enclosing field() consumed the first element's tag,
+      * except at top level, where no enclosing field exists: consume the tag now to learn the
+      * real field number. Empty input is an empty collection.
+      */
+    private def firstElement(frame: RepeatedFrame): Boolean =
+        frame.firstPending = false
+        val topLevel = frame.fieldNumber == 0 && limits.size == 1
+        if !topLevel then true
         else if pos >= limits.head then false
         else
-            // Peek the next tag: another element only if it repeats this field's number.
+            val tag = readVarint().toInt
+            frame.fieldNumber = tag >>> 3
+            currentFieldNumber = tag >>> 3
+            currentWireType = tag & 0x7
+            true
+        end if
+    end firstElement
+
+    /** Peek the next tag: another element only if it repeats this field's number; any other tag
+      * is un-read and left for the enclosing message loop.
+      */
+    private def peekNextElementTag(frame: RepeatedFrame): Boolean =
+        if pos >= limits.head then false
+        else
             val start = pos
             val tag   = readVarint().toInt
             if (tag >>> 3) == frame.fieldNumber then
@@ -227,10 +235,10 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
                 currentWireType = tag & 0x7
                 true
             else
-                pos = start // un-read; the tag belongs to the enclosing message loop
+                pos = start
                 false
             end if
-    end hasNextElementUnpacked
+    end peekNextElementTag
 
     // Establishes (or continues) a packed scalar run for the current repeated frame. Returns true
     // when the current element is a bare packed value. On first call of a packed run, consumes the
@@ -421,6 +429,7 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
 
     def hasNextEntry(): Boolean =
         mapFrames match
+            case Nil => hasNextField()
             case f :: _ =>
                 if f.entryLimitPushed then
                     // Finished the previous entry: drop its limit and return to the map level.
@@ -428,44 +437,53 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
                     limits = limits.tail
                     f.entryLimitPushed = false
                 end if
-                val more =
-                    if f.firstPending then
-                        f.firstPending = false
-                        if f.fieldNumber == 0 && limits.size == 1 then
-                            // Top-level map: no enclosing field consumed the first entry's tag;
-                            // read it now (empty input is an empty map).
-                            if pos >= limits.head then false
-                            else
-                                val tag = readVarint().toInt
-                                f.fieldNumber = tag >>> 3
-                                currentWireType = tag & 0x7
-                                true
-                        else true
-                        end if
-                    else if pos >= limits.head then false
-                    else
-                        val start = pos
-                        val tag   = readVarint().toInt
-                        if (tag >>> 3) == f.fieldNumber then
-                            currentWireType = tag & 0x7
-                            true
-                        else
-                            pos = start // un-read; the tag belongs to the enclosing message loop
-                            false
-                        end if
-                if more then
-                    // Enter the MapEntry message: consume its length prefix and push a limit.
-                    val len = readVarint().toInt
-                    if len < 0 || pos + len > data.length then
-                        throw TruncatedInputException(Protobuf(), s"map entry length $len exceeds remaining data")
-                    limits = (pos + len) :: limits
-                    f.entryLimitPushed = true
-                    true
-                else false
-                end if
-            case Nil =>
-                hasNextField()
+                val more = if f.firstPending then firstEntry(f) else peekNextEntryTag(f)
+                if more then enterMapEntry(f)
+                more
     end hasNextEntry
+
+    /** First hasNextEntry of a frame. The enclosing field() consumed the first entry's tag,
+      * except at top level, where no enclosing field exists: consume the tag now to learn the
+      * real field number. Empty input is an empty map.
+      */
+    private def firstEntry(f: MapFrame): Boolean =
+        f.firstPending = false
+        val topLevel = f.fieldNumber == 0 && limits.size == 1
+        if !topLevel then true
+        else if pos >= limits.head then false
+        else
+            val tag = readVarint().toInt
+            f.fieldNumber = tag >>> 3
+            currentWireType = tag & 0x7
+            true
+        end if
+    end firstEntry
+
+    /** Peek the next tag: another entry only if it repeats the map's field number; any other tag
+      * is un-read and left for the enclosing message loop.
+      */
+    private def peekNextEntryTag(f: MapFrame): Boolean =
+        if pos >= limits.head then false
+        else
+            val start = pos
+            val tag   = readVarint().toInt
+            if (tag >>> 3) == f.fieldNumber then
+                currentWireType = tag & 0x7
+                true
+            else
+                pos = start
+                false
+            end if
+    end peekNextEntryTag
+
+    /** Enter the MapEntry message: consume its length prefix and push a limit. */
+    private def enterMapEntry(f: MapFrame): Unit =
+        val len = readVarint().toInt
+        if len < 0 || pos + len > data.length then
+            throw TruncatedInputException(Protobuf(), s"map entry length $len exceeds remaining data")
+        limits = (pos + len) :: limits
+        f.entryLimitPushed = true
+    end enterMapEntry
 
     def bytes(): Span[Byte] =
         val len = readVarint().toInt

--- a/kyo-schema-protobuf/shared/src/main/scala/kyo/internal/ProtobufReader.scala
+++ b/kyo-schema-protobuf/shared/src/main/scala/kyo/internal/ProtobufReader.scala
@@ -46,7 +46,23 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     // consumed entry tag is wire type 2 (LengthDelimited) reads the length once, sets packedLimit,
     // flips packed=true, then reads bare values until packedLimit. A mixed producer (some packed,
     // some unpacked under the same field) is handled by resetting packed when the run is exhausted.
-    final private class RepeatedFrame(val fieldNumber: Int, var firstPending: Boolean, var packed: Boolean, var packedLimit: Int)
+    // bare/bareLimit describe a NESTED collection (a collection directly inside another
+    // collection), which the writer emits as one length-delimited record of bare elements:
+    // scalars as raw varint/fixed bytes, strings/bytes/messages/deeper collections as
+    // length-prefixed blobs with no tag. limitDepth records limits.size at frame creation; a
+    // second arrayStart at the same depth (no message boundary in between) is by construction a
+    // nested collection. fieldNumber is a var because a TOP-LEVEL collection's first tag is
+    // consumed by hasNextElement (nothing enclosing consumed it), which is when the real field
+    // number becomes known.
+    final private class RepeatedFrame(
+        var fieldNumber: Int,
+        var firstPending: Boolean,
+        var packed: Boolean,
+        var packedLimit: Int,
+        val bare: Boolean,
+        val bareLimit: Int,
+        val limitDepth: Int
+    )
     private var repeatedFrames: List[RepeatedFrame] = Nil
 
     // Per-map decode frame. A map is a repeated MapEntry message under the map field number
@@ -56,8 +72,15 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     // value tag. field() is a map-key read only when an entry limit is pushed and we are at
     // the entry level (baseLimitDepth + 1); a field() nested inside an entry value is ordinary.
     // Frames stack for a map-valued map.
-    final private class MapFrame(val fieldNumber: Int, val baseLimitDepth: Int, var firstPending: Boolean, var entryLimitPushed: Boolean)
+    // fieldNumber is a var for the same reason RepeatedFrame's is: a TOP-LEVEL map's first entry
+    // tag is consumed by hasNextEntry, which is when the real field number becomes known.
+    final private class MapFrame(var fieldNumber: Int, val baseLimitDepth: Int, var firstPending: Boolean, var entryLimitPushed: Boolean)
     private var mapFrames: List[MapFrame] = Nil
+
+    // Set by the map-entry arm of field() when the entry ends after its key: proto3 encodes an
+    // empty or default entry value as a key-only entry. The next value read consumes the flag and
+    // presents the absent form (isNil for Maybe/Option, an empty frame for collections and maps).
+    private var absentEntryValue: Boolean = false
 
     /** Set field name mapping for the current message level. */
     def withFieldNames(names: Map[Int, String]): this.type =
@@ -110,13 +133,20 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
         mapFrames match
             case f :: _ if f.entryLimitPushed && limits.size == f.baseLimitDepth + 1 =>
                 // Map entry: read the key at field 1, then advance past the value's field-2 tag
-                // so the following value read sees the right wire type. Returns the decoded key.
+                // so the following value read sees the right wire type. A key-only entry (proto3's
+                // encoding of an empty or default value) sets absentEntryValue instead. Returns
+                // the decoded key.
                 val keyTag = readVarint().toInt
                 currentWireType = keyTag & 0x7
-                val key    = string()
-                val valTag = readVarint().toInt
-                currentFieldNumber = valTag >>> 3
-                currentWireType = valTag & 0x7
+                val key = string()
+                if pos < limits.head then
+                    val valTag = readVarint().toInt
+                    currentFieldNumber = valTag >>> 3
+                    currentWireType = valTag & 0x7
+                    absentEntryValue = false
+                else
+                    absentEntryValue = true
+                end if
                 pendingTag = false
                 key
             case _ =>
@@ -154,30 +184,53 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     def hasNextElement(): Boolean =
         repeatedFrames match
             case frame :: _ =>
-                if frame.packed && pos >= frame.packedLimit then
-                    frame.packed = false // packed run exhausted; a mixed producer may continue
-                if frame.packed then
-                    true // still inside the current packed run, no tag to peek
-                else if frame.firstPending then
-                    frame.firstPending = false
-                    true
-                else if pos >= limits.head then false
-                else
-                    // Peek the next tag: another element only if it repeats this field's number.
-                    val start = pos
-                    val tag   = readVarint().toInt
-                    if (tag >>> 3) == frame.fieldNumber then
-                        currentFieldNumber = tag >>> 3
-                        currentWireType = tag & 0x7
+                if frame.bare then
+                    if pos < frame.bareLimit then
+                        // Bare elements: length-prefixed blobs (messages, strings, deeper
+                        // collections) consume their own length, which is what LengthDelimited
+                        // signals; bare scalars never consult the wire type.
+                        currentWireType = LengthDelimited
                         true
-                    else
-                        pos = start // un-read; the tag belongs to the enclosing message loop
-                        false
-                    end if
-                end if
+                    else false
+                else
+                    if frame.packed && pos >= frame.packedLimit then
+                        frame.packed = false // packed run exhausted; a mixed producer may continue
+                    hasNextElementUnpacked(frame)
             case Nil =>
                 hasNextField()
     end hasNextElement
+
+    private def hasNextElementUnpacked(frame: RepeatedFrame): Boolean =
+        if frame.packed then
+            true // still inside the current packed run, no tag to peek
+        else if frame.firstPending then
+            frame.firstPending = false
+            if frame.fieldNumber == 0 && limits.size == 1 then
+                // Top-level collection: no enclosing field consumed the first tag; read it
+                // now to learn the real field number (empty input is an empty collection).
+                if pos >= limits.head then false
+                else
+                    val tag = readVarint().toInt
+                    frame.fieldNumber = tag >>> 3
+                    currentFieldNumber = tag >>> 3
+                    currentWireType = tag & 0x7
+                    true
+            else true
+            end if
+        else if pos >= limits.head then false
+        else
+            // Peek the next tag: another element only if it repeats this field's number.
+            val start = pos
+            val tag   = readVarint().toInt
+            if (tag >>> 3) == frame.fieldNumber then
+                currentFieldNumber = tag >>> 3
+                currentWireType = tag & 0x7
+                true
+            else
+                pos = start // un-read; the tag belongs to the enclosing message loop
+                false
+            end if
+    end hasNextElementUnpacked
 
     // Establishes (or continues) a packed scalar run for the current repeated frame. Returns true
     // when the current element is a bare packed value. On first call of a packed run, consumes the
@@ -185,7 +238,11 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     private def packedScalar(): Boolean =
         repeatedFrames match
             case frame :: _ =>
-                if frame.packed then true
+                if frame.bare then
+                    // Bare scalars inside a nested-collection record: raw values until the record
+                    // limit, no per-run length to consume.
+                    true
+                else if frame.packed then true
                 else if currentWireType == LengthDelimited then
                     val len = readVarint().toInt
                     if len < 0 || pos + len > data.length then
@@ -260,7 +317,13 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
         v.toChar
     end char
 
-    def isNil(): Boolean = false // protobuf has no null
+    def isNil(): Boolean =
+        // Protobuf has no null; the one absent form is a key-only map entry, which Maybe/Option
+        // value schemas probe through this method.
+        if absentEntryValue then
+            absentEntryValue = false
+            true
+        else false
 
     def skip(): Unit =
         currentWireType match
@@ -296,23 +359,49 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
 
     def arrayStart(): Int =
         checkDepth()
-        // The enclosing field() consumed the first element's tag; start the frame with it pending.
-        repeatedFrames = new RepeatedFrame(currentFieldNumber, true, false, 0) :: repeatedFrames
+        if absentEntryValue then
+            // The map entry carried no value bytes: present an empty collection.
+            absentEntryValue = false
+            repeatedFrames = new RepeatedFrame(currentFieldNumber, false, false, 0, false, 0, limits.size) :: repeatedFrames
+        else
+            val nested = repeatedFrames match
+                case head :: _ => head.limitDepth == limits.size
+                case Nil       => false
+            if nested then
+                // Nested collection: consume the record's length prefix; elements are bare and
+                // bounded by the record limit, no tags to peek.
+                val len = readVarint().toInt
+                if len < 0 || pos + len > data.length then
+                    throw TruncatedInputException(Protobuf(), s"nested collection record length $len exceeds remaining data")
+                repeatedFrames = new RepeatedFrame(currentFieldNumber, false, false, 0, true, pos + len, limits.size) :: repeatedFrames
+            else
+                // The enclosing field() consumed the first element's tag; start the frame with it
+                // pending.
+                repeatedFrames = new RepeatedFrame(currentFieldNumber, true, false, 0, false, 0, limits.size) :: repeatedFrames
+            end if
+        end if
         -1
     end arrayStart
 
     def arrayEnd(): Unit =
         decrementDepth()
         repeatedFrames match
-            case _ :: rest => repeatedFrames = rest
-            case Nil       => ()
+            case frame :: rest =>
+                if frame.bare then pos = frame.bareLimit // skip any unread bytes in the record
+                repeatedFrames = rest
+            case Nil => ()
+        end match
     end arrayEnd
 
     def mapStart(): Int =
         checkDepth()
         // The enclosing field() consumed the first entry's MapEntry tag (currentWireType == LD);
-        // entries are read by hasNextEntry() / field(). No wrapper message, so no limit is pushed here.
-        mapFrames = new MapFrame(currentFieldNumber, limits.size, true, false) :: mapFrames
+        // entries are read by hasNextEntry() / field(). No wrapper message, so no limit is pushed
+        // here. An absent map value (key-only entry) presents as an empty map: no first entry
+        // pending.
+        val first = !absentEntryValue
+        absentEntryValue = false
+        mapFrames = new MapFrame(currentFieldNumber, limits.size, first, false) :: mapFrames
         -1
     end mapStart
 
@@ -342,7 +431,17 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
                 val more =
                     if f.firstPending then
                         f.firstPending = false
-                        true
+                        if f.fieldNumber == 0 && limits.size == 1 then
+                            // Top-level map: no enclosing field consumed the first entry's tag;
+                            // read it now (empty input is an empty map).
+                            if pos >= limits.head then false
+                            else
+                                val tag = readVarint().toInt
+                                f.fieldNumber = tag >>> 3
+                                currentWireType = tag & 0x7
+                                true
+                        else true
+                        end if
                     else if pos >= limits.head then false
                     else
                         val start = pos

--- a/kyo-schema-protobuf/shared/src/main/scala/kyo/internal/ProtobufWriter.scala
+++ b/kyo-schema-protobuf/shared/src/main/scala/kyo/internal/ProtobufWriter.scala
@@ -37,11 +37,19 @@ final class ProtobufWriter extends Writer:
     private var repeatedFieldNumber: Int    = 0
     private var inArray: Boolean            = false
 
-    // Saved (inArray, repeatedFieldNumber) pairs. A nested objectStart and a nested
-    // arrayStart each push the current array state and the matching objectEnd / arrayEnd
+    // Saved (inArray, repeatedFieldNumber, inBareRecord) triples. A nested objectStart and a
+    // nested arrayStart each push the current array state and the matching objectEnd / arrayEnd
     // restores it, so a repeated message's own fields are written under their own field
     // numbers (not the enclosing list's) and nested arrays restore the outer array context.
-    private var arrayStateStack: List[(Boolean, Int)] = Nil
+    private var arrayStateStack: List[(Boolean, Int, Boolean)] = Nil
+
+    // True while writing the elements of a NESTED collection (a collection directly inside
+    // another collection). Such a collection is one length-delimited record under the enclosing
+    // repeated field number, and its elements are written bare into the record buffer: scalars as
+    // raw varint/fixed bytes, strings/bytes/messages/deeper collections as length-prefixed blobs
+    // with no tag. This is what preserves inner-collection boundaries (including empty inner
+    // collections) that proto3's flat repeated encoding cannot express.
+    private var inBareRecord: Boolean = false
 
     // Per-array packed accumulator for repeated SCALAR fields. arrayStart pushes a fresh buffer,
     // each scalar element appends its raw value bytes (no per-element tag), and arrayEnd flushes
@@ -86,13 +94,21 @@ final class ProtobufWriter extends Writer:
     private def current: java.io.ByteArrayOutputStream = bufferStack.head
 
     def objectStart(name: String, size: Int): Unit =
-        if currentFieldNumber > 0 then
+        if inBareRecord then
+            // Bare element message inside a nested-collection record: emitted length-prefixed with
+            // no tag. The -1 sentinel on fieldNumberStack tells objectEnd to skip the tag.
+            fieldNumberStack = -1 :: fieldNumberStack
+            arrayStateStack = (inArray, repeatedFieldNumber, inBareRecord) :: arrayStateStack
+            inArray = false
+            inBareRecord = false
+            bufferStack = new java.io.ByteArrayOutputStream(128) :: bufferStack
+        else if currentFieldNumber > 0 then
             // Nested message: push a new buffer and remember the outer field number
             // so objectEnd can length-prefix the nested bytes under the correct tag,
             // even after inner fieldBytes calls overwrite currentFieldNumber. Save the
             // array context and reset it: the message's own fields are not array elements.
             fieldNumberStack = currentFieldNumber :: fieldNumberStack
-            arrayStateStack = (inArray, repeatedFieldNumber) :: arrayStateStack
+            arrayStateStack = (inArray, repeatedFieldNumber, inBareRecord) :: arrayStateStack
             inArray = false
             bufferStack = new java.io.ByteArrayOutputStream(128) :: bufferStack
     end objectStart
@@ -103,20 +119,27 @@ final class ProtobufWriter extends Writer:
             bufferStack = bufferStack.tail
             val outerFieldNumber = fieldNumberStack.head
             fieldNumberStack = fieldNumberStack.tail
-            // Write tag for nested message field using the field number captured at
-            // objectStart, not the currentFieldNumber (which may have been clobbered
-            // by inner fieldBytes calls during the nested write).
-            writeTag(outerFieldNumber, LengthDelimited)
-            writeVarint(nested.length.toLong)
-            current.write(nested)
-            // Restore the outer field number so sibling writes after this objectEnd
-            // continue to use the parent message's currentFieldNumber (e.g. repeated
-            // nested messages in a List field share the same field number).
-            currentFieldNumber = outerFieldNumber
+            if outerFieldNumber == -1 then
+                // Bare element message inside a nested-collection record: length prefix only.
+                writeVarint(nested.length.toLong)
+                current.write(nested)
+            else
+                // Write tag for nested message field using the field number captured at
+                // objectStart, not the currentFieldNumber (which may have been clobbered
+                // by inner fieldBytes calls during the nested write).
+                writeTag(outerFieldNumber, LengthDelimited)
+                writeVarint(nested.length.toLong)
+                current.write(nested)
+                // Restore the outer field number so sibling writes after this objectEnd
+                // continue to use the parent message's currentFieldNumber (e.g. repeated
+                // nested messages in a List field share the same field number).
+                currentFieldNumber = outerFieldNumber
+            end if
             arrayStateStack match
-                case (ia, rfn) :: rest =>
+                case (ia, rfn, bare) :: rest =>
                     inArray = ia
                     repeatedFieldNumber = rfn
+                    inBareRecord = bare
                     arrayStateStack = rest
                 case Nil => ()
             end match
@@ -157,32 +180,72 @@ final class ProtobufWriter extends Writer:
     end closeMapEntry
 
     def arrayStart(size: Int): Unit =
-        arrayStateStack = (inArray, repeatedFieldNumber) :: arrayStateStack
-        packedBufferStack = new java.io.ByteArrayOutputStream(64) :: packedBufferStack
-        repeatedFieldNumber = currentFieldNumber
+        arrayStateStack = (inArray, repeatedFieldNumber, inBareRecord) :: arrayStateStack
+        if inArray then
+            // Nested collection: one length-delimited record; elements are written bare into the
+            // record buffer. The buffer sits on BOTH stacks: scalars append through packedTarget
+            // (packedBufferStack head), strings/messages/deeper collections through current
+            // (bufferStack head).
+            val record = new java.io.ByteArrayOutputStream(64)
+            bufferStack = record :: bufferStack
+            packedBufferStack = record :: packedBufferStack
+            inBareRecord = true
+        else
+            packedBufferStack = new java.io.ByteArrayOutputStream(64) :: packedBufferStack
+            repeatedFieldNumber = currentFieldNumber
+            inBareRecord = false
+        end if
         inArray = true
     end arrayStart
 
     def arrayEnd(): Unit =
-        packedBufferStack match
-            case buf :: bufRest =>
-                if buf.size() > 0 then
-                    // Flush the accumulated scalars as one packed length-delimited record.
-                    val packed = buf.toByteArray
-                    writeTag(repeatedFieldNumber, LengthDelimited)
-                    writeVarint(packed.length.toLong)
-                    current.write(packed)
-                end if
-                packedBufferStack = bufRest
-            case Nil => ()
-        end match
-        arrayStateStack match
-            case (ia, rfn) :: rest =>
-                inArray = ia
-                repeatedFieldNumber = rfn
-                arrayStateStack = rest
-            case Nil => inArray = false
-        end match
+        if inBareRecord then
+            // Close the nested-collection record: pop it, restore the parent context, then emit it
+            // there. In a depth-1 parent the record is tagged with the repeated field number; in a
+            // bare parent (depth three or more) it is a bare length-prefixed blob. An empty inner
+            // collection emits a zero-length record, keeping it distinct from an absent one.
+            val record = current.toByteArray
+            bufferStack = bufferStack.tail
+            packedBufferStack = packedBufferStack.tail
+            arrayStateStack match
+                case (ia, rfn, bare) :: rest =>
+                    inArray = ia
+                    repeatedFieldNumber = rfn
+                    inBareRecord = bare
+                    arrayStateStack = rest
+                case Nil =>
+                    inArray = false
+                    inBareRecord = false
+            end match
+            if inBareRecord then
+                writeVarint(record.length.toLong)
+            else
+                writeTag(repeatedFieldNumber, LengthDelimited)
+                writeVarint(record.length.toLong)
+            end if
+            current.write(record)
+        else
+            packedBufferStack match
+                case buf :: bufRest =>
+                    if buf.size() > 0 then
+                        // Flush the accumulated scalars as one packed length-delimited record.
+                        val packed = buf.toByteArray
+                        writeTag(repeatedFieldNumber, LengthDelimited)
+                        writeVarint(packed.length.toLong)
+                        current.write(packed)
+                    end if
+                    packedBufferStack = bufRest
+                case Nil => ()
+            end match
+            arrayStateStack match
+                case (ia, rfn, bare) :: rest =>
+                    inArray = ia
+                    repeatedFieldNumber = rfn
+                    inBareRecord = bare
+                    arrayStateStack = rest
+                case Nil => inArray = false
+            end match
+        end if
     end arrayEnd
 
     private def packedTarget: java.io.ByteArrayOutputStream =
@@ -208,11 +271,17 @@ final class ProtobufWriter extends Writer:
     end long
 
     def string(value: String): Unit =
-        val fn    = if inArray then repeatedFieldNumber else currentFieldNumber
         val bytes = value.getBytes("UTF-8")
-        writeTag(fn, LengthDelimited)
-        writeVarint(bytes.length.toLong)
-        current.write(bytes)
+        if inBareRecord then
+            // Bare element inside a nested-collection record: length prefix only, no tag.
+            writeVarint(bytes.length.toLong)
+            current.write(bytes)
+        else
+            val fn = if inArray then repeatedFieldNumber else currentFieldNumber
+            writeTag(fn, LengthDelimited)
+            writeVarint(bytes.length.toLong)
+            current.write(bytes)
+        end if
     end string
 
     def double(value: Double): Unit =
@@ -248,8 +317,37 @@ final class ProtobufWriter extends Writer:
 
     def nil(): Unit = () // protobuf has no null representation; omit the field
 
+    // Field number each entry message of the active non-string map is tagged with. The Writer
+    // default envelope routes every entry through objectStart, which captures currentFieldNumber
+    // at that moment; without pinning it here the first entry of a TOP-LEVEL map has no field
+    // number at all and every later entry inherits the previous entry's "value" field id (2).
+    private var entryFieldStack: List[Int] = Nil
+
+    override def mapEntriesStart(size: Int): Unit =
+        // A top-level map has no enclosing field; entries go under synthetic field 1 so the entry
+        // messages are well-formed and the reader can recognize the repetition.
+        val fn = if currentFieldNumber > 0 then currentFieldNumber else 1
+        entryFieldStack = fn :: entryFieldStack
+        currentFieldNumber = fn
+        arrayStart(size)
+    end mapEntriesStart
+
+    override def mapEntryStart(): Unit =
+        currentFieldNumber = entryFieldStack.head
+        objectStart("", 2)
+        field("key", 1)
+    end mapEntryStart
+
+    override def mapEntriesEnd(): Unit =
+        arrayEnd()
+        entryFieldStack = entryFieldStack.tail
+    end mapEntriesEnd
+
     def mapStart(size: Int): Unit =
-        mapFrames = new MapFrame(currentFieldNumber, bufferStack.size, false) :: mapFrames
+        // A top-level map has no enclosing field; entries go under synthetic field 1 so each
+        // entry message is framed (openMapEntry's objectStart requires a positive field number).
+        val fn = if currentFieldNumber > 0 then currentFieldNumber else 1
+        mapFrames = new MapFrame(fn, bufferStack.size, false) :: mapFrames
     end mapStart
 
     def mapEnd(): Unit =
@@ -261,11 +359,17 @@ final class ProtobufWriter extends Writer:
     end mapEnd
 
     def bytes(value: Span[Byte]): Unit =
-        val fn  = if inArray then repeatedFieldNumber else currentFieldNumber
         val arr = value.toArray
-        writeTag(fn, LengthDelimited)
-        writeVarint(arr.length.toLong)
-        current.write(arr)
+        if inBareRecord then
+            // Bare element inside a nested-collection record: length prefix only, no tag.
+            writeVarint(arr.length.toLong)
+            current.write(arr)
+        else
+            val fn = if inArray then repeatedFieldNumber else currentFieldNumber
+            writeTag(fn, LengthDelimited)
+            writeVarint(arr.length.toLong)
+            current.write(arr)
+        end if
     end bytes
 
     def bigInt(value: BigInt): Unit         = string(value.toString)

--- a/kyo-schema-tests/jvm/src/test/scala/kyo/ProtobufDifferentialTest.scala
+++ b/kyo-schema-tests/jvm/src/test/scala/kyo/ProtobufDifferentialTest.scala
@@ -1,0 +1,319 @@
+package kyo
+
+import com.google.protobuf.ByteString
+import com.google.protobuf.DescriptorProtos.DescriptorProto
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import com.google.protobuf.DescriptorProtos.MessageOptions
+import com.google.protobuf.Descriptors
+import com.google.protobuf.DynamicMessage
+import kyo.schema.*
+import proteus.ProtobufCodec
+import proteus.ProtobufDeriver
+import scala.jdk.CollectionConverters.*
+
+// Differential oracle for the Protobuf codec (issue #1747): kyo's bytes are checked against two
+// independent implementations instead of against kyo's own reading of proto3.
+//
+//   - protobuf-java is the WIRE oracle: given a descriptor equivalent to what protoSchema
+//     declares, are kyo's bytes parseable, and are protobuf-java's bytes decodable by kyo?
+//     Descriptors are built programmatically (no protoc, no codegen), and fixtures pin kyo's
+//     field numbers with @proto.fieldNumber so the descriptors match by construction.
+//   - Proteus is the SCHEMA-MAPPING oracle: a code-first Scala 3 library with kyo's constraint
+//     set (derive codecs from types, no codegen). It answers the questions .proto cannot
+//     express: what happens to None, to an empty collection, to nested collections.
+//
+// Both oracles cover only canonical proto3 shapes; kyo's non-canonical extensions (nested
+// collection records, empty-value map entries) are guarded by ProtobufCollectionsTest.
+
+// --- kyo fixtures, field numbers pinned 1..n in declaration order ---
+
+case class PDScalars(
+    @proto.fieldNumber(1) i: Int,
+    @proto.fieldNumber(2) l: Long,
+    @proto.fieldNumber(3) d: Double,
+    @proto.fieldNumber(4) f: Float,
+    @proto.fieldNumber(5) b: Boolean,
+    @proto.fieldNumber(6) s: String
+) derives Schema, CanEqual
+
+case class PDRepeated(
+    @proto.fieldNumber(1) nums: List[Int],
+    @proto.fieldNumber(2) names: List[String]
+) derives Schema, CanEqual
+
+case class PDItem(
+    @proto.fieldNumber(1) n: Int,
+    @proto.fieldNumber(2) tag: String
+) derives Schema, CanEqual
+
+case class PDNested(
+    @proto.fieldNumber(1) item: PDItem,
+    @proto.fieldNumber(2) items: List[PDItem]
+) derives Schema, CanEqual
+
+case class PDMaps(
+    @proto.fieldNumber(1) byName: Map[String, Int],
+    @proto.fieldNumber(2) byId: Map[Int, String]
+) derives Schema, CanEqual
+
+case class PDOpt(
+    @proto.fieldNumber(1) o: Maybe[Int],
+    @proto.fieldNumber(2) s: String
+) derives Schema, CanEqual
+
+// --- kyo fixtures mirrored against Proteus (sequential numbers match Proteus's own) ---
+
+case class KDText(
+    @proto.fieldNumber(1) a: String,
+    @proto.fieldNumber(2) b: String
+) derives Schema, CanEqual
+
+case class KDNum(@proto.fieldNumber(1) n: Int) derives Schema, CanEqual
+
+case class KDOptList(
+    @proto.fieldNumber(1) o: Option[Int],
+    @proto.fieldNumber(2) xs: List[Int]
+) derives Schema, CanEqual
+
+// --- Proteus fixtures (Proteus assigns sequential field numbers 1..n by declaration) ---
+
+given ProtobufDeriver = ProtobufDeriver
+
+case class PRText(a: String, b: String) derives ProtobufCodec
+case class PRNum(n: Int) derives ProtobufCodec
+case class PROptList(o: Option[Int], xs: List[Int]) derives ProtobufCodec
+
+class ProtobufDifferentialTest extends kyo.test.Test[Any]:
+
+    given CanEqual[Any, Any] = CanEqual.derived
+
+    // ===== protobuf-java wire oracle =====
+
+    import FieldDescriptorProto.Label
+    import FieldDescriptorProto.Type as PType
+
+    private def scalarField(name: String, number: Int, tpe: PType): FieldDescriptorProto =
+        FieldDescriptorProto.newBuilder().setName(name).setNumber(number).setType(tpe).setLabel(Label.LABEL_OPTIONAL).build()
+
+    private def repeatedField(name: String, number: Int, tpe: PType): FieldDescriptorProto =
+        FieldDescriptorProto.newBuilder().setName(name).setNumber(number).setType(tpe).setLabel(Label.LABEL_REPEATED).build()
+
+    private def messageField(name: String, number: Int, typeName: String, repeated: Boolean = false): FieldDescriptorProto =
+        FieldDescriptorProto.newBuilder().setName(name).setNumber(number).setType(PType.TYPE_MESSAGE)
+            .setLabel(if repeated then Label.LABEL_REPEATED else Label.LABEL_OPTIONAL)
+            .setTypeName(typeName).build()
+
+    private def mapEntryType(name: String, keyType: PType, valueType: PType): DescriptorProto =
+        DescriptorProto.newBuilder().setName(name)
+            .setOptions(MessageOptions.newBuilder().setMapEntry(true))
+            .addField(scalarField("key", 1, keyType))
+            .addField(scalarField("value", 2, valueType))
+            .build()
+
+    // One file holding every message the wire-oracle tests use; mirrors protoSchema's primitive
+    // mapping (Int -> sint32, Long -> sint64, the rest direct).
+    private val fileDescriptor: Descriptors.FileDescriptor =
+        val scalars = DescriptorProto.newBuilder().setName("PDScalars")
+            .addField(scalarField("i", 1, PType.TYPE_SINT32))
+            .addField(scalarField("l", 2, PType.TYPE_SINT64))
+            .addField(scalarField("d", 3, PType.TYPE_DOUBLE))
+            .addField(scalarField("f", 4, PType.TYPE_FLOAT))
+            .addField(scalarField("b", 5, PType.TYPE_BOOL))
+            .addField(scalarField("s", 6, PType.TYPE_STRING))
+            .build()
+        val repeated = DescriptorProto.newBuilder().setName("PDRepeated")
+            .addField(repeatedField("nums", 1, PType.TYPE_SINT32))
+            .addField(repeatedField("names", 2, PType.TYPE_STRING))
+            .build()
+        val item = DescriptorProto.newBuilder().setName("PDItem")
+            .addField(scalarField("n", 1, PType.TYPE_SINT32))
+            .addField(scalarField("tag", 2, PType.TYPE_STRING))
+            .build()
+        val nested = DescriptorProto.newBuilder().setName("PDNested")
+            .addField(messageField("item", 1, ".pd.PDItem"))
+            .addField(messageField("items", 2, ".pd.PDItem", repeated = true))
+            .build()
+        val maps = DescriptorProto.newBuilder().setName("PDMaps")
+            .addNestedType(mapEntryType("ByNameEntry", PType.TYPE_STRING, PType.TYPE_SINT32))
+            .addNestedType(mapEntryType("ByIdEntry", PType.TYPE_SINT32, PType.TYPE_STRING))
+            .addField(messageField("byName", 1, ".pd.PDMaps.ByNameEntry", repeated = true))
+            .addField(messageField("byId", 2, ".pd.PDMaps.ByIdEntry", repeated = true))
+            .build()
+        val opt = DescriptorProto.newBuilder().setName("PDOpt")
+            .addField(scalarField("o", 1, PType.TYPE_SINT32))
+            .addField(scalarField("s", 2, PType.TYPE_STRING))
+            .build()
+        val file = FileDescriptorProto.newBuilder()
+            .setName("pd.proto").setPackage("pd").setSyntax("proto3")
+            .addMessageType(scalars).addMessageType(repeated).addMessageType(item)
+            .addMessageType(nested).addMessageType(maps).addMessageType(opt)
+            .build()
+        Descriptors.FileDescriptor.buildFrom(file, Array.empty)
+    end fileDescriptor
+
+    private def descriptor(name: String): Descriptors.Descriptor =
+        fileDescriptor.findMessageTypeByName(name)
+
+    private def parseWithOracle(name: String, bytes: Span[Byte]): DynamicMessage =
+        DynamicMessage.parseFrom(descriptor(name), bytes.toArray)
+
+    private def fd(msg: Descriptors.Descriptor, name: String): Descriptors.FieldDescriptor =
+        msg.findFieldByName(name)
+
+    "protobuf-java wire oracle" - {
+
+        "scalars: kyo bytes parse to the same values" in {
+            val value  = PDScalars(-2, 300L, 1.5d, 2.5f, true, "hello")
+            val parsed = parseWithOracle("PDScalars", Protobuf.encode(value))
+            val d      = parsed.getDescriptorForType
+            assert(parsed.getField(fd(d, "i")) == -2)
+            assert(parsed.getField(fd(d, "l")) == 300L)
+            assert(parsed.getField(fd(d, "d")) == 1.5d)
+            assert(parsed.getField(fd(d, "f")) == 2.5f)
+            assert(parsed.getField(fd(d, "b")) == true)
+            assert(parsed.getField(fd(d, "s")) == "hello")
+        }
+
+        "scalars: oracle bytes decode to the same value in kyo" in {
+            val d = descriptor("PDScalars")
+            val oracleBytes = DynamicMessage.newBuilder(d)
+                .setField(fd(d, "i"), -2)
+                .setField(fd(d, "l"), 300L)
+                .setField(fd(d, "d"), 1.5d)
+                .setField(fd(d, "f"), 2.5f)
+                .setField(fd(d, "b"), true)
+                .setField(fd(d, "s"), "hello")
+                .build().toByteArray
+            val decoded = Protobuf.decode[PDScalars](Span.from(oracleBytes))
+            assert(decoded == Result.succeed(PDScalars(-2, 300L, 1.5d, 2.5f, true, "hello")))
+        }
+
+        "scalars: oracle re-serialization of kyo bytes is byte-identical for non-default values" in {
+            // kyo writes fields in declaration order, which equals field-number order here, and
+            // protobuf-java serializes in field-number order, so the canonical forms coincide as
+            // long as no value is a proto3 default (a canonical proto3 serializer omits defaults).
+            val bytes = Protobuf.encode(PDScalars(-2, 300L, 1.5d, 2.5f, true, "hello"))
+            val again = parseWithOracle("PDScalars", bytes).toByteArray
+            assert(java.util.Arrays.equals(again, bytes.toArray))
+        }
+
+        "repeated: kyo packed sint32 run and per-element strings parse" in {
+            val value  = PDRepeated(List(1, -2, 300), List("a", "b"))
+            val parsed = parseWithOracle("PDRepeated", Protobuf.encode(value))
+            val d      = parsed.getDescriptorForType
+            assert(parsed.getField(fd(d, "nums")).asInstanceOf[java.util.List[?]].asScala.toList == List(1, -2, 300))
+            assert(parsed.getField(fd(d, "names")).asInstanceOf[java.util.List[?]].asScala.toList == List("a", "b"))
+        }
+
+        "repeated: oracle bytes decode in kyo, including an empty repeated" in {
+            val d       = descriptor("PDRepeated")
+            val builder = DynamicMessage.newBuilder(d)
+            builder.addRepeatedField(fd(d, "nums"), 1)
+            builder.addRepeatedField(fd(d, "nums"), -2)
+            builder.addRepeatedField(fd(d, "nums"), 300)
+            // names left empty: proto3 encodes an empty repeated as absent
+            val decoded = Protobuf.decode[PDRepeated](Span.from(builder.build().toByteArray))
+            assert(decoded == Result.succeed(PDRepeated(List(1, -2, 300), List.empty)))
+        }
+
+        "nested: kyo bytes parse and oracle bytes decode" in {
+            val value  = PDNested(PDItem(7, "x"), List(PDItem(1, "a"), PDItem(2, "b")))
+            val parsed = parseWithOracle("PDNested", Protobuf.encode(value))
+            val d      = parsed.getDescriptorForType
+            val itemD  = descriptor("PDItem")
+            val inner  = parsed.getField(fd(d, "item")).asInstanceOf[DynamicMessage]
+            assert(inner.getField(fd(itemD, "n")) == 7)
+            assert(inner.getField(fd(itemD, "tag")) == "x")
+            val elems = parsed.getField(fd(d, "items")).asInstanceOf[java.util.List[?]].asScala.toList
+            assert(elems.map(_.asInstanceOf[DynamicMessage].getField(fd(itemD, "tag"))) == List("a", "b"))
+
+            val roundTripped = Protobuf.decode[PDNested](Span.from(parsed.toByteArray))
+            assert(roundTripped == Result.succeed(value))
+        }
+
+        "maps: kyo entries parse as canonical MapEntry messages and round-trip through the oracle" in {
+            val value       = PDMaps(Map("a" -> 1, "b" -> -2), Map(1 -> "one", 2 -> "two"))
+            val parsed      = parseWithOracle("PDMaps", Protobuf.encode(value))
+            val d           = parsed.getDescriptorForType
+            val byNameEntry = d.findNestedTypeByName("ByNameEntry")
+            val byName = parsed.getField(fd(d, "byName")).asInstanceOf[java.util.List[?]].asScala.toList
+                .map(_.asInstanceOf[DynamicMessage])
+                .map(m => m.getField(fd(byNameEntry, "key")) -> m.getField(fd(byNameEntry, "value")))
+                .toMap
+            assert(byName == Map("a" -> 1, "b" -> -2))
+            val byIdEntry = d.findNestedTypeByName("ByIdEntry")
+            val byId = parsed.getField(fd(d, "byId")).asInstanceOf[java.util.List[?]].asScala.toList
+                .map(_.asInstanceOf[DynamicMessage])
+                .map(m => m.getField(fd(byIdEntry, "key")) -> m.getField(fd(byIdEntry, "value")))
+                .toMap
+            assert(byId == Map(1 -> "one", 2 -> "two"))
+
+            val roundTripped = Protobuf.decode[PDMaps](Span.from(parsed.toByteArray))
+            assert(roundTripped == Result.succeed(value))
+        }
+
+        "scalars: canonical zero-omitted oracle bytes decode to proto3 defaults in kyo" in {
+            // A canonical proto3 serializer omits default-valued scalar fields entirely.
+            // protobuf-java drops every field of an all-defaults message, so the wire is empty;
+            // kyo must decode absence as the proto3 default, not as a missing field.
+            val d           = descriptor("PDScalars")
+            val oracleBytes = DynamicMessage.newBuilder(d).build().toByteArray
+            assert(oracleBytes.isEmpty)
+            val decoded = Protobuf.decode[PDScalars](Span.from(oracleBytes))
+            assert(decoded == Result.succeed(PDScalars(0, 0L, 0.0d, 0.0f, false, "")))
+        }
+
+        "optional: presence semantics match" in {
+            val d = descriptor("PDOpt")
+            // Present -> the oracle sees the field.
+            val present = parseWithOracle("PDOpt", Protobuf.encode(PDOpt(Maybe(5), "x")))
+            assert(present.getField(fd(d, "o")) == 5)
+            // Absent -> kyo writes nothing for the field, so the oracle reads proto3's default.
+            val absent = parseWithOracle("PDOpt", Protobuf.encode(PDOpt(Maybe.empty, "x")))
+            assert(absent.getField(fd(d, "o")) == 0)
+            // Oracle bytes without the field decode to Absent in kyo.
+            val oracleBytes = DynamicMessage.newBuilder(d).setField(fd(d, "s"), "x").build().toByteArray
+            assert(Protobuf.decode[PDOpt](Span.from(oracleBytes)) == Result.succeed(PDOpt(Maybe.empty, "x")))
+        }
+    }
+
+    // ===== Proteus schema-mapping oracle =====
+
+    "Proteus schema-mapping oracle" - {
+
+        "aligned encodings are byte-identical and cross-decode (strings)" in {
+            val kyoBytes     = Protobuf.encode(KDText("hello", "world"))
+            val proteusBytes = ProtobufCodec[PRText].encode(PRText("hello", "world"))
+            assert(java.util.Arrays.equals(kyoBytes.toArray, proteusBytes))
+            assert(Protobuf.decode[KDText](Span.from(proteusBytes)) == Result.succeed(KDText("hello", "world")))
+            assert(ProtobufCodec[PRText].decode(kyoBytes.toArray) == PRText("hello", "world"))
+        }
+
+        "integer mappings diverge as documented: kyo sint32 (zigzag), Proteus int32 (plain varint)" in {
+            val kyoBytes     = Protobuf.encode(KDNum(1))
+            val proteusBytes = ProtobufCodec[PRNum].encode(PRNum(1))
+            // kyo: tag 0x08, zigzag(1) = 2. Proteus: tag 0x08, plain 1.
+            assert(kyoBytes.toArray.toList == List[Byte](0x08, 0x02))
+            assert(proteusBytes.toList == List[Byte](0x08, 0x01))
+            assert(Protobuf.decode[KDNum](kyoBytes) == Result.succeed(KDNum(1)))
+            assert(ProtobufCodec[PRNum].decode(proteusBytes) == PRNum(1))
+        }
+
+        "Scala-shape decisions agree: None and empty collections survive a round-trip" in {
+            val kyoDecoded = Protobuf.decode[KDOptList](Protobuf.encode(KDOptList(None, List.empty)))
+            assert(kyoDecoded == Result.succeed(KDOptList(None, List.empty)))
+            val proteusCodec   = ProtobufCodec[PROptList]
+            val proteusDecoded = proteusCodec.decode(proteusCodec.encode(PROptList(None, List.empty)))
+            assert(proteusDecoded == PROptList(None, List.empty))
+        }
+
+        "Scala-shape decisions agree: Some and non-empty collections survive a round-trip" in {
+            val kyoDecoded = Protobuf.decode[KDOptList](Protobuf.encode(KDOptList(Some(5), List(1, 2))))
+            assert(kyoDecoded == Result.succeed(KDOptList(Some(5), List(1, 2))))
+            val proteusCodec   = ProtobufCodec[PROptList]
+            val proteusDecoded = proteusCodec.decode(proteusCodec.encode(PROptList(Some(5), List(1, 2))))
+            assert(proteusDecoded == PROptList(Some(5), List(1, 2)))
+        }
+    }
+end ProtobufDifferentialTest

--- a/kyo-schema-tests/shared/src/test/scala/kyo/ProtobufCollectionsTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/ProtobufCollectionsTest.scala
@@ -1,0 +1,145 @@
+package kyo
+
+// Regression matrix for issue #1747: the Protobuf codec must round-trip empty
+// collection values, nested collections, and optional-valued maps, keeping
+// distinct values distinct on the wire.
+
+class ProtobufCollectionsTest extends kyo.test.Test[Any]:
+
+    given CanEqual[Any, Any] = CanEqual.derived
+
+    private def roundTrip[A](value: A)(using Schema[A], Frame, kyo.test.AssertScope): Unit =
+        val bytes   = Protobuf.encode(value)
+        val decoded = Protobuf.decode[A](bytes)
+        assert(
+            decoded == Result.succeed(value),
+            s"round-trip mismatch: expected $value, got $decoded, bytes ${bytes.toArray.map(b => f"$b%02x").mkString}"
+        )
+    end roundTrip
+
+    // Dict and OrderedDict are opaque types without structural ==; compare their contents.
+    private def roundTripDict[K, V](value: Dict[K, V])(using Schema[Dict[K, V]], Frame, kyo.test.AssertScope): Unit =
+        val bytes   = Protobuf.encode(value)
+        val decoded = Protobuf.decode[Dict[K, V]](bytes)
+        assert(
+            decoded.map(_.toMap) == Result.succeed(value.toMap),
+            s"round-trip mismatch: expected ${value.toMap}, got ${decoded.map(_.toMap)}, bytes ${bytes.toArray.map(b => f"$b%02x").mkString}"
+        )
+    end roundTripDict
+
+    private def roundTripOrderedDict[K, V](value: OrderedDict[K, V])(using
+        Schema[OrderedDict[K, V]],
+        Frame,
+        kyo.test.AssertScope
+    ): Unit =
+        val bytes   = Protobuf.encode(value)
+        val decoded = Protobuf.decode[OrderedDict[K, V]](bytes)
+        assert(
+            decoded.map(_.toChunk) == Result.succeed(value.toChunk),
+            s"round-trip mismatch: expected ${value.toChunk}, got ${decoded.map(_.toChunk)}, bytes ${bytes.toArray.map(b => f"$b%02x").mkString}"
+        )
+    end roundTripOrderedDict
+
+    "empty collection map values" - {
+        "first position" in {
+            roundTrip(Map(1 -> Chunk.empty[String], 2 -> Chunk("b"), 3 -> Chunk("c")))
+        }
+        "middle position" in {
+            roundTrip(Map(1 -> Chunk("a"), 2 -> Chunk.empty[String], 3 -> Chunk("c")))
+        }
+        "last position" in {
+            roundTrip(Map(1 -> Chunk("a"), 2 -> Chunk.empty[String]))
+        }
+        "multiple empties" in {
+            roundTrip(Map(1 -> Chunk.empty[String], 2 -> Chunk("b"), 3 -> Chunk.empty[String]))
+        }
+        "all empty" in {
+            roundTrip(Map(1 -> Chunk.empty[String], 2 -> Chunk.empty[String]))
+        }
+        "string-keyed map" in {
+            roundTrip(Map("a" -> Chunk.empty[Int], "b" -> Chunk(1)))
+        }
+        "Dict string-keyed" in {
+            roundTripDict(Dict("a" -> Chunk.empty[Int], "b" -> Chunk(1)))
+        }
+        "Dict non-string-keyed" in {
+            roundTripDict(Dict(1 -> Chunk.empty[String], 2 -> Chunk("b")))
+        }
+        "OrderedDict non-string-keyed" in {
+            roundTripOrderedDict(OrderedDict(1 -> Chunk.empty[String], 2 -> Chunk("b")))
+        }
+    }
+
+    "nested collections keep boundaries" - {
+        "map value: empty vs one-empty vs two-empties are distinct" in {
+            val a = Map(1 -> Chunk.empty[Chunk[String]])
+            val b = Map(1 -> Chunk(Chunk.empty[String]))
+            val c = Map(1 -> Chunk(Chunk.empty[String], Chunk.empty[String]))
+            roundTrip(a)
+            roundTrip(b)
+            roundTrip(c)
+            assert(Protobuf.encode(a) != Protobuf.encode(b))
+            assert(Protobuf.encode(b) != Protobuf.encode(c))
+        }
+        "map value: non-empty nested" in {
+            roundTrip(Map(1 -> Chunk(Chunk("a"), Chunk("b", "c"))))
+        }
+        "field: List[List[Int]] boundaries" in {
+            roundTrip(PCBoxII(List(List(1, 2), List(3))))
+            roundTrip(PCBoxII(List(List(1, 2, 3))))
+            assert(Protobuf.encode(PCBoxII(List(List(1, 2), List(3)))) != Protobuf.encode(PCBoxII(List(List(1, 2, 3)))))
+        }
+        "field: List[List[String]] boundaries" in {
+            roundTrip(PCBoxSS(List(List("a"), List("b", "c"))))
+            roundTrip(PCBoxSS(List(List("a", "b"), List("c"))))
+            assert(Protobuf.encode(PCBoxSS(List(List("a"), List("b", "c")))) != Protobuf.encode(PCBoxSS(List(List("a", "b"), List("c")))))
+        }
+        "field: empty inner lists survive" in {
+            roundTrip(PCBoxII(List(List.empty, List(1))))
+            roundTrip(PCBoxII(List(List.empty)))
+            roundTrip(PCBoxII(List.empty))
+            assert(Protobuf.encode(PCBoxII(List(List.empty))) != Protobuf.encode(PCBoxII(List.empty)))
+        }
+        "triple nesting" in {
+            roundTrip(PCBoxTriple(List(List(List(1), List.empty), List.empty)))
+        }
+        "nested collection of messages" in {
+            roundTrip(PCBoxMsg(List(List(PCItem(1)), List.empty, List(PCItem(2), PCItem(3)))))
+        }
+    }
+
+    "optional values" - {
+        "Maybe-valued map" in {
+            roundTrip(Map("a" -> Maybe(1), "b" -> Maybe.empty[Int]))
+        }
+        "Option-valued map" in {
+            roundTrip(Map("a" -> Option(1), "b" -> Option.empty[Int]))
+        }
+    }
+
+    "collection-valued maps still round-trip" - {
+        "non-empty values" in {
+            roundTrip(Map("a" -> List(1, 2), "b" -> List(3)))
+        }
+        "message values" in {
+            roundTrip(Map(1 -> Chunk(PCItem(1), PCItem(2)), 2 -> Chunk.empty[PCItem]))
+        }
+    }
+
+    "dict with non-string keys round-trips" - {
+        "Dict[Int, String]" in {
+            roundTripDict(Dict(1 -> "one", 2 -> "two"))
+        }
+        "Dict[Int, Int] (both packable)" in {
+            roundTripDict(Dict(1 -> 10, 2 -> 20))
+        }
+    }
+end ProtobufCollectionsTest
+
+// Top-level fixtures: `derives` clauses on locals cannot summon the enclosing
+// test's givens cleanly, and shared fixtures keep each case terse.
+case class PCItem(n: Int) derives Schema, CanEqual
+case class PCBoxII(xs: List[List[Int]]) derives Schema, CanEqual
+case class PCBoxSS(xs: List[List[String]]) derives Schema, CanEqual
+case class PCBoxTriple(xs: List[List[List[Int]]]) derives Schema, CanEqual
+case class PCBoxMsg(xs: List[List[PCItem]]) derives Schema, CanEqual

--- a/kyo-schema-tests/shared/src/test/scala/kyo/ProtobufTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/ProtobufTest.scala
@@ -762,12 +762,17 @@ class ProtobufTest extends kyo.test.Test[Any]:
             assert(result.failure.exists(_.isInstanceOf[LimitExceededException]))
         }
 
-        // --- Protobuf.decode: MissingFieldException ---
+        // --- Protobuf.decode: absent fields ---
 
-        "Protobuf.decode returns MissingFieldException when required field is absent" in {
+        "Protobuf.decode reads absent scalar fields as proto3 defaults" in {
+            // A canonical proto3 serializer omits default-valued fields, so an all-defaults
+            // message is zero bytes on the wire. Decoding absence as the proto3 default is what
+            // every conformant implementation does (verified against protobuf-java in
+            // ProtobufDifferentialTest); it used to raise MissingFieldException here, which made
+            // canonical external output undecodable.
             val empty  = Span.empty[Byte]
             val result = Protobuf.decode[MTPerson](empty)
-            assert(result.failure.exists(_.isInstanceOf[MissingFieldException]))
+            assert(result == Result.succeed(MTPerson("", 0)))
         }
 
         // --- Protobuf.decode: UnknownVariantException ---

--- a/kyo-schema-tests/shared/src/test/scala/kyo/SchemaCodecTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/SchemaCodecTest.scala
@@ -1531,9 +1531,10 @@ class SchemaCodecTest extends kyo.test.Test[Any]:
             assert(decoded.name == user.name)
             assert(decoded.age == user.age)
             assert(decoded.email == user.email)
-            // ssn was dropped from serialization, so it gets the JVM default for its declared type
-            // (`null` for `String`, `0` for `Int`, `false` for `Boolean`, etc.).
-            assert(decoded.ssn == null)
+            // ssn was dropped from serialization, so it decodes to its schema's absent default:
+            // the typed empty value (`""` for `String`, `0` for `Int`, `false` for `Boolean`),
+            // never `null`.
+            assert(decoded.ssn == "")
         }
 
         "schema.encode[Json] produces bytes" in {

--- a/kyo-schema-tests/shared/src/test/scala/kyo/SchemaCodecTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/SchemaCodecTest.scala
@@ -2232,7 +2232,7 @@ class SchemaCodecTest extends kyo.test.Test[Any]:
             "Dict[String, Int] schema round-trip" in {
                 given schema: Schema[Dict[String, Int]] = Schema.stringDictSchema[Int]
                 val v                                   = Dict("a" -> 1, "b" -> 2, "c" -> 3)
-                val decoded                             = roundTrip(v)(using schema)
+                val decoded                             = jsonRoundTrip(v)(using schema)
                 assert(decoded.get("a") == Maybe(1))
                 assert(decoded.get("b") == Maybe(2))
                 assert(decoded.get("c") == Maybe(3))
@@ -2241,7 +2241,7 @@ class SchemaCodecTest extends kyo.test.Test[Any]:
             "Dict[String, Int] empty round-trip" in {
                 given schema: Schema[Dict[String, Int]] = Schema.stringDictSchema[Int]
                 val v                                   = Dict.empty[String, Int]
-                val decoded                             = roundTrip(v)(using schema)
+                val decoded                             = jsonRoundTrip(v)(using schema)
                 assert(decoded.isEmpty)
             }
 
@@ -2265,19 +2265,19 @@ class SchemaCodecTest extends kyo.test.Test[Any]:
 
             // OrderedDict codec
 
-            "stringOrderedDictSchema encode/decode preserves insertion order over the format-agnostic Writer/Reader contract" in {
+            "stringOrderedDictSchema encode/decode preserves insertion order over a real codec" in {
                 given schema: Schema[OrderedDict[String, Int]] = Schema.stringOrderedDictSchema[Int]
                 val v       = OrderedDict("zeta" -> 10, "alpha" -> 20, "mike" -> 30, "bravo" -> 40, "yankee" -> 50, "delta" -> 60)
-                val decoded = roundTrip(v)(using schema)
+                val decoded = jsonRoundTrip(v)(using schema)
                 assert(decoded.size == 6)
                 assert(decoded.get("zeta") == Maybe(10))
                 assert(decoded.toChunk.map(_._1) == Chunk("zeta", "alpha", "mike", "bravo", "yankee", "delta"))
             }
 
-            "orderedDictSchema round-trips non-String keys as OBJECT-form entries preserving insertion order, not sorted" in {
+            "orderedDictSchema round-trips non-String keys preserving insertion order, not sorted" in {
                 given schema: Schema[OrderedDict[Int, String]] = Schema.orderedDictSchema[Int, String]
                 val v       = OrderedDict(30 -> "gold", 10 -> "bronze", 20 -> "silver", 50 -> "copper", 40 -> "tin", 60 -> "iron")
-                val decoded = roundTrip(v)(using schema)
+                val decoded = jsonRoundTrip(v)(using schema)
                 assert(decoded.toChunk.map(_._1) == Chunk(30, 10, 20, 50, 40, 60))
             }
 

--- a/kyo-schema/shared/src/main/scala/kyo/Codec.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Codec.scala
@@ -93,6 +93,21 @@ object Codec:
         private[kyo] var maxCollectionSize: Int = DefaultMaxCollectionSize
         private var _depth: Int                 = 0
 
+        private var _schemaTransformOverrides: List[Schema[?]] = Nil
+
+        /** Innermost-first stack of configured schemas active for the current read.
+          *
+          * A schema with structural transforms (discriminator, variant naming, field renames)
+          * registers itself here for the duration of its transformed read, so a raw Product or Sum
+          * schema of the same nominal type reached deeper in the same operation delegates to the
+          * configured schema instead of its raw read. This is what makes fluent configuration apply
+          * to recursive occurrences of the type. Wrapper readers override both accessors to share
+          * the wrapped reader's stack.
+          */
+        private[kyo] def schemaTransformOverrides: List[Schema[?]] = _schemaTransformOverrides
+        private[kyo] def schemaTransformOverrides_=(next: List[Schema[?]]): Unit =
+            _schemaTransformOverrides = next
+
         /** Fails unless everything left after the decoded root value is insignificant.
           *
           * Decoding a value is not the same as decoding the input. A reader that stops at the end of
@@ -285,6 +300,22 @@ object Codec:
       *   [[kyo.Codec]] for the factory that pairs a Writer with a Reader
       */
     abstract class Writer:
+
+        private var _schemaTransformOverrides: List[Schema[?]] = Nil
+
+        /** Innermost-first stack of configured schemas active for the current write.
+          *
+          * A schema with structural transforms (discriminator, variant naming, field renames)
+          * registers itself here for the duration of its transformed write, so a raw Product or Sum
+          * schema of the same nominal type reached deeper in the same operation delegates to the
+          * configured schema instead of its raw write. This is what makes fluent configuration apply
+          * to recursive occurrences of the type. Wrapper writers override both accessors to share
+          * the wrapped writer's stack.
+          */
+        private[kyo] def schemaTransformOverrides: List[Schema[?]] = _schemaTransformOverrides
+        private[kyo] def schemaTransformOverrides_=(next: List[Schema[?]]): Unit =
+            _schemaTransformOverrides = next
+
         def objectStart(name: String, size: Int): Unit
         def objectEnd(): Unit
         def arrayStart(size: Int): Unit

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -113,25 +113,90 @@ abstract class Schema[A] @publicInBinary private[kyo] (
       * `Schema.init`'s inline `serializeWrite` / `serializeRead` call these only when transforms exist.
       */
     @publicInBinary private[kyo] def transformedWrite(value: A, writer: Writer): Unit =
-        internal.SchemaSerializer.writeWithTransforms(this, value, writer)(using Frame.internal)
+        val prior = writer.schemaTransformOverrides
+        if nominalIdentity.nonEmpty then writer.schemaTransformOverrides = this :: prior
+        try internal.SchemaSerializer.writeWithTransforms(this, value, writer)(using Frame.internal)
+        finally writer.schemaTransformOverrides = prior
+    end transformedWrite
     @publicInBinary private[kyo] def transformedRead(reader: Reader): A =
-        representationChain match
-            case Maybe.Present(chain) =>
-                internal.SchemaSerializer.readChain(this, reader, chain)
-            case Maybe.Absent =>
-                representation match
-                    case Schema.UnionRepresentation.External =>
-                        internal.SchemaSerializer.readWithTransforms(this, reader)
-                    case Schema.UnionRepresentation.Internal(_) =>
-                        internal.SchemaSerializer.readWithDiscriminator(this, reader)
-                    case Schema.UnionRepresentation.Adjacent(tagKey, contentKey) =>
-                        internal.SchemaSerializer.readAdjacent(this, reader, tagKey, contentKey)
-                    case Schema.UnionRepresentation.Tuple =>
-                        internal.SchemaSerializer.readTuple(this, reader)
-                    case Schema.UnionRepresentation.TupleFlat =>
-                        internal.SchemaSerializer.readTupleFlat(this, reader)
-                    case Schema.UnionRepresentation.Untagged =>
-                        internal.SchemaSerializer.readUntagged(this, reader)
+        val prior = reader.schemaTransformOverrides
+        if nominalIdentity.nonEmpty then reader.schemaTransformOverrides = this :: prior
+        try
+            representationChain match
+                case Maybe.Present(chain) =>
+                    internal.SchemaSerializer.readChain(this, reader, chain)
+                case Maybe.Absent =>
+                    representation match
+                        case Schema.UnionRepresentation.External =>
+                            internal.SchemaSerializer.readWithTransforms(this, reader)
+                        case Schema.UnionRepresentation.Internal(_) =>
+                            internal.SchemaSerializer.readWithDiscriminator(this, reader)
+                        case Schema.UnionRepresentation.Adjacent(tagKey, contentKey) =>
+                            internal.SchemaSerializer.readAdjacent(this, reader, tagKey, contentKey)
+                        case Schema.UnionRepresentation.Tuple =>
+                            internal.SchemaSerializer.readTuple(this, reader)
+                        case Schema.UnionRepresentation.TupleFlat =>
+                            internal.SchemaSerializer.readTupleFlat(this, reader)
+                        case Schema.UnionRepresentation.Untagged =>
+                            internal.SchemaSerializer.readUntagged(this, reader)
+        finally reader.schemaTransformOverrides = prior
+        end try
+    end transformedRead
+
+    /** This schema's nominal identity (simple name plus runtime tag) when its structure is a Product
+      * or Sum, absent otherwise. Container and primitive schemas have no nominal identity and never
+      * participate in transform-override resolution. Lazy: forcing `structure` during init would
+      * break recursive structure graphs.
+      */
+    @publicInBinary private[kyo] lazy val nominalIdentity: Maybe[(String, Tag[Any])] =
+        structure match
+            case p: Structure.Type.Product => Maybe((p.name, p.tag))
+            case s: Structure.Type.Sum     => Maybe((s.name, s.tag))
+            case _                         => Maybe.empty
+
+    /** Resolves the innermost registered transform override matching this schema's nominal type.
+      * `this` never matches itself, so a configured schema running its own raw write/read is not
+      * re-dispatched into its transformed path.
+      */
+    @publicInBinary private[kyo] def transformOverrideFor(overrides: List[Schema[?]]): Maybe[Schema[A]] =
+        nominalIdentity match
+            case Maybe.Present((name, tag)) =>
+                @tailrec def loop(rest: List[Schema[?]]): Maybe[Schema[A]] =
+                    rest match
+                        case Nil => Maybe.empty
+                        case s :: tail =>
+                            val matches = (s ne this) && (s.nominalIdentity match
+                                case Maybe.Present((n, t)) => n == name && t.equals(tag)
+                                case _                     => false)
+                            if matches then Maybe(s.asInstanceOf[Schema[A]])
+                            else loop(tail)
+                loop(overrides)
+            case _ => Maybe.empty
+
+    /** Raw write, unless a configured schema for this nominal type is registered on the writer, in
+      * which case the write delegates there so recursive occurrences keep the configuration. Called
+      * by `serializeWrite` on the transform-free branch only.
+      */
+    @publicInBinary private[kyo] def writeResolvingOverride(value: A, writer: Writer): Unit =
+        val overrides = writer.schemaTransformOverrides
+        if overrides.isEmpty then rawSerializeWrite(value, writer)
+        else
+            transformOverrideFor(overrides) match
+                case Maybe.Present(configured) => configured.serializeWrite(value, writer)
+                case _                         => rawSerializeWrite(value, writer)
+        end if
+    end writeResolvingOverride
+
+    /** Read counterpart of [[writeResolvingOverride]]. */
+    @publicInBinary private[kyo] def readResolvingOverride(reader: Reader): A =
+        val overrides = reader.schemaTransformOverrides
+        if overrides.isEmpty then rawSerializeRead(reader)
+        else
+            transformOverrideFor(overrides) match
+                case Maybe.Present(configured) => configured.serializeRead(reader)
+                case _                         => rawSerializeRead(reader)
+        end if
+    end readResolvingOverride
 
     /** Threads this schema's own field-id overrides onto a Protobuf writer/reader, at whatever nesting
       * depth this schema is reached (the outermost schema passed to `Schema.encode[C]`/`Protobuf.encode`,
@@ -1813,7 +1878,7 @@ object Schema:
                 val priorFieldIdOverrides = threadFieldIdOverridesForWrite(writeWriter)
                 try
                     if hasTransforms then transformedWrite(value, writeWriter)
-                    else rawSerializeWrite(value, writeWriter)
+                    else writeResolvingOverride(value, writeWriter)
                 finally restoreFieldIdOverridesForWrite(writeWriter, priorFieldIdOverrides)
                 end try
             end serializeWrite
@@ -1821,7 +1886,7 @@ object Schema:
                 val priorFieldIdOverrides = threadFieldIdOverridesForRead(reader)
                 try
                     if hasReadTransforms then transformedRead(reader)
-                    else rawSerializeRead(reader)
+                    else readResolvingOverride(reader)
                 finally restoreFieldIdOverridesForRead(reader, priorFieldIdOverrides)
                 end try
             end serializeRead
@@ -3623,7 +3688,7 @@ object Schema:
                 val priorFieldIdOverrides = threadFieldIdOverridesForWrite(writeWriter)
                 try
                     if hasTransforms then transformedWrite(value, writeWriter)
-                    else rawSerializeWrite(value, writeWriter)
+                    else writeResolvingOverride(value, writeWriter)
                 finally restoreFieldIdOverridesForWrite(writeWriter, priorFieldIdOverrides)
                 end try
             end serializeWrite
@@ -3631,7 +3696,7 @@ object Schema:
                 val priorFieldIdOverrides = threadFieldIdOverridesForRead(reader)
                 try
                     if hasReadTransforms then transformedRead(reader)
-                    else rawSerializeRead(reader)
+                    else readResolvingOverride(reader)
                 finally restoreFieldIdOverridesForRead(reader, priorFieldIdOverrides)
                 end try
             end serializeRead

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -3006,6 +3006,9 @@ object Schema:
             readFn = reader =>
                 if reader.isNil() then Maybe.empty
                 else Maybe(inner.serializeRead(reader)),
+            // Absent on the wire decodes to Absent: proto3 encodes an absent optional map value as
+            // a key-only entry, and the map read loops fall back to this default.
+            absentDefaultValue = Maybe(Maybe.empty[A]),
             // Non-inline givens have no implicit Tag[A] in scope; fall back to Tag[Any].
             structure = Structure.Type.Optional(
                 "Maybe",
@@ -3028,6 +3031,9 @@ object Schema:
             readFn = reader =>
                 if reader.isNil() then None
                 else Some(inner.serializeRead(reader)),
+            // Absent on the wire decodes to None: proto3 encodes an absent optional map value as
+            // a key-only entry, and the map read loops fall back to this default.
+            absentDefaultValue = Maybe(None),
             // Non-inline givens have no implicit Tag[A] in scope; fall back to Tag[Any].
             structure = Structure.Type.Optional(
                 "Option",
@@ -3111,9 +3117,17 @@ object Schema:
                         discard(reader.hasNextField())
                         discard(reader.field()) // "key"
                         val k = kSchema.serializeRead(reader)
-                        discard(reader.hasNextField())
-                        discard(reader.field()) // "value"
-                        val v = vSchema.serializeRead(reader)
+                        // The value-side hasNextField both advances the separator and carries the
+                        // presence signal: proto3 encodes an empty or default value as a key-only
+                        // entry, which decodes to the value schema's absent default.
+                        val v =
+                            if reader.hasNextField() then
+                                discard(reader.field()) // "value"
+                                vSchema.serializeRead(reader)
+                            else
+                                vSchema.absentDefaultValue match
+                                    case Maybe.Present(dv) => dv
+                                    case _                 => throw MissingFieldException(Seq.empty, "value")(using reader.frame)
                         reader.objectEnd()
                         builder += (k -> v)
                         loop(count + 1)
@@ -3350,9 +3364,17 @@ object Schema:
                         discard(reader.hasNextField())
                         discard(reader.field()) // "key"
                         val k = kSchema.serializeRead(reader)
-                        discard(reader.hasNextField())
-                        discard(reader.field()) // "value"
-                        val v = vSchema.serializeRead(reader)
+                        // The value-side hasNextField both advances the separator and carries the
+                        // presence signal: proto3 encodes an empty or default value as a key-only
+                        // entry, which decodes to the value schema's absent default.
+                        val v =
+                            if reader.hasNextField() then
+                                discard(reader.field()) // "value"
+                                vSchema.serializeRead(reader)
+                            else
+                                vSchema.absentDefaultValue match
+                                    case Maybe.Present(dv) => dv
+                                    case _                 => throw MissingFieldException(Seq.empty, "value")(using reader.frame)
                         reader.objectEnd()
                         loop(dict.update(k, v), count + 1)
                     else dict
@@ -3460,9 +3482,17 @@ object Schema:
                         discard(reader.hasNextField())
                         discard(reader.field()) // "key"
                         val k = kSchema.serializeRead(reader)
-                        discard(reader.hasNextField())
-                        discard(reader.field()) // "value"
-                        val v = vSchema.serializeRead(reader)
+                        // The value-side hasNextField both advances the separator and carries the
+                        // presence signal: proto3 encodes an empty or default value as a key-only
+                        // entry, which decodes to the value schema's absent default.
+                        val v =
+                            if reader.hasNextField() then
+                                discard(reader.field()) // "value"
+                                vSchema.serializeRead(reader)
+                            else
+                                vSchema.absentDefaultValue match
+                                    case Maybe.Present(dv) => dv
+                                    case _                 => throw MissingFieldException(Seq.empty, "value")(using reader.frame)
                         reader.objectEnd()
                         loop(map.update(k, v), count + 1)
                     else map

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -2546,11 +2546,17 @@ object Schema:
     end checkVariantWireExists
 
     // --- Primitive Schema givens ---
+    // Each primitive declares its proto3 default as absentDefaultValue: a canonical proto3
+    // serializer omits default-valued fields, so a reader that reports absence-as-default
+    // (ProtobufReader) decodes them back. Self-describing codecs ignore these for product
+    // fields (their absentDefaultedFieldsMask stays 0), so JSON and friends still require
+    // presence.
 
     /** Schema for String values. */
     given stringSchema: Schema[String] = Schema.init[String](
         writeFn = (v, w) => w.string(v),
         readFn = _.string(),
+        absentDefaultValue = Maybe(""),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.String, Tag[String].asInstanceOf[Tag[Any]])
     )
 
@@ -2558,6 +2564,7 @@ object Schema:
     given booleanSchema: Schema[Boolean] = Schema.init[Boolean](
         writeFn = (v, w) => w.boolean(v),
         readFn = _.boolean(),
+        absentDefaultValue = Maybe(false),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.Boolean, Tag[Boolean].asInstanceOf[Tag[Any]])
     )
 
@@ -2565,6 +2572,7 @@ object Schema:
     given intSchema: Schema[Int] = Schema.init[Int](
         writeFn = (v, w) => w.int(v),
         readFn = _.int(),
+        absentDefaultValue = Maybe(0),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.Int, Tag[Int].asInstanceOf[Tag[Any]])
     )
 
@@ -2572,6 +2580,7 @@ object Schema:
     given longSchema: Schema[Long] = Schema.init[Long](
         writeFn = (v, w) => w.long(v),
         readFn = _.long(),
+        absentDefaultValue = Maybe(0L),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.Long, Tag[Long].asInstanceOf[Tag[Any]])
     )
 
@@ -2579,6 +2588,7 @@ object Schema:
     given floatSchema: Schema[Float] = Schema.init[Float](
         writeFn = (v, w) => w.float(v),
         readFn = _.float(),
+        absentDefaultValue = Maybe(0.0f),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.Float, Tag[Float].asInstanceOf[Tag[Any]])
     )
 
@@ -2586,6 +2596,7 @@ object Schema:
     given doubleSchema: Schema[Double] = Schema.init[Double](
         writeFn = (v, w) => w.double(v),
         readFn = _.double(),
+        absentDefaultValue = Maybe(0.0d),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.Double, Tag[Double].asInstanceOf[Tag[Any]])
     )
 
@@ -2593,6 +2604,7 @@ object Schema:
     given shortSchema: Schema[Short] = Schema.init[Short](
         writeFn = (v, w) => w.short(v),
         readFn = _.short(),
+        absentDefaultValue = Maybe(0.toShort),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.Short, Tag[Short].asInstanceOf[Tag[Any]])
     )
 
@@ -2600,6 +2612,7 @@ object Schema:
     given byteSchema: Schema[Byte] = Schema.init[Byte](
         writeFn = (v, w) => w.byte(v),
         readFn = _.byte(),
+        absentDefaultValue = Maybe(0.toByte),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.Byte, Tag[Byte].asInstanceOf[Tag[Any]])
     )
 
@@ -2607,6 +2620,7 @@ object Schema:
     given charSchema: Schema[Char] = Schema.init[Char](
         writeFn = (v, w) => w.char(v),
         readFn = _.char(),
+        absentDefaultValue = Maybe(0.toChar),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.Char, Tag[Char].asInstanceOf[Tag[Any]])
     )
 
@@ -2615,6 +2629,7 @@ object Schema:
         Schema.init[BigDecimal](
             writeFn = (v, w) => w.bigDecimal(v),
             readFn = _.bigDecimal(),
+            absentDefaultValue = Maybe(BigDecimal(0)),
             structure = Structure.Type.Primitive(Structure.PrimitiveKind.BigDecimal, Tag[BigDecimal].asInstanceOf[Tag[Any]])
         )
 
@@ -2622,6 +2637,7 @@ object Schema:
     given bigIntSchema: Schema[BigInt] = Schema.init[BigInt](
         writeFn = (v, w) => w.bigInt(v),
         readFn = _.bigInt(),
+        absentDefaultValue = Maybe(BigInt(0)),
         structure = Structure.Type.Primitive(Structure.PrimitiveKind.BigInt, Tag[BigInt].asInstanceOf[Tag[Any]])
     )
 
@@ -2630,6 +2646,7 @@ object Schema:
         Schema.init[java.time.Instant](
             writeFn = (v, w) => w.instant(v),
             readFn = _.instant(),
+            absentDefaultValue = Maybe(java.time.Instant.EPOCH),
             structure = Structure.Type.Primitive(Structure.PrimitiveKind.Instant, Tag[java.time.Instant].asInstanceOf[Tag[Any]])
         )
 
@@ -2638,6 +2655,7 @@ object Schema:
         Schema.init[java.time.Duration](
             writeFn = (v, w) => w.duration(v),
             readFn = _.duration(),
+            absentDefaultValue = Maybe(java.time.Duration.ZERO),
             structure = Structure.Type.Primitive(Structure.PrimitiveKind.Duration, Tag[java.time.Duration].asInstanceOf[Tag[Any]])
         )
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -140,6 +140,10 @@ private[kyo] object SchemaSerializer:
         end if
 
         val structWriter = StructureValueWriter()
+        // The raw materialization below reaches nested schemas through their serializeWrite, which
+        // consults the writer's transform-override stack; carry the enclosing writer's stack so
+        // recursive occurrences of a configured type keep their configuration.
+        structWriter.schemaTransformOverrides = writer.schemaTransformOverrides
         schema.rawSerializeWrite(value, structWriter)
         val original = structWriter.getResult
 
@@ -365,8 +369,9 @@ private[kyo] object SchemaSerializer:
                     "representation-chain decode requires a self-describing reader (such as: Json, Yaml, Ion, MsgPack)"
                 )
         @tailrec def attempt(idx: Int): A =
-            val rep    = chain(idx)
-            val fresh  = new StructureValueReader(captured)
+            val rep   = chain(idx)
+            val fresh = new StructureValueReader(captured)
+            fresh.schemaTransformOverrides = reader.schemaTransformOverrides
             val result = Result.catching[SchemaException](readForRepresentation(schema, fresh, rep))
             result match
                 case Result.Success(value)                       => value
@@ -1187,6 +1192,7 @@ private[kyo] object SchemaSerializer:
                         throw NoVariantMatchException(Seq.empty, wireNames)
                     else
                         val fresh = new StructureValueReader(tree)
+                        fresh.schemaTransformOverrides = reader.schemaTransformOverrides
                         // The per-variant decoders are heterogeneous (typed `Reader => Any` because each
                         // returns a distinct variant subtype); the value a decoder returns is always one of
                         // this sum's variants, which widens to A, so the cast is sound.
@@ -1229,7 +1235,8 @@ private[kyo] object SchemaSerializer:
         @tailrec def collect(idx: Int, acc: List[(Int, A)]): List[(Int, A)] =
             if idx >= decoders.size then acc
             else
-                val fresh  = new StructureValueReader(tree)
+                val fresh = new StructureValueReader(tree)
+                fresh.schemaTransformOverrides = reader.schemaTransformOverrides
                 val result = Result.catching[DecodeException](decoders(idx)(fresh).asInstanceOf[A])
                 result match
                     case Result.Success(value) => collect(idx + 1, (idx, value) :: acc)
@@ -1314,6 +1321,12 @@ private[kyo] object SchemaSerializer:
 
         // A wrapper consumes nothing of its own; whether the input is exhausted is the reader it wraps.
         private[kyo] def requireEndOfInput(): Unit = inner.requireEndOfInput()
+
+        // Share the wrapped reader's transform-override stack: the macro read bodies receive this
+        // wrapper, so a lookup or registration here must reach the same stack the enclosing
+        // transformed read registered on.
+        override private[kyo] def schemaTransformOverrides: List[Schema[?]]               = inner.schemaTransformOverrides
+        override private[kyo] def schemaTransformOverrides_=(next: List[Schema[?]]): Unit = inner.schemaTransformOverrides = next
 
         protected var delegateReader: Maybe[Reader]   = Maybe.empty
         protected var delegateDepth: Int              = 0
@@ -1954,6 +1967,10 @@ private[kyo] object SchemaSerializer:
 
         // A wrapper consumes nothing of its own; whether the input is exhausted is the reader it wraps.
         private[kyo] def requireEndOfInput(): Unit = inner.requireEndOfInput()
+
+        // Share the wrapped reader's transform-override stack (see DelegatingWrapperReader).
+        override private[kyo] def schemaTransformOverrides: List[Schema[?]]               = inner.schemaTransformOverrides
+        override private[kyo] def schemaTransformOverrides_=(next: List[Schema[?]]): Unit = inner.schemaTransformOverrides = next
 
         // Pre-compute the dropped-field bitmask once per reader instance.
         // Bit i is set iff field index i is dropped. Indices >= 64 are clamped to 63 (see the 64-field macro limit).


### PR DESCRIPTION
Fixes two kyo-schema bug reports and adds the differential testing #1747 called for. Three commits, one per concern.

Closes #1887. Closes #1747.

## Behavior changes at a glance

| Change | Scope | Kind |
|---|---|---|
| Fluent config (discriminator, variant/field renames) now reaches recursive occurrences | all codecs | breaking for data persisted in the old mixed format |
| Empty collection / absent optional map values round-trip instead of corrupting or throwing | Protobuf | fix; wire unchanged |
| Nested collections get framed records instead of collapsing | Protobuf | wire change, only for shapes that previously corrupted |
| Non-string map entries share one field number; top-level maps work | Protobuf | wire change, only for shapes that previously corrupted |
| Absent scalar field decodes to its proto3 default instead of `MissingFieldException` | Protobuf reader only | behavior change; matches every conformant implementation |
| Dropped field decodes to typed empty value (`""`), not `null` | all codecs | behavior change, strictly safer |

Everything that round-tripped before is byte-identical: the pre-existing byte-exact conformance suites pass unchanged.

## 1. Configured transforms now apply to recursive occurrences (#1887)

### The bug

The reporter's setup, reduced:

```scala
sealed trait Node
case class Parent(ref: String, children: Seq[Node]) extends Node
case class Child(ref: String) extends Node

final case class Container(items: Seq[Node]) derives Schema

given Schema[Node] = Schema[Node]
    .discriminator("type")
    .renameAllVariants(Schema.NameCase.KebabCase)
```

The configuration silently applied only at the top level. Encoding shows it directly:

```scala
Json.encode(Container(Seq(Parent("p1", Seq(Child("c1"))))))
// before: {"items":[{"type":"parent","ref":"p1","children":[{"Child":{"ref":"c1"}}]}]}
//                    outer level flat, as configured ^^^^^^^^  nested child in raw wrapper format
// after:  {"items":[{"type":"parent","ref":"p1","children":[{"type":"child","ref":"c1"}]}]}
```

Decoding the flat format the user actually wrote failed symmetrically, producing the reported errors, because the nested decoder expected `{"Child":{...}}` and treated the first flat field name as a variant name:

```
Issue 1: Unknown variant 'type'
Issue 2: Unknown variant 'extra'
```

### Root cause

The derivation macro resolves recursive references by summoning. Inside the right-hand side of a **top-level** given, the self-summon finds nothing eligible and falls back to a fresh, unconfigured `Schema.derived`; an **object-scoped** given ties the knot to the configured instance. Measured across a 2x2 matrix (top-level vs object-scoped, given before vs after the container): both top-level arrangements fail, both object-scoped arrangements work, declaration order is irrelevant. The same mechanism affects enums and recursive products with `renameAllFields` (nested fields kept their original names).

### The fix

Make every arrangement behave like the working one, at runtime: a schema with structural transforms registers itself on the Writer/Reader for the duration of its transformed write/read, and a transform-free Product or Sum schema reached deeper in the same operation delegates to the innermost registered override with the same nominal identity (name plus tag). Wrapper readers share the wrapped reader's stack; internally constructed replay readers/writers inherit it. When nothing is registered the raw path costs one empty-list check.

### Behavior change

Recursive sums configured through the fluent API previously produced the mixed wire format above, which round-tripped only through kyo itself. They now encode uniformly, so pre-existing persisted data in the mixed format does not decode unchanged. Object-scoped givens and annotation-configured schemas already produced the uniform format and are unaffected.

## 2. Protobuf codec: empty and nested collections (#1747)

### Symptoms fixed

All four reported symptoms confirmed at HEAD by measurement.

**Empty collection map values corrupted the next entry** (symptom 1). proto3 encodes an empty `repeated` value as a key-only entry; the read loop discarded the one signal that reveals this and read a value anyway, consuming the following entry's bytes:

```
input:   Map(1 -> Chunk("a"), 2 -> Chunk.empty, 3 -> Chunk("c"))
decoded: Map(1 -> Chunk("a"), 2 -> Chunk("c"), 3 -> Chunk("c"))   // entry 2 stole entry 3's value
```

The value read is now gated on `hasNextField`; a key-only entry decodes to the value schema's `absentDefaultValue`:

```scala
val v =
    if reader.hasNextField() then
        discard(reader.field()) // "value"
        vSchema.serializeRead(reader)
    else
        vSchema.absentDefaultValue match
            case Maybe.Present(dv) => dv
            case _                 => throw MissingFieldException(Seq.empty, "value")(using reader.frame)
```

**Nested collections collapsed at encode** (symptom 2). Three distinct values, one encoding:

```
1 -> []        = 8aa9ea04020802
1 -> [[]]      = 8aa9ea04020802
1 -> [[],[]]   = 8aa9ea04020802
```

A nested collection is now one length-delimited record under the enclosing repeated field number with bare elements inside; an empty inner collection is a zero-length record, so all three values above get distinct bytes and round-trip. Verified to depth three, including messages and mixed packability.

**Maybe/Option-valued maps failed** (symptom 4): `maybeSchema` and `optionSchema` gained `absentDefaultValue`, and the reader's string-keyed entry arm presents a key-only entry through `isNil`.

(Symptom 3, the Dict decode failures, was partially fixed in #1744; the remainder is the finding below.)

### New finding: the map entry envelope leaked field numbers

Every entry after the first inherited the previous entry's value field id, and a top-level map's first entry had no field number at all:

```
Dict(1 -> 10, 2 -> 20) at top level, before:
12 04 08 04 10 28   02 02 02 14
^^ second entry, accidentally tagged with field 2 (the previous entry's "value" id)
                    ^^ first entry, written as a bare packed run with no entry framing at all
decoded: Dict(1 -> 1, 4 -> 8)
```

Top-level and multi-entry non-string maps could not round-trip; the token-based tests the issue flagged had routed around exactly this. Entries now share the map's field number (synthetic field 1 at top level), and top-level collection decode learns its field number from the first tag.

### Behavior and wire implications

- Depth-one repeated fields and every previously round-tripping shape are byte-identical; the existing conformance suites pass unchanged.
- The new framing applies only to shapes that previously produced corrupt bytes (nested collections, multi-entry and top-level non-string maps), so no working persisted data is affected.
- `validateCanonical`'s doc now states the measured rejection set: non-native map keys remain the only rejected shape; nested and empty repeated are lossless codec extensions, while `protoSchema` still rejects them in `.proto` text generation, where they genuinely have no declaration.
- The two bypassing token-based Dict/OrderedDict tests now go through a real codec, and a new `ProtobufCollectionsTest` matrix (22 cases: empty values in every position, nesting to depth three, optional values, non-string keys) guards the codec.

## 3. Differential oracle: protobuf-java + Proteus (#1747 proposal, scoped small)

### Overview

The conformance tests validated kyo against kyo's own reading of proto3, so a misreading shared by writer and reader could not fail. `ProtobufDifferentialTest` (JVM-only) checks kyo against two independent implementations, chosen small to keep CI time flat: in-memory encodes only, two cached test-scope jars, no protoc, no codegen.

- **protobuf-java 4.35.0 (wire oracle)**: descriptors equivalent to `protoSchema`'s mapping are built programmatically; kyo bytes must parse to the same values through `DynamicMessage`, protobuf-java bytes must decode to the same values through kyo, and re-serialization is byte-identical for non-default values. Covers scalars (zigzag proof on negatives), packed repeated, nested and repeated messages, canonical map entries, and `Maybe` presence.
- **Proteus 0.6.0 (schema-mapping oracle)**: code-first Scala 3 library with kyo's constraint set, included because it had to answer the questions `.proto` cannot express. String shapes are byte-identical and cross-decode in both directions; `None` and empty-collection decisions agree; the integer mapping divergence is asserted as a recorded fact rather than skipped:

```scala
Protobuf.encode(KDNum(1)).toArray.toList        // List(0x08, 0x02)  kyo: sint32, zigzag
ProtobufCodec[PRNum].encode(PRNum(1)).toList    // List(0x08, 0x01)  Proteus: int32, plain varint
```

### What it caught on its first run

A canonical proto3 serializer omits default-valued scalar fields, so an all-defaults message is zero bytes on the wire, and kyo raised `MissingFieldException` on such input:

```scala
val oracleBytes = DynamicMessage.newBuilder(descriptor).build().toByteArray  // Array() : empty
Protobuf.decode[PDScalars](Span.from(oracleBytes))
// before: Failure(MissingFieldException)      canonical external output was undecodable
// after:  Success(PDScalars(0, 0L, 0.0, 0.0f, false, ""))
```

### Behavior changes

- Primitive schemas now declare their proto3 default as `absentDefaultValue`. The existing absent-default machinery turns that into absence-as-default **on the Protobuf reader only**; self-describing codecs (JSON, YAML, ...) still require field presence. This matches proto3 semantics and every conformant implementation, at the cost that a genuinely missing scalar field on Protobuf now reads as its default instead of failing.
- A dropped field's decode seed is now the typed empty value, so a dropped `String` reads back as `""` rather than `null`. This applies on every codec and is strictly safer; two test expectations documenting the old behavior were updated.

## Verification

- New regression suites: `SchemaRecursiveTransformTest` (8 tests, the failing top-level arrangement, sealed trait + enum + product renames), `ProtobufCollectionsTest` (22), `ProtobufDifferentialTest` (13).
- All seven codec modules green on JVM; kyo-schema, kyo-schema-json, and kyo-schema-tests green on JS and Native.
- Byte-exact Protobuf conformance tests pass unchanged, proving zero wire drift for previously working shapes.
