### PR TITLE
[kyo-core][kyo-net] fix silent drops on close and transport paths

### DIFF
--- a/kyo-actor/shared/src/main/scala/kyo/Actor.scala
+++ b/kyo-actor/shared/src/main/scala/kyo/Actor.scala
@@ -138,10 +138,19 @@ sealed abstract class Actor[+E, A, B](
       *   - Returns any messages that were queued but not yet processed
       *   - Does not interrupt the processing of the current message if one is being handled
       *
+      * The returned messages are complete: a send that was accepted is among them, and one that was refused never reached the mailbox.
+      * Delivering that guarantee costs a suspension, because a send that began before this close can still be committing when it runs.
+      *
       * @return
       *   A Maybe containing a sequence of any messages that were in the mailbox if the close is successful
       */
-    def close(using Frame): Maybe[Seq[A]] < Sync
+    def close(using Frame): Maybe[Seq[A]] < Async
+
+    /** Closes the actor's mailbox, discarding any messages that were queued but not yet processed.
+      *
+      * The `Sync`-only counterpart to `close`, for callers that do not read the unprocessed messages.
+      */
+    def closeDiscard(using Frame): Unit < Sync
 
 end Actor
 
@@ -762,17 +771,18 @@ object Actor:
                             }
                     }
                 }.handle(
-                    Sync.ensure(mailbox.close), // Ensure mailbox cleanup by closing it when the actor completes or fails
-                    Env.run(_subject),          // Provide the actor's Subject to the environment so it can be accessed via Actor.self
-                    Scope.run,                  // Close used resources
-                    Fiber.init                  // Start the actor's processing loop in an async context
+                    Sync.ensure(mailbox.closeDiscard), // Ensure mailbox cleanup by closing it when the actor completes or fails
+                    Env.run(_subject), // Provide the actor's Subject to the environment so it can be accessed via Actor.self
+                    Scope.run,         // Close used resources
+                    Fiber.init         // Start the actor's processing loop in an async context
                 )
             _ <-
                 // Single termination hook (installed once, not per ask): sweep the pending registry so every
                 // outstanding ask completes when the actor's consumer fiber ends.
                 _consumer.onComplete(_ => Sync.Unsafe.defer(pending.terminate))
         yield new Actor[E, A, B](_subject, _consumer, pending):
-            def close(using Frame) = mailbox.close
+            def close(using Frame)        = mailbox.close
+            def closeDiscard(using Frame) = mailbox.closeDiscard
 
     /** Interface for sending messages to a recipient.
       *

--- a/kyo-actor/shared/src/main/scala/kyo/PubSub.scala
+++ b/kyo-actor/shared/src/main/scala/kyo/PubSub.scala
@@ -213,7 +213,7 @@ object PubSub:
                     actor.ask(Command.Count(_))
 
                 def close(using Frame): Unit < Sync =
-                    actor.close.unit
+                    actor.closeDiscard
         }
     end linearized
 

--- a/kyo-ai/shared/src/main/scala/kyo/Agent.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/Agent.scala
@@ -42,9 +42,18 @@ object Agent:
         def ask(in: In)(using Frame): Out < (Async & Abort[Closed | Error]) =
             self.ask(Message[In, Out](in, _))
 
-        /** Closes the agent's mailbox, preventing it from receiving any new messages. */
-        def close(using Frame): Maybe[Seq[In]] < Sync =
+        /** Closes the agent's mailbox, preventing it from receiving any new messages.
+          *
+          * The returned inputs are complete: one whose send was accepted is among them, and a refused send never reached the mailbox.
+          * Delivering that costs a suspension, because a send that began before this close can still be committing when it runs. Use
+          * `closeDiscard` to close without the unprocessed inputs and stay in `Sync`.
+          */
+        def close(using Frame): Maybe[Seq[In]] < Async =
             (self: Actor[Error, Message[In, Out], Any]).close.map(_.map(_.map(_.input)))
+
+        /** Closes the agent's mailbox, discarding any unprocessed inputs. The `Sync`-only counterpart to `close`. */
+        def closeDiscard(using Frame): Unit < Sync =
+            (self: Actor[Error, Message[In, Out], Any]).closeDiscard
     end extension
 
     /** Creates an agent with an explicit config and any mix of enablements (tools, prompts, thoughts, modes).

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserCoreTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserCoreTest.scala
@@ -1,6 +1,7 @@
 package kyo
 
 import kyo.BrowserElementNotActionableException.Reason
+import kyo.internal.Actionability
 import kyo.internal.BrowserEval
 import kyo.internal.CdpBackend
 import kyo.internal.CdpNoParams
@@ -637,13 +638,20 @@ class BrowserCoreTest extends BrowserTest:
             </body>""")
             for
                 _       <- Browser.goto(p)
+                gate    <- Actionability.check(Browser.Selector.id("b"), requireFillable = false, requireEnabled = true)
                 urlPre  <- Browser.url
                 _       <- Browser.click(Browser.Selector.id("b"))
                 urlPost <- Browser.url
                 clicked <- Browser.eval("String(window.__kyoClicked === true)")
             yield
-                // A no-nav-intent click leaves the URL unchanged (NavigationWatcher saw no nav frame) AND the JS handler
-                // ran (`__kyoClicked === true`). Together these prove armAround's short-circuit fired, with no wall clock.
+                // `navigatesOnClick` IS the branch condition in Browser.click: false routes the click through mutation
+                // settlement and never arms the NavigationWatcher. Asserting it directly is what separates a
+                // short-circuit from a nav path that waited out its grace window and returned the same state, which the
+                // two checks below cannot distinguish on their own; both hold either way.
+                val nonNav = gate match
+                    case Result.Success(ref) => !ref.navigatesOnClick
+                    case _                   => false
+                assert(nonNav, s"the gate must classify a plain button as non-navigating, so click takes the short-circuit; got $gate")
                 assert(
                     urlPost == urlPre,
                     s"expected URL unchanged after no-nav-intent click but pre='$urlPre' post='$urlPost' (nav frame observed)"

--- a/kyo-core/README.md
+++ b/kyo-core/README.md
@@ -374,7 +374,7 @@ case class Order(id: Long, customerId: Long, items: Chunk[Item], total: BigDecim
 case class Item(sku: String, qty: Int, price: BigDecimal)
 val channel: Channel[Order] = ???
 
-val remaining: Maybe[Seq[Order]] < Sync = channel.close
+val remaining: Maybe[Seq[Order]] < Async = channel.close
 ```
 
 `closeAwaitEmpty` closes the channel to new producers and waits until all buffered elements have been consumed:

--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/LogPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/LogPlatformSpecific.scala
@@ -86,19 +86,32 @@ private[kyo] object LogDaemon:
         // Drain-on-exit: close the channel and dispatch the remainder before the process exits.
         // A hard kill (SIGKILL) can still lose the tail; this is inherent to async logging.
         java.lang.Runtime.getRuntime.addShutdownHook(new Thread(() =>
-            channel.close() match
-                case Present(remaining) =>
-                    // Unsafe: shutdown hook runs in a raw JVM Thread outside the kyo effect system;
-                    // AllowUnsafe cannot be propagated from any kyo caller at this boundary.
-                    given AllowUnsafe = AllowUnsafe.embrace.danger
-                    given Frame       = Frame.internal
-                    remaining.foreach { e =>
+            // Unsafe: shutdown hook runs in a raw JVM Thread outside the kyo effect system;
+            // AllowUnsafe cannot be propagated from any kyo caller at this boundary.
+            given AllowUnsafe = AllowUnsafe.embrace.danger
+            given Frame       = Frame.internal
+            // The channel reports its remaining events through a handover rather than a return value, because a log call already
+            // committing when this runs would otherwise be missed. With nothing in flight that handover settles inside close() and the
+            // dispatch below runs inline on this thread; with a log call in flight it settles on that logging thread instead.
+            //
+            // Unsafe: this thread then WAITS on the handover, the one place in the module that blocks. A shutdown hook exists precisely
+            // to finish work before the process exits, and the JVM keeps running only while its hooks do: returning early would let the
+            // process exit mid-handover and lose every buffered event, not merely the tail. No effect-level suspension is reachable from
+            // a raw hook thread, so the wait is a latch. It is bounded so a wedged producer delays exit by at most that budget rather
+            // than hanging it, which is the same trade the runtime already makes for hooks generally.
+            val handedOver = new java.util.concurrent.CountDownLatch(1)
+            channel.close().onComplete { backlog =>
+                try
+                    backlog.foreach(_.eval.foreach(_.foreach { e =>
                         if e ne LogShared.fence then
                             // Contain ANY throw (not just NonFatal): shutdown hook must not propagate.
                             try LogShared.dispatch(e)
                             catch case t: Throwable => reportDrainFailure(e, t)
-                    }
-                case Absent => ()
+                    }))
+                finally discard(handedOver.countDown())
+                end try
+            }
+            discard(handedOver.await(Log.asyncLogging.shutdownDrainBudget().toMillis, java.util.concurrent.TimeUnit.MILLISECONDS))
         ))
         discard(initCount.incrementAndGet())
         new Daemon(channel, flushWaiters, overflow)

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -212,10 +212,23 @@ object Channel:
 
         /** Closes the channel.
           *
+          * The returned elements are the buffered ones, complete: a `put` that was accepted is among them, and one that was refused never
+          * reached the buffer. Delivering that guarantee costs a suspension, because a put that began before this close can still be
+          * committing when it runs. Use `closeDiscard` to close without the elements and stay in `Sync`.
+          *
+          * Interrupting a caller parked here discards those elements. The channel still closes, but they have no receiver, so an
+          * interrupted close behaves as `closeDiscard`. Mask the interrupt where the elements own a resource that must be released.
+          *
           * @return
-          *   A sequence of remaining elements
+          *   A sequence of remaining elements, or absent when another close owns the closure
           */
-        def close(using Frame): Maybe[Seq[A]] < Sync = Sync.Unsafe.defer(self.close())
+        def close(using Frame): Maybe[Seq[A]] < Async = Sync.Unsafe.defer(self.close().safe.get)
+
+        /** Closes the channel, discarding any buffered elements.
+          *
+          * The `Sync`-only counterpart to `close`, for callers that do not read the remaining elements.
+          */
+        def closeDiscard(using Frame): Unit < Sync = Sync.Unsafe.defer(discard(self.close()))
 
         /** Closes the channel and asynchronously waits until it's empty.
           *
@@ -350,7 +363,7 @@ object Channel:
     )(using inline frame: Frame): B < (S & Sync) =
         Sync.Unsafe.defer:
             val channel = Unsafe.init[A](capacity, access)
-            Sync.ensure(Channel.close(channel)):
+            Sync.ensure(Channel.closeDiscard(channel)):
                 f(channel)
 
     /** Initializes a new Channel without guaranteeing eventual cleanup.
@@ -406,7 +419,7 @@ object Channel:
 
         def drain()(using AllowUnsafe, Frame): Result[Closed, Chunk[A]]
         def drainUpTo(max: Int)(using AllowUnsafe, Frame): Result[Closed, Chunk[A]]
-        def close()(using Frame, AllowUnsafe): Maybe[Seq[A]]
+        def close()(using Frame, AllowUnsafe): Fiber.Unsafe[Maybe[Seq[A]], Any]
         def closeAwaitEmpty()(using Frame, AllowUnsafe): Fiber.Unsafe[Boolean, Any]
 
         def empty()(using AllowUnsafe, Frame): Result[Closed, Boolean]
@@ -629,15 +642,18 @@ object Channel:
                 loop(Chunk.empty)
             end drain
 
-            def close()(using frame: Frame, allow: AllowUnsafe) =
+            // A zero-capacity channel has no ring, so no offer can be mid-commit and the backlog is always known immediately.
+            private def closeAndFlush()(using Frame, AllowUnsafe): Maybe[Chunk[A]] =
                 if isClosed.getAndSet(true) then Absent
                 else
                     flush()
                     Present(Chunk.empty)
-            end close
+
+            def close()(using frame: Frame, allow: AllowUnsafe) =
+                Fiber.Unsafe.fromResult(Result.succeed(closeAndFlush()))
 
             def closeAwaitEmpty()(using Frame, AllowUnsafe) =
-                Fiber.Unsafe.fromResult(Result.succeed(close().isDefined))
+                Fiber.Unsafe.fromResult(Result.succeed(closeAndFlush().isDefined))
 
             def empty()(using AllowUnsafe, Frame) = succeedIfOpen(true)
             def full()(using AllowUnsafe, Frame)  = succeedIfOpen(true)
@@ -791,10 +807,12 @@ object Channel:
             end drain
 
             def close()(using Frame, AllowUnsafe) =
-                queue.close().map { backlog =>
-                    flush()
-                    backlog
-                }
+                val r = queue.close()
+                // The ring is drained by whoever wins the queue's handover, which may be an offer still in flight, so the flush that
+                // fails parked puts and wakes parked takes runs on completion rather than here. Same shape as closeAwaitEmpty below.
+                r.onComplete(_ => flush())
+                r
+            end close
 
             def closeAwaitEmpty()(using Frame, AllowUnsafe) =
                 val r = queue.closeAwaitEmpty()

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -95,15 +95,27 @@ final class Hub[A] private[kyo] (
       *   a Maybe containing any messages that were in the Hub's buffer at the time of closing. Returns Absent if the close operation fails
       *   (e.g., if the Hub was already closed).
       */
-    def close(using frame: Frame): Maybe[Seq[A]] < Sync =
+    def close(using frame: Frame): Maybe[Seq[A]] < Async =
         fiber.interruptDiscard(Result.Failure(Closed("Hub", initFrame))).andThen {
             ch.close.map { r =>
-                Sync.defer {
-                    val l = Chunk.fromNoCopy(listeners.toArray()).asInstanceOf[Chunk[Listener[A]]]
-                    discard(listeners.removeIf(_ => true)) // clear is not available in Scala Native
-                    Kyo.foreachDiscard(l)(_.child.close.unit).andThen(r)
-                }
+                detachListeners.andThen(r)
             }
+        }
+
+    /** Closes the Hub, discarding any messages left in its buffer.
+      *
+      * The `Sync`-only counterpart to `close`, for callers that do not read the remaining messages.
+      */
+    def closeDiscard(using frame: Frame): Unit < Sync =
+        fiber.interruptDiscard(Result.Failure(Closed("Hub", initFrame))).andThen {
+            ch.closeDiscard.andThen(detachListeners)
+        }
+
+    private def detachListeners(using Frame): Unit < Sync =
+        Sync.defer {
+            val l = Chunk.fromNoCopy(listeners.toArray()).asInstanceOf[Chunk[Listener[A]]]
+            discard(listeners.removeIf(_ => true)) // clear is not available in Scala Native
+            Kyo.foreachDiscard(l)(_.child.closeDiscard)
         }
 
     /** Creates a new listener for this Hub with the default buffer size.
@@ -230,7 +242,7 @@ object Hub:
 
     def use[A](capacity: Int)[B, S](f: Hub[A] => B < S)(using Frame): B < (S & Sync) =
         initUnscopedWith[A](capacity): hub =>
-            Sync.ensure(hub.close)(f(hub))
+            Sync.ensure(hub.closeDiscard)(f(hub))
 
     def initUnscoped[A](capacity: Int)(using Frame): Hub[A] < Sync =
         initUnscopedWith[A](capacity)(identity)
@@ -344,7 +356,7 @@ object Hub:
           * @return
           *   a Maybe containing any remaining elements in the Listener's buffer
           */
-        def close(using Frame): Maybe[Seq[A]] < Sync =
+        def close(using Frame): Maybe[Seq[A]] < Async =
             hub.remove(this).andThen(child.close)
 
         /** Stream elements from listener, optionally specifying a maximum chunk size.

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -569,6 +569,16 @@ object Log extends kyo.internal.LogPlatformSpecific:
 
         /** Default overflow policy (`-Dkyo.Log.asyncLogging.overflow`), parsed by the custom `Flag.Reader[Log.Overflow]`. */
         private[kyo] object overflow extends StaticFlag[Overflow](Overflow.SyncFallback)
+
+        /** How long the JVM/Native exit hook waits for the buffer to hand over its remaining events before letting the process exit
+          * (`-Dkyo.Log.asyncLogging.shutdownDrainBudget`), clamped `>= 0`.
+          *
+          * Bounds a wait whose expected duration is the tail of one in-flight log call, so the default is generous by orders of
+          * magnitude: it is reached only when a producer is wedged, and it caps how long that producer can delay exit. Deployments that
+          * would rather lose the tail than delay exit can shorten it; `0` gives up immediately. No effect on JS/Wasm, which log
+          * synchronously and install no hook.
+          */
+        private[kyo] object shutdownDrainBudget extends StaticFlag[Duration](2.seconds, d => Right(d.max(Duration.Zero)))
     end asyncLogging
 
 end Log

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -117,10 +117,31 @@ object Queue:
         /** Closes the queue and returns any remaining elements. On a queue with a pending `closeAwaitEmpty`, this aborts the drain: the awaiter
           * completes `false` and this returns the undrained backlog.
           *
+          * The backlog is complete: an offer that was accepted is in it, and one that was refused never reached the queue. Delivering that
+          * guarantee costs a suspension, because an offer that began before this close can still be committing when it runs, and the
+          * elements it has not written yet cannot be reported synchronously. When nothing is in flight, which is always the case on the
+          * single-threaded platforms, the result is already available and this does not suspend. Use `closeDiscard` to close without the
+          * backlog and stay in `Sync`.
+          *
+          * Consumers are locked out from the moment this is called: a `poll` or `drain` racing it aborts as closed rather than competing
+          * with the drain. A consumer already inside `poll` is the caller's own business, as it is on an open queue.
+          *
+          * Interrupting a caller parked here discards the backlog. The queue still closes and still drains, but the elements have no
+          * receiver and are dropped, so an interrupted close behaves as `closeDiscard`. Mask the interrupt where the elements own a
+          * resource that must be released.
+          *
           * @return
-          *   a sequence of remaining elements
+          *   a sequence of remaining elements, or absent when another close owns the closure. Absent means this call did not close the
+          *   queue, not necessarily that the queue is already closed: the close that did own it may still be draining.
           */
-        def close(using Frame): Maybe[Seq[A]] < Sync = Sync.Unsafe.defer(self.close())
+        def close(using Frame): Maybe[Seq[A]] < Async = Sync.Unsafe.defer(self.close().safe.get)
+
+        /** Closes the queue, discarding any remaining elements.
+          *
+          * The `Sync`-only counterpart to `close`, for callers that do not read the backlog. Nothing is awaited: the drain still happens,
+          * on whichever offer is last to leave, and its result is dropped.
+          */
+        def closeDiscard(using Frame): Unit < Sync = Sync.Unsafe.defer(discard(self.close()))
 
         /** Closes the queue and asynchronously waits until it's empty.
           *
@@ -198,7 +219,7 @@ object Queue:
         using frame: Frame
     ): B < (Sync & S) =
         initUnscopedWith[A](capacity, access): queue =>
-            Sync.ensure(Queue.close(queue))(f(queue))
+            Sync.ensure(Queue.closeDiscard(queue))(f(queue))
 
     /** Initializes a new queue with the specified capacity and access pattern without guaranteeing cleanup. The actual capacity will be
       * rounded up to the next power of two.
@@ -296,7 +317,7 @@ object Queue:
             using frame: Frame
         ): B < (Sync & S) =
             initUnscopedWith[A](access, chunkSize): queue =>
-                Sync.ensure(Queue.close(queue))(f(queue))
+                Sync.ensure(Queue.closeDiscard(queue))(f(queue))
 
         /** Initializes a new unbounded queue with the specified access pattern and chunk size without guaranteeing cleanup.
           *
@@ -364,7 +385,7 @@ object Queue:
             using Frame
         ): B < (Sync & S) =
             initDroppingUnscoped[A](capacity, access).map: queue =>
-                Sync.ensure(Queue.close(queue))(f(queue))
+                Sync.ensure(Queue.closeDiscard(queue))(f(queue))
 
         /** Initializes a new dropping queue with the specified capacity and access pattern without guaranteeing cleanup.
           *
@@ -422,7 +443,7 @@ object Queue:
             using Frame
         ): B < (Sync & S) =
             initSlidingUnscoped[A](capacity, access).map: queue =>
-                Sync.ensure(Queue.close(queue))(f(queue))
+                Sync.ensure(Queue.closeDiscard(queue))(f(queue))
 
         /** Initializes a new sliding queue with the specified capacity and access pattern without guaranteeing cleanup.
           *
@@ -488,13 +509,27 @@ object Queue:
                 end new
             end initDropping
 
+            // Sliding removes the oldest element to make room, and that removal runs on whichever thread offered. A queue that admits
+            // only one consumer cannot serve that: the offering thread would be a second consumer beside the real one, which is exactly
+            // what the single-consumer algorithms are not written for, so they spin on a slot the other consumer already emptied. The
+            // consumer side is therefore widened to one that permits it, the same substitution `Queue.Unsafe.init` already makes when
+            // the requested implementation cannot meet the requirement. The caller's own contract is untouched: as many producers as
+            // asked for, and one consumer. The cost is a multi-consumer structure on every sliding path, which a backing ring that
+            // overwrites its oldest slot by design, letting a producer advance the consumer index without becoming a second consumer,
+            // would remove by making the cheaper single-consumer implementations usable here again.
+            private def slidingAccess(access: Access): Access =
+                access match
+                    case Access.MultiProducerSingleConsumer  => Access.MultiProducerMultiConsumer
+                    case Access.SingleProducerSingleConsumer => Access.SingleProducerMultiConsumer
+                    case multiConsumer                       => multiConsumer
+
             def initSliding[A](_capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unsafe[A] =
                 new Unsafe[A]:
-                    val underlying                 = Queue.Unsafe.init[A](_capacity, access)
+                    val underlying                 = Queue.Unsafe.init[A](_capacity, slidingAccess(access))
                     def capacity                   = _capacity
                     def size()(using AllowUnsafe)  = underlying.size()
                     def empty()(using AllowUnsafe) = underlying.empty()
@@ -533,7 +568,7 @@ object Queue:
         def drainUpTo(max: Int)(using AllowUnsafe): Result[Closed, Chunk[A]]
         def peek()(using AllowUnsafe): Result[Closed, Maybe[A]]
         def drain()(using AllowUnsafe): Result[Closed, Chunk[A]]
-        def close()(using Frame, AllowUnsafe): Maybe[Seq[A]]
+        def close()(using Frame, AllowUnsafe): Fiber.Unsafe[Maybe[Seq[A]], Any]
         def closeAwaitEmpty()(using Frame, AllowUnsafe): Fiber.Unsafe[Boolean, Any]
         def closed()(using AllowUnsafe): Boolean
 
@@ -555,47 +590,63 @@ object Queue:
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
 
+        // `Draining` is the window between a close deciding to close and the backlog being handed over. Offers and consumer operations are
+        // already refused in it, so the only party that may still touch the ring is the one that wins the single-shot CAS out of it.
         private enum State derives CanEqual:
             case Open
             case HalfOpen(p: Promise.Unsafe[Boolean, Any], r: Result.Error[Closed])
+            case Draining(r: Result.Error[Closed])
             case FullyClosed(r: Result.Error[Closed])
         end State
 
         sealed abstract private class Closeable[A](initFrame: Frame) extends Unsafe[A]:
             import AllowUnsafe.embrace.danger
+            // Both atomics are read against each other in opposite orders (a closer writes the state then reads the count, an offer writes
+            // the count then reads the state), so the handover below is only correct while these carry sequentially consistent semantics.
             final private val state        = AtomicRef.Unsafe.init[State](State.Open)
             final private val activeOffers = AtomicInt.Unsafe.init(0)
+            // Where the backlog is delivered. Held beside the state rather than inside it because a promise is invariant in its value and
+            // the state is shared by every element type. Claiming it is what elects the one close that owns the drain; the claim is made
+            // before the move into Draining, so any thread that observes Draining also observes the promise.
+            final private val backlog = AtomicRef.Unsafe.init(Maybe.empty[Promise.Unsafe[Maybe[Seq[A]], Any]])
 
-            final def close()(using frame: Frame, allow: AllowUnsafe) =
+            final def close()(using frame: Frame, allow: AllowUnsafe): Fiber.Unsafe[Maybe[Seq[A]], Any] =
                 val fail = Result.Failure(Closed("Queue", initFrame))
-                // A hard close on a HalfOpen queue aborts the await-empty: complete its promise false (the queue did not drain before this
-                // close) so a parked closeAwaitEmpty caller does not hang.
-                @tailrec
-                def escalate(): Boolean =
-                    state.get() match
-                        case State.Open =>
-                            if state.compareAndSet(State.Open, State.FullyClosed(fail)) then true
-                            else escalate()
-                        case s @ State.HalfOpen(p, _) =>
-                            if state.compareAndSet(s, State.FullyClosed(fail)) then
-                                p.completeDiscard(Result.succeed(false))
-                                true
-                            else escalate()
-                        case _: State.FullyClosed => false
-                    end match
-                end escalate
-                Maybe.when(escalate()) {
-                    // Race: an in-flight offer that read state=Open before our CAS may still
-                    // commit and run race-repair, which can re-insert via q.offer (when the
-                    // polled item is not its own). If that re-insert lands AFTER _drain() exits,
-                    // the item is stranded in the closed queue. Wait for active offers to drain
-                    // out, then re-drain to capture any late re-inserts. The increment in
-                    // offerOp happens BEFORE the state read, so any offer that could possibly
-                    // commit is observable here as activeOffers > 0.
-                    val initial = _drain()
-                    while activeOffers.get() > 0 do ()
-                    initial ++ _drain()
-                }
+                val p    = Promise.Unsafe.init[Maybe[Seq[A]], Any]()
+                // Claiming the backlog slot elects the single close that owns the drain, and it happens before the move into Draining so
+                // that observing Draining implies observing the promise. A close that loses this claim closed nothing and answers Absent,
+                // which also covers a queue that reached FullyClosed on its own through a completed closeAwaitEmpty.
+                if !backlog.compareAndSet(Absent, Present(p)) then
+                    p.completeDiscard(Result.succeed(Absent))
+                else
+                    // A hard close on a HalfOpen queue aborts the await-empty: complete its promise false (the queue did not drain before
+                    // this close) so a parked closeAwaitEmpty caller does not hang.
+                    @tailrec
+                    def escalate(): Boolean =
+                        state.get() match
+                            case State.Open =>
+                                if state.compareAndSet(State.Open, State.Draining(fail)) then true
+                                else escalate()
+                            case s @ State.HalfOpen(await, _) =>
+                                if state.compareAndSet(s, State.Draining(fail)) then
+                                    await.completeDiscard(Result.succeed(false))
+                                    true
+                                else escalate()
+                            case _ => false
+                        end match
+                    end escalate
+                    if !escalate() then p.completeDiscard(Result.succeed(Absent))
+                    else
+                        // An offer counts itself in activeOffers BEFORE it reads the state, and this CAS landed BEFORE the count is read
+                        // below, so the two cannot miss each other: either the count is seen nonzero here, or that offer reads Draining
+                        // and gives up. A zero therefore proves no offer can still reach the ring, which makes this thread the only
+                        // possible consumer and lets it drain and answer without waiting. Offers cannot overlap a close at all on the
+                        // single-threaded platforms, so this is the only path taken there.
+                        // A nonzero count hands the drain to whichever offer decrements it to zero; see helpComplete.
+                        if activeOffers.get() == 0 then helpComplete()
+                    end if
+                end if
+                p
             end close
 
             final def closeAwaitEmpty()(using frame: Frame, allow: AllowUnsafe): Fiber.Unsafe[Boolean, Any] =
@@ -616,12 +667,38 @@ object Queue:
             end closeAwaitEmpty
 
             final def closed()(using AllowUnsafe) =
-                state.get().isInstanceOf[State.FullyClosed]
+                state.get() match
+                    case _: State.Draining    => true
+                    case _: State.FullyClosed => true
+                    case _                    => false
+
+            /** Completes a pending close, or a pending await-empty, if this thread can prove it is alone with the ring.
+              *
+              * Called by `close` when it observes no offers in flight, and by the last offer to leave when one was. Exactly one caller wins
+              * the CAS out of `Draining`, and only that winner drains, so the ring keeps a single consumer throughout. The drain runs after
+              * the CAS, by which point every offer has either committed (its element is in the ring) or read a closed state and stopped.
+              *
+              * The count is re-read HERE, after the state, and that order is what makes the pair mean anything. The zero an offer observes
+              * on its way out may have been observed while the state was still Open, which says nothing about offers that began afterwards:
+              * trusting it would let a close that correctly declined to drain be overridden by a straggler, stranding an element whose offer
+              * had already returned true. Reading the count only once Draining is visible closes that: an offer that could still commit
+              * either incremented before this read, and is seen, or reads Draining and never touches the ring.
+              */
+            final private def helpComplete(): Unit =
+                state.get() match
+                    case s @ State.Draining(r) =>
+                        if activeOffers.get() == 0 && state.compareAndSet(s, State.FullyClosed(r)) then
+                            // Reaching Draining means the claim in close already published the promise, so this is never absent.
+                            backlog.get().foreach(_.completeDiscard(Result.succeed(Present(_drain()))))
+                    case _: State.HalfOpen => handleHalfOpen()
+                    case _                 =>
+            end helpComplete
 
             override private[kyo] def diagnosticState(): String =
                 val st = state.get() match
                     case State.Open           => "Open"
                     case State.HalfOpen(p, _) => s"HalfOpen(awaitEmptyDone=${p.done()})"
