### PR TITLE
[kyo-schema, kyo-schema-json] preserve arbitrary-precision Structure numbers

### DIFF
--- a/kyo-schema-json/shared/src/main/scala/kyo/internal/JsonReader.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/internal/JsonReader.scala
@@ -666,10 +666,14 @@ final class JsonReader private (private var input: Span[Byte], private var _fram
                 Structure.Value.Null
             case _ =>
                 val numStr = readNumber()
-                if numStr.indexOf('.') >= 0 || numStr.indexOf('e') >= 0 || numStr.indexOf('E') >= 0 then
-                    Structure.Value.Decimal(numStr.toDouble)
+                val exact  = BigDecimal(numStr)
+                if numStr.indexOf('.') < 0 && numStr.indexOf('e') < 0 && numStr.indexOf('E') < 0 then
+                    if exact.isValidLong then Structure.Value.Integer(exact.toLong)
+                    else Structure.Value.BigNum(exact)
                 else
-                    Structure.Value.Integer(numStr.toLong)
+                    val decimal = numStr.toDouble
+                    if decimal.isFinite && BigDecimal(decimal.toString) == exact then Structure.Value.Decimal(decimal)
+                    else Structure.Value.BigNum(exact)
                 end if
         end match
     end readStructure

--- a/kyo-schema-json/shared/src/main/scala/kyo/internal/JsonWriter.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/internal/JsonWriter.scala
@@ -175,6 +175,10 @@ final class JsonWriter private (
         maybeComma()
         writeQuotedString(value.toString)
 
+    override def bigNumber(value: BigDecimal): Unit =
+        maybeComma()
+        writeAscii(value.toString)
+
     def instant(value: java.time.Instant): Unit =
         maybeComma()
         writeQuotedString(value.toString)

--- a/kyo-schema-json/shared/src/test/scala/kyo/SchemaStructureTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/kyo/SchemaStructureTest.scala
@@ -1657,6 +1657,26 @@ class SchemaStructureTest extends kyo.test.Test[Any]:
             assert(decoded == v)
         }
 
+        "BigNum encodes as a bare JSON number" in {
+            val v    = Structure.Value.BigNum(BigDecimal("18446744073709551615"))
+            val json = Json.encode(v)
+            assert(json == "18446744073709551615")
+        }
+
+        "integer beyond Long range decodes losslessly as BigNum" in {
+            val json    = "18446744073709551615"
+            val decoded = Json.decode[Structure.Value](json).getOrThrow
+            assert(decoded == Structure.Value.BigNum(BigDecimal(json)))
+        }
+
+        "high-precision decimal round-trips through JSON as BigNum" in {
+            val v       = Structure.Value.BigNum(BigDecimal("0.12345678901234567890123456789"))
+            val encoded = Json.encode(v)
+            val decoded = Json.decode[Structure.Value](encoded).getOrThrow
+            assert(encoded == "0.12345678901234567890123456789")
+            assert(decoded == v)
+        }
+
         "Bool encodes as bare JSON boolean" in {
             val v    = Structure.Value.Bool(true)
             val json = Json.encode(v)

--- a/kyo-schema/shared/src/main/scala/kyo/Codec.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Codec.scala
@@ -374,6 +374,14 @@ object Codec:
         def bytes(value: Span[Byte]): Unit
         def bigInt(value: BigInt): Unit
         def bigDecimal(value: BigDecimal): Unit
+
+        /** Writes an arbitrary-precision numeric scalar.
+          *
+          * The default delegates to [[bigDecimal]] so existing codecs retain their wire representation. Self-describing codecs whose
+          * native number representation differs from their typed `BigDecimal` representation can override this hook.
+          */
+        def bigNumber(value: BigDecimal): Unit = bigDecimal(value)
+
         def instant(value: java.time.Instant): Unit
         def duration(value: java.time.Duration): Unit
         def result(): Span[Byte]

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -960,7 +960,7 @@ private[kyo] object SchemaSerializer:
                 else writer.long(l)
             case Structure.Value.Decimal(d)  => writer.double(d)
             case Structure.Value.Bool(b)     => writer.boolean(b)
-            case Structure.Value.BigNum(bd)  => writer.bigDecimal(bd)
+            case Structure.Value.BigNum(bd)  => writer.bigNumber(bd)
             case Structure.Value.Bytes(b)    => writer.bytes(b)
             case Structure.Value.Instant(i)  => writer.instant(i)
             case Structure.Value.Duration(d) => writer.duration(d)


### PR DESCRIPTION
`Structure.Value.BigNum` is the exact numeric case for self-describing structure trees, but JSON could neither read nor write it as an exact JSON number.

## Problem

The untyped `Structure.Value` JSON path had three different numeric behaviors:

- integral JSON numbers were parsed with `String.toLong`, so a valid number outside the signed 64-bit range failed instead of becoming `BigNum`
- decimal JSON numbers were parsed through `Double`, silently narrowing values with more precision than a `Double` can retain
- `Structure.Value.BigNum` reused the typed `BigDecimal` writer, whose existing compatibility contract encodes the value as a JSON string

That made the structure representation asymmetric:

```scala
val value = Structure.Value.BigNum(BigDecimal("18446744073709551615"))

Json.encode(value)
// before: "\"18446744073709551615\""
// after:  "18446744073709551615"

Json.decode[Structure.Value]("18446744073709551615")
// before: failure from Long overflow
// after:  Result.succeed(value)
```

This surfaced in a downstream JSON-RPC protocol whose document version is an unsigned 64-bit number. The maximum value, `18446744073709551615`, is valid protocol data but could not cross Kyo's self-describing JSON boundary without precision loss or a second JSON stack.

## Fix

`Codec.Writer` gains a `bigNumber` hook for an arbitrary-precision numeric scalar. Its default delegates to `bigDecimal`, so existing codecs retain their current wire representation. `SchemaSerializer` uses that hook only for `Structure.Value.BigNum`.

The JSON codec then supplies the self-describing behavior:

- `JsonWriter.bigNumber` emits the decimal text as a bare JSON number
- `JsonReader.readStructure` parses the token exactly as `BigDecimal`
- integral values that fit in `Long` remain `Structure.Value.Integer`; larger values become `BigNum`
- decimal values that round-trip exactly through a finite `Double` remain `Structure.Value.Decimal`; higher-precision values become `BigNum`

The reader therefore keeps the existing compact cases when they are lossless and promotes only values that need arbitrary precision.

## Compatibility

- Typed `BigInt` and `BigDecimal` schemas still use their existing JSON string representation.
- Existing `Long`-range integers and exactly representable decimals retain their current `Structure.Value` cases.
- Other codecs inherit `bigNumber = bigDecimal`, so their wire behavior is unchanged.
- The behavior change is limited to the previously non-round-tripping `Structure.Value.BigNum` JSON path and JSON numbers that previously overflowed or narrowed.

## Verification

- `sbt 'kyo-schema-jsonJVM/test'`
- `sbt 'kyo-schema-jsonJS/test'` (706 passed)
- `sbt 'kyo-schema-jsonNative/test'` (706 passed)
- release-probe passed
- downstream `morphir-scala` proof passed all 59 MEP tests plus its native-image smoke target, including bare-number round trips for `0` and `18446744073709551615` and invalid-params rejection for negative, fractional, and above-u64 document versions