+                    case _: State.Draining    => s"Draining(backlogDone=${backlog.get().exists(_.done())})"
                     case _: State.FullyClosed => "FullyClosed"
                 val ringSize = this.size() match
                     case Result.Success(n) => n.toString
@@ -638,8 +715,11 @@ object Queue:
             protected def _drain(max: Maybe[Int] = Maybe.Absent): Chunk[A]
             protected def _isEmpty(): Boolean
 
+            // Consumer operations are refused from Draining on, not just FullyClosed: the ring in that window belongs to whoever wins the
+            // handover CAS, and a user-side poll running alongside that drain would be a second consumer.
             private def opClosed: Maybe[Result.Error[Closed]] =
                 state.get() match
+                    case State.Draining(r)    => Present(r)
                     case State.FullyClosed(r) => Present(r)
                     case _                    => Absent
 
@@ -657,31 +737,32 @@ object Queue:
                 state.get() match
                     case State.Open           => Absent
                     case State.HalfOpen(_, r) => Present(r)
+                    case State.Draining(r)    => Present(r)
                     case State.FullyClosed(r) => Present(r)
 
-            protected inline def offerOp(inline f: => Boolean, inline raceRepair: => Boolean): Result[Closed, Boolean] =
-                // Increment BEFORE reading state. Pairs with close()'s wait-for-zero: any offer
-                // that could still commit (already past offerClosed) is observable as in-flight.
-                // try/finally ensures the decrement runs even if `f` throws — leaking the counter
-                // would deadlock close()'s spin.
+            protected inline def offerOp(inline f: => Boolean): Result[Closed, Boolean] =
+                // Increment BEFORE reading state, so a close that CASes after this point still sees this offer as in flight and leaves the
+                // ring alone. An offer that gets past `offerClosed` is therefore free to commit: a close either waits for it or has not
+                // happened yet, and either way its element ends up in the backlog rather than stranded.
+                // try/finally ensures the decrement runs even if `f` throws; a leaked count would strand a pending close forever.
                 discard(activeOffers.incrementAndGet())
-                try
-                    offerClosed.getOrElse {
-                        val result = f
-                        if result && closed() then
-                            Result(raceRepair)
-                        else
-                            Result(result)
-                        end if
-                    }
+                try offerClosed.getOrElse(Result(f))
                 finally
-                    discard(activeOffers.decrementAndGet())
+                    // Last one out gives whatever the close (or the await-empty) left pending a chance to complete. This zero is only a
+                    // reason to look: it may have been read while the queue was still open, so it proves nothing on its own and
+                    // helpComplete re-reads the count against the state it actually finds.
+                    if activeOffers.decrementAndGet() == 0 then helpComplete()
                 end try
             end offerOp
 
             private def handleHalfOpen(): Unit =
+                // The count is read BEFORE the emptiness check, mirroring close: an offer in flight may still commit, so an empty ring
+                // proves nothing while one is outstanding. Completing on it would tell the awaiter the queue drained and then strand the
+                // element that lands next. When the count is nonzero this does nothing and the last offer out re-runs it via helpComplete,
+                // so the awaiter cannot be left waiting on a queue that did empty.
                 state.get() match
-                    case s: State.HalfOpen if _isEmpty() && state.compareAndSet(s, State.FullyClosed(s.r)) =>
+                    case s: State.HalfOpen
+                        if activeOffers.get() == 0 && _isEmpty() && state.compareAndSet(s, State.FullyClosed(s.r)) =>
                         s.p.completeDiscard(Result.succeed(true))
                     case _ =>
 
@@ -711,7 +792,7 @@ object Queue:
                         def size()(using AllowUnsafe)  = op(if state.get().isEmpty then 0 else 1)
                         def full()(using AllowUnsafe)  = op(state.get().isDefined)
                         def offer(v: A)(using AllowUnsafe) =
-                            offerOp(state.compareAndSet(Maybe.empty, Maybe(v)), !state.compareAndSet(Maybe(v), Maybe.empty))
+                            offerOp(state.compareAndSet(Maybe.empty, Maybe(v)))
                         def poll()(using AllowUnsafe) = pollOp(state.getAndSet(Maybe.empty))
                         def peek()(using AllowUnsafe) = op(state.get())
                         def _drain(max: Maybe[Int] = Maybe.Absent) =
@@ -738,24 +819,13 @@ object Queue:
 
         private[Queue] def fromInternal[A](q: UnsafeQueue[A])(using initFrame: Frame, allow: AllowUnsafe): Unsafe[A] =
             new Closeable[A](initFrame):
-                def capacity                   = q.capacity
-                def size()(using AllowUnsafe)  = op(q.size())
-                def empty()(using AllowUnsafe) = op(q.isEmpty())
-                def full()(using AllowUnsafe)  = op(q.isFull())
-                def offer(v: A)(using AllowUnsafe) =
-                    offerOp(
-                        q.offer(v),
-                        q.poll() match
-                            case Maybe.Present(polled) =>
-                                val isOurs = polled.asInstanceOf[AnyRef] eq v.asInstanceOf[AnyRef]
-                                if !isOurs then
-                                    // Polled someone else's element — put it back
-                                    discard(q.offer(polled))
-                                !isOurs
-                            case _ => true
-                    )
-                def poll()(using AllowUnsafe) = pollOp(q.poll())
-                def peek()(using AllowUnsafe) = op(q.peek())
+                def capacity                       = q.capacity
+                def size()(using AllowUnsafe)      = op(q.size())
+                def empty()(using AllowUnsafe)     = op(q.isEmpty())
+                def full()(using AllowUnsafe)      = op(q.isFull())
+                def offer(v: A)(using AllowUnsafe) = offerOp(q.offer(v))
+                def poll()(using AllowUnsafe)      = pollOp(q.poll())
+                def peek()(using AllowUnsafe)      = op(q.peek())
                 def _drain(max: Maybe[Int] = Maybe.Absent) =
                     val b = Chunk.newBuilder[A]
                     max match

--- a/kyo-core/shared/src/main/scala/kyo/Scope.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Scope.scala
@@ -173,21 +173,34 @@ object Scope:
 
                         def close(ex: Maybe[Error[Any]])(using Frame): Unit < Sync =
                             Sync.Unsafe.defer {
-                                queue.close() match
-                                    case Absent => ()
-                                    case Present(tasks) =>
-                                        if tasks.isEmpty then
-                                            promise.completeUnitDiscard
-                                        else
-                                            Async.foreachDiscard(tasks.reverse, parallelism) { task =>
-                                                Abort.run[Throwable](task(ex))
-                                                    .map(_.foldError(
-                                                        _ => (),
-                                                        ex => Log.error("Scope finalizer failed", ex.exception)
-                                                    ))
-                                            }
-                                                .handle(Fiber.initUnscoped[Nothing, Unit, Any, Any])
-                                                .map(promise.becomeDiscard)
+                                // The queue hands its backlog over asynchronously, because an `ensure` that began before this close may
+                                // still be committing its task and no synchronous answer could include it. Nothing here waits for that:
+                                // the finalizers already ran on a detached fiber with `await` parked on `promise`, so registering a
+                                // continuation keeps this `Sync` and leaves both of `run`'s close paths, including the panic path that
+                                // cannot suspend, exactly as they were.
+                                queue.close().safe.onComplete { backlog =>
+                                    backlog.foldError(
+                                        _.map {
+                                            case Absent => Kyo.unit
+                                            case Present(tasks) =>
+                                                if tasks.isEmpty then
+                                                    promise.completeUnitDiscard
+                                                else
+                                                    Async.foreachDiscard(tasks.reverse, parallelism) { task =>
+                                                        Abort.run[Throwable](task(ex))
+                                                            .map(_.foldError(
+                                                                _ => (),
+                                                                ex => Log.error("Scope finalizer failed", ex.exception)
+                                                            ))
+                                                    }
+                                                        .handle(Fiber.initUnscoped[Nothing, Unit, Any, Any])
+                                                        .map(promise.becomeDiscard)
+                                        },
+                                        // The backlog handover is completed with a success by whoever wins the drain, so this is
+                                        // unreachable; leaving `promise` alone lets `await` surface the real failure.
+                                        _ => Kyo.unit
+                                    )
+                                }
                             }
 
                         def await(using Frame): Unit < Async = promise.get

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -400,7 +400,7 @@ object StreamCoreExtensions:
                     Meter.useSemaphore(parallel): semaphore =>
                         // Ensure lingering fibers are interrupted
                         val cleanup = Abort.run[Closed]:
-                            Sync.ensure(channelOut.close):
+                            Sync.ensure(channelOut.closeDiscard):
                                 Loop.foreach:
                                     channelOut.drain.map: chunk =>
                                         if chunk.isEmpty then Loop.done
@@ -448,7 +448,7 @@ object StreamCoreExtensions:
                                             case Result.Failure(e) =>
                                                 // Not Closed, must be E
                                                 fiberError.set(Present(Right(e)))
-                                Sync.ensure(channelOut.close):
+                                Sync.ensure(channelOut.closeDiscard):
                                     Abort.run[Closed](emit).unit
                                 .andThen(fiberError)
                         end emitResults
@@ -508,7 +508,7 @@ object StreamCoreExtensions:
                         Meter.useSemaphore(parallel): semaphore =>
                             // Ensure lingering fibers are interrupted
                             val cleanup = Abort.run[Closed]:
-                                Sync.ensure(channelPar.close.andThen(channelOut.close)):
+                                Sync.ensure(channelPar.closeDiscard.andThen(channelOut.closeDiscard)):
                                     Loop.foreach:
                                         channelPar.drain.map: chunk =>
                                             if chunk.isEmpty then Loop.done
@@ -620,7 +620,7 @@ object StreamCoreExtensions:
                     Meter.useSemaphore(parallel): semaphore =>
                         // Ensure lingering fibers are interrupted
                         val cleanup = Abort.run[Closed]:
-                            Sync.ensure(channelOut.close):
+                            Sync.ensure(channelOut.closeDiscard):
                                 Loop.foreach:
                                     channelOut.drain.map: chunk =>
                                         if chunk.isEmpty then Loop.done
@@ -670,7 +670,7 @@ object StreamCoreExtensions:
                                             case Result.Failure(e) =>
                                                 // Not Closed, must be E
                                                 fiberError.set(Present(Right(e)))
-                                Sync.ensure(channelOut.close):
+                                Sync.ensure(channelOut.closeDiscard):
                                     Abort.run[Closed](emit).unit
                                 .andThen(fiberError)
                         end emitResults
@@ -736,7 +736,7 @@ object StreamCoreExtensions:
                         Meter.useSemaphore(parallel): semaphore =>
                             // Ensure lingering fibers are interrupted
                             val cleanup = Abort.run[Closed]:
-                                Sync.ensure(channelPar.close.andThen(channelOut.close)):
+                                Sync.ensure(channelPar.closeDiscard.andThen(channelOut.closeDiscard)):
                                     Loop.foreach:
                                         channelPar.drain.map: chunk =>
                                             if chunk.isEmpty then Loop.done

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -1717,9 +1717,13 @@ class ChannelTest extends kyo.test.Test[Any]:
                 val p3    = c.putFiber(3)       // parks: channel full
                 val drain = c.closeAwaitEmpty() // HalfOpen: queue non-empty, put parked
                 // pre-fix: close() only transitioned from Open, so it no-oped on a HalfOpen queue and both promises hung forever
-                val backlog = c.close()
-                val p3r     = p3.poll()    // the parked put must be settled Closed, not left hanging
-                val dr      = drain.poll() // the await-empty must settle (aborted), not left pending
+                // close hands its elements over through a fiber so a put still committing is not missed. Nothing is in flight on this
+                // single thread, so the handover settles inside close and refusing to wait keeps a regression there visible.
+                val backlog = c.close().poll() match
+                    case Present(Result.Success(b)) => b.eval
+                    case other                      => throw AssertionError(s"close did not settle synchronously: $other")
+                val p3r = p3.poll()    // the parked put must be settled Closed, not left hanging
+                val dr  = drain.poll() // the await-empty must settle (aborted), not left pending
                 assert(backlog.contains(Seq(1, 2)), s"the closer must receive the undrained backlog=$backlog")
                 assert(p3r.exists { case Result.Failure(_: Closed) => true; case _ => false }, s"parked put settled=$p3r")
                 assert(dr.exists { case Result.Success(b) => !b.eval; case _ => false }, s"await-empty settled=$dr")

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -300,6 +300,14 @@ class QueueTest extends kyo.test.Test[Any]:
         def withQueue[A](f: Queue.Unsafe[Int] => A): A =
             f(Queue.Unsafe.init[Int](2))
 
+        // close hands its backlog over through a fiber, because an offer still committing could not be reported synchronously. These
+        // leaves drive the queue from one thread with nothing in flight, so the handover always settles inside close itself; anything
+        // else is a defect in the handover rather than a slow test, which is why this refuses to wait.
+        def closeNow[A](queue: Queue.Unsafe[A]): Maybe[Seq[A]] =
+            queue.close().poll() match
+                case Present(Result.Success(backlog)) => backlog.eval
+                case other                            => throw AssertionError(s"close did not settle synchronously: $other")
+
         "should offer and poll correctly" in withQueue { testUnsafe =>
             assert(testUnsafe.offer(1).contains(true))
             assert(testUnsafe.poll().contains(Maybe(1)))
@@ -341,16 +349,16 @@ class QueueTest extends kyo.test.Test[Any]:
 
         "should close correctly" in withQueue { testUnsafe =>
             testUnsafe.offer(5)
-            val closed = testUnsafe.close()
+            val closed = closeNow(testUnsafe)
             assert(closed == Maybe(Seq(5)))
-            assert(testUnsafe.close().isEmpty)
+            assert(closeNow(testUnsafe).isEmpty)
         }
 
         "a hard close aborts a pending closeAwaitEmpty and returns the backlog" in withQueue { testUnsafe =>
             discard(testUnsafe.offer(1))
             discard(testUnsafe.offer(2))
-            val await   = testUnsafe.closeAwaitEmpty() // HalfOpen: queue non-empty, so the await parks
-            val backlog = testUnsafe.close()           // escalate HalfOpen -> FullyClosed: abort the await, return the backlog
+            val await = testUnsafe.closeAwaitEmpty() // HalfOpen: queue non-empty, so the await parks
+            val backlog = closeNow(testUnsafe) // escalate HalfOpen -> Draining -> FullyClosed: abort the await, hand over the backlog
             val ar      = await.poll()
             assert(backlog.contains(Seq(1, 2)), s"close must return the undrained backlog=$backlog")
             assert(ar.exists { case Result.Success(b) => !b.eval; case _ => false }, s"the aborted await must settle false=$ar")
@@ -501,6 +509,235 @@ class QueueTest extends kyo.test.Test[Any]:
             )
                 .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .unit
+        }
+    }
+
+    "close versus in-flight offers" - {
+
+        // Fewer repeats than the plain concurrency group above, because each scenario here drains thousands of elements. Both defects
+        // these guard showed up within the first repeat when they were live, so the count is margin rather than the mechanism.
+        val repeats = 25
+
+        // A close consumes the queue itself, so the closer has to be the only consumer for the whole close. These scenarios put dense
+        // offers against a long drain on every access pattern: each element an offer accepted must reach the closer's backlog exactly
+        // once, with nothing duplicated by a second consumer and nothing stranded in the queue after it is closed.
+        // A hang is caught by the suite's per-leaf cap; there is deliberately no in-test deadline racing the work.
+
+        def producerCount(access: Access) =
+            access match
+                case Access.MultiProducerMultiConsumer | Access.MultiProducerSingleConsumer   => 8
+                case Access.SingleProducerMultiConsumer | Access.SingleProducerSingleConsumer => 1
+
+        def preloadCount(capacity: Int) =
+            if capacity == Int.MaxValue then 4096 else capacity / 2
+
+        // Distinct ids per producer, all above the preloaded range, so the backlog identifies where every element came from. The producer
+        // reports itself running before its first offer, which is what lets the closer land while offers are genuinely in flight; the
+        // iteration cap is only a runaway guard, since the loop ends on the first refusal.
+        def offerUntilClosed(queue: Queue[Int], running: Latch, producer: Int)(using Frame): Chunk[Int] < Async =
+            running.release.andThen {
+                Loop.indexed(Chunk.empty[Int]) { (i, accepted) =>
+                    if i == 20000 then Loop.done(accepted)
+                    else
+                        val id = producer * 1000000 + i
+                        Abort.run(queue.offer(id)).map {
+                            case Result.Success(true)  => Loop.continue(accepted.append(id))
+                            case Result.Success(false) => Loop.continue(accepted)
+                            case _                     => Loop.done(accepted)
+                        }
+                    end if
+                }
+            }
+
+        // Drains rather than polls one at a time: each drain leaves the queue empty, which is the state in which a closing transition
+        // decides it has seen everything, so this is what puts that decision against the offers still in flight.
+        def drainUntilClosed(queue: Queue[Int])(using Frame): Chunk[Int] < Sync =
+            Loop(Chunk.empty[Int]) { polled =>
+                Abort.run(queue.drain).map {
+                    case Result.Success(batch) => Loop.continue(polled.concat(batch))
+                    case _                     => Loop.done(polled)
+                }
+            }
+
+        def closeRace(capacity: Int, access: Access)(using Frame, kyo.test.AssertScope) =
+            val producers = producerCount(access)
+            val preload   = preloadCount(capacity)
+            for
+                queue   <- Queue.initUnscoped[Int](capacity, access)
+                _       <- Kyo.foreachDiscard(1 to preload)(i => Abort.run(queue.offer(i)))
+                running <- Latch.init(producers)
+                producerFiber <- Fiber.initUnscoped(
+                    Async.foreach(1 to producers, producers)(offerUntilClosed(queue, running, _))
+                )
+                closeFiber <- Fiber.initUnscoped(running.await.andThen(queue.close))
+                accepted   <- producerFiber.get
+                backlog    <- closeFiber.get
+            yield
+                val acceptedIds = accepted.flatten.toSet
+                val expected    = (1 to preload).toSet ++ acceptedIds
+                val drained     = backlog.getOrElse(Seq.empty)
+                val duplicated  = drained.diff(drained.distinct)
+                assert(
+                    duplicated.isEmpty,
+                    s"the backlog repeated ${duplicated.size} element(s) for capacity=$capacity access=$access: ${duplicated.take(5)}"
+                )
+                assert(
+                    drained.toSet == expected,
+                    s"for capacity=$capacity access=$access the backlog stranded ${(expected -- drained.toSet).take(5)} " +
+                        s"and invented ${(drained.toSet -- expected).take(5)}"
+                )
+            end for
+        end closeRace
+
+        def awaitEmptyRace(capacity: Int, access: Access)(using Frame, kyo.test.AssertScope) =
+            val producers = producerCount(access)
+            for
+                queue   <- Queue.initUnscoped[Int](capacity, access)
+                running <- Latch.init(producers)
+                producerFiber <- Fiber.initUnscoped(
+                    Async.foreach(1 to producers, producers)(offerUntilClosed(queue, running, _))
+                )
+                drainFiber <- Fiber.initUnscoped(drainUntilClosed(queue))
+                closeFiber <- Fiber.initUnscoped(running.await.andThen(queue.closeAwaitEmpty))
+                accepted   <- producerFiber.get
+                reported   <- closeFiber.get
+                polled     <- drainFiber.get
+            yield
+                val acceptedIds = accepted.flatten.toSet
+                assert(reported, s"closeAwaitEmpty must report the queue drained for capacity=$capacity access=$access")
+                assert(
+                    polled.toSet == acceptedIds,
+                    s"for capacity=$capacity access=$access closeAwaitEmpty reported drained while " +
+                        s"${(acceptedIds -- polled.toSet).take(5)} was still in flight"
+                )
+            end for
+        end awaitEmptyRace
+
+        "a close never leaves an accepted element behind and never hands one out twice" - {
+            access.foreach { access =>
+                access.toString in {
+                    (for
+                        capacity <- Choice.eval(4096, Int.MaxValue)
+                        _        <- closeRace(capacity, access)
+                    yield ())
+                        .handle(Choice.run, _.unit, Loop.repeat(repeats))
+                        .unit
+                }
+            }
+        }
+
+        // Small capacities on purpose: the backlog a drain has to clear before the queue looks empty stays near zero, which is what puts
+        // the "everything has been consumed" decision inside the window of an offer that is still in flight.
+        "closeAwaitEmpty never reports drained while an offer is in flight" - {
+            access.foreach { access =>
+                access.toString in {
+                    (for
+                        capacity <- Choice.eval(2, 64)
+                        _        <- awaitEmptyRace(capacity, access)
+                    yield ())
+                        .handle(Choice.run, _.unit, Loop.repeat(repeats))
+                        .unit
+                }
+            }
+        }
+    }
+
+    "sliding while a consumer polls" - {
+
+        val repeats           = 25
+        val offersPerProducer = 2000
+
+        // A sliding queue makes room by removing its oldest element, and that removal runs on whichever thread offered. These scenarios
+        // start the queue full so every offer slides, and keep a consumer polling for the whole run: the offering thread and the consumer
+        // are then removing elements at the same time. No offer may hang, no element may reach the consumer twice, and sliding must stay
+        // sliding, meaning every offer is accepted.
+
+        def producerCount(access: Access) =
+            access match
+                case Access.MultiProducerMultiConsumer | Access.MultiProducerSingleConsumer   => 8
+                case Access.SingleProducerMultiConsumer | Access.SingleProducerSingleConsumer => 1
+
+        def slideUntilDone(queue: Queue.Unbounded[Int], running: Latch, producer: Int)(
+            using Frame
+        ): Chunk[Result[Closed, Boolean]] < Async =
+            running.release.andThen {
+                Loop.indexed(Chunk.empty[Result[Closed, Boolean]]) { (i, results) =>
+                    if i == offersPerProducer then Loop.done(results)
+                    else Abort.run(queue.offer(producer * 1000000 + i)).map(r => Loop.continue(results.append(r)))
+                }
+            }
+
+        // The producers set `finished` only after their last offer has returned, so reading it after a poll came back empty is what tells
+        // the consumer no element can still arrive. Anything offered in between is left in the queue, which the assertions allow: a
+        // sliding queue drops elements by design, so completeness is not one of its invariants.
+        def pollUntilDone(queue: Queue.Unbounded[Int], finished: AtomicBoolean)(using Frame): Chunk[Int] < Sync =
+            Loop(Chunk.empty[Int]) { polled =>
+                Abort.run(queue.poll).map { attempt =>
+                    finished.get.map { done =>
+                        attempt match
+                            case Result.Success(Maybe.Present(v)) => Loop.continue(polled.append(v))
+                            case Result.Success(_) if !done       => Loop.continue(polled)
+                            case _                                => Loop.done(polled)
+                    }
+                }
+            }
+
+        def slideRace(capacity: Int, access: Access)(using Frame, kyo.test.AssertScope) =
+            val producers = producerCount(access)
+            for
+                queue    <- Queue.Unbounded.initSlidingUnscoped[Int](capacity, access)
+                _        <- Kyo.foreachDiscard(1 to capacity)(i => Abort.run(queue.offer(i)))
+                finished <- AtomicBoolean.init(false)
+                running  <- Latch.init(producers)
+                producerFiber <- Fiber.initUnscoped(
+                    Async.foreach(1 to producers, producers)(slideUntilDone(queue, running, _))
+                        .map(results => finished.set(true).andThen(results))
+                )
+                consumerFiber <- Fiber.initUnscoped(running.await.andThen(pollUntilDone(queue, finished)))
+                offered       <- producerFiber.get
+                polled        <- consumerFiber.get
+            yield
+                val offeredIds = (1 to producers).flatMap(p => (0 until offersPerProducer).map(i => p * 1000000 + i)).toSet
+                val duplicated = polled.diff(polled.distinct)
+                assert(
+                    offered.flatten.forall(_.contains(true)),
+                    s"for capacity=$capacity access=$access a sliding offer was refused: " +
+                        s"${offered.flatten.filterNot(_.contains(true)).take(5)}"
+                )
+                assert(
+                    duplicated.isEmpty,
+                    s"for capacity=$capacity access=$access the consumer received ${duplicated.size} element(s) twice: " +
+                        s"${duplicated.take(5)}"
+                )
+                assert(
+                    polled.toSet.subsetOf((1 to capacity).toSet ++ offeredIds),
+                    s"for capacity=$capacity access=$access the consumer received elements nobody offered: " +
+                        s"${(polled.toSet -- ((1 to capacity).toSet ++ offeredIds)).take(5)}"
+                )
+            end for
+        end slideRace
+
+        // How to read one of these per-access results. Only MultiProducerSingleConsumer turns this leaf red on a queue built without the
+        // access mapping; the two multi-consumer values are sound to begin with, so nothing there is expected to fail.
+        // SingleProducerSingleConsumer breaks the same contract and the mapping is what fixes it, but a green on that leg is not evidence
+        // the mapping is unnecessary. With one producer, the thread taking the illegal second poll is the only producer, so nothing
+        // refills the queue underneath the real consumer while that poll runs, and the interleavings left over are mostly harmless: both
+        // pollers return the same element and the sliding wrapper discards its copy. The damaging one needs the producer descheduled
+        // inside a window of a few instructions, so that its stale consumer-index write lands after the consumer has moved past that slot;
+        // the consumer is then left reading a slot nobody will fill, and the sliding loop alternates forever between an offer that reports
+        // full and a poll that reports empty. The single-consumer half of the mapping is pinned by the contract, not by a red run.
+        // A hang is caught by the suite's per-leaf cap; there is deliberately no in-test deadline racing the work.
+        "a sliding offer never hangs and never hands the consumer the same element twice" - {
+            access.foreach { access =>
+                access.toString in {
+                    (for
+                        capacity <- Choice.eval(4, 64)
+                        _        <- slideRace(capacity, access)
+                    yield ())
+                        .handle(Choice.run, _.unit, Loop.repeat(repeats))
+                        .unit
+                }
+            }
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/ScopeTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ScopeTest.scala
@@ -205,6 +205,74 @@ class ScopeTest extends kyo.test.Test[Any]:
             end for
         }
 
+        "a resource acquired after the scope closed is released rather than leaked".pendingUntilFixed(
+            "acquisition and registration are two steps, so a scope that closes between them refuses the registration and the acquired resource is never released"
+        ) in {
+            for
+                acquired <- AtomicInt.init(0)
+                released <- AtomicInt.init(0)
+                gate     <- Latch.init(1)
+                fiber <- Scope.run {
+                    Fiber.initUnscoped(
+                        gate.await.andThen(
+                            Scope.acquireRelease(acquired.incrementAndGet)(_ => released.incrementAndGet.unit)
+                        )
+                    )
+                }
+                // The gate opens only once Scope.run has returned, so the acquisition below is guaranteed to find the scope closed.
+                _      <- gate.release
+                result <- fiber.getResult
+                a      <- acquired.get
+                r      <- released.get
+            yield
+                // Only the leak invariant is pinned, deliberately. Asserting that the resource was acquired first would pin the shape of
+                // the current defect, so a fix that refuses before acquiring would leave this leaf failing forever instead of turning red.
+                // Either outcome is correct as long as nothing acquired goes unreleased.
+                assert(
+                    result.isSuccess || result.panic.exists(_.isInstanceOf[Closed]),
+                    s"registering on a closed scope must either succeed or panic Closed: $result"
+                )
+                assert(r == a, s"every acquired resource must be released: acquired=$a released=$r")
+            end for
+        }
+
+        "fibers registering finalizers while their scope closes: each accepted registration runs exactly once" in {
+            // A scope closes by draining its finalizer queue, and the fibers below stay free to register for the whole drain, so
+            // registration and close overlap by construction. The scope is preloaded first so the drain is long enough for the two to
+            // meet. Every registration the scope accepted has to run, and none of them twice.
+            (for
+                accepted <- AtomicInt.init(0)
+                ran      <- AtomicInt.init(0)
+                fibers <- Scope.run {
+                    val register =
+                        Abort.run[Nothing](Scope.ensure(ran.incrementAndGet.unit)).map {
+                            case Result.Success(_) => accepted.incrementAndGet.andThen(true)
+                            case _                 => false
+                        }
+                    for
+                        _       <- Loop.repeat(8192)(register)
+                        started <- Latch.init(8)
+                        fibers <- Kyo.fill(8) {
+                            Fiber.initUnscoped(
+                                started.release.andThen(
+                                    Loop.indexed { i =>
+                                        if i == 100000 then Loop.done
+                                        else register.map(ok => if ok then Loop.continue else Loop.done)
+                                    }
+                                )
+                            )
+                        }
+                        _ <- started.await
+                    yield fibers
+                    end for
+                }
+                _ <- Kyo.foreachDiscard(fibers)(_.get)
+                a <- accepted.get
+                r <- ran.get
+            yield assert(r == a, s"each accepted registration must run exactly once: ran=$r accepted=$a"))
+                .handle(Loop.repeat(20))
+        }
+
         "concurrent acquireRelease all cleaned up" in {
             AtomicInt.init.map { counter =>
                 Scope.run {

--- a/kyo-ffi/it/shared/src/test/scala/kyo/ffi/it/PosixTest.scala
+++ b/kyo-ffi/it/shared/src/test/scala/kyo/ffi/it/PosixTest.scala
@@ -86,16 +86,17 @@ class PosixTest extends ItTestBase:
         "reads the same epoch clock as java.lang.System" in {
             assumePosixSymbols()
             val posix = Ffi.load[PosixBindings]
-            // Assert the native time(2) read is the same ORDER OF MAGNITUDE as java.lang.System's epoch, not equal to
-            // the second. The two are different clocks (on Scala.js java.lang.System is V8's Date.now while posix.time
-            // is a native time(2) downcall), so any exact or few-seconds comparison flips whenever the process stalls
-            // across that gap. What the binding can actually get wrong is off by orders of magnitude: milliseconds
-            // instead of seconds (~1000x), the wrong epoch, or garbage. An order-of-magnitude window catches all of
-            // those and can never flip on a stall, since a stall would have to shift the wall clock by decades to
-            // leave it. Ordering and positivity are asserted independently by the other leaves.
-            val jSecs = java.lang.System.currentTimeMillis() / 1000L
-            val cSecs = posix.time(0L)
-            assert(cSecs > jSecs / 2 && cSecs < jSecs * 2, s"time()=$cSecs not the same order of magnitude as java.lang.System=$jSecs")
+            // Bracket the C read between two Java reads, with a second of slack. The bracket absorbs host slowness
+            // structurally: however long the process stalls between the reads, a same-clock value still lands inside
+            // it. The slack absorbs the one real cross-clock difference, that on Scala.js `java.lang.System` reads
+            // V8's Date.now while `posix.time` is a genuine time(2) downcall, so the two can round across a second
+            // boundary differently. A binding with the wrong unit, the wrong epoch, or garbage misses by orders of
+            // magnitude and still fails here, and unlike a magnitude window this also catches one that is merely off
+            // by an hour or a day. Ordering and positivity are asserted independently by the other leaves.
+            val jBefore = java.lang.System.currentTimeMillis() / 1000L
+            val cSecs   = posix.time(0L)
+            val jAfter  = java.lang.System.currentTimeMillis() / 1000L
+            assert(cSecs >= jBefore - 1 && cSecs <= jAfter + 1, s"time()=$cSecs not within a second of [$jBefore, $jAfter]")
         }
 
         "two calls are monotonic non-decreasing" in {
@@ -135,18 +136,19 @@ class PosixTest extends ItTestBase:
             last
         }
 
-        "each rapid read stays the same order of magnitude as java.lang.System" in {
+        "each rapid read stays within a second of java.lang.System" in {
             assumePosixSymbols()
-            // Same order-of-magnitude check across a 32-call burst (see the single-read leaf above): the two are
-            // different clocks on Scala.js, so any exact or few-seconds comparison flips on a stall. The magnitude
-            // window catches wrong-unit/epoch/garbage without flake; ordering is a separate leaf.
+            // The single-read leaf's bracket applied to every call in a 32-call burst, so a binding that drifts only
+            // under repeated calls is caught too. Each read gets its own surrounding pair rather than one pair around
+            // the whole loop, which would widen the window by the loop's duration and weaken every iteration.
             val posix      = Ffi.load[PosixBindings]
             var i          = 0
             var last: Unit = succeed
             while i < 32 do
-                val jSecs = java.lang.System.currentTimeMillis() / 1000L
-                val cur   = posix.time(0L)
-                last = assert(cur > jSecs / 2 && cur < jSecs * 2, s"time()=$cur not the same order of magnitude as java.lang.System=$jSecs")
+                val jBefore = java.lang.System.currentTimeMillis() / 1000L
+                val cur     = posix.time(0L)
+                val jAfter  = java.lang.System.currentTimeMillis() / 1000L
+                last = assert(cur >= jBefore - 1 && cur <= jAfter + 1, s"time()=$cur not within a second of [$jBefore, $jAfter]")
                 i += 1
             end while
             last

--- a/kyo-http/shared/src/main/scala/kyo/HttpWebSocket.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpWebSocket.scala
@@ -137,12 +137,12 @@ object HttpWebSocket:
                                         .andThen(closeRef2.set(Present((code, reason))))
                                         .andThen(peerClosed1.completeUnit.unit)
                                         .andThen(peerClosed2.completeUnit.unit)
-                                        .andThen(ch1to2.close.unit)
-                                        .andThen(ch2to1.close.unit)
+                                        .andThen(ch1to2.closeDiscard)
+                                        .andThen(ch2to1.closeDiscard)
                                 val ws1 = new HttpWebSocket(ch2to1, ch1to2, closeRef1, peerClosed1, doClose)
                                 val ws2 = new HttpWebSocket(ch1to2, ch2to1, closeRef2, peerClosed2, doClose)
                                 Sync.ensure {
-                                    ch1to2.close.unit.andThen(ch2to1.close.unit)
+                                    ch1to2.closeDiscard.andThen(ch2to1.closeDiscard)
                                 } {
                                     // Race: when either party completes, close channels to unblock the other
                                     Async.raceFirst(

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -940,7 +940,7 @@ final private[kyo] class HttpClientBackend private (
                     Fiber.Promise.init[Unit, Any].map { peerClosedPromise =>
                         val closeFn: (Int, String) => Unit < Async = (code, reason) =>
                             closeReasonRef.set(Present((code, reason))).andThen {
-                                outbound.close.unit
+                                outbound.closeDiscard
                             }
                         val ws = new HttpWebSocket(inbound, outbound, closeReasonRef, peerClosedPromise, closeFn)
 
@@ -967,7 +967,7 @@ final private[kyo] class HttpClientBackend private (
                                         case Result.Failure(_) => Kyo.unit
                                         case Result.Panic(t)   => Log.warn("HttpWebSocket client reader panicked", t)
                                         case Result.Success(_) => Kyo.unit
-                                    log.andThen(inbound.close.unit).andThen(peerClosedPromise.completeUnit.unit)
+                                    log.andThen(inbound.closeDiscard).andThen(peerClosedPromise.completeUnit.unit)
                                 }
                             }.map { monitorFiber =>
                                 Fiber.initUnscoped {
@@ -997,8 +997,8 @@ final private[kyo] class HttpClientBackend private (
                                         readFiber.interrupt.unit
                                             .andThen(writeFiber.interrupt.unit)
                                             .andThen(monitorFiber.interrupt.unit)
-                                            .andThen(inbound.close.unit)
-                                            .andThen(outbound.close.unit)
+                                            .andThen(inbound.closeDiscard)
+                                            .andThen(outbound.closeDiscard)
                                     ) {
                                         f(ws)
                                     }

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
@@ -442,7 +442,7 @@ private[kyo] object UnsafeServerDispatch:
                         // conn), eliminating the put/close race that surfaced under caliban WS load on arm64 CI.
                         val closeFn: (Int, String) => Unit < Async = (code, reason) =>
                             closeReasonRef.set(Present((code, reason))).andThen {
-                                outbound.close.unit
+                                outbound.closeDiscard
                             }
                         val ws      = new HttpWebSocket(inbound, outbound, closeReasonRef, peerClosedPromise, closeFn)
                         val request = HttpRequest(HttpMethod.GET, url, headers, Record.empty)
@@ -470,7 +470,7 @@ private[kyo] object UnsafeServerDispatch:
                                         case Result.Failure(_) => Kyo.unit
                                         case Result.Panic(t)   => Log.warn("HttpWebSocket server reader panicked", t)
                                         case Result.Success(_) => Kyo.unit
-                                    log.andThen(inbound.close.unit).andThen(peerClosedPromise.completeUnit.unit)
+                                    log.andThen(inbound.closeDiscard).andThen(peerClosedPromise.completeUnit.unit)
                                 }
                             }.map { monitorFiber =>
                                 Fiber.initUnscoped {
@@ -495,14 +495,14 @@ private[kyo] object UnsafeServerDispatch:
                                                     Abort.run[Any](WebSocketCodec.writeClose(conn, code, reason, mask = false)).unit
                                                 case Absent => Kyo.unit
                                             }
-                                        }.andThen(outbound.close.unit)
+                                        }.andThen(outbound.closeDiscard)
                                     }
                                 }.map { writeFiber =>
                                     Sync.ensure(
                                         readFiber.interrupt.unit
                                             .andThen(writeFiber.interrupt.unit)
                                             .andThen(monitorFiber.interrupt.unit)
-                                            .andThen(outbound.close.unit)
+                                            .andThen(outbound.closeDiscard)
                                     ) {
                                         Abort.run[Any](wsHandler.wsHandler(request, ws)).map { _ =>
                                             // After handler returns: if no close reason was registered AND the reader
@@ -513,9 +513,9 @@ private[kyo] object UnsafeServerDispatch:
                                                 case Absent =>
                                                     readFiber.done.map { isDone =>
                                                         if isDone then Kyo.unit
-                                                        else closeReasonRef.set(Present((1000, ""))).andThen(outbound.close.unit)
+                                                        else closeReasonRef.set(Present((1000, ""))).andThen(outbound.closeDiscard)
                                                     }
-                                                case _ => outbound.close.unit
+                                                case _ => outbound.closeDiscard
                                             }.andThen(writeFiber.get.unit)
                                         }
                                     }

--- a/kyo-http/shared/src/test/scala/kyo/HttpWebSocketTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpWebSocketTest.scala
@@ -1016,7 +1016,7 @@ class HttpWebSocketTest extends BaseHttpTest with internal.UnixSocketTestHelperI
                             Fiber.Promise.init[Unit, Any].map { pc2 =>
                                 val ws1 = new HttpWebSocket(ch2to1, ch1to2, ref, pc1, closeFn)
                                 val ws2 = new HttpWebSocket(ch1to2, ch2to1, ref, pc2, closeFn)
-                                Sync.ensure(ch1to2.close.unit.andThen(ch2to1.close.unit)) {
+                                Sync.ensure(ch1to2.closeDiscard.andThen(ch2to1.closeDiscard)) {
                                     Async.raceFirst(
                                         Abort.run[Closed](ws1.take()).unit,
                                         Abort.run[Closed](ws2.close(1001, "going away")).unit
@@ -1042,7 +1042,7 @@ class HttpWebSocketTest extends BaseHttpTest with internal.UnixSocketTestHelperI
                             Fiber.Promise.init[Unit, Any].map { pc2 =>
                                 val ws1 = new HttpWebSocket(ch2to1, ch1to2, ref, pc1, closeFn)
                                 val ws2 = new HttpWebSocket(ch1to2, ch2to1, ref, pc2, closeFn)
-                                Sync.ensure(ch1to2.close.unit.andThen(ch2to1.close.unit)) {
+                                Sync.ensure(ch1to2.closeDiscard.andThen(ch2to1.closeDiscard)) {
                                     Async.raceFirst(
                                         Abort.run[Closed](ws1.take()).unit,
                                         Abort.run[Closed](ws2.close(4000, "app error")).unit

--- a/kyo-net/js-wasm/src/main/scala/kyo/net/internal/JsTransport.scala
+++ b/kyo-net/js-wasm/src/main/scala/kyo/net/internal/JsTransport.scala
@@ -937,176 +937,193 @@ final private[kyo] class JsTransport private (
 
         // Detach closes channels and pauses+cancels the socket without destroying it.
         // Any bytes the ReadPump had already staged but caller had not consumed are returned.
-        val preRead = jsConn.detachForUpgrade()
-        if preRead.isEmpty then
-            // The claim was won but the connection reached a terminal state before the detach (a close raced or preceded this call):
-            // nothing was detached and the close path owns the socket. Fail typed; the owner hook above releases through its
-            // destroyed-guarded destroy, a no-op for a socket the close already destroyed.
-            promise.completeDiscard(Result.fail(NetAlreadyDetachedException()))
-            return promise.asInstanceOf[Fiber.Unsafe[NetConnection, Abort[NetException]]]
-        end if
-
-        // Push pre-read bytes and any peer-close-probe-staged leftover back into the socket (unshift) so the TLS engine sees them first. Order:
-        // channel-drained preRead is older than the listener-stashed leftover, so preRead precedes it; draining leftover here also fixes its pre-existing silent drop at upgrade.
-        var replay: Chunk[Array[Byte]] = preRead match
-            case Present(chunks) => chunks.map(_.toArray)
-            case Absent          => Chunk.empty
-        var draining = true
-        while draining do
-            handle.dequeueLeftover() match
-                case Present(JsHandle.Leftover(buf, off, len)) =>
-                    replay = replay.append(if off == 0 && len == buf.length then buf else java.util.Arrays.copyOfRange(buf, off, off + len))
-                case Absent => draining = false
-            end match
-        end while
-        if replay.nonEmpty then
-            val totalLen = replay.foldLeft(0)(_ + _.length)
-            val buf      = new Array[Byte](totalLen)
-            var off      = 0
-            replay.foreach { arr =>
-                // System.arraycopy: no kyo equivalent for a bulk primitive-array copy; fully qualified so kyo.System does not shadow it.
-                java.lang.System.arraycopy(arr, 0, buf, off, arr.length)
-                off += arr.length
-            }
-            val nodeBuffer = js.Dynamic.global.Buffer.from(
-                js.typedarray.byteArray2Int8Array(buf).buffer
-            )
-            discard(socket.unshift(nodeBuffer))
-        end if
-
-        // Remove the JsHandle's permanent listeners from the plaintext socket. They were registered
-        // by JsHandle.init and would intercept TLS handshake bytes if left in place after the
-        // TLSSocket takes ownership of the underlying socket's data stream.
-        discard(socket.removeAllListeners())
-
-        // The underlying socket was paused by detachForUpgrade. Resume it so the TLS layer can
-        // read the handshake bytes (ClientHello / ServerHello). The TLS layer manages its own
-        // internal flow; we will pause the TLSSocket's application-data stream after handshake.
-        discard(socket.resume())
-
-        val tlsModule = NodeTls.asInstanceOf[js.Dynamic]
-        val fsModule  = NodeFs.asInstanceOf[js.Dynamic]
-
-        // The TLS role follows the connection's TCP origin: an accepted connection (isServerOrigin) upgrades as the TLS server, a connected one
-        // as the client (STARTTLS initiate). The origin is authoritative: a config heuristic ("has a cert+key therefore server") would
-        // misclassify a mutual-TLS client that presents its own client certificate, upgrading it in the server role.
-        val isServerSide = jsConn.isServerOrigin
-
-        val tlsSocket =
-            if isServerSide then
-                // Server-side STARTTLS: wrap the existing socket as a TLS server socket.
-                // Node.js requires tls.TLSSocket constructor with isServer=true.
-                val opts = js.Dynamic.literal()
-                opts.isServer = true
-                // Constrain the negotiated TLS version on the upgraded server socket (CWE-326).
-                applyVersionBounds(opts, tls)
-                tls.certChainPath match
-                    case Present(p) => opts.cert = fsModule.readFileSync(p, "utf8")
-                    case Absent     => ()
-                tls.privateKeyPath match
-                    case Present(p) => opts.key = fsModule.readFileSync(p, "utf8")
-                    case Absent     => ()
-                // Mutual TLS: honor clientAuth on the upgraded server socket, matching listen(tls) and the posix/NIO server STARTTLS path.
-                applyServerClientAuth(opts, tls)
-                // Construct TLSSocket directly with the existing socket and server opts
-                js.Dynamic.newInstance(tlsModule.selectDynamic("TLSSocket"))(socket, opts)
-            else
-                // Client-side STARTTLS: use tls.connect({ socket }) which drives the TLS handshake.
-                val opts = js.Dynamic.literal()
-                opts.socket = socket
-                val sni = tls.sniHostname.getOrElse("localhost")
-                opts.servername = sni
-                opts.host = sni
-                // Constrain the negotiated TLS version on the upgraded client socket (CWE-326).
-                applyVersionBounds(opts, tls)
-                // rejectUnauthorized drives certificate-chain validation only; hostname check is
-                // a separate concern routed through checkServerIdentity.
-                opts.rejectUnauthorized = !tls.trustAll
-                if !tls.hostnameVerification then
-                    // No-op identity check: cert chain still validated when rejectUnauthorized=true,
-                    // but SAN/CN vs servername mismatch is ignored (verify-ca semantics).
-                    opts.checkServerIdentity = ({ (_: js.Any, _: js.Any) => js.undefined }: js.Function2[js.Any, js.Any, js.Any])
-                end if
-                tls.caCertPath match
-                    case Present(path) =>
-                        opts.ca = fsModule.readFileSync(path, "utf8")
-                    case Absent => ()
-                end match
-                // Client certificate for mutual TLS: present it when the server requests one. A no-op for the common (no client cert) client.
-                (tls.certChainPath, tls.privateKeyPath) match
-                    case (Present(certPath), Present(keyPath)) =>
-                        opts.cert = fsModule.readFileSync(certPath, "utf8")
-                        opts.key = fsModule.readFileSync(keyPath, "utf8")
-                    case _ => ()
-                end match
-                tlsModule.connect(opts)
+        // The detach reports the staged bytes through a handover rather than a return value, matching the other transports. On this
+        // platform the handover always settles inside the call itself (nothing else runs concurrently to hold an offer open), so the
+        // continuation below runs inline and the sequence is unchanged; it is written this way so the transport does not depend on that.
+        def afterDetach(preRead: Maybe[Chunk[Span[Byte]]]): Unit =
+            if preRead.isEmpty then
+                // The claim was won but the connection reached a terminal state before the detach (a close raced or preceded this call):
+                // nothing was detached and the close path owns the socket. Fail typed; the owner hook above releases through its
+                // destroyed-guarded destroy, a no-op for a socket the close already destroyed.
+                promise.completeDiscard(Result.fail(NetAlreadyDetachedException()))
+                return ()
             end if
-        end tlsSocket
 
-        // Server-side tls.TLSSocket (created via new tls.TLSSocket(..., {isServer:true}))
-        // emits 'secure' once the handshake completes.
-        // Client-side tls.TLSSocket (created via tls.connect({socket})) emits 'secureConnect'.
-        val handshakeEvent = if isServerSide then "secure" else "secureConnect"
-
-        val driver = pool.next()
-
-        // Bound the upgrade handshake. The plaintext connection was already detached above, so `promise` is the sole owner of the socket for
-        // the duration; a peer that never completes its side of the STARTTLS handshake would otherwise leave it parked forever with nothing to
-        // reclaim it, and the process-shared transport is never closed. Settling `promise` runs the same release a handshake failure takes, so
-        // the deadline reuses that path rather than adding a second teardown. There is no fresh connect port for an upgrade, so the leaf carries
-        // -1, matching the other backends. `Duration.Infinity` arms no timer.
-        if tls.handshakeTimeout.isFinite then
-            val deadline = Clock.live.unsafe.sleep(tls.handshakeTimeout)
-            deadline.onComplete { _ =>
-                val host = tls.sniHostname.getOrElse("")
-                if promise.complete(Result.fail(NetTlsHandshakeTimeoutException(host, -1, tls.handshakeTimeout))) then
-                    discard(tlsSocket.destroy())
-            }
-            promise.onComplete { _ =>
-                deadline.interruptDiscard(Result.Panic(Interrupted(frame, "upgrade settled before deadline")))
-            }
-        end if
-
-        discard(tlsSocket.once(
-            handshakeEvent,
-            { () =>
-                // Pause the TLS socket now that the handshake is done: kyo controls data flow.
-                // (We cannot pause before the handshake as that blocks TLS record delivery.)
-                discard(tlsSocket.pause())
-                val newHandle = JsHandle.init(tlsSocket, driver, frame)
-                newHandle.peerCloseGrace = handle.peerCloseGrace // the upgraded connection inherits the original connection's reclaim grace
-                val newConn = Connection.init(newHandle, driver, channelCapacity, handle.peerCloseGrace)
-                // Preserve the upgrade role on the new TLS connection so a further upgrade does not silently flip client/server.
-                newConn.isServerOrigin = isServerSide
-                // Wire upgrade function on the new TLS connection so further upgrade attempts
-                // are routed back through this transport (which will then fail with a TLS-on-TLS error).
-                newConn.upgradeFn = Present { (tls2, frame2) =>
-                    given Frame = frame2
-                    upgradeToTls(newConn, tls2, channelCapacity)
+            // Push pre-read bytes and any peer-close-probe-staged leftover back into the socket (unshift) so the TLS engine sees them first. Order:
+            // channel-drained preRead is older than the listener-stashed leftover, so preRead precedes it; draining leftover here also fixes its pre-existing silent drop at upgrade.
+            var replay: Chunk[Array[Byte]] = preRead match
+                case Present(chunks) => chunks.map(_.toArray)
+                case Absent          => Chunk.empty
+            var draining = true
+            while draining do
+                handle.dequeueLeftover() match
+                    case Present(JsHandle.Leftover(buf, off, len)) =>
+                        replay =
+                            replay.append(if off == 0 && len == buf.length then buf else java.util.Arrays.copyOfRange(buf, off, off + len))
+                    case Absent => draining = false
+                end match
+            end while
+            if replay.nonEmpty then
+                val totalLen = replay.foldLeft(0)(_ + _.length)
+                val buf      = new Array[Byte](totalLen)
+                var off      = 0
+                replay.foreach { arr =>
+                    // System.arraycopy: no kyo equivalent for a bulk primitive-array copy; fully qualified so kyo.System does not shadow it.
+                    java.lang.System.arraycopy(arr, 0, buf, off, arr.length)
+                    off += arr.length
                 }
-                // Install certHashFn so SCRAM-PLUS channel binding (RFC 5929
-                // tls-server-end-point) can read the peer-cert SHA-256.
-                installCertHashFn(newConn, tlsSocket)
-                if newConn.start() then
-                    // Checked complete, mirroring the NIO completeConnect: the abandon path can settle `promise` (and destroy the raw
-                    // socket) while this handshake-completion event was already queued on the Node event loop. Discarding the lost
-                    // completion would leave this freshly built connection's pumps parked forever on a socket nobody references; close
-                    // the orphan instead. The caller sees the settlement it already observed.
-                    if !promise.complete(Result.succeed(newConn)) then
-                        newConn.close()
-                else
-                    // The upgraded connection raced to a terminal/Upgrading state before start (a close won); it must not be handed out as open.
-                    promise.completeDiscard(Result.fail(NetConnectionClosedException(Operation.Start)))
-                end if
-            }: js.Function0[Unit]
-        ))
+                val nodeBuffer = js.Dynamic.global.Buffer.from(
+                    js.typedarray.byteArray2Int8Array(buf).buffer
+                )
+                discard(socket.unshift(nodeBuffer))
+            end if
 
-        discard(tlsSocket.once(
-            "error",
-            { (err: js.Dynamic) =>
-                promise.completeDiscard(Result.fail(NetTlsHandshakeException(upgradeHost, -1, errMessage(err))))
-            }: js.Function1[js.Dynamic, Unit]
-        ))
+            // Remove the JsHandle's permanent listeners from the plaintext socket. They were registered
+            // by JsHandle.init and would intercept TLS handshake bytes if left in place after the
+            // TLSSocket takes ownership of the underlying socket's data stream.
+            discard(socket.removeAllListeners())
+
+            // The underlying socket was paused by detachForUpgrade. Resume it so the TLS layer can
+            // read the handshake bytes (ClientHello / ServerHello). The TLS layer manages its own
+            // internal flow; we will pause the TLSSocket's application-data stream after handshake.
+            discard(socket.resume())
+
+            val tlsModule = NodeTls.asInstanceOf[js.Dynamic]
+            val fsModule  = NodeFs.asInstanceOf[js.Dynamic]
+
+            // The TLS role follows the connection's TCP origin: an accepted connection (isServerOrigin) upgrades as the TLS server, a connected one
+            // as the client (STARTTLS initiate). The origin is authoritative: a config heuristic ("has a cert+key therefore server") would
+            // misclassify a mutual-TLS client that presents its own client certificate, upgrading it in the server role.
+            val isServerSide = jsConn.isServerOrigin
+
+            val tlsSocket =
+                if isServerSide then
+                    // Server-side STARTTLS: wrap the existing socket as a TLS server socket.
+                    // Node.js requires tls.TLSSocket constructor with isServer=true.
+                    val opts = js.Dynamic.literal()
+                    opts.isServer = true
+                    // Constrain the negotiated TLS version on the upgraded server socket (CWE-326).
+                    applyVersionBounds(opts, tls)
+                    tls.certChainPath match
+                        case Present(p) => opts.cert = fsModule.readFileSync(p, "utf8")
+                        case Absent     => ()
+                    tls.privateKeyPath match
+                        case Present(p) => opts.key = fsModule.readFileSync(p, "utf8")
+                        case Absent     => ()
+                    // Mutual TLS: honor clientAuth on the upgraded server socket, matching listen(tls) and the posix/NIO server STARTTLS path.
+                    applyServerClientAuth(opts, tls)
+                    // Construct TLSSocket directly with the existing socket and server opts
+                    js.Dynamic.newInstance(tlsModule.selectDynamic("TLSSocket"))(socket, opts)
+                else
+                    // Client-side STARTTLS: use tls.connect({ socket }) which drives the TLS handshake.
+                    val opts = js.Dynamic.literal()
+                    opts.socket = socket
+                    val sni = tls.sniHostname.getOrElse("localhost")
+                    opts.servername = sni
+                    opts.host = sni
+                    // Constrain the negotiated TLS version on the upgraded client socket (CWE-326).
+                    applyVersionBounds(opts, tls)
+                    // rejectUnauthorized drives certificate-chain validation only; hostname check is
+                    // a separate concern routed through checkServerIdentity.
+                    opts.rejectUnauthorized = !tls.trustAll
+                    if !tls.hostnameVerification then
+                        // No-op identity check: cert chain still validated when rejectUnauthorized=true,
+                        // but SAN/CN vs servername mismatch is ignored (verify-ca semantics).
+                        opts.checkServerIdentity = ({ (_: js.Any, _: js.Any) => js.undefined }: js.Function2[js.Any, js.Any, js.Any])
+                    end if
+                    tls.caCertPath match
+                        case Present(path) =>
+                            opts.ca = fsModule.readFileSync(path, "utf8")
+                        case Absent => ()
+                    end match
+                    // Client certificate for mutual TLS: present it when the server requests one. A no-op for the common (no client cert) client.
+                    (tls.certChainPath, tls.privateKeyPath) match
+                        case (Present(certPath), Present(keyPath)) =>
+                            opts.cert = fsModule.readFileSync(certPath, "utf8")
+                            opts.key = fsModule.readFileSync(keyPath, "utf8")
+                        case _ => ()
+                    end match
+                    tlsModule.connect(opts)
+                end if
+            end tlsSocket
+
+            // Server-side tls.TLSSocket (created via new tls.TLSSocket(..., {isServer:true}))
+            // emits 'secure' once the handshake completes.
+            // Client-side tls.TLSSocket (created via tls.connect({socket})) emits 'secureConnect'.
+            val handshakeEvent = if isServerSide then "secure" else "secureConnect"
+
+            val driver = pool.next()
+
+            // Bound the upgrade handshake. The plaintext connection was already detached above, so `promise` is the sole owner of the socket for
+            // the duration; a peer that never completes its side of the STARTTLS handshake would otherwise leave it parked forever with nothing to
+            // reclaim it, and the process-shared transport is never closed. Settling `promise` runs the same release a handshake failure takes, so
+            // the deadline reuses that path rather than adding a second teardown. There is no fresh connect port for an upgrade, so the leaf carries
+            // -1, matching the other backends. `Duration.Infinity` arms no timer.
+            if tls.handshakeTimeout.isFinite then
+                val deadline = Clock.live.unsafe.sleep(tls.handshakeTimeout)
+                deadline.onComplete { _ =>
+                    val host = tls.sniHostname.getOrElse("")
+                    if promise.complete(Result.fail(NetTlsHandshakeTimeoutException(host, -1, tls.handshakeTimeout))) then
+                        discard(tlsSocket.destroy())
+                }
+                promise.onComplete { _ =>
+                    deadline.interruptDiscard(Result.Panic(Interrupted(frame, "upgrade settled before deadline")))
+                }
+            end if
+
+            discard(tlsSocket.once(
+                handshakeEvent,
+                { () =>
+                    // Pause the TLS socket now that the handshake is done: kyo controls data flow.
+                    // (We cannot pause before the handshake as that blocks TLS record delivery.)
+                    discard(tlsSocket.pause())
+                    val newHandle = JsHandle.init(tlsSocket, driver, frame)
+                    newHandle.peerCloseGrace =
+                        handle.peerCloseGrace // the upgraded connection inherits the original connection's reclaim grace
+                    val newConn = Connection.init(newHandle, driver, channelCapacity, handle.peerCloseGrace)
+                    // Preserve the upgrade role on the new TLS connection so a further upgrade does not silently flip client/server.
+                    newConn.isServerOrigin = isServerSide
+                    // Wire upgrade function on the new TLS connection so further upgrade attempts
+                    // are routed back through this transport (which will then fail with a TLS-on-TLS error).
+                    newConn.upgradeFn = Present { (tls2, frame2) =>
+                        given Frame = frame2
+                        upgradeToTls(newConn, tls2, channelCapacity)
+                    }
+                    // Install certHashFn so SCRAM-PLUS channel binding (RFC 5929
+                    // tls-server-end-point) can read the peer-cert SHA-256.
+                    installCertHashFn(newConn, tlsSocket)
+                    if newConn.start() then
+                        // Checked complete, mirroring the NIO completeConnect: the abandon path can settle `promise` (and destroy the raw
+                        // socket) while this handshake-completion event was already queued on the Node event loop. Discarding the lost
+                        // completion would leave this freshly built connection's pumps parked forever on a socket nobody references; close
+                        // the orphan instead. The caller sees the settlement it already observed.
+                        if !promise.complete(Result.succeed(newConn)) then
+                            newConn.close()
+                    else
+                        // The upgraded connection raced to a terminal/Upgrading state before start (a close won); it must not be handed out as open.
+                        promise.completeDiscard(Result.fail(NetConnectionClosedException(Operation.Start)))
+                    end if
+                }: js.Function0[Unit]
+            ))
+
+            discard(tlsSocket.once(
+                "error",
+                { (err: js.Dynamic) =>
+                    promise.completeDiscard(Result.fail(NetTlsHandshakeException(upgradeHost, -1, errMessage(err))))
+                }: js.Function1[js.Dynamic, Unit]
+            ))
+
+        end afterDetach
+        // Contain ANY throw out of the body above. Completion callbacks run under a catch-all that logs rather than propagates
+        // (IOPromise.eval), so an escaping throw would settle nothing: the caller would park on an upgrade that can never finish while the
+        // detached socket stayed open until the peer FINs it into CLOSE_WAIT. While the detach reported its staging by return value this
+        // body ran on the caller's own stack, where such a throw reached the caller as a panic, and callers classify on that (kyo-sql's
+        // TlsUpgrade maps it to a connect failure). Reproduce that; the owner hook armed on `promise` above then performs the release,
+        // which is why nothing is destroyed here.
+        jsConn.detachForUpgrade().onComplete { r =>
+            try afterDetach(r.foldError(_.eval, _ => Absent))
+            catch case t: Throwable => promise.completeDiscard(Result.panic(t))
+        }
 
         // Fiber.Unsafe[A, S] is an opaque alias over IOPromiseBase[Any, A < (Async & S)] (kyo.Fiber.scala), structurally different from this
         // plainly-constructed, invariant IOPromise[NetException, Connection[JsHandle]], even though both erase to the same runtime object;

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/IoUringUpgradeHandoffDropTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/IoUringUpgradeHandoffDropTest.scala
@@ -96,7 +96,11 @@ class IoUringUpgradeHandoffDropTest extends Test:
                                 assert(parked, "chunk B's recv never reaped / its put never parked (a hang, not the race under test)")
 
                                 handle.upgrading = true
-                                val buffered = conn.detachForUpgrade()
+                                // The detach hands its bytes over through a fiber. This leaf parks chunk B's put deliberately, so the
+                                // handover is exactly what must not be read early: settling it is part of what the leaf asserts.
+                                val buffered = conn.detachForUpgrade().poll() match
+                                    case Present(Result.Success(v)) => v.eval
+                                    case other                      => fail(s"detachForUpgrade did not settle synchronously: $other")
                                 val bufferedBytes: Array[Byte] =
                                     buffered.map(chunks => chunks.toArray.flatMap(_.toArray)).getOrElse(Array.emptyByteArray)
                                 assert(

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/KqueuePollerBackendTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/KqueuePollerBackendTest.scala
@@ -81,6 +81,55 @@ class KqueuePollerBackendTest extends Test:
             }
         }
 
+        "an entry the kernel rejects does not stop the rest of a flushed batch from being armed" in {
+            assumeKqueue()
+            val backend  = PollerBackend.default()
+            val pollerFd = backend.create()
+            assert(pollerFd >= 0, s"kqueue create failed: $pollerFd")
+            val scratch = backend.newPollScratch()
+            PosixTestSockets.loopbackPair().map { case (client, accepted) =>
+                PosixTestSockets.loopbackPair().map { case (filler, fillerAccepted) =>
+                    PosixTestSockets.loopbackPair().map { case (doomedClient, doomed) =>
+                        // A closed fd is what the kernel rejects, and it is the realistic case: an fd closed between staging its interest
+                        // change and submitting the batch comes back EBADF. Close it before anything is staged so the rejection is certain.
+                        discard(sock.close(doomedClient))
+                        discard(sock.close(doomed))
+
+                        // Fill exactly one batch with the rejected entry FIRST and the fd under test behind it. The kernel stops at the first
+                        // rejected entry when it has nowhere to report the error, so everything staged after `doomed` is what goes missing.
+                        discard(backend.registerRead(pollerFd, doomed, doomed.toLong, scratch))
+                        discard(backend.registerRead(pollerFd, accepted, accepted.toLong, scratch))
+                        val filling = backend.MaxEvents - 2
+                        (0 until filling).foreach(_ =>
+                            discard(backend.registerRead(pollerFd, fillerAccepted, fillerAccepted.toLong, scratch))
+                        )
+                        val kq = scratch.kqueueData.get
+                        assert(kq.nChanges == backend.MaxEvents, s"expected a full batch staged, got ${kq.nChanges}")
+
+                        // One more change tips the batch over capacity and flushes it. It must not be for `accepted`: a later re-arm would
+                        // register the fd through the poll call's own submission and hide whether the flush applied it.
+                        discard(backend.registerRead(pollerFd, fillerAccepted, fillerAccepted.toLong, scratch))
+                        assert(kq.nChanges == 1, s"expected the batch to have flushed and restarted, got ${kq.nChanges}")
+
+                        assert(sock.sendNow(client, Buffer.fromArray[Byte](Array[Byte](7)), 1L, 0).value == 1L)
+                        backend.poll(pollerFd, 1000, kq.changelistBuf, kq.nChanges, scratch).safe.get.map { n =>
+                            val firedFds = (0 until n).map(scratch.fds(_)).toList
+                            scratch.close()
+                            discard(sock.close(client))
+                            discard(sock.close(accepted))
+                            discard(sock.close(filler))
+                            discard(sock.close(fillerAccepted))
+                            backend.close(pollerFd)
+                            assert(
+                                firedFds.contains(accepted),
+                                s"the read interest staged behind a rejected entry was never armed: expected $accepted to fire, got $firedFds"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
         "a registered read interest does not fire while the fd has nothing to read" in {
             assumeKqueue()
             val backend  = PollerBackend.default()

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/PollerIoDriverEdgeTriggeredTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/PollerIoDriverEdgeTriggeredTest.scala
@@ -28,8 +28,9 @@ import kyo.net.internal.transport.ReadOutcome
   *     then delivers `Span.empty` without a spurious Closed. On epoll ET, EPOLLRDHUP fires once alongside EPOLLIN; after the data is
   *     consumed via the first recv, the driver sets `readMightHaveMore = true` (because `eofPending` is set) to force re-dispatch on
   *     the next `awaitRead`, where a second recv returns 0 (FIN) and delivers `Span.empty`.
-  *   - `changelistBatchingNoDeadlock`: confirms that on kqueue (where `disableWrite` batches EV_DISABLE into the changelist), both write
-  *     promises resolve, registerWrite fires exactly twice, and at least one poll cycle carried a non-empty changelist (batch path active).
+  *   - `changelistBatchingNoDeadlock`: confirms that on kqueue (where interest changes are batched into a changelist rather than issued as
+  *     individual syscalls), both write promises resolve, registerWrite fires exactly twice, and at least one poll cycle carried a non-empty
+  *     changelist (batch path active).
   *     Gated on kqueue: epoll EPOLLET fires the write edge only on write-buffer transitions; a loopback fd that is always writable fires
   *     once on ADD and not again without a not-writable->writable transition, making a second sequential awaitWritable incompatible with
   *     the epoll ET model.
@@ -44,8 +45,8 @@ import kyo.net.internal.transport.ReadOutcome
   *   - `wakeLatencyBounded`: confirms that a `awaitRead` submitted while the poll loop is parked wakes the loop (via `backend.wake`) and
   *     delivers the readiness promptly, not just after the 100ms timeout.
   *
-  * Gate: `PosixTestSockets.assumePoller()` for most leaves; `changelistBatchingNoDeadlock` uses `assumeKqueue()` because it tests
-  * kqueue-specific EV_DISABLE changelist batching and a second sequential awaitWritable that requires EV_CLEAR re-evaluation semantics
+  * Gate: `PosixTestSockets.assumePoller()` for most leaves; `changelistBatchingNoDeadlock` uses `assumeKqueue()` because it tests the
+  * kqueue-specific changelist batching and a second sequential awaitWritable that requires EV_CLEAR re-evaluation semantics
   * not available under epoll EPOLLET. No leaf sleeps; all synchronize on real promises.
   */
 class PollerIoDriverEdgeTriggeredTest extends Test:
@@ -339,9 +340,9 @@ class PollerIoDriverEdgeTriggeredTest extends Test:
 
     "changelistBatchingNoDeadlock: two sequential write arms each resolve; registerWrite fires exactly twice; kqueue batches interest changes" in {
         PosixTestSockets.assumeKqueue()
-        // The ET kqueue path batches EV_DISABLE into the changelist inside disableWrite (called from dispatchWritable). This test confirms
-        // that the batching does not deadlock the poll loop: both write promises resolve, the registerWrite count is exactly 2 (one per
-        // awaitWritable call), and at least one poll cycle carried a non-empty changelist (the batched EV_DISABLE submission).
+        // The ET kqueue path accumulates interest changes in a changelist and submits them with the poll wait. This test confirms that the
+        // batching does not deadlock the poll loop: both write promises resolve, the registerWrite count is exactly 2 (one per awaitWritable
+        // call), and at least one poll cycle carried a non-empty changelist (the batched registration submission).
         // Gate: kqueue only. On epoll EPOLLET the fd stays armed and only fires an edge on write-buffer transition (not-writable to
         // writable). A loopback fd that is always writable fires the EPOLLOUT edge exactly once on ADD; a second awaitWritable after
         // dispatchWritable consumed the first edge finds no new transition and parks until timeout. The changelist batch is also
@@ -374,14 +375,14 @@ class PollerIoDriverEdgeTriggeredTest extends Test:
                     // registerWrite fires once per awaitWritable call: 2 write arms must produce exactly 2 registerWrite calls.
                     val wc = backend.registerWriteCount.get()
                     assert(wc == 2, s"exactly 2 registerWrite calls expected for 2 awaitWritable arms; got $wc")
-                    // On kqueue, EV_DISABLE from dispatchWritable is batched into the changelist and submitted atomically with the next kevent
-                    // call. At least one poll cycle must have carried a non-empty changelist, confirming the batch path is active.
+                    // On kqueue the registrations above are batched into the changelist and submitted atomically with the next kevent call.
+                    // At least one poll cycle must have carried a non-empty changelist, confirming the batch path is active.
                     // epoll does not use the changelist (nChanges is always 0 there), so this assertion is kqueue-only.
                     if PosixConstants.isMacOrBsd then
                         val batchedCycles = backend.pollWithChangesCount.get()
                         assert(
                             batchedCycles > 0,
-                            s"kqueue: at least one poll cycle must carry a non-empty changelist (EV_DISABLE batch); got batchedCycles=$batchedCycles"
+                            s"kqueue: at least one poll cycle must carry a non-empty changelist; got batchedCycles=$batchedCycles"
                         )
                     end if
                 }

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/PosixTransportUpgradeReleaseTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/PosixTransportUpgradeReleaseTest.scala
@@ -61,6 +61,28 @@ private class FinishWithCertHookEngine(onCertSha: () => Unit) extends TlsEngine:
     def free()(using AllowUnsafe): Unit        = freed.set(true)
 end FinishWithCertHookEngine
 
+/** A scripted [[TlsEngine]] that builds successfully and then throws `cause` out of `feedCiphertext`, which is how the upgrade's
+  * staged-ciphertext feed fails after the engine already exists. `fed` records that the feed was genuinely reached (an empty staging would skip
+  * it and leave the leaf proving nothing); `freed` records the engine release the failure path owes.
+  */
+private class ThrowOnFeedEngine(cause: Throwable) extends TlsEngine:
+    val freed = new JAtomicBoolean(false)
+    val fed   = new JAtomicBoolean(false)
+
+    def handshakeStep()(using AllowUnsafe): Int = 0
+    def feedCiphertext(buf: Buffer[Byte], len: Int)(using AllowUnsafe): Int =
+        fed.set(true)
+        throw cause
+    def drainCiphertext(buf: Buffer[Byte], len: Int)(using AllowUnsafe): Int = 0
+    def readPlain(buf: Buffer[Byte], len: Int)(using AllowUnsafe): Int       = 0
+    def writePlain(buf: Buffer[Byte], len: Int)(using AllowUnsafe): Int      = len
+    def hasBufferedPlaintext(using AllowUnsafe): Boolean                     = false
+    def readBuffered()(using AllowUnsafe): Span[Byte]                        = Span.empty
+    def certSha256()(using AllowUnsafe): Maybe[Span[Byte]]                   = Absent
+    def shutdownStep()(using AllowUnsafe): Int                               = 0
+    def free()(using AllowUnsafe): Unit                                      = freed.set(true)
+end ThrowOnFeedEngine
+
 /** Release discipline of an abandoned or failed STARTTLS upgrade in [[PosixTransport]]: every release of the detached fd must route through
   * the driver's close (`closeUnwiredHandle` -> `driver.closeHandle`), never a bare `PosixHandle.close`.
   *
@@ -84,6 +106,12 @@ class PosixTransportUpgradeReleaseTest extends Test:
     private val transportConfig = kyo.net.NetConfig.default
 
     private def sock = Ffi.load[SocketBindings]
+
+    /** Whether the connection is holding unconsumed inbound bytes, which is what `detachForUpgrade` hands the upgrade as its staging. A closed
+      * channel counts as no bytes: the caller polls this to reach a staged state, and a close means that state is unreachable.
+      */
+    private def hasBytes[A](ch: Channel.Unsafe[A])(using AllowUnsafe, Frame): Boolean =
+        ch.empty().contains(false)
 
     private def awaitCondition(bound: Duration)(cond: => Boolean)(using Frame): Boolean < Async =
         val deadline = java.lang.System.nanoTime() + bound.toNanos
@@ -348,6 +376,130 @@ class PosixTransportUpgradeReleaseTest extends Test:
                                     }
                                 }
                             }
+                        }
+                    }
+                }
+            }.map(_ => succeed)
+        }
+    }
+
+    "an engine build that throws something other than a NetTlsException" - {
+
+        "must settle the upgrade as a panic and release the fd, rather than strand both" in {
+            PosixTestSockets.assumePoller()
+            val driver = PollerIoDriver.init()
+            discard(driver.start())
+            // Not a NetTlsException, so the buildEngine arm inside the upgrade does not handle it: this is the throw the containment at the
+            // detach-handover boundary has to catch. The real shape is a TLS provider that lets a raw failure escape its build (the JDK
+            // floor's CertificateException for a file that exists but holds no certificate); an identity-checked RuntimeException pins the
+            // mechanism without depending on which provider the host stages.
+            val boom = new RuntimeException("engine build failed outside the NetTlsException taxonomy")
+            val transport =
+                TestTransports.forTesting(
+                    driver,
+                    Ffi.load[SocketBindings],
+                    backendIsEpoll = false,
+                    buildEngine = (_, _, _) => throw boom
+                )
+            Sync.ensure(Sync.defer(driver.close())) {
+                PosixTestSockets.loopbackPair().map { case (client, accepted) =>
+                    Sync.ensure(Sync.defer(discard(sock.close(accepted)))) {
+                        val handle    = PosixHandle.socket(client, PosixHandle.DefaultReadBufferSize, Absent, Frame.internal)
+                        val plaintext = transport.openWith(handle, driver, transportConfig.channelCapacity)
+                        assert(plaintext.start(), "the plaintext connection must start")
+                        // The post-detach body runs inside a completion callback, and completion callbacks are run under a catch-all that
+                        // logs rather than propagates. An unhandled throw there settles nothing, so this get is what fails when the
+                        // containment is missing: it parks forever on a promise no path can complete, and the leaf's own cap reports it.
+                        Abort.run[NetException](transport.upgradeToTls(plaintext, NetTlsConfig(trustAll = true), 16).safe.get).map {
+                            outcome =>
+                                // Defensive, as in the leaves above: a regression that let this upgrade succeed must not leak its connection.
+                                outcome.foreach(_.close())
+                                outcome match
+                                    case Result.Panic(t) =>
+                                        // Identity, not just the type: the caller has to receive the original throwable, because that is what
+                                        // classifies the failure upstream (kyo-sql's TlsUpgrade reads the panic's cause to report a connect
+                                        // failure). A substituted or wrapped throwable would pass a type check and still lose the diagnosis.
+                                        assert(t eq boom, s"the caller must receive the engine build's own throwable, got $t")
+                                    case other =>
+                                        fail(
+                                            s"an engine build throwing outside the NetTlsException taxonomy must panic the upgrade, got $other"
+                                        )
+                                end match
+                                // The detach already handed the fd to the upgrade, and no engine exists to own it, so the escape path is the
+                                // only thing that can release it: the plaintext connection's own close cannot take an Upgrading fd and this
+                                // transport is never swept. Left open, the fd sits until the peer FINs it into CLOSE_WAIT.
+                                awaitCondition(10.seconds)(handle.readBuffer.isClosed).map { released =>
+                                    assert(released, "the escape path must release the detached fd it was left holding")
+                                }
+                        }
+                    }
+                }
+            }.map(_ => succeed)
+        }
+
+        "must free the ENGINE too when the throw lands after the engine was built" in {
+            PosixTestSockets.assumePoller()
+            val driver = PollerIoDriver.init()
+            discard(driver.start())
+            // The window between the engine build and the upgrade's owner hook has two throw sites of its own, `feedStaged` and
+            // `feedCoalescedHandshake`, and by then the release owes the engine as well as the fd. The leaf above cannot reach that: it throws
+            // during the build, when no engine exists yet. Reaching it needs staged ciphertext, since `feedStaged` only enters the engine for
+            // spans that carry bytes, which is why the peer writes first and the upgrade waits for those bytes to be sitting unconsumed.
+            val boom   = new RuntimeException("staged-ciphertext feed failed outside the NetTlsException taxonomy")
+            val engine = new ThrowOnFeedEngine(boom)
+            val transport =
+                TestTransports.forTesting(driver, Ffi.load[SocketBindings], backendIsEpoll = false, buildEngine = (_, _, _) => engine)
+            Sync.ensure(Sync.defer(driver.close())) {
+                PosixTestSockets.loopbackPair().map { case (client, accepted) =>
+                    Sync.ensure(Sync.defer(discard(sock.close(accepted)))) {
+                        val handle    = PosixHandle.socket(client, PosixHandle.DefaultReadBufferSize, Absent, Frame.internal)
+                        val plaintext = transport.openWith(handle, driver, transportConfig.channelCapacity)
+                        assert(plaintext.start(), "the plaintext connection must start")
+                        val payload = "staged-ciphertext".getBytes("UTF-8")
+                        assert(
+                            sock.sendNow(
+                                accepted,
+                                Buffer.fromArray[Byte](payload),
+                                payload.length.toLong,
+                                0
+                            ).value == payload.length.toLong,
+                            "the peer write that produces the staging must land in full"
+                        )
+                        // Barrier, not a sleep: the bytes must be off the socket and sitting unconsumed in the inbound channel, because that
+                        // is exactly what `detachForUpgrade` hands back as `staged`. Upgrading before they land would feed an empty chunk and
+                        // silently exercise the leaf above instead of this one.
+                        awaitCondition(
+                            5.seconds
+                        )(hasBytes(plaintext.inbound)).map {
+                            staged =>
+                                assert(
+                                    staged,
+                                    "the peer's bytes never reached the inbound channel, so nothing would be staged for the engine"
+                                )
+                                Abort.run[NetException](transport.upgradeToTls(plaintext, NetTlsConfig(trustAll = true), 16).safe.get).map {
+                                    outcome =>
+                                        outcome.foreach(_.close())
+                                        outcome match
+                                            case Result.Panic(t) =>
+                                                assert(t eq boom, s"the caller must receive the feed's own throwable, got $t")
+                                            case other =>
+                                                fail(
+                                                    s"a staged-ciphertext feed throwing outside the NetTlsException taxonomy must panic the upgrade, got $other"
+                                                )
+                                        end match
+                                        assert(
+                                            engine.fed.get(),
+                                            "the leaf did not reach `feedStaged`, so it proves nothing about the post-build window"
+                                        )
+                                        // Both obligations, because by this point the upgrade owns both and the fd-only release the pre-build
+                                        // path uses would strand the engine's native memory with no other owner able to reach it.
+                                        awaitCondition(10.seconds)(handle.readBuffer.isClosed && engine.freed.get()).map { released =>
+                                            assert(
+                                                released,
+                                                s"fd released=${handle.readBuffer.isClosed} engine freed=${engine.freed.get()}"
+                                            )
+                                        }
+                                }
                         }
                     }
                 }

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/StartTlsUpgradeCloseRaceTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/StartTlsUpgradeCloseRaceTest.scala
@@ -70,9 +70,13 @@ class StartTlsUpgradeCloseRaceTest extends Test:
                             latchFired.get() == iterations,
                             s"latch fired ${latchFired.get()}/$iterations times: the close did not land in the upgrade window every run"
                         )
+                        // EVERY iteration must abort, not merely one of them. The client never sends a ClientHello, so the server's
+                        // re-handshake cannot complete on its own, and `latchFired` above already asserts the close landed inside the
+                        // upgrade window every run. Those two together make the abort forced rather than raced, so the exact count is
+                        // the honest assertion: `> 0` would pass while 39 iterations silently took some other path.
                         assert(
-                            abortBranch.get() > 0,
-                            s"the close-mid-upgrade abort branch was never exercised (abortBranch=${abortBranch.get()})"
+                            abortBranch.get() == iterations,
+                            s"every close-mid-upgrade must abort, but only ${abortBranch.get()}/$iterations did"
                         )
                         succeed
                     }
@@ -121,29 +125,44 @@ class StartTlsUpgradeCloseRaceTest extends Test:
                                     closeFiber.get.map { _ =>
                                         // Idempotent extra close of the plaintext connection.
                                         serverPlain.close()
-                                        // Real close count from spy (mirrors LatchingSockets.closesOf(serverFd)).
-                                        val closes = spy.closeCounts.getOrDefault(serverFd, 0)
-                                        assert(
-                                            closes == 1,
-                                            s"[iter $iter] upgrading fd=$serverFd closed $closes times (expected exactly 1: no double-close, no leak)"
-                                        )
-                                        upgradeResult match
-                                            case Result.Failure(e: NetConnectionClosedException) =>
-                                                assert(
-                                                    e.operation == Operation.Handshake || e.operation == Operation.Upgrade,
-                                                    s"[iter $iter] close-mid-upgrade failure must name handshake or upgrade, got operation=${e.operation}"
-                                                )
-                                                discard(abortBranch.incrementAndGet())
-                                                Loop.continue
-                                            case Result.Success(conn) =>
-                                                conn.close()
-                                                assert(!conn.isOpen, s"[iter $iter] upgraded connection left open after a concurrent close")
-                                                Loop.continue
-                                            case Result.Failure(other) =>
-                                                fail(s"[iter $iter] close-mid-upgrade failed with an unexpected NetException leaf: $other")
-                                            case Result.Panic(e) =>
-                                                fail(s"[iter $iter] upgrade racing close panicked (crash, not a clean state): $e")
-                                        end match
+                                        // Await the real close(fd) before counting it. The fd close is DEFERRED behind a credit: closeHandle
+                                        // installs `fdCloseSink` and only `freeResources`, running on whichever carrier releases the last guard
+                                        // holder, performs the syscall. When that last holder is the poll carrier's own dispatch bracket, the
+                                        // upgrade settles (freeResources fails the parked upgrade waiter before it discharges the credit) and the
+                                        // close fiber completes while the syscall is still pending, so both of this leaf's other barriers can be
+                                        // satisfied with the count still at zero. Sampling here read a state nothing had waited for.
+                                        // `spy.closed` exists for exactly this and is used the same way by the other close-during-io leaves; a
+                                        // genuine leak never completes it and surfaces as the per-leaf timeout rather than a miscounted close.
+                                        spy.closed(serverFd).safe.get.map { _ =>
+                                            // Real close count from spy (mirrors LatchingSockets.closesOf(serverFd)).
+                                            val closes = spy.closeCounts.getOrDefault(serverFd, 0)
+                                            assert(
+                                                closes == 1,
+                                                s"[iter $iter] upgrading fd=$serverFd closed $closes times (expected exactly 1: no double-close, no leak)"
+                                            )
+                                            upgradeResult match
+                                                case Result.Failure(e: NetConnectionClosedException) =>
+                                                    assert(
+                                                        e.operation == Operation.Handshake || e.operation == Operation.Upgrade,
+                                                        s"[iter $iter] close-mid-upgrade failure must name handshake or upgrade, got operation=${e.operation}"
+                                                    )
+                                                    discard(abortBranch.incrementAndGet())
+                                                    Loop.continue
+                                                case Result.Success(conn) =>
+                                                    conn.close()
+                                                    assert(
+                                                        !conn.isOpen,
+                                                        s"[iter $iter] upgraded connection left open after a concurrent close"
+                                                    )
+                                                    Loop.continue
+                                                case Result.Failure(other) =>
+                                                    fail(
+                                                        s"[iter $iter] close-mid-upgrade failed with an unexpected NetException leaf: $other"
+                                                    )
+                                                case Result.Panic(e) =>
+                                                    fail(s"[iter $iter] upgrade racing close panicked (crash, not a clean state): $e")
+                                            end match
+                                        }
                                     }
                                 }
                             }

--- a/kyo-net/jvm/src/main/scala/kyo/net/internal/NioStdioConnection.scala
+++ b/kyo-net/jvm/src/main/scala/kyo/net/internal/NioStdioConnection.scala
@@ -86,13 +86,15 @@ private[kyo] object NioStdioConnection:
         })
 
         new NetConnection:
-            def inbound: Channel.Unsafe[Span[Byte]]                                    = inboundCh
-            def outbound: Channel.Unsafe[Span[Byte]]                                   = outboundCh
-            def isOpen(using AllowUnsafe): Boolean                                     = !closedFlag.get()
-            def close()(using AllowUnsafe, Frame): Unit                                = closeConnection()
-            private[kyo] def onClosing: Fiber.Unsafe[Unit, Any]                        = closingPromise
-            def detachForUpgrade()(using AllowUnsafe, Frame): Maybe[Chunk[Span[Byte]]] = Absent // not upgradable: no driver or socket
-            private[net] def start()(using AllowUnsafe, Frame): Boolean                = true   // pumps already started at open
+            def inbound: Channel.Unsafe[Span[Byte]]             = inboundCh
+            def outbound: Channel.Unsafe[Span[Byte]]            = outboundCh
+            def isOpen(using AllowUnsafe): Boolean              = !closedFlag.get()
+            def close()(using AllowUnsafe, Frame): Unit         = closeConnection()
+            private[kyo] def onClosing: Fiber.Unsafe[Unit, Any] = closingPromise
+            // not upgradable: no driver or socket, so the answer is known immediately
+            def detachForUpgrade()(using AllowUnsafe, Frame): Fiber.Unsafe[Maybe[Chunk[Span[Byte]]], Any] =
+                Fiber.Unsafe.fromResult(Result.succeed(Absent))
+            private[net] def start()(using AllowUnsafe, Frame): Boolean = true // pumps already started at open
             // Plaintext, driverless connection: no peer certificate to hash and no close_notify exchange to observe.
             def serverCertificateHash: Maybe[Span[Byte]] = Absent
             def status: NetConnection.Status             = NetConnection.Status.Active

--- a/kyo-net/jvm/src/main/scala/kyo/net/internal/NioTransport.scala
+++ b/kyo-net/jvm/src/main/scala/kyo/net/internal/NioTransport.scala
@@ -1489,35 +1489,54 @@ final private[kyo] class NioTransport private (
                 // blocks forever waiting for data that was consumed and discarded. Whether the pump raced
                 // ahead and buffered this flight is timing-dependent on fast loopback, so preRead is often
                 // empty (no-op) and sometimes non-empty (corrective).
-                val preRead: Maybe[Chunk[Span[Byte]]] = nioConn.detachForUpgrade()
-                if preRead.isEmpty then
-                    // The claim was won but the connection reached a terminal state before the detach (a close raced or preceded this call):
-                    // nothing was detached and the close path owns the channel, so fail typed. The failure settlement runs the owner arm
-                    // above, whose closeQuietly is idempotent against the close that won.
-                    promise.completeDiscard(Result.fail(NetAlreadyDetachedException()))
-                // Step 2: re-register the same channel (still open) with the driver for TLS handshake I/O.
-                else if !driver.registerChannel(handle) then
-                    promise.completeDiscard(Result.fail(NetTlsHandshakeException(host, -1, "")))
-                else
-                    // Step 3: drive TLS handshake on the same SocketChannel.
-                    // The TLS role follows the connection's TCP origin: an accepted connection (isServerOrigin) upgrades as the TLS server, a
-                    // connected one as the client (e.g. a Postgres client doing an SSLRequest upgrade). The origin is authoritative: a config
-                    // heuristic ("has a cert+key therefore server") would misclassify a mutual-TLS client that presents its own client certificate.
-                    val isServer = nioConn.isServerOrigin
-                    startTlsHandshake(
-                        handle.channel,
-                        host,
-                        -1,
-                        tls,
-                        isServer = isServer,
-                        promise,
-                        Present(handle),
-                        preRead,
-                        channelCapacity,
-                        handle.readBufferSize,
-                        handle.peerCloseGrace
-                    )
-                end if
+                // The detach reports the staged bytes through a handover rather than a return value, because a pump offer carrying that
+                // first flight can still be committing when the inbound channel closes. Everything downstream of the detach therefore runs
+                // on the handover's completion, which settles inline whenever no offer is in flight. The try lives inside the callback:
+                // completion callbacks are run under a catch-all that logs rather than propagates, so an exception raised out here would be
+                // swallowed instead of failing the upgrade promise.
+                nioConn.detachForUpgrade().onComplete { detached =>
+                    try
+                        val preRead: Maybe[Chunk[Span[Byte]]] = detached.foldError(_.eval, _ => Absent)
+                        if preRead.isEmpty then
+                            // The claim was won but the connection reached a terminal state before the detach (a close raced or preceded this
+                            // call): nothing was detached and the close path owns the channel, so fail typed. The failure settlement runs the
+                            // owner arm above, whose closeQuietly is idempotent against the close that won.
+                            promise.completeDiscard(Result.fail(NetAlreadyDetachedException()))
+                        // Step 2: re-register the same channel (still open) with the driver for TLS handshake I/O.
+                        else if !driver.registerChannel(handle) then
+                            promise.completeDiscard(Result.fail(NetTlsHandshakeException(host, -1, "")))
+                        else
+                            // Step 3: drive TLS handshake on the same SocketChannel.
+                            // The TLS role follows the connection's TCP origin: an accepted connection (isServerOrigin) upgrades as the TLS
+                            // server, a connected one as the client (e.g. a Postgres client doing an SSLRequest upgrade). The origin is
+                            // authoritative: a config heuristic ("has a cert+key therefore server") would misclassify a mutual-TLS client that
+                            // presents its own client certificate.
+                            val isServer = nioConn.isServerOrigin
+                            startTlsHandshake(
+                                handle.channel,
+                                host,
+                                -1,
+                                tls,
+                                isServer = isServer,
+                                promise,
+                                Present(handle),
+                                preRead,
+                                channelCapacity,
+                                handle.readBufferSize,
+                                handle.peerCloseGrace
+                            )
+                        end if
+                    catch
+                        case e: Exception =>
+                            promise.completeDiscard(Result.fail(NetTlsHandshakeException(host, -1, e)))
+                        case t: Throwable =>
+                            // The outer catch this mirrors takes Exception, which is the right leaf for a handshake that failed on its own
+                            // terms. An Error is not that, and here it cannot be left to unwind either: the enclosing callback runs under a
+                            // catch-all that logs rather than propagates, so an unhandled one would settle nothing and park the caller on an
+                            // upgrade that can never finish. Hand it back as the panic it would have been before the detach became a handover.
+                            promise.completeDiscard(Result.panic(t))
+                    end try
+                }
             end if
         catch
             case e: Exception =>

--- a/kyo-net/shared/src/main/scala/kyo/net/Connection.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/Connection.scala
@@ -42,8 +42,12 @@ abstract class Connection:
       * Returns any bytes that the ReadPump had already placed in the inbound channel. These bytes are raw ciphertext that must be fed to the
       * TLS engine before registering for further socket reads, to avoid silently discarding data that was already consumed from the kernel
       * buffer. Returns Absent if the connection was already closed (idempotent).
+      *
+      * The bytes arrive through a handover rather than a return value because the driver is detached only after the inbound channel closes,
+      * so a ReadPump offer carrying the peer's first handshake flight can still be committing at that moment. Losing one strands the
+      * handshake waiting for data that was read and dropped. The handover settles inside this call whenever no offer is in flight.
       */
-    def detachForUpgrade()(using AllowUnsafe, Frame): Maybe[Chunk[Span[Byte]]]
+    def detachForUpgrade()(using AllowUnsafe, Frame): Fiber.Unsafe[Maybe[Chunk[Span[Byte]]], Any]
 
     /** Start the connection. Begins pumping data between socket and channels. Called by Transport after creating the connection. Returns true
       * when the Created -> Established CAS won and the pumps started; false when the connection had already raced to a terminal or Upgrading

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/IoUringDriver.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/IoUringDriver.scala
@@ -933,6 +933,11 @@ final private[net] class IoUringDriver private[posix] (
       *   - `flushSubmits` pushes the prepped SQEs to the kernel while the fd is still open (the kernel resolves the fd at submit), so no
       *     unsubmitted SQE can resolve the number after `closeFd` releases it. The shutdown inside `closeFd` then completes the in-kernel
       *     accept, whose CQE reaps the pending entry onto the already-failed promise.
+      *
+      * A bare `requestClose` is correct HERE specifically, unlike on a connection handle, where the read path routes through `closeHandle`
+      * instead because a kernel-owned recv can already hold a reference to the buffers `requestClose` frees. An accept SQE captures none of
+      * that state: it names the listen fd and its own completion, never the handle's read buffer, staging buffers, or TLS engine. So freeing
+      * those here cannot be observed by an accept still in the kernel, and the accept's own ordering is handled by the three steps above.
       */
     override def closeListener(handle: PosixHandle, closeFd: () => Unit)(using AllowUnsafe, Frame): Unit =
         submitEngineOp { () =>
@@ -1996,6 +2001,9 @@ final private[net] class IoUringDriver private[posix] (
                                                 // recv for this same handle (the STARTTLS upgrade-handoff window allows more than one) is still
                                                 // in flight and has already captured a reference to those buffers. closeHandle defers the actual
                                                 // free until every op still in flight for the handle (this deferred decrement included) drains.
+                                                // This is a rule about CONNECTION handles, not a blanket ban on requestClose: what makes the bare
+                                                // form unsafe is an in-flight op holding the freed buffers, and only a recv does that. closeListener
+                                                // does use the bare form, correctly, because an accept SQE captures none of that state.
                                                 // fatalRecord is a LOCAL flag, not a shared/ambient signal: closeHandle only marks pendingCloses
                                                 // (shared across every close reason for this handle) synchronously, so checking pendingCloses here
                                                 // would also misfire for an unrelated concurrent close racing a read that decoded cleanly.

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/KqueuePollerBackend.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/KqueuePollerBackend.scala
@@ -8,9 +8,10 @@ import kyo.ffi.Ffi
   *
   * Unlike epoll there is no separate `epoll_ctl`: registration, deregistration, and polling all go through `kevent`. Read interest is
   * registered edge-triggered (`EV_ADD | EV_CLEAR`): the filter auto-resets after delivery (fires once per empty->ready transition) and stays
-  * in the interest set without re-registration. Write interest is registered with `EV_ADD | EV_CLEAR | EV_ENABLE` and toggled off with
-  * `EV_DISABLE` after a write completes to suppress spurious wakeups while no write is pending. Readiness is decoded from the returned event's
-  * `filter` (`EVFILT_READ` / `EVFILT_WRITE`), never a bitmask; the watched fd is the event's `ident`.
+  * in the interest set without re-registration. Write interest is registered the same way plus `EV_ENABLE`, and is likewise left armed: being
+  * edge-triggered it reports one event per not-writable-to-writable transition, so a socket that simply stays writable does not re-fire.
+  * Readiness is decoded from the returned event's `filter` (`EVFILT_READ` / `EVFILT_WRITE`), never a bitmask; the watched fd is the event's
+  * `ident`.
   *
   * `kqueue` is a plain (non-blocking) downcall. Interest changes ([[registerRead]] / [[registerWrite]] / [[deregister]]) are batched into a
   * changelist and submitted atomically alongside the poll wait: `drainChanges` accumulates up to `MaxChanges * KEvent.size` bytes into
@@ -48,8 +49,9 @@ private[net] object KqueuePollerBackend extends PollerBackend:
         change(pollerFd, fd, PosixConstants.EVFILT_READ, (PosixConstants.EV_ADD | PosixConstants.EV_CLEAR).toShort, id, scratch.kqueueData)
 
     def registerWrite(pollerFd: Int, fd: Int, id: Long, scratch: PollScratch)(using AllowUnsafe, Frame): Int =
-        // EV_CLEAR + EV_ENABLE: register enabled. After write completes, disableWrite issues EV_DISABLE to suppress spurious wakeups. udata=id tags
-        // the knote with the owning handle id (the stale-event discriminator; EV_ADD on a fresh or recycled fd sets the current owner's id).
+        // EV_CLEAR + EV_ENABLE: register enabled and edge-triggered, so the filter reports one event per not-writable-to-writable transition and
+        // is never disabled again. udata=id tags the knote with the owning handle id (the stale-event discriminator; EV_ADD on a fresh or
+        // recycled fd sets the current owner's id).
         change(
             pollerFd,
             fd,
@@ -75,14 +77,15 @@ private[net] object KqueuePollerBackend extends PollerBackend:
         end if
     end deregister
 
-    /** Disable the EVFILT_WRITE filter on `fd` without removing it. Called from `dispatchWritable` after the write completes so the
-      * write-ready filter does not fire spuriously while no write is pending. The filter remains registered (ready for `EV_ENABLE` when the
-      * next awaitWritable arms the fd). Encodes into `changelistBuf` for delivery at the next poll call (the filter stays enabled until
-      * the next kevent syscall completes the batch; no spurious event can fire before then since the poll loop is single-carrier).
-      */
-    override def disableWrite(pollerFd: Int, fd: Int, scratch: PollScratch)(using AllowUnsafe, Frame): Unit =
-        // EV_DISABLE matches the existing knote by ident+filter and does not create one, so udata is irrelevant; pass the fd as an inert value.
-        discard(change(pollerFd, fd, PosixConstants.EVFILT_WRITE, PosixConstants.EV_DISABLE, fd.toLong, scratch.kqueueData))
+    override def drainFailedRegistrations(scratch: PollScratch, handler: RegistrationFailureHandler)(using AllowUnsafe, Frame): Unit =
+        scratch.kqueueData.foreach { data =>
+            var i = 0
+            while i < data.failedCount do
+                handler.onRejected(data.failedFds(i), data.failedIsWrite(i), data.failedErrnos(i), data.failedOwnerIds(i))
+                i += 1
+            end while
+            data.failedCount = 0
+        }
 
     def registerWake(pollerFd: Int, scratch: PollScratch)(using AllowUnsafe, Frame): Boolean =
         // Register the EVFILT_USER wake filter on the fixed wakeUserIdent with EV_CLEAR (auto-reset on delivery). No wake fd: the filter lives on
@@ -151,7 +154,8 @@ private[net] object KqueuePollerBackend extends PollerBackend:
       * `keventNow` with fresh per-call allocation. This preserves the test path behavior without requiring a full scratch to be set up.
       */
     private def change(pollerFd: Int, fd: Int, filter: Short, flags: Short, udata: Long, kqData: Maybe[KqueuePollData])(using
-        AllowUnsafe
+        AllowUnsafe,
+        Frame
     ): Int =
         kqData match
             case Present(data) =>
@@ -160,11 +164,7 @@ private[net] object KqueuePollerBackend extends PollerBackend:
                 // aborts the cycle with IndexOutOfBounds, taking the driver down with it. Two ways to get there, both reachable under load:
                 // many fds re-arming in one cycle, and terminalTeardown's drain, which has no following poll to flush the batch at all.
                 // Submitting the full batch here and starting a fresh one costs an extra kevent under load instead of losing the driver.
-                // Passing changelistBuf as the eventlist with nevents = 0 is the same no-read idiom used by changeNow above.
-                if data.nChanges >= MaxEvents then
-                    discard(kq.keventNow(pollerFd, data.changelistBuf, data.nChanges, data.changelistBuf, 0, ZeroTimeout))
-                    data.nChanges = 0
-                end if
+                if data.nChanges >= MaxEvents then flushChanges(pollerFd, data)
                 val slot = data.nChanges
                 KEvent.encodeChange(data.changelistBuf, slot, fd, filter, flags, udata)
                 data.nChanges = slot + 1
@@ -183,7 +183,60 @@ private[net] object KqueuePollerBackend extends PollerBackend:
         end match
     end change
 
-    /** Submit a single one-element change immediately via `keventNow` (without batching). Used by `deregister` and `disableWrite` paths where the
+    /** Submit the full changelist mid-drain and start a fresh batch, recording any entry the kernel rejected.
+      *
+      * Every entry is submitted with [[PosixConstants.EV_RECEIPT]] added to its flags, and the eventlist is `flushEventsBuf` with room for
+      * exactly `nChanges` receipts. That combination is what makes this submission safe, and both halves are load-bearing.
+      *
+      * Room for receipts is what keeps the batch whole. `man 2 kevent`: "If an error occurs while processing an element of the changelist and
+      * there is enough room in the eventlist, then the event will be placed in the eventlist with EV_ERROR set in flags and the system error in
+      * data. Otherwise, -1 will be returned". Submitting with no eventlist room takes that second branch, which stops at the first rejected
+      * entry and leaves every later entry in the batch unapplied, while the call reports only a single errno for the batch as a whole. Since a
+      * dropped `EV_ADD` is a read or write interest that the kernel never registers, the pending operation behind it waits for a readiness event
+      * that can never arrive: one closed fd early in a batch could strand every healthy connection staged behind it.
+      *
+      * EV_RECEIPT is what keeps readiness whole. It forces a receipt for every entry, success included (`data` is 0 on success), so the eventlist
+      * fills with exactly `nChanges` receipts and has no room left for a pending readiness event. Without it, a submission carrying an eventlist
+      * would drain readiness events into a buffer no one reads, and because read interest is registered edge-triggered (`EV_CLEAR`) a consumed
+      * event is gone: that would replace one silent loss with a worse one.
+      *
+      * A rejected entry cannot be reported to whoever staged it, since `change` returned 0 to that caller cycles ago. It is recorded on the
+      * scratch instead and drained by the driver through [[drainFailedRegistrations]].
+      */
+    private def flushChanges(pollerFd: Int, data: KqueuePollData)(using AllowUnsafe, Frame): Unit =
+        val n = data.nChanges
+        var i = 0
+        while i < n do
+            KEvent.addFlags(data.changelistBuf, i, PosixConstants.EV_RECEIPT)
+            i += 1
+        end while
+        val rc = kq.keventNow(pollerFd, data.changelistBuf, n, data.flushEventsBuf, n, ZeroTimeout)
+        data.nChanges = 0
+        // A negative rc means the call itself failed before producing any receipt (a bad kqueue fd, an unreadable changelist), so there is
+        // nothing per-entry to read and this batch is lost the way every batch used to be. Nothing here can attribute that to a connection, so
+        // it is logged rather than swallowed: the whole point of this path is that a lost batch stops being invisible.
+        if rc.isError then Log.live.unsafe.error(s"kqueue changelist flush failed errno=${rc.errorCode} nChanges=$n")
+        val received = if rc.isError then 0 else rc.value
+        i = 0
+        while i < received do
+            val errno = KEvent.data(data.flushEventsBuf, i).toInt
+            if errno != 0 then
+                // The receipt echoes the knote's udata, which is the registering handle's id. Carrying it through is what lets the driver tell a
+                // rejection that belongs to a still-live operation from one whose fd has already been closed and recycled: the commonest
+                // rejection here is EBADF from exactly that race, and failing by fd number alone would kill whichever connection now holds it.
+                val isWrite = KEvent.filter(data.flushEventsBuf, i) == PosixConstants.EVFILT_WRITE
+                data.recordFailedRegistration(
+                    KEvent.ident(data.flushEventsBuf, i).toInt,
+                    isWrite,
+                    errno,
+                    KEvent.udata(data.flushEventsBuf, i)
+                )
+            end if
+            i += 1
+        end while
+    end flushChanges
+
+    /** Submit a single one-element change immediately via `keventNow` (without batching). Used by the `deregister` path, where the
       * change must be applied outside the normal `drainChanges`-to-`poll` batch cycle (or when kqData is Absent in the test path).
       */
     private def changeNow(pollerFd: Int, fd: Int, filter: Short, flags: Short, udata: Long, kqData: Maybe[KqueuePollData])(using
@@ -219,7 +272,7 @@ private[net] object KqueuePollerBackend extends PollerBackend:
 
     /** Poll using the caller-owned reused buffers from [[KqueuePollData]]. The changelist batch (built by `drainChanges`) is passed alongside
       * the poll wait so interest changes and event collection happen in one atomic `kevent` syscall. After submission, `data.nChanges`
-      * is reset to 0 so subsequent `change()` calls (e.g. from `disableWrite` during `drainReady`) accumulate fresh changes for the next cycle.
+      * is reset to 0 so the changes staged by the next `drainChanges` accumulate into a fresh batch.
       *
       * Reuses the per-driver poll memo in `data` to avoid allocating a new [[Timespec]] on every call. The memo is owned by the poll-loop
       * carrier for this driver's scratch (see [[KqueuePollData]]). Since the poll loop always calls with the same `timeoutMs`, the memo
@@ -242,7 +295,7 @@ private[net] object KqueuePollerBackend extends PollerBackend:
                 data.pollMemoTs = ts
                 ts
         // Submit the changelist alongside the wait; interest changes and the blocking wait happen atomically in one kevent syscall.
-        data.nChanges = 0 // reset BEFORE the kevent call so disableWrite calls during drainReady accumulate into slots 0+
+        data.nChanges = 0 // reset BEFORE the kevent call so the next drain's changes start at slot 0 of a fresh batch
         val fiber = kq.kevent(pollerFd, changelist, nChanges, data.eventsBuffer, MaxEvents, timeout)
         fiber.poll() match
             case Present(result) =>
@@ -360,7 +413,11 @@ private[net] object KqueuePollerBackend extends PollerBackend:
         val kqData = new KqueuePollData(
             armBuf = Buffer.alloc[Byte](KEvent.size),                   // reused arm buffer for immediate changeNow calls (deregister path)
             eventsBuffer = Buffer.alloc[Byte](MaxEvents * KEvent.size), // poll eventlist buffer
-            changelistBuf = Buffer.alloc[Byte](MaxEvents * KEvent.size) // batch changelist: up to MaxEvents changes per poll cycle
+            changelistBuf = Buffer.alloc[Byte](MaxEvents * KEvent.size), // batch changelist: up to MaxEvents changes per poll cycle
+            // Receipt eventlist for the mid-drain flush. Sharing eventsBuffer would in fact be safe today, because a flush cannot overlap a
+            // pending poll: both change drains run outside the wait (one before `backend.poll`, one after it has completed). This buffer is
+            // separate so that the flush does not depend on that ordering holding, since nothing in either signature enforces it.
+            flushEventsBuf = Buffer.alloc[Byte](MaxEvents * KEvent.size)
         )
         val sentinelEvents = Buffer.alloc[Byte](0) // unused on kqueue; closed via PollScratch.close
         val sentinelArm    = Buffer.alloc[Byte](0) // unused on kqueue; closed via PollScratch.close

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PollerBackend.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PollerBackend.scala
@@ -44,11 +44,17 @@ private[net] trait PollerBackend:
       */
     def deregister(pollerFd: Int, fd: Int, fdClosing: Boolean, scratch: PollScratch)(using AllowUnsafe, Frame): Unit
 
-    /** Disable the kqueue EVFILT_WRITE filter on `fd` without removing it. Called from `dispatchWritable` after the write completes so the
-      * write-ready filter does not keep firing spuriously while no write is pending. On epoll this is a no-op (write interest is expressed
-      * atomically in the per-fd interest union and the ET mask already collapses write-only events correctly).
+    /** Report every interest registration the backend has discovered was rejected since the last call, then clear the record.
+      *
+      * A backend that batches interest changes cannot always answer "did this registration succeed" when the registering call returns, because
+      * the batch has not reached the kernel yet. Such a backend returns success optimistically and discovers the real per-entry outcome when the
+      * batch is submitted, by which point the caller that could have failed the pending operation is long gone. This is the way back: the driver
+      * calls it after each change drain and fails the operations whose registrations never took, instead of leaving them waiting for readiness
+      * the kernel will never report.
+      *
+      * Default: a no-op, for backends that submit each change immediately and so report failures through the registering call's own return.
       */
-    def disableWrite(pollerFd: Int, fd: Int, scratch: PollScratch)(using AllowUnsafe, Frame): Unit = ()
+    def drainFailedRegistrations(scratch: PollScratch, handler: RegistrationFailureHandler)(using AllowUnsafe, Frame): Unit = ()
 
     /** Fill the `scratch.fds` and `scratch.flags` arrays with decoded event data after a `timeoutMs` wait (`timeoutMs < 0` means
       * indefinite: blocks until an event or a wake arrives). The `@Ffi.blocking` `epoll_wait` / `kevent` runs inline on JVM/Native
@@ -124,6 +130,19 @@ private[net] trait PollerBackend:
 
 end PollerBackend
 
+/** Receives the interest registrations a batching backend discovered the kernel had rejected, reported by
+  * [[PollerBackend.drainFailedRegistrations]].
+  *
+  * A single-method trait rather than a `(Int, Boolean, Int) => Unit`, because a function value cannot carry a `using` clause: the handler needs
+  * a `Frame` for the failure it raises, and taking one per call means the frame comes from the live call site (the poll cycle's drain) instead
+  * of being captured when the handler was built. The driver holds one long-lived instance, so the poll loop still allocates nothing per cycle.
+  *
+  * `isWrite` false means the rejected registration was for read interest, which covers both read and accept registrations. `ownerId` is the id
+  * of the handle that registered, so the receiver can drop a rejection whose fd has since been recycled into a different handle.
+  */
+private[posix] trait RegistrationFailureHandler:
+    def onRejected(fd: Int, isWrite: Boolean, errno: Int, ownerId: Long)(using AllowUnsafe, Frame): Unit
+
 /** Kqueue-specific buffers held inside [[PollScratch]], allocated once at driver init and closed when the driver closes.
   *
   * `keventNow` and `kevent` take raw `Buffer[Byte]` changelists / eventlists (the same `Buffer[Byte]` the epoll arm uses), sized as a whole
@@ -144,22 +163,56 @@ end PollerBackend
 final private[net] class KqueuePollData(
     val armBuf: kyo.ffi.Buffer[Byte],
     val eventsBuffer: kyo.ffi.Buffer[Byte],
-    val changelistBuf: kyo.ffi.Buffer[Byte]
+    val changelistBuf: kyo.ffi.Buffer[Byte],
+    val flushEventsBuf: kyo.ffi.Buffer[Byte]
 ):
     // Poll-loop-carrier-owned memo: one entry per driver. Single owner: the poll-loop carrier for this driver's scratch.
     var pollMemoMs: Int      = -1
     var pollMemoTs: Timespec = null.asInstanceOf[Timespec]
 
     // Number of changes currently encoded in changelistBuf, ready to be passed to the next kevent call. Reset to 0 inside poll() after the
-    // changelist is submitted. Accumulates across drainChanges cycles: drainChanges appends starting at nChanges; backend.disableWrite (called
-    // from dispatchWritable during drainReady) also appends here so the EV_DISABLE lands in the next poll's changelist. Single owner: the
-    // poll-loop carrier for this scratch (drainChanges, drainReady, and poll all run on the same carrier).
+    // changelist is submitted, and inside change() when a full batch is flushed mid-drain. Accumulates across drainChanges cycles: drainChanges
+    // appends starting at nChanges. Single owner: the poll-loop carrier for this scratch (drainChanges and poll both run on that carrier).
     var nChanges: Int = 0
+
+    // Registrations the mid-drain flush found the kernel had rejected, held until the driver drains them. The registering call has already
+    // returned 0 to its caller by the time the batch reaches the kernel, so a per-entry errno discovered at flush time has no caller left to
+    // return to; without this record the pending read or write it belongs to would wait forever for readiness the kernel will never report.
+    // Parallel arrays rather than a case class per failure: the poll loop allocates nothing per cycle, and failures are rare enough that the
+    // arrays stay at their initial length in every run that has no rejected registration.
+    var failedFds: Array[Int]         = new Array[Int](8)
+    var failedIsWrite: Array[Boolean] = new Array[Boolean](8)
+    var failedErrnos: Array[Int]      = new Array[Int](8)
+    var failedOwnerIds: Array[Long]   = new Array[Long](8)
+    var failedCount: Int              = 0
+
+    /** Record one rejected registration, growing the parallel arrays when they are full. Dropping on overflow would reintroduce exactly the
+      * silent loss this record exists to close, so the arrays grow instead of capping.
+      *
+      * `ownerId` is the registering handle's id, carried on the knote as `udata` and returned verbatim on the receipt. An fd number alone cannot
+      * identify the operation to fail: by the time the rejection is read, the fd may already have been closed and recycled into a different
+      * handle, and failing "the pending op on fd N" would then kill an unrelated live connection.
+      */
+    def recordFailedRegistration(fd: Int, isWrite: Boolean, errno: Int, ownerId: Long): Unit =
+        if failedCount == failedFds.length then
+            val grown = failedCount * 2
+            failedFds = java.util.Arrays.copyOf(failedFds, grown)
+            failedIsWrite = java.util.Arrays.copyOf(failedIsWrite, grown)
+            failedErrnos = java.util.Arrays.copyOf(failedErrnos, grown)
+            failedOwnerIds = java.util.Arrays.copyOf(failedOwnerIds, grown)
+        end if
+        failedFds(failedCount) = fd
+        failedIsWrite(failedCount) = isWrite
+        failedErrnos(failedCount) = errno
+        failedOwnerIds(failedCount) = ownerId
+        failedCount += 1
+    end recordFailedRegistration
 
     def close()(using AllowUnsafe): Unit =
         armBuf.close()
         eventsBuffer.close()
         changelistBuf.close()
+        flushEventsBuf.close()
     end close
 end KqueuePollData
 

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PollerIoDriver.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PollerIoDriver.scala
@@ -536,8 +536,8 @@ final private[net] class PollerIoDriver private[posix] (
                 diagPollCycles += 1L
                 wakePending.set(false)
                 drainChanges()
-                // Pass the kqueue changelist (changelistBuf + nChanges) so kevent can submit pending changes (e.g. EV_DISABLE from
-                // dispatchWritable) atomically with the wait. On epoll the changelist / nChanges arguments are ignored by
+                // Pass the kqueue changelist (changelistBuf + nChanges) so kevent submits the interest changes this drain staged atomically
+                // with the wait. On epoll the changelist / nChanges arguments are ignored by
                 // EpollPollerBackend.poll. Read into locals rather than a tuple: this runs on every cycle, and Maybe is opaque and
                 // null-backed, so isDefined/get allocate nothing.
                 val kq    = pollScratch.kqueueData
@@ -2619,13 +2619,57 @@ final private[net] class PollerIoDriver private[posix] (
       * so the registration's map puts are applied between the prior command and this one (an intervening OpDeregister therefore cannot clear a
       * registration whose register command has not yet run). A command offered after this returns empty is drained on the next poll cycle.
       */
-    @scala.annotation.tailrec
     private def drainChanges()(using AllowUnsafe, Frame): Unit =
+        drainChangeQueue()
+        // A batching backend answers "did this registration take" only once the batch reaches the kernel, which happens after the registering
+        // command has already returned. Collect the rejections it discovered during this drain and fail their operations here; left unclaimed,
+        // each one is a read or write waiting on interest the kernel never registered.
+        backend.drainFailedRegistrations(pollScratch, failRejectedRegistration)
+    end drainChanges
+
+    @scala.annotation.tailrec
+    private def drainChangeQueue()(using AllowUnsafe, Frame): Unit =
         val cmd = changeQueue.poll()
         if cmd != MpscLongQueue.Empty then
             dispatchCmd(cmd)
-            drainChanges()
-    end drainChanges
+            drainChangeQueue()
+    end drainChangeQueue
+
+    /** Fails the pending operation whose interest registration the backend reported rejected. Mirrors the `rc < 0` branches in [[dispatchCmd]],
+      * which handle the same failure when the backend can report it synchronously; the only difference is that the errno is known here.
+      *
+      * Read-side rejections check accepts and reads, since both register read interest.
+      *
+      * A rejection is dropped when `ownerId` no longer matches the fd's current owner: the fd was closed and recycled between staging the change
+      * and reading the receipt, so the pending operation now on that fd number belongs to a different handle and is not the one that failed.
+      * This is the same discriminator `drainReady` applies to a stale readiness event, compared over the low 32 bits for the same reason.
+      *
+      * Held as one long-lived instance rather than built per drain: the poll loop allocates nothing per cycle, and a fresh handler on every
+      * `drainChanges` would be exactly such an allocation.
+      */
+    private val failRejectedRegistration: RegistrationFailureHandler = new RegistrationFailureHandler:
+        def onRejected(fd: Int, isWrite: Boolean, errno: Int, ownerId: Long)(using AllowUnsafe, Frame): Unit =
+            if (activeFds.getOrElse(fd, -1L) & 0xffffffffL) != (ownerId & 0xffffffffL) then ()
+            else if isWrite then
+                Maybe(pendingWritables.remove(fd)).foreach { entry =>
+                    entry.promise.completeDiscard(Result.fail(
+                        Closed(s"connection ${handleLabel(entry.handle)}", entry.handle.createdAt, s"register failed errno=$errno")
+                    ))
+                }
+            else
+                Maybe(pendingAccepts.remove(fd)).foreach { h =>
+                    h.pendingAcceptPromise.foreach(_.completeDiscard(Result.fail(
+                        Closed(s"listener ${handleLabel(h)}", h.createdAt, s"register failed errno=$errno")
+                    )))
+                    h.pendingAcceptPromise = Absent
+                }
+                Maybe(pendingReads.remove(fd)).foreach { h =>
+                    h.pendingReadPromise.getAndSet(Absent).foreach(_.completeDiscard(Result.fail(
+                        Closed(s"connection ${handleLabel(h)}", h.createdAt, s"register failed errno=$errno")
+                    )))
+                }
+            end if
+        end onRejected
 
     // No read re-arm path exists: edge-triggered registration (EPOLLET / EV_CLEAR) keeps the fd persistently armed, so
     // re-arming after a readiness event is neither necessary nor correct under ET (opcode value 2 is a reserved gap; see the opcode constant comment).

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixConstants.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixConstants.scala
@@ -143,15 +143,17 @@ private[net] object PosixConstants:
     val EV_ADD: Short      = 0x0001
     val EV_DELETE: Short   = 0x0002
     val EV_ENABLE: Short   = 0x0004
-    // EV_DISABLE deactivates a kqueue filter without removing it from the interest list. Used to suppress spurious write-ready events after a
-    // write completes: the EVFILT_WRITE filter stays registered (EV_ADD | EV_CLEAR | EV_ENABLE) and is toggled off with EV_DISABLE after the
-    // write drains, then toggled back on with EV_ENABLE when the next awaitWritable call arms the fd for writing. This avoids the overhead of
-    // EV_DELETE + EV_ADD per write cycle while preventing the send-buffer-full filter from firing continuously.
-    val EV_DISABLE: Short = 0x0008
     // EV_CLEAR auto-resets the EVFILT_USER trigger state after the event is delivered, so one NOTE_TRIGGER wakes the poll exactly once and the
     // filter re-arms for the next wake without an explicit reset (the level-vs-edge analog of draining the epoll eventfd counter).
     val EV_CLEAR: Short   = 0x0020
     val EV_ONESHOT: Short = 0x0010
+    // EV_RECEIPT makes a change submission report per-entry results instead of failing the whole call. `man 2 kevent`: "useful for making bulk
+    // changes to a kqueue without draining any pending events. When passed as input, it forces EV_ERROR to always be returned. When a filter is
+    // successfully added, the data field will be zero." Both halves matter for the mid-drain changelist flush. Without it, a submission that
+    // passes no eventlist room hits the other branch of the same contract ("Otherwise, -1 will be returned"), which aborts at the first bad
+    // entry and silently leaves the rest of the batch unapplied; with it, every entry is processed and reports its own errno. And because the
+    // eventlist fills with one receipt per change, a readiness event cannot be consumed by a call whose results nothing reads.
+    val EV_RECEIPT: Short = 0x0040
     // NOTE_TRIGGER is the fflags bit that fires an already-registered EVFILT_USER filter; the wake path encodes it into the change so the parked
     // `kevent` returns. Stable macOS/BSD ABI value.
     val NOTE_TRIGGER: Int = 0x01000000

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixStructs.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixStructs.scala
@@ -167,6 +167,14 @@ private[net] object KEvent:
         putLongLe(buf, base + 24, udata)    // udata (owning handle id; the stale-event discriminator)
     end encodeChange
 
+    /** OR `extra` into the `flags` of the already-encoded entry at element `slot`, leaving every other field untouched. Used by the changelist
+      * flush to add `EV_RECEIPT` to a batch whose entries were encoded one at a time as they were staged, without re-encoding them.
+      */
+    def addFlags(buf: Buffer[Byte], slot: Int, extra: Short)(using AllowUnsafe): Unit =
+        val offset = slot * size + 10
+        putShortLe(buf, offset, (getShortLe(buf, offset) | extra).toShort)
+    end addFlags
+
     /** Write a one-element `EVFILT_USER` changelist at element 0 of `buf` with explicit `fflags`. Used by the kqueue poll-loop wakeup: the
       * register call passes `flags = EV_ADD | EV_CLEAR` and `fflags = 0`; the trigger call passes `flags = 0` and `fflags = NOTE_TRIGGER`. The
       * `ident` is a fixed wakeup key (not an fd), distinct from any socket fd so its delivered event is recognized and consumed by the poll loop

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixTransport.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixTransport.scala
@@ -1612,239 +1612,275 @@ final private[net] class PosixTransport private[posix] (
                 handle.upgradeActive = true
                 handle.upgrading =
                     true // durable across the whole window, cleared with upgradeActive at onFinished; io_uring read-routing reads it
-                posixConn.detachForUpgrade() match
-                    case Absent =>
-                        // The claim above was won, so no other upgrade can be in flight: losing the detach CAS here means the connection
-                        // reached a terminal state first (a close raced or preceded this call). Undo this call's own pre-detach arm; the
-                        // close path owns the fd.
-                        handle.upgradeActive = false
-                        handle.upgrading = false
-                        out.completeDiscard(Result.fail(NetAlreadyDetachedException()))
-                    case Present(staged) =>
-                        // Committed to the upgrade: mark it durably (see PosixHandle.isUpgraded) before any handshakeOwned recv can be armed, so
-                        // the io_uring reap can recognize one that outlives onFinished's flag-clear even after upgradeActive/upgrading go false.
-                        handle.isUpgraded = true
-                        // buildEngine can throw a NetTlsException here (an unavailable pinned provider, an unreadable PEM, or an SSL
-                        // context/engine init failure; and on the JDK floor provider, a verifying STARTTLS client with no reference identity,
-                        // i.e. no sniHostname), so a build failure must release the detached-but-open fd and fail the upgrade promise rather
-                        // than escaping. No engine exists yet on this path, so only the fd is released (releaseFailedUpgrade also frees
-                        // the engine, which is absent here). The release routes through closeUnwiredHandle, never a bare PosixHandle.close:
-                        // driver.closeHandle runs first, so on io_uring the read-buffer free is deferred until every kernel-owned SQE for
-                        // this handle reaps. The stale plaintext recv the upgrade window leaves in flight is kernel-owned by construction
-                        // here, with the buffer's address already captured; an inline free would return that off-heap memory to the
-                        // process-wide allocator while the kernel can still complete the recv into it. The real close(fd) is deferred to
-                        // freeResources via the fdCloseSink credit closeUnwiredHandle installs.
-                        val engine =
-                            try buildEngine(tls, upgradeHost(tls, isServer), isServer)
-                            catch
-                                case e: NetTlsException =>
-                                    closeUnwiredHandle(handle, handle.driver, connectPhase = false)
-                                    out.completeDiscard(Result.fail(e))
-                                    // Fiber.Unsafe[A, S] is an opaque alias over IOPromiseBase[Any, A < (Async & S)] (kyo.Fiber.scala),
-                                    // structurally different from this plainly-constructed, invariant IOPromise[NetException, Connection],
-                                    // even though both erase to the same runtime object; the alias is transparent only inside kyo.Fiber's
-                                    // own defining scope, so returning this promise as the locked Transport.upgradeToTls result needs this
-                                    // erased-boundary cast. Safe: the promise is completed only with the NetException/Connection values above.
-                                    return out.asInstanceOf[Fiber.Unsafe[Connection, Abort[NetException]]]
-                        // Feed every staged ciphertext byte into the engine before the first post-upgrade read.
-                        feedStaged(engine, staged)
-                        // Recover the peer's first handshake flight when it arrived coalesced with the upgrade signal. A STARTTLS
-                        // client writes its signal byte and its ClientHello back to back, so on a loopback the kernel can hand both
-                        // to one `recv`; the consumer takes the whole chunk as "the signal" and discards the ClientHello bytes riding
-                        // behind it. feedCoalescedHandshake re-feeds those bytes (everything from the chunk's first TLS record on) so
-                        // the engine sees the ClientHello the handshake would otherwise wait for forever. A no-op when the last read
-                        // was the bare signal or ordinary plaintext (no TLS record found). The last read is skipped when it is itself
-                        // one of the staged spans (the ClientHello arrived in its own read and `feedStaged` already fed it), so it is
-                        // never fed twice. It also cannot be fed twice against `PosixHandle.onInboundClosedDuringRead`'s salvage, which
-                        // aliases the SAME chunk when the plaintext pump's channel-offer failed instead of landing it in `staged`:
-                        // `feedCoalescedHandshake` claims `handle.lastPlaintextRead` before feeding, so exactly one of the two ever delivers it.
-                        feedCoalescedHandshake(handle, engine, staged)
-                        // upgradeActive stays set (it was armed before detach) all the way into driveHandshake. While it is set, awaitRead's
-                        // single-recv gate drops every recv arm requested for this fd, so no NEW recv can register during the upgrade: the only recv
-                        // that can be in flight is the genuine stale one the plaintext ReadPump armed before detach (kernel-owned, uncancellable). The
-                        // no-stale-recv decision is therefore made later, ON THE REAP CARRIER, by the handshake's first read (driveUpgradeRead), whose
-                        // hasInFlightRead scans both `pending` AND `stalledSubmits` authoritatively: the genuine stale recv is registered before
-                        // driveUpgradeRead runs (FIFO on the reap carrier), in `pending` if its SQE went out or in `stalledSubmits` if it parked on a
-                        // full SQ, and a stray ReadPump re-arm racing the upgrade was gated away and reached neither. Making the decision here on the
-                        // upgrade carrier instead would be a TOCTOU (a hasInFlightRead snapshot could miss a not-yet-registered stale recv).
-                        // On a poller the poll carrier is the standing producer for every upgrade read (driveUpgradeRead parks a waiter it fulfils via
-                        // armUpgradeProducerRead), so upgradeActive stays set across the whole handshake; it is cleared at completion (onFinished below).
-                        // Register this in-flight STARTTLS handshake so a transport `close()` racing it (no deadline exists on the upgrade path
-                        // either) reclaims the fd/engine and fails `out` instead of leaking them / stranding the upgrade fiber past shutdown.
-                        // `driveHandshake` guarantees exactly one of onFinished/onFailed/onPanic ever fires, so `handshakeDisarm` builds its own
-                        // fresh gate, same as the connect-side registration above. See [[pendingHandshakes]].
-                        //
-                        // `reaped` mirrors the accept-side reap guard and the connect-side registration above: the sweep below can free the
-                        // engine while the handshake machine is still actively chaining (a `close()` racing a mid-flight upgrade wins
-                        // `handshakeDisarm` and offers its free op into the engine FIFO; the machine's own next step thunk, already in flight,
-                        // enqueues AFTER it). A FIFO honors submission order, so it cannot protect an op enqueued after the free: `reaped` is
-                        // the guard `isReaped` reads inside driveHandshake's handshakeStep/feedCiphertext/awaitReadCiphertext thunks, set as the
-                        // FIRST statement of every path here that frees the engine, so a step thunk that runs AFTER the free skips instead of
-                        // touching freed native memory.
-                        val reaped = AtomicBoolean.Unsafe.init(false)
-                        val (handshakeToken, handshakeDisarm) = registerHandshake(() =>
-                            handle.driver.submitEngineOp { () =>
-                                reaped.set(true)
-                                releaseFailedUpgrade(handle, engine)
-                                out.completeDiscard(Result.fail(NetConnectionClosedException(Operation.Handshake)))
+                // The detach reports the staged ciphertext through a handover rather than a return value: the driver is detached after the
+                // inbound channel closes, so a ReadPump offer carrying the peer's first TLS flight can still be committing then, and those
+                // bytes are already off the socket where the engine will never see them again. Everything below therefore runs once the
+                // handover settles, which is inline whenever no offer is in flight.
+                //
+                // What an escaping throw has to release, updated as the body below takes ownership: nothing at entry (the close path still
+                // owns the fd), the detached-but-engineless fd once the detach commits, fd and engine once the engine is built, and nothing
+                // again once the discharge hook is installed, since settling `out` then performs the release itself. Read only by the
+                // containment at the call site, which is the one place that can observe a throw from this body.
+                var releaseOnEscape: () => Unit = () => ()
+                def afterDetach(detached: Maybe[Chunk[Span[Byte]]]): Unit =
+                    detached match
+                        case Absent =>
+                            // The claim above was won, so no other upgrade can be in flight: losing the detach CAS here means the connection
+                            // reached a terminal state first (a close raced or preceded this call). Undo this call's own pre-detach arm; the
+                            // close path owns the fd.
+                            handle.upgradeActive = false
+                            handle.upgrading = false
+                            out.completeDiscard(Result.fail(NetAlreadyDetachedException()))
+                        case Present(staged) =>
+                            // Committed to the upgrade: mark it durably (see PosixHandle.isUpgraded) before any handshakeOwned recv can be armed, so
+                            // the io_uring reap can recognize one that outlives onFinished's flag-clear even after upgradeActive/upgrading go false.
+                            handle.isUpgraded = true
+                            // The fd is detached and open from here on, with no engine yet, so an escaping throw releases exactly what the
+                            // NetTlsException arm just below releases.
+                            releaseOnEscape = () => closeUnwiredHandle(handle, handle.driver, connectPhase = false)
+                            // buildEngine can throw a NetTlsException here (an unavailable pinned provider, an unreadable PEM, or an SSL
+                            // context/engine init failure; and on the JDK floor provider, a verifying STARTTLS client with no reference identity,
+                            // i.e. no sniHostname), so a build failure must release the detached-but-open fd and fail the upgrade promise rather
+                            // than escaping. No engine exists yet on this path, so only the fd is released (releaseFailedUpgrade also frees
+                            // the engine, which is absent here). The release routes through closeUnwiredHandle, never a bare PosixHandle.close:
+                            // driver.closeHandle runs first, so on io_uring the read-buffer free is deferred until every kernel-owned SQE for
+                            // this handle reaps. The stale plaintext recv the upgrade window leaves in flight is kernel-owned by construction
+                            // here, with the buffer's address already captured; an inline free would return that off-heap memory to the
+                            // process-wide allocator while the kernel can still complete the recv into it. The real close(fd) is deferred to
+                            // freeResources via the fdCloseSink credit closeUnwiredHandle installs.
+                            val engine =
+                                try buildEngine(tls, upgradeHost(tls, isServer), isServer)
+                                catch
+                                    case e: NetTlsException =>
+                                        closeUnwiredHandle(handle, handle.driver, connectPhase = false)
+                                        out.completeDiscard(Result.fail(e))
+                                        // Fiber.Unsafe[A, S] is an opaque alias over IOPromiseBase[Any, A < (Async & S)] (kyo.Fiber.scala),
+                                        // structurally different from this plainly-constructed, invariant IOPromise[NetException, Connection],
+                                        // even though both erase to the same runtime object; the alias is transparent only inside kyo.Fiber's
+                                        // own defining scope, so returning this promise as the locked Transport.upgradeToTls result needs this
+                                        // erased-boundary cast. Safe: the promise is completed only with the NetException/Connection values above.
+                                        return ()
+                            // The engine now exists and is known only to this upgrade, so an escaping throw has to free it along with the
+                            // fd. Direct rather than through submitEngineOp: driveHandshake has not run yet, so no other op can be queued
+                            // against this engine and there is nothing for a FIFO ordering to protect.
+                            releaseOnEscape = () => releaseFailedUpgrade(handle, engine)
+                            // Feed every staged ciphertext byte into the engine before the first post-upgrade read.
+                            feedStaged(engine, staged)
+                            // Recover the peer's first handshake flight when it arrived coalesced with the upgrade signal. A STARTTLS
+                            // client writes its signal byte and its ClientHello back to back, so on a loopback the kernel can hand both
+                            // to one `recv`; the consumer takes the whole chunk as "the signal" and discards the ClientHello bytes riding
+                            // behind it. feedCoalescedHandshake re-feeds those bytes (everything from the chunk's first TLS record on) so
+                            // the engine sees the ClientHello the handshake would otherwise wait for forever. A no-op when the last read
+                            // was the bare signal or ordinary plaintext (no TLS record found). The last read is skipped when it is itself
+                            // one of the staged spans (the ClientHello arrived in its own read and `feedStaged` already fed it), so it is
+                            // never fed twice. It also cannot be fed twice against `PosixHandle.onInboundClosedDuringRead`'s salvage, which
+                            // aliases the SAME chunk when the plaintext pump's channel-offer failed instead of landing it in `staged`:
+                            // `feedCoalescedHandshake` claims `handle.lastPlaintextRead` before feeding, so exactly one of the two ever delivers it.
+                            feedCoalescedHandshake(handle, engine, staged)
+                            // upgradeActive stays set (it was armed before detach) all the way into driveHandshake. While it is set, awaitRead's
+                            // single-recv gate drops every recv arm requested for this fd, so no NEW recv can register during the upgrade: the only recv
+                            // that can be in flight is the genuine stale one the plaintext ReadPump armed before detach (kernel-owned, uncancellable). The
+                            // no-stale-recv decision is therefore made later, ON THE REAP CARRIER, by the handshake's first read (driveUpgradeRead), whose
+                            // hasInFlightRead scans both `pending` AND `stalledSubmits` authoritatively: the genuine stale recv is registered before
+                            // driveUpgradeRead runs (FIFO on the reap carrier), in `pending` if its SQE went out or in `stalledSubmits` if it parked on a
+                            // full SQ, and a stray ReadPump re-arm racing the upgrade was gated away and reached neither. Making the decision here on the
+                            // upgrade carrier instead would be a TOCTOU (a hasInFlightRead snapshot could miss a not-yet-registered stale recv).
+                            // On a poller the poll carrier is the standing producer for every upgrade read (driveUpgradeRead parks a waiter it fulfils via
+                            // armUpgradeProducerRead), so upgradeActive stays set across the whole handshake; it is cleared at completion (onFinished below).
+                            // Register this in-flight STARTTLS handshake so a transport `close()` racing it (no deadline exists on the upgrade path
+                            // either) reclaims the fd/engine and fails `out` instead of leaking them / stranding the upgrade fiber past shutdown.
+                            // `driveHandshake` guarantees exactly one of onFinished/onFailed/onPanic ever fires, so `handshakeDisarm` builds its own
+                            // fresh gate, same as the connect-side registration above. See [[pendingHandshakes]].
+                            //
+                            // `reaped` mirrors the accept-side reap guard and the connect-side registration above: the sweep below can free the
+                            // engine while the handshake machine is still actively chaining (a `close()` racing a mid-flight upgrade wins
+                            // `handshakeDisarm` and offers its free op into the engine FIFO; the machine's own next step thunk, already in flight,
+                            // enqueues AFTER it). A FIFO honors submission order, so it cannot protect an op enqueued after the free: `reaped` is
+                            // the guard `isReaped` reads inside driveHandshake's handshakeStep/feedCiphertext/awaitReadCiphertext thunks, set as the
+                            // FIRST statement of every path here that frees the engine, so a step thunk that runs AFTER the free skips instead of
+                            // touching freed native memory.
+                            val reaped = AtomicBoolean.Unsafe.init(false)
+                            val (handshakeToken, handshakeDisarm) = registerHandshake(() =>
+                                handle.driver.submitEngineOp { () =>
+                                    reaped.set(true)
+                                    releaseFailedUpgrade(handle, engine)
+                                    out.completeDiscard(Result.fail(NetConnectionClosedException(Operation.Handshake)))
+                                }
+                            )
+                            // `out` is this upgrade's fd-and-engine owner. driveHandshake's three outcomes below each discharge the obligation
+                            // themselves (they win `handshakeDisarm` and unregister), so this hook bites for exactly the settlements they do NOT
+                            // cover: the caller's fiber interrupting the upgrade it was awaiting (Async.useResult links the awaiting task to `out`,
+                            // so a timeout, a losing race arm, or an enclosing abort settles it), and the plaintext connection's close() routing
+                            // through the `upgradeAbandon` thunk armed above. Both leave the handshake parked on a read nothing will ever complete,
+                            // holding a detached fd that no other closer can reach: the connection's own closeFn cannot take an Upgrading fd, and
+                            // a transport-wide sweep no longer exists, and this transport is process-lifetime anyway. So the fd would stay
+                            // open forever and, once the peer FINs, sit in CLOSE_WAIT with no shutdown. Discharging the registered obligation runs the
+                            // identical release the shutdown sweep would.
+                            //
+                            // Installed AFTER registerHandshake so the obligation exists to discharge, and BEFORE driveHandshake so an `out` already
+                            // settled by this point (an interrupt landing during the engine build above) fires the hook immediately: `reaped` is then
+                            // set and driveHandshake's steps skip rather than touching a freed engine.
+                            out.onComplete {
+                                case Result.Success(_) => ()
+                                case _                 => dischargePendingHandshake(handshakeToken)
                             }
-                        )
-                        // `out` is this upgrade's fd-and-engine owner. driveHandshake's three outcomes below each discharge the obligation
-                        // themselves (they win `handshakeDisarm` and unregister), so this hook bites for exactly the settlements they do NOT
-                        // cover: the caller's fiber interrupting the upgrade it was awaiting (Async.useResult links the awaiting task to `out`,
-                        // so a timeout, a losing race arm, or an enclosing abort settles it), and the plaintext connection's close() routing
-                        // through the `upgradeAbandon` thunk armed above. Both leave the handshake parked on a read nothing will ever complete,
-                        // holding a detached fd that no other closer can reach: the connection's own closeFn cannot take an Upgrading fd, and
-                        // a transport-wide sweep no longer exists, and this transport is process-lifetime anyway. So the fd would stay
-                        // open forever and, once the peer FINs, sit in CLOSE_WAIT with no shutdown. Discharging the registered obligation runs the
-                        // identical release the shutdown sweep would.
-                        //
-                        // Installed AFTER registerHandshake so the obligation exists to discharge, and BEFORE driveHandshake so an `out` already
-                        // settled by this point (an interrupt landing during the engine build above) fires the hook immediately: `reaped` is then
-                        // set and driveHandshake's steps skip rather than touching a freed engine.
-                        out.onComplete {
-                            case Result.Success(_) => ()
-                            case _                 => dischargePendingHandshake(handshakeToken)
-                        }
-                        // Bound the upgrade handshake, the third handshake role. A peer that never sends its side of the STARTTLS handshake
-                        // leaves this parked on a read forever; the plaintext connection has already been detached by now, so nothing else owns
-                        // the fd or the engine, and on the process-shared transport no later close() sweeps them. `handshakeDisarm` is the same
-                        // exactly-once gate driveHandshake's three outcomes use, so the deadline and the real outcome are mutually exclusive.
-                        // The teardown rides submitEngineOp for the same UAF reason the registered obligation above does. There is no fresh
-                        // connect port for an upgrade, so the leaf carries -1, matching the convention the handshake-failure leaf uses here.
-                        // `Duration.Infinity` arms no timer.
-                        if tls.handshakeTimeout.isFinite then
-                            val deadline = Clock.live.unsafe.sleep(tls.handshakeTimeout)
-                            deadline.onComplete { _ =>
-                                if handshakeDisarm() then
-                                    unregisterHandshake(handshakeToken)
-                                    handle.driver.submitEngineOp { () =>
+                            // From here the hook above IS the release: any non-success settlement of `out`, including the panic an escaping
+                            // throw produces, discharges the registered obligation. Releasing again here would free the engine twice.
+                            releaseOnEscape = () => ()
+                            // Bound the upgrade handshake, the third handshake role. A peer that never sends its side of the STARTTLS handshake
+                            // leaves this parked on a read forever; the plaintext connection has already been detached by now, so nothing else owns
+                            // the fd or the engine, and on the process-shared transport no later close() sweeps them. `handshakeDisarm` is the same
+                            // exactly-once gate driveHandshake's three outcomes use, so the deadline and the real outcome are mutually exclusive.
+                            // The teardown rides submitEngineOp for the same UAF reason the registered obligation above does. There is no fresh
+                            // connect port for an upgrade, so the leaf carries -1, matching the convention the handshake-failure leaf uses here.
+                            // `Duration.Infinity` arms no timer.
+                            if tls.handshakeTimeout.isFinite then
+                                val deadline = Clock.live.unsafe.sleep(tls.handshakeTimeout)
+                                deadline.onComplete { _ =>
+                                    if handshakeDisarm() then
+                                        unregisterHandshake(handshakeToken)
+                                        handle.driver.submitEngineOp { () =>
+                                            reaped.set(true)
+                                            releaseFailedUpgrade(handle, engine)
+                                            out.completeDiscard(Result.fail(
+                                                NetTlsHandshakeTimeoutException(upgradeHost(tls, isServer), -1, tls.handshakeTimeout)
+                                            ))
+                                        }
+                                }
+                                out.onComplete { _ =>
+                                    deadline.interruptDiscard(
+                                        Result.Panic(Interrupted(frame, "upgrade settled before deadline"))
+                                    )
+                                }
+                            end if
+                            // driveUpgradeRead's parked waiter fails with the transport's own typed leaf (a close raced the in-flight read): surface
+                            // it directly rather than re-wrapping a transport failure as a handshake one. Any other cause is a genuine handshake
+                            // failure (protocol error, engine throw), wrapped as NetTlsHandshakeException as before.
+                            def completeUpgradeFailure(cause: HandshakeFailure | String | Throwable): Unit =
+                                cause match
+                                    case netEx: NetException => out.completeDiscard(Result.fail(netEx))
+                                    case other =>
+                                        val causeMsg: String | Throwable = other match
+                                            case hf: HandshakeFailure.EngineThrew => hf.cause
+                                            case hf: HandshakeFailure             => hf.toString
+                                            case st: (String | Throwable)         => st
+                                        out.completeDiscard(Result.fail(NetTlsHandshakeException(upgradeHost(tls, isServer), -1, causeMsg)))
+                            driveHandshake(
+                                handle,
+                                engine,
+                                onFinished = () =>
+                                    if handshakeDisarm() then
+                                        unregisterHandshake(handshakeToken)
+                                        // Clear the upgrade flags before attaching the engine and starting the pumps. upgradeActive/upgrading stay set for
+                                        // the WHOLE upgrade on every backend (driveUpgradeRead never clears them itself; see its scaladoc), and a handshake
+                                        // that completes purely from staged ciphertext (feedStaged / feedCoalescedHandshake) never reaches driveUpgradeRead
+                                        // at all, so onFinished is the single clear point that covers every path. It runs on the I/O carrier, so this clear
+                                        // happens-before the new ReadPump's recv is armed by upgraded.start(). handshakeReading is cleared here too so the
+                                        // poller admits the upgraded connection's ReadPump read arm (the failure paths clear both via PosixHandle.close).
+                                        // PosixHandle.isUpgraded is NOT cleared here (and never is): it must outlive this clear so the io_uring reap can
+                                        // still recognize an orphaned handshakeOwned recv and route it correctly (see IoUringDriver.complete), and so
+                                        // IoUringDriver.submitRecv can recognize the upgraded connection's first post-upgrade recv and queue it behind
+                                        // any such orphan still in flight (see PosixHandle.queuedRecv) instead of racing it for the same staging buffer.
+                                        // lastPlaintextRead is also cleared here (re-upgrade hygiene): a stale claim left over from THIS upgrade's
+                                        // feedCoalescedHandshake/salvage race must not alias a future upgrade's own coalesced flight.
+                                        handle.lastPlaintextRead.set(Absent)
+                                        handle.upgradeActive = false
+                                        handle.handshakeReading = false
+                                        handle.tls = Present(engine)
+                                        // Clear the durable upgrade-window marker AFTER tls becomes Present, so the io_uring reap never observes
+                                        // upgrading=false while tls is still Absent (which would route a reaping recv to the raw plainReadComplete path).
+                                        // Volatile-write ordering: a reaper that sees upgrading=false also sees tls=Present, so it takes the TLS branch.
+                                        handle.upgrading = false
+                                        val upgraded =
+                                            InternalConnection.init(handle, handle.driver, channelCapacity, handle.peerCloseGrace)
+                                        // Wire the cert-hash and re-upgrade functions on the upgraded connection, exactly as completeConnect /
+                                        // spawnHandler do for a directly-connected or accepted connection. Without this the TLS connection
+                                        // produced by STARTTLS could not report its RFC 5929 channel-binding hash (certHashFn stays null ->
+                                        // serverCertificateHash returns Absent). The re-upgrade function keeps the same role this upgrade ran in.
+                                        wireUpgraded(upgraded, isServer, channelCapacity)
+                                        // Re-point the handle's inboundSink at the UPGRADED connection now (see PosixHandle.inboundSink), before anything
+                                        // below can reap a late-arriving orphan recv that uses it: onFinished runs synchronously on the same carrier that
+                                        // drains every completion for this handle (the reap carrier, for io_uring), so this write happens-before any
+                                        // later completion on that same carrier observes it -- no separate synchronization needed.
+                                        handle.inboundSink = bytes => discard(upgraded.inbound.offer(bytes))
+                                        // Post-FINISHED slot drain: a peer flight (a TLS 1.3 NewSessionTicket, or any post-handshake record) can land in the
+                                        // upgradeHandoff slot during the FINISHED transition with no parked waiter to consume it (the handshake stopped parking).
+                                        // Feed it to the engine BEFORE deliverHandshakePlaintext so the engine's record sequence stays intact (an un-fed
+                                        // post-FINISHED record desyncs the sequence and the next record fails to decrypt) and deliverHandshakePlaintext then
+                                        // flushes any application bytes it produced. The posix analog of nio's drainUpgradeLeftover; a no-op when the slot is Idle.
+                                        handle.upgradeHandoff.get() match
+                                            case staged: PosixHandle.UpgradeHandoff.Carryover =>
+                                                discard(handle.upgradeHandoff.compareAndSet(staged, PosixHandle.UpgradeHandoff.Idle))
+                                                val drainBuf = Buffer.fromArray[Byte](staged.bytes)
+                                                try discard(engine.feedCiphertext(drainBuf, staged.bytes.length))
+                                                finally drainBuf.close()
+                                            case _ => ()
+                                        end match
+                                        // Deliver any application plaintext the handshake already decrypted before the pumps start, so a record
+                                        // that arrived with the handshake's final flight is not stranded in the engine (see completeConnect).
+                                        deliverHandshakePlaintext(handle, upgraded.inbound)
+                                        // Force the first ReadPump read to re-evaluate socket readiness: the peer's first application flight (e.g. the
+                                        // STARTTLS echo) can arrive in the socket BEFORE upgraded.start() arms the read, and on epoll the register-once
+                                        // re-arm skips the MOD so that buffered flight gets no new edge and the read strands. A no-op on every other backend.
+                                        handle.driver.forceReadRecovery(handle)
+                                        // Open the kqueue post-upgrade read window: a TLS 1.3 NewSessionTicket (or any post-handshake record) lands between
+                                        // here and the echo, reads as 0 plaintext, and the bare re-arm trusts an EV_CLEAR edge for the echo that kqueue can
+                                        // lose. While set, dispatchReadTls re-issues the kqueue read registration (EV_ADD re-evaluates) on a 0-plaintext
+                                        // drained re-arm; it clears on the first application read. A no-op on epoll/io_uring (gated at the use site).
+                                        handle.postUpgradeReadWindow = true
+                                        // upgraded.start() arms the new ReadPump's first recv immediately: it does NOT wait for any handshake-window recv
+                                        // still in flight for this handle (the orphaned-producer TOCTOU, see PosixHandle.isUpgraded) to drain first.
+                                        // Blocking here instead (parking a waiter and deferring start()) would deadlock, since
+                                        // BOTH peers of an upgrade can symmetrically be waiting on their own orphan to drain while that orphan's bytes are
+                                        // exactly the OTHER peer's first post-upgrade write, which peer's own (symmetrically blocked) upgrade fiber never
+                                        // reaches (IoUringMutualTlsStressTest exercises this io_uring-only stress path). The ordering invariant instead
+                                        // lives entirely in IoUringDriver.awaitRead/submitRecv: the
+                                        // new ReadPump's first recv arm QUEUES behind a still-in-flight orphan (PosixHandle.queuedRecv) rather than racing
+                                        // it for the same staging buffer, and fires the moment that orphan's CQE reaps -- non-blocking, no fiber parked.
+                                        if upgraded.start() then
+                                            // Checked complete, mirroring completeConnect: a caller interrupt or the plaintext connection's
+                                            // close() can settle `out` after onFinished won `handshakeDisarm` above (the discharge hook then
+                                            // loses the gate and releases nothing) and before this success delivery. Discarding the lost
+                                            // completion would leave this fully started connection live but unreferenced on the never-swept
+                                            // process-shared transport while the caller believes the fd was released; close the orphan.
+                                            if !out.complete(Result.succeed(upgraded: Connection)) then
+                                                upgraded.close()
+                                        else
+                                            // The upgraded connection raced to a terminal/Upgrading state before start (a close won); it must not be
+                                            // handed out as open.
+                                            out.completeDiscard(Result.fail(NetConnectionClosedException(Operation.Start)))
+                                        end if
+                                    end if
+                                ,
+                                onFailed = cause =>
+                                    if handshakeDisarm() then
+                                        unregisterHandshake(handshakeToken)
                                         reaped.set(true)
                                         releaseFailedUpgrade(handle, engine)
-                                        out.completeDiscard(Result.fail(
-                                            NetTlsHandshakeTimeoutException(upgradeHost(tls, isServer), -1, tls.handshakeTimeout)
-                                        ))
-                                    }
-                            }
-                            out.onComplete { _ =>
-                                deadline.interruptDiscard(
-                                    Result.Panic(Interrupted(frame, "upgrade settled before deadline"))
-                                )
-                            }
-                        end if
-                        // driveUpgradeRead's parked waiter fails with the transport's own typed leaf (a close raced the in-flight read): surface
-                        // it directly rather than re-wrapping a transport failure as a handshake one. Any other cause is a genuine handshake
-                        // failure (protocol error, engine throw), wrapped as NetTlsHandshakeException as before.
-                        def completeUpgradeFailure(cause: HandshakeFailure | String | Throwable): Unit =
-                            cause match
-                                case netEx: NetException => out.completeDiscard(Result.fail(netEx))
-                                case other =>
-                                    val causeMsg: String | Throwable = other match
-                                        case hf: HandshakeFailure.EngineThrew => hf.cause
-                                        case hf: HandshakeFailure             => hf.toString
-                                        case st: (String | Throwable)         => st
-                                    out.completeDiscard(Result.fail(NetTlsHandshakeException(upgradeHost(tls, isServer), -1, causeMsg)))
-                        driveHandshake(
-                            handle,
-                            engine,
-                            onFinished = () =>
-                                if handshakeDisarm() then
-                                    unregisterHandshake(handshakeToken)
-                                    // Clear the upgrade flags before attaching the engine and starting the pumps. upgradeActive/upgrading stay set for
-                                    // the WHOLE upgrade on every backend (driveUpgradeRead never clears them itself; see its scaladoc), and a handshake
-                                    // that completes purely from staged ciphertext (feedStaged / feedCoalescedHandshake) never reaches driveUpgradeRead
-                                    // at all, so onFinished is the single clear point that covers every path. It runs on the I/O carrier, so this clear
-                                    // happens-before the new ReadPump's recv is armed by upgraded.start(). handshakeReading is cleared here too so the
-                                    // poller admits the upgraded connection's ReadPump read arm (the failure paths clear both via PosixHandle.close).
-                                    // PosixHandle.isUpgraded is NOT cleared here (and never is): it must outlive this clear so the io_uring reap can
-                                    // still recognize an orphaned handshakeOwned recv and route it correctly (see IoUringDriver.complete), and so
-                                    // IoUringDriver.submitRecv can recognize the upgraded connection's first post-upgrade recv and queue it behind
-                                    // any such orphan still in flight (see PosixHandle.queuedRecv) instead of racing it for the same staging buffer.
-                                    // lastPlaintextRead is also cleared here (re-upgrade hygiene): a stale claim left over from THIS upgrade's
-                                    // feedCoalescedHandshake/salvage race must not alias a future upgrade's own coalesced flight.
-                                    handle.lastPlaintextRead.set(Absent)
-                                    handle.upgradeActive = false
-                                    handle.handshakeReading = false
-                                    handle.tls = Present(engine)
-                                    // Clear the durable upgrade-window marker AFTER tls becomes Present, so the io_uring reap never observes
-                                    // upgrading=false while tls is still Absent (which would route a reaping recv to the raw plainReadComplete path).
-                                    // Volatile-write ordering: a reaper that sees upgrading=false also sees tls=Present, so it takes the TLS branch.
-                                    handle.upgrading = false
-                                    val upgraded = InternalConnection.init(handle, handle.driver, channelCapacity, handle.peerCloseGrace)
-                                    // Wire the cert-hash and re-upgrade functions on the upgraded connection, exactly as completeConnect /
-                                    // spawnHandler do for a directly-connected or accepted connection. Without this the TLS connection
-                                    // produced by STARTTLS could not report its RFC 5929 channel-binding hash (certHashFn stays null ->
-                                    // serverCertificateHash returns Absent). The re-upgrade function keeps the same role this upgrade ran in.
-                                    wireUpgraded(upgraded, isServer, channelCapacity)
-                                    // Re-point the handle's inboundSink at the UPGRADED connection now (see PosixHandle.inboundSink), before anything
-                                    // below can reap a late-arriving orphan recv that uses it: onFinished runs synchronously on the same carrier that
-                                    // drains every completion for this handle (the reap carrier, for io_uring), so this write happens-before any
-                                    // later completion on that same carrier observes it -- no separate synchronization needed.
-                                    handle.inboundSink = bytes => discard(upgraded.inbound.offer(bytes))
-                                    // Post-FINISHED slot drain: a peer flight (a TLS 1.3 NewSessionTicket, or any post-handshake record) can land in the
-                                    // upgradeHandoff slot during the FINISHED transition with no parked waiter to consume it (the handshake stopped parking).
-                                    // Feed it to the engine BEFORE deliverHandshakePlaintext so the engine's record sequence stays intact (an un-fed
-                                    // post-FINISHED record desyncs the sequence and the next record fails to decrypt) and deliverHandshakePlaintext then
-                                    // flushes any application bytes it produced. The posix analog of nio's drainUpgradeLeftover; a no-op when the slot is Idle.
-                                    handle.upgradeHandoff.get() match
-                                        case staged: PosixHandle.UpgradeHandoff.Carryover =>
-                                            discard(handle.upgradeHandoff.compareAndSet(staged, PosixHandle.UpgradeHandoff.Idle))
-                                            val drainBuf = Buffer.fromArray[Byte](staged.bytes)
-                                            try discard(engine.feedCiphertext(drainBuf, staged.bytes.length))
-                                            finally drainBuf.close()
-                                        case _ => ()
-                                    end match
-                                    // Deliver any application plaintext the handshake already decrypted before the pumps start, so a record
-                                    // that arrived with the handshake's final flight is not stranded in the engine (see completeConnect).
-                                    deliverHandshakePlaintext(handle, upgraded.inbound)
-                                    // Force the first ReadPump read to re-evaluate socket readiness: the peer's first application flight (e.g. the
-                                    // STARTTLS echo) can arrive in the socket BEFORE upgraded.start() arms the read, and on epoll the register-once
-                                    // re-arm skips the MOD so that buffered flight gets no new edge and the read strands. A no-op on every other backend.
-                                    handle.driver.forceReadRecovery(handle)
-                                    // Open the kqueue post-upgrade read window: a TLS 1.3 NewSessionTicket (or any post-handshake record) lands between
-                                    // here and the echo, reads as 0 plaintext, and the bare re-arm trusts an EV_CLEAR edge for the echo that kqueue can
-                                    // lose. While set, dispatchReadTls re-issues the kqueue read registration (EV_ADD re-evaluates) on a 0-plaintext
-                                    // drained re-arm; it clears on the first application read. A no-op on epoll/io_uring (gated at the use site).
-                                    handle.postUpgradeReadWindow = true
-                                    // upgraded.start() arms the new ReadPump's first recv immediately: it does NOT wait for any handshake-window recv
-                                    // still in flight for this handle (the orphaned-producer TOCTOU, see PosixHandle.isUpgraded) to drain first.
-                                    // Blocking here instead (parking a waiter and deferring start()) would deadlock, since
-                                    // BOTH peers of an upgrade can symmetrically be waiting on their own orphan to drain while that orphan's bytes are
-                                    // exactly the OTHER peer's first post-upgrade write, which peer's own (symmetrically blocked) upgrade fiber never
-                                    // reaches (IoUringMutualTlsStressTest exercises this io_uring-only stress path). The ordering invariant instead
-                                    // lives entirely in IoUringDriver.awaitRead/submitRecv: the
-                                    // new ReadPump's first recv arm QUEUES behind a still-in-flight orphan (PosixHandle.queuedRecv) rather than racing
-                                    // it for the same staging buffer, and fires the moment that orphan's CQE reaps -- non-blocking, no fiber parked.
-                                    if upgraded.start() then
-                                        // Checked complete, mirroring completeConnect: a caller interrupt or the plaintext connection's
-                                        // close() can settle `out` after onFinished won `handshakeDisarm` above (the discharge hook then
-                                        // loses the gate and releases nothing) and before this success delivery. Discarding the lost
-                                        // completion would leave this fully started connection live but unreferenced on the never-swept
-                                        // process-shared transport while the caller believes the fd was released; close the orphan.
-                                        if !out.complete(Result.succeed(upgraded: Connection)) then
-                                            upgraded.close()
-                                    else
-                                        // The upgraded connection raced to a terminal/Upgrading state before start (a close won); it must not be
-                                        // handed out as open.
-                                        out.completeDiscard(Result.fail(NetConnectionClosedException(Operation.Start)))
-                                    end if
-                                end if
-                            ,
-                            onFailed = cause =>
-                                if handshakeDisarm() then
-                                    unregisterHandshake(handshakeToken)
-                                    reaped.set(true)
-                                    releaseFailedUpgrade(handle, engine)
-                                    completeUpgradeFailure(cause),
-                            onPanic = e =>
-                                if handshakeDisarm() then
-                                    unregisterHandshake(handshakeToken)
-                                    reaped.set(true)
-                                    releaseFailedUpgrade(handle, engine)
-                                    out.completeDiscard(Result.panic(e)),
-                            isReaped = () => reaped.get()
-                        )
-                end match
+                                        completeUpgradeFailure(cause),
+                                onPanic = e =>
+                                    if handshakeDisarm() then
+                                        unregisterHandshake(handshakeToken)
+                                        reaped.set(true)
+                                        releaseFailedUpgrade(handle, engine)
+                                        out.completeDiscard(Result.panic(e)),
+                                isReaped = () => reaped.get()
+                            )
+                    end match
+                end afterDetach
+                // Contain ANY throw out of the body above. Completion callbacks run under a catch-all that logs rather than propagates
+                // (IOPromise.eval), so an escaping throw would settle nothing: the caller would park on an upgrade that can never finish
+                // while the detached fd stayed open until the peer FINs it into CLOSE_WAIT. While the detach reported its staging by
+                // return value this body ran on the caller's own stack, where such a throw reached the caller as a panic, and callers
+                // classify on that (kyo-sql's TlsUpgrade maps it to a connect failure). Reproduce that: release whatever the body owned
+                // at the point it threw, then hand the throwable back as the same panic.
+                posixConn.detachForUpgrade().onComplete { r =>
+                    try afterDetach(r.foldError(_.eval, _ => Absent))
+                    catch
+                        case t: Throwable =>
+                            releaseOnEscape()
+                            out.completeDiscard(Result.panic(t))
+                }
                 // Fiber.Unsafe[A, S] is an opaque alias over IOPromiseBase[Any, A < (Async & S)] (kyo.Fiber.scala), structurally different
                 // from this plainly-constructed, invariant IOPromise[NetException, Connection], even though both erase to the same runtime
                 // object; the alias is transparent only inside kyo.Fiber's own defining scope, so returning this promise as the locked

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/transport/Connection.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/transport/Connection.scala
@@ -191,7 +191,7 @@ final private[kyo] class Connection[Handle] private (
       *
       * This method is idempotent. On second call it returns Absent (channel was already closed).
       */
-    def detachForUpgrade()(using AllowUnsafe, Frame): Maybe[Chunk[Span[Byte]]] =
+    def detachForUpgrade()(using AllowUnsafe, Frame): Fiber.Unsafe[Maybe[Chunk[Span[Byte]]], Any] =
         // Win the detach by CASing Established -> Upgrading: the Upgrading state keeps the fd open and
         // bars teardown, so the socket can be handed to the TLS upgrade. A second detach, or a detach
         // after a close already won, loses the CAS and returns Absent (idempotent), so the fd is never
@@ -201,6 +201,11 @@ final private[kyo] class Connection[Handle] private (
         then
             // Close inbound and capture any bytes the ReadPump already staged but nobody consumed.
             // These are raw network bytes (TLS ciphertext) that the handshake engine needs.
+            //
+            // The capture is a handover rather than a return value because the driver is detached below, AFTER this line: a ReadPump
+            // offer carrying the peer's first flight can still be committing right here. Missing it would strand the handshake waiting
+            // for bytes that were read and dropped, so the result is delivered once that offer lands. The handover settles inline
+            // whenever no offer is in flight, which is the ordinary case.
             val buffered = inbound.close()
             // The outbound close result is intentionally discarded: detachForUpgrade hands the fd to the TLS upgrade, so any queued outbound
             // bytes are abandoned by design (the upgrade re-drives the socket); unlike inbound, whose staged ciphertext the handshake needs.
@@ -209,8 +214,8 @@ final private[kyo] class Connection[Handle] private (
             // driver.cancel so a driver can keep its transport registration for the upgrade: the NIO driver keeps the SelectionKey (avoiding a
             // cancel+re-register race), while other drivers fall back to cancel. Intentionally does NOT call driver.closeHandle so the fd stays open.
             driver.detachForUpgrade(handle)
-            buffered.map(Chunk.from(_))
-        else Absent
+            buffered.map(_.map(Chunk.from(_)))
+        else Fiber.Unsafe.fromResult(Result.succeed(Absent))
         end if
     end detachForUpgrade
 
@@ -430,9 +435,10 @@ private[kyo] object Connection:
                     closingPromise.completeDiscard(Result.succeed(()))
                     discard(in.close())
                     discard(out.close())
-            private[kyo] def onClosing: Fiber.Unsafe[Unit, Any]                        = closingPromise
-            def detachForUpgrade()(using AllowUnsafe, Frame): Maybe[Chunk[Span[Byte]]] = Absent // not upgradable: no driver or socket
-            private[net] def start()(using AllowUnsafe, Frame): Boolean                = true   // no pumps; immediately usable
+            private[kyo] def onClosing: Fiber.Unsafe[Unit, Any] = closingPromise
+            // not upgradable: no driver or socket, so the answer is known immediately
+            def detachForUpgrade()(using AllowUnsafe, Frame)            = Fiber.Unsafe.fromResult(Result.succeed(Absent))
+            private[net] def start()(using AllowUnsafe, Frame): Boolean = true // no pumps; immediately usable
             // Plaintext, driverless connection: no peer certificate to hash and no close_notify exchange to observe.
             def serverCertificateHash: Maybe[Span[Byte]] = Absent
             def status: kyo.net.Connection.Status        = kyo.net.Connection.Status.Active

--- a/kyo-net/shared/src/test/scala/kyo/net/ConnectionDetachForUpgradeTest.scala
+++ b/kyo-net/shared/src/test/scala/kyo/net/ConnectionDetachForUpgradeTest.scala
@@ -40,9 +40,13 @@ class ConnectionDetachForUpgradeTest extends Test:
         val conn = Connection.init[Unit]((), spy, 1)
         conn.start()
         Sync.defer {
-            val result = conn.detachForUpgrade()
-            // detachForUpgrade returns Present when it wins the CAS (Established -> Upgrading).
-            assert(result.isDefined, "detachForUpgrade on an Established connection must return Present")
+            val result = conn.detachForUpgrade().poll()
+            // detachForUpgrade reports Present when it wins the CAS (Established -> Upgrading). Nothing is offering here, so the handover
+            // settles inside the call; asserting on the settled result pins that too.
+            assert(
+                result.exists { case Result.Success(v) => v.eval.isDefined; case _ => false },
+                s"detachForUpgrade on an Established connection must settle synchronously and report Present, got $result"
+            )
             assert(
                 spy.closeHandleCount.get() == 0,
                 s"closeHandle must NOT be called after detachForUpgrade, got ${spy.closeHandleCount.get()}"

--- a/kyo-net/shared/src/test/scala/kyo/net/internal/transport/ConnectionStateTest.scala
+++ b/kyo-net/shared/src/test/scala/kyo/net/internal/transport/ConnectionStateTest.scala
@@ -76,10 +76,10 @@ class ConnectionStateTest extends Test:
         val spy  = new SpyDriver
         val conn = makeEstablished(spy)
         Sync.defer {
-            val buffered = conn.detachForUpgrade()
+            val buffered = conn.detachForUpgrade().poll()
             assert(
-                buffered.isDefined || buffered.isEmpty,
-                "detachForUpgrade returns a Maybe (present or absent, both OK for empty channel)"
+                buffered.exists(_.isSuccess),
+                s"detachForUpgrade must settle synchronously when nothing is in flight (present or absent both OK for an empty channel), got $buffered"
             )
             conn.close()
             assert(spy.closeHandleCount.get() == 0, s"closeHandle must NOT be called after a detach, got ${spy.closeHandleCount.get()}")
@@ -95,8 +95,11 @@ class ConnectionStateTest extends Test:
             conn.close()
             // After close() the outbound channel is empty (no queued writes in this test), so teardownHandle fires synchronously:
             // the state advances Closing -> Closed.
-            val result = conn.detachForUpgrade()
-            assert(result.isEmpty, s"detachForUpgrade after close must return Absent, got $result")
+            val result = conn.detachForUpgrade().poll()
+            assert(
+                result.exists { case Result.Success(v) => v.eval.isEmpty; case _ => false },
+                s"detachForUpgrade after close must report Absent, got $result"
+            )
             // No second teardown: closeHandle count is exactly 1 from the close() path.
             assert(spy.closeHandleCount.get() == 1, s"closeHandle must be called exactly once, got ${spy.closeHandleCount.get()}")
         }

--- a/kyo-net/shared/src/test/scala/kyo/net/internal/transport/InMemoryConnectionTest.scala
+++ b/kyo-net/shared/src/test/scala/kyo/net/internal/transport/InMemoryConnectionTest.scala
@@ -80,8 +80,11 @@ class InMemoryConnectionTest extends Test:
 
         "detachForUpgrade returns Absent (not upgradable)" in {
             val (a, _)   = Connection.inMemoryPair()
-            val detached = a.detachForUpgrade()
-            assert(detached.isEmpty, s"detachForUpgrade must return Absent, got $detached")
+            val detached = a.detachForUpgrade().poll()
+            assert(
+                detached.exists { case Result.Success(v) => v.eval.isEmpty; case _ => false },
+                s"detachForUpgrade must report Absent, got $detached"
+            )
         }
     }
 end InMemoryConnectionTest

--- a/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/WorkerConcurrentRunTest.scala
+++ b/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/WorkerConcurrentRunTest.scala
@@ -123,11 +123,15 @@ class WorkerConcurrentRunTest extends AnyFreeSpec with NonImplicitAssertions {
             i += 1
         }
         // Catastrophic-only watchdog: nothing at the effect level can preempt this raw busy-spin, so the deadline exists solely to break out of a
-        // genuine hang, never as a throughput gate. How many tasks drain within it is machine-dependent and not asserted; the invariant is that
-        // the witness never sees two task bodies of this worker run at once.
+        // genuine hang, never as a throughput gate. Every task is enqueued up front, so ran == total is the strand invariant, not a measure of
+        // throughput, and the budget sits three orders of magnitude above a healthy drain. Falling short means a task was stranded.
         val end = deadlineMs(300000)
         while (ran.get() < total && System.currentTimeMillis() < end) {}
         h.stop.set(true)
+        assert(
+            ran.get() == total,
+            s"probe1 STRANDED ${total - ran.get()} task(s): ran=${ran.get()}/$total queueLoad=${h.worker.load()}"
+        )
         assert(
             h.maxConcurrentRun == 1,
             s"probe1 maxConcurrentRun=${h.maxConcurrentRun} maxRunOverlap=${h.maxRunOverlap} ran=${ran.get()}/$total (expected 1)"
@@ -145,8 +149,9 @@ class WorkerConcurrentRunTest extends AnyFreeSpec with NonImplicitAssertions {
         val rounds = 200000
         val ran    = new AtomicInteger(0)
 
-        // Catastrophic-only watchdogs on every raw spin below: they break a genuine hang, never gate throughput. How many boundary rounds the
-        // machine completes is not asserted; the invariants are that no round overlaps two run()s and no enqueued task is stranded.
+        // Catastrophic-only watchdogs on every raw spin below: they break a genuine hang, never gate throughput. The budget sits orders of
+        // magnitude above a healthy run, so reaching it means the loop wedged rather than ran slowly, and a probe that stopped short of its
+        // round count exercised the boundary too few times to guard anything. Both are asserted below, ahead of the invariants they validate.
         var round = 0
         val end   = deadlineMs(600000)
         while (round < rounds && System.currentTimeMillis() < end) {
@@ -161,6 +166,10 @@ class WorkerConcurrentRunTest extends AnyFreeSpec with NonImplicitAssertions {
         while (ran.get() < round && System.currentTimeMillis() < tailEnd) {}
         h.stop.set(true)
 
+        assert(
+            round == rounds,
+            s"probe2 WATCHDOG fired at round=$round/$rounds: the boundary loop wedged, so this run guards nothing"
+        )
         assert(ran.get() == round, s"probe2 STRANDED ${round - ran.get()} task(s): ran=${ran.get()}/$round")
         assert(
             !h.concurrentSeen,
@@ -187,8 +196,9 @@ class WorkerConcurrentRunTest extends AnyFreeSpec with NonImplicitAssertions {
         val enq       = new AtomicInteger(0)
         val started   = new CountDownLatch(injectors)
         val go        = new CountDownLatch(1)
-        // Catastrophic-only watchdogs throughout: they break a genuine hang, never gate throughput. How many tasks the injectors enqueue and drain
-        // is machine-dependent and not asserted; the invariants are no concurrent run() and no stranded task.
+        // Catastrophic-only watchdogs throughout: they break a genuine hang, never gate throughput. The budget sits orders of magnitude above a
+        // healthy run, so an injector that stopped short of perInj wedged rather than ran slowly, and the probe then exercised the boundary too
+        // few times to guard anything. That is asserted below, ahead of the invariants it validates.
         val end = deadlineMs(600000)
 
         val threads =
@@ -215,6 +225,10 @@ class WorkerConcurrentRunTest extends AnyFreeSpec with NonImplicitAssertions {
         threads.foreach(_.join(610000)) // above the injector deadline so a slow-but-progressing injector is joined, not abandoned
 
         val totalEnq = enq.get()
+        assert(
+            totalEnq == total,
+            s"probe3 WATCHDOG fired at enqueued=$totalEnq/$total: the injectors wedged, so this run guards nothing"
+        )
         // Wait for every enqueued task to run. A strand is ran < totalEnq that never advances after all
         // injectors have stopped producing: no live run() and no pending wakeup to recover it.
         val tailEnd = deadlineMs(300000)

--- a/kyo-slack/shared/src/main/scala/kyo/internal/SlackSocketEngine.scala
+++ b/kyo-slack/shared/src/main/scala/kyo/internal/SlackSocketEngine.scala
@@ -247,7 +247,7 @@ final private[kyo] class SlackSocketEngine private[kyo] (
       * they share one close rather than racing a plain `close` against a `closeAwaitEmpty`
       * that would leave the channel waiting for a consumer the rotation has stopped being.
       */
-    private[kyo] def closeInbound(using Frame): Unit < Sync =
+    private[kyo] def closeInbound(using Frame): Unit < Async =
         inbound.close.map {
             case Present(residue) => inboundResidue.complete(Result.succeed(Chunk.from(residue))).unit
             case Absent           => Kyo.unit

--- a/kyo-sql/shared/src/main/scala/kyo/internal/client/SqlConnectionPool.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/client/SqlConnectionPool.scala
@@ -202,7 +202,7 @@ final private[kyo] class SqlConnectionPool[C <: Connection](
                     // Unsafe: channel.close and the final connection closes require AllowUnsafe.
                     Sync.Unsafe.defer {
                         slotChans.forEach { (_, ch) =>
-                            discard(Sync.Unsafe.evalOrThrow(Abort.run[Closed](ch.close)))
+                            discard(Sync.Unsafe.evalOrThrow(ch.closeDiscard))
                         }
                         slotChans.clear()
                         idleConns.foreach(_.closeNow)

--- a/kyo-sql/shared/src/test/scala/kyo/net/StubConnection.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/net/StubConnection.scala
@@ -29,10 +29,11 @@ object StubConnection:
             end close
             private[kyo] def onClosing: Fiber.Unsafe[Unit, Any] =
                 closing
-            def detachForUpgrade()(using AllowUnsafe, Frame): Maybe[Chunk[Span[Byte]]] = Maybe.Absent
-            private[net] def start()(using AllowUnsafe, Frame): Boolean                = true
-            def serverCertificateHash: Maybe[Span[Byte]]                               = Maybe.Absent
-            def status: Connection.Status                                              = Connection.Status.Active
+            def detachForUpgrade()(using AllowUnsafe, Frame): Fiber.Unsafe[Maybe[Chunk[Span[Byte]]], Any] =
+                Fiber.Unsafe.fromResult(Result.succeed(Maybe.Absent))
+            private[net] def start()(using AllowUnsafe, Frame): Boolean = true
+            def serverCertificateHash: Maybe[Span[Byte]]                = Maybe.Absent
+            def status: Connection.Status                               = Connection.Status.Active
         end new
     end apply
 

--- a/kyo-stm/shared/src/test/scala/kyo/STMStressTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMStressTest.scala
@@ -176,9 +176,13 @@ class STMStressTest extends kyo.test.Test[Any]:
         yield
             assert(elderRes.isSuccess, s"the elder did not commit within the hang-guard (starvation/deadlock); attempts=$attempts")
             assert(youngRes.isSuccess, "the young transactions did not complete within the hang-guard")
-            // The property is no-starvation: the elder EVENTUALLY commits under contention. How many retries it took is contention-dependent, not
-            // a correctness bound, so it is reported for diagnostics but never asserted.
+            // The property is no-starvation: the elder eventually commits under contention. The retry count is contention-dependent, so it is
+            // bounded only catastrophically, never tightly: measured at 2 across repeated local runs, so 2000 is three orders of magnitude of
+            // headroom and can only trip on a scheduler or STM regression that starves the elder pathologically, not on a slow machine.
+            // Without any bound an elder that retried ten thousand times would still pass, which is the fairness failure this leaf exists to
+            // catch.
             assert(done, s"the elder must eventually commit under contention; done=$done attempts=$attempts")
+            assert(attempts < 2000, s"the elder was starved pathologically before committing: attempts=$attempts")
     }
 
     "nested transaction rollback under concurrent contention does not leak inner writes".notJs in {

--- a/kyo-test/runner/jvm/src/test/scala/kyo/test/runner/LeakCheckTest.scala
+++ b/kyo-test/runner/jvm/src/test/scala/kyo/test/runner/LeakCheckTest.scala
@@ -387,20 +387,29 @@ class LeakCheckTest extends AnyFunSuite with NonImplicitAssertions:
         // Wait for the PERSISTENT recursion frame (the `.map` call site, `LeakCheckTest.kyoBusyLoop(...)`), not merely any
         // non-empty trace: a transient startup frame is the newest line early on but does not survive once the 16-slot
         // ring fills with the steady-state recursion frame, so a token taken from it would not match a later detect render.
-        val observed = awaitTrue(2000)(Scheduler.get.busyFiberTraces().exists(_.fiberTrace.contains("LeakCheckTest.kyoBusyLoop(")))
+        // The token is derived inside the wait, not after it. busyFiberTraces is a live sample of whichever workers are busy at the
+        // instant it is called, so a frame present in one call can be absent from the next: awaiting the frame and then re-sampling to
+        // extract it leaves the extraction racing the sampler, and a miss yields an empty token rather than a retry.
+        var steadyLine = ""
+        val observed = awaitTrue(2000) {
+            steadyLine = Scheduler.get.busyFiberTraces().iterator
+                .flatMap(_.fiberTrace.linesIterator)
+                .find(_.contains("LeakCheckTest.kyoBusyLoop("))
+                .getOrElse("")
+            steadyLine.nonEmpty
+        }
         // Reproduce the Busy branch's allowlist match text against the REAL busy fiber: per worker, its rendered kyo
         // trace joined with its JVM stack. The token is the ` @ <class>.<caller>(File:line)` fragment of the recursion
         // frame: a JVM StackTraceElement carries no ` @ ` separator, so the token appears ONLY in the kyo trace, never in
         // the JVM stack. The padded snippet (before ` @ `) and the trailing ` (xN)` repeat-count suffix are dropped (the
         // count grows as the ring fills, so a count-bearing token would not match a later render).
-        val busy       = Scheduler.get.busyFiberTraces()
-        val jvmStacks  = busy.map(w => LeakCheck.stackOfThread(w.mount).getOrElse("")).mkString("\n")
-        val matchText  = busy.map(w => w.fiberTrace + "\n" + LeakCheck.stackOfThread(w.mount).getOrElse("")).mkString("\n")
-        val steadyLine = busy.iterator.flatMap(_.fiberTrace.linesIterator).find(_.contains("LeakCheckTest.kyoBusyLoop(")).getOrElse("")
-        val atIdx      = steadyLine.indexOf(" @ ")
-        val afterAt    = if atIdx >= 0 then steadyLine.substring(atIdx) else steadyLine
-        val xIdx       = afterAt.indexOf(" (x")
-        val kyoOnly    = if xIdx >= 0 then afterAt.substring(0, xIdx) else afterAt
+        val busy      = Scheduler.get.busyFiberTraces()
+        val jvmStacks = busy.map(w => LeakCheck.stackOfThread(w.mount).getOrElse("")).mkString("\n")
+        val matchText = busy.map(w => w.fiberTrace + "\n" + LeakCheck.stackOfThread(w.mount).getOrElse("")).mkString("\n")
+        val atIdx     = steadyLine.indexOf(" @ ")
+        val afterAt   = if atIdx >= 0 then steadyLine.substring(atIdx) else steadyLine
+        val xIdx      = afterAt.indexOf(" (x")
+        val kyoOnly   = if xIdx >= 0 then afterAt.substring(0, xIdx) else afterAt
         // End-to-end: ONE detect with the kyo-trace token suppresses the finding (a single Busy probe, as reliable as
         // the kyo-trace-frame arm above; a second back-to-back probe races the first probe's System.gc() and is avoided).
         val suppressed = detectFiberReport(Chunk(kyoOnly))

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -263,6 +263,12 @@ run_in_container() {
     if [ -n "${KYO_POD_SOCKET:-}" ]; then
         args+=(--network host -v "${KYO_POD_SOCKET}:${KYO_POD_SOCKET}")
         envs+=(-e "CONTAINER_HOST=unix://${KYO_POD_SOCKET}")
+        # /tmp at the SAME path on both sides, because a sibling container's bind mounts are resolved by the daemon, not by us. A suite that
+        # generates a file and hands its path to a sibling (kyo-sql's TLS suites write server certs to a temp dir and bind it into Postgres at
+        # /etc/ssl-pg) otherwise names a path that exists only inside this container: the sibling mounts an empty directory, Postgres starts
+        # without TLS, and every TLS leaf fails with the server answering 'N' to SSLRequest rather than anything resembling the real defect.
+        # Sharing the daemon's own /tmp makes the two views agree, so the generated path resolves identically on both.
+        args+=(-v /tmp:/tmp)
     fi
     # Forward the BoringSSL-staging flag; when set the container builds the vendored BoringSSL before the command so kyo-net's TLS tests run
     # against real libssl/libcrypto instead of cancelling.


### PR DESCRIPTION
### Problem

Three paths discarded work without reporting it. A closing queue spun waiting for its backlog instead of handing it over, and a sliding offer could act as a second consumer, so a close could observe a count no state ever held. A throw from the TLS upgrade's detach handover was swallowed, stranding the upgrade and leaking the accepted descriptor, since its only releasing owner was installed after the throw. The kqueue changelist flush submitted with no eventlist room, so a rejected entry made the kernel stop there and abandon the rest of the batch while the return code was discarded, leaving reads and writes parked on interest the kernel never registered.

### Solution

Queue close hands the backlog to the last consumer out and checks offer counts against the state actually found, and that contract is carried through its actor, http, sql, slack and net consumers. The upgrade path settles its promise and releases the connection when the handover callback throws, on every transport. The changelist flush submits with EV_RECEIPT and an eventlist sized to the batch, so every entry is processed and each rejection is routed to fail the operation it belongs to, carrying the registering handle's id so a recycled descriptor is never mistaken for its predecessor.

### Notes

Each fix carries a regression test whose negative control fails without it. Also removes a kqueue write-filter disable that had no caller, and makes the async logging exit-hook drain budget a static flag.
