### PR TITLE
[test] assert on settled state, and keep the evidence when a leg dies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,3 +143,28 @@ jobs:
         run: |
           action="${{ inputs.mode == 'diff' && 'testDiff' || 'test' }}"
           ./scripts/ci-test.sh "${{ matrix.target }}" "$action"
+
+      # A JVM that dies in native code writes its diagnosis next to the forked test process and the runner
+      # discards it with the workspace, so the only trace left in the log is a task failure carrying no test
+      # name. That shape is indistinguishable from an ordinary failure at a glance and has already cost one
+      # investigation that began by looking for a broken test that had in fact passed. Failure-only, so a
+      # passing leg is unaffected.
+      #
+      # The line budget is sized for the THREAD LIST, not the header. The header names the faulting frame,
+      # which is the cheap half; the question that actually decides a native-teardown crash is which threads
+      # were still alive when it faulted, and that section sits several hundred lines in. A budget that stops
+      # at the header buys a report that reproduces what the console already printed.
+      - name: crash reports (${{ inputs.os }})
+        if: failure()
+        shell: bash
+        run: |
+          reports=$(find . -name 'hs_err_pid*.log' -type f 2>/dev/null || true)
+          if [ -z "$reports" ]; then
+            echo "no JVM crash reports in the workspace"
+          else
+            for report in $reports; do
+              echo "::group::$report"
+              head -600 "$report"
+              echo "::endgroup::"
+            done
+          fi

--- a/kyo-browser/shared/src/main/scala/kyo/Browser.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/Browser.scala
@@ -465,9 +465,18 @@ object Browser:
             // after dispatch would race the event loop and manufacture the very false negative described above.
             if !confirmDelivery then Kyo.unit
             else
-                BrowserEval.clickWasReceived.map { received =>
-                    if received then Kyo.unit
-                    else
+                BrowserEval.clickDelivery.map {
+                    case BrowserEval.ClickDelivery.Received        => Kyo.unit
+                    case BrowserEval.ClickDelivery.Unsubstantiated =>
+                        // The probe is gone, so the document it lived on was replaced between dispatch and read. That refutes nothing,
+                        // and failing a caller on a lost-click claim we cannot make would be worse than letting the click stand. What it
+                        // must not do is look identical to a confirmed delivery: when a later assertion fails on the state this click was
+                        // supposed to produce, whether the click was ever confirmed is the first thing worth knowing.
+                        Log.warn(
+                            s"click: delivery to ${Browser.selectorNodeDescription(Selector.toNode(selector))} is unconfirmed because " +
+                                "the click probe is gone, which a navigation between dispatch and read does"
+                        )
+                    case BrowserEval.ClickDelivery.Missed =>
                         Abort.fail(
                             BrowserElementNotActionableException(
                                 Browser.selectorNodeDescription(Selector.toNode(selector)),

--- a/kyo-browser/shared/src/main/scala/kyo/internal/BrowserEval.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/BrowserEval.scala
@@ -139,7 +139,7 @@ private[kyo] object BrowserEval:
 
     // ---- Mouse-event dispatch ----
 
-    /** Records the page's current click tally as the baseline a following [[clickWasReceived]] compares against.
+    /** Records the page's current click tally as the baseline a following [[clickDelivery]] compares against.
       *
       * The listener goes on `window` in the CAPTURE phase, which is the first node an event visits and the only placement that survives a
       * page suppressing its own clicks: `stopPropagation` blocks the next node, never the remaining listeners on the node already being
@@ -158,13 +158,37 @@ private[kyo] object BrowserEval:
                 """w.__kyoClickProbe.baseline=w.__kyoClickProbe.count;return 'armed';})()"""
         ).unit
 
-    /** True when at least one click reached the document since [[armClickProbe]]. A missing probe reads as received: the document was
-      * replaced (a navigation) between arming and reading, and a lost-click claim we cannot substantiate must never fail a caller.
-      */
-    private[kyo] def clickWasReceived(using Frame): Boolean < (Browser & Abort[BrowserReadException]) =
+    /** What the page reports about a dispatched click, read back after [[armClickProbe]]. */
+    private[kyo] enum ClickDelivery derives CanEqual:
+        /** The window-capture tally advanced, so the event reached the document. */
+        case Received
+
+        /** The tally is intact and did not move, so the browser never delivered the event. */
+        case Missed
+
+        /** The probe object itself is gone, which is what a navigation between arming and reading does to it. Delivery is then neither
+          * confirmed nor refuted, and the two are worth distinguishing: a caller must never be failed on a lost-click claim we cannot
+          * substantiate, but an unconfirmed click must also not be indistinguishable from a confirmed one when a later assertion fails on
+          * the state that click was supposed to produce.
+          */
+        case Unsubstantiated
+    end ClickDelivery
+
+    /** Reads the probe tally armed by [[armClickProbe]] and classifies the dispatch as [[ClickDelivery]]. */
+    private[kyo] def clickDelivery(using Frame): ClickDelivery < (Browser & Abort[BrowserReadException]) =
         evalJs(
-            """(function(){var p=window.__kyoClickProbe;return String(!p||p.count>p.baseline);})()"""
-        ).map(_ == "true")
+            """(function(){var p=window.__kyoClickProbe;""" +
+                """return !p?'absent':(p.count>p.baseline?'received':'missed');})()"""
+        ).map {
+            case "received" => ClickDelivery.Received
+            case "missed"   => ClickDelivery.Missed
+            case "absent"   => ClickDelivery.Unsubstantiated
+            case other      =>
+                // An unrecognised reading means the template and this consumer have drifted apart. Treat it the way an absent probe is
+                // treated, since neither substantiates a loss, and name the reading so the drift is findable.
+                Log.warn(s"clickDelivery: unrecognised probe reading '$other'; treating the dispatch as unsubstantiated")
+                    .andThen(ClickDelivery.Unsubstantiated)
+        }
 
     /** Dispatches a click at pre-resolved coordinates. Called from the Actionability-gated interaction paths; the gate has already produced
       * the center, so there is no need to re-evaluate the element's rect.

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserActionabilityTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserActionabilityTest.scala
@@ -34,23 +34,50 @@ class BrowserActionabilityTest extends BrowserTest:
     // The gate above runs entirely BEFORE the dispatch, so it cannot see whether the event it sends arrives. These cover the
     // post-dispatch probe: what it counts, what it must never fail, and that it reads false when nothing was delivered.
 
-    "the delivery probe reads false when nothing was clicked after arming" in {
+    "the delivery probe reads missed when nothing was clicked after arming" in {
         withBrowser {
             onPage("""<body><button id="t" style="width:80px;height:30px">Go</button></body>""") {
-                BrowserEval.armClickProbe.andThen(BrowserEval.clickWasReceived).map { received =>
-                    assert(!received, "the probe must not report a delivery when no click was dispatched")
+                BrowserEval.armClickProbe.andThen(BrowserEval.clickDelivery).map { delivery =>
+                    assert(
+                        delivery == BrowserEval.ClickDelivery.Missed,
+                        s"the probe must not report a delivery when no click was dispatched, got $delivery"
+                    )
                 }
             }
         }
     }
 
-    "the delivery probe reads true once a click reaches the document" in {
+    "the delivery probe reads received once a click reaches the document" in {
         withBrowser {
             onPage("""<body><button id="t" style="width:80px;height:30px">Go</button></body>""") {
                 BrowserEval.armClickProbe
                     .andThen(Browser.eval("document.getElementById('t').click(); 'done'"))
-                    .andThen(BrowserEval.clickWasReceived)
-                    .map(received => assert(received, "a click that reached the document must read as delivered"))
+                    .andThen(BrowserEval.clickDelivery)
+                    .map(delivery =>
+                        assert(
+                            delivery == BrowserEval.ClickDelivery.Received,
+                            s"a click that reached the document must read as delivered, got $delivery"
+                        )
+                    )
+            }
+        }
+    }
+
+    // A probe that is gone carries no evidence either way, and the distinction is the whole point of the third state: a navigation
+    // between arming and reading wipes it, and reporting that as a delivery hides an unconfirmed click behind a confirmed one.
+    // Deleting the object reproduces exactly the state a navigation leaves behind, without needing a real navigation.
+    "the delivery probe reads unsubstantiated when the probe object is gone" in {
+        withBrowser {
+            onPage("""<body><button id="t" style="width:80px;height:30px">Go</button></body>""") {
+                BrowserEval.armClickProbe
+                    .andThen(Browser.eval("delete window.__kyoClickProbe; 'done'"))
+                    .andThen(BrowserEval.clickDelivery)
+                    .map(delivery =>
+                        assert(
+                            delivery == BrowserEval.ClickDelivery.Unsubstantiated,
+                            s"a missing probe substantiates nothing and must not read as a delivery, got $delivery"
+                        )
+                    )
             }
         }
     }

--- a/kyo-http/shared/src/test/scala/kyo/internal/HttpClientBackendStreamingTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/HttpClientBackendStreamingTest.scala
@@ -28,6 +28,15 @@ class HttpClientBackendStreamingTest extends kyo.BaseHttpTest:
     private def dripReq    = HttpRequest.getRaw(HttpUrl.fromUri("/drip"))
     private def plainReq   = HttpRequest.getRaw(HttpUrl.fromUri("/plain"))
 
+    /** Body chunks to feed when a leaf needs the decoder blocked in `put` rather than waiting on input.
+      *
+      * The decoded channel `HttpClientBackend.buildBodyStream` allocates is small and fixed; feeding comfortably more than it can hold,
+      * while the consumer holds after its first chunk, leaves the decoder parked mid-put. Interrupting the consumer then closes that
+      * channel under a parked put, which fails immediately, so the taint is deterministic instead of depending on whether the
+      * finalizer beats the next delivery. Sized well above the channel rather than to it, so it does not encode the capacity.
+      */
+    private val backlogChunks = 16
+
     private val streamHeaders = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
     private val chunk1        = "6\r\nchunk1\r\n"
     private val chunk2AndEnd  = "6\r\nchunk2\r\n0\r\n\r\n"
@@ -88,21 +97,25 @@ class HttpClientBackendStreamingTest extends kyo.BaseHttpTest:
             val respFiber                = backend.sendStreaming(conn, dripRoute, dripReq, 1024 * 1024, Absent, Present(bodyOutcome))
             serverConn.inbound.safe.take.map { _ =>
                 discard(serverConn.outbound.offer(spanOf(streamHeaders)))
-                discard(serverConn.outbound.offer(spanOf(chunk1)))
+                // Enough body chunks to fill the decoded channel and leave the decoder blocked in `put`, and deliberately no
+                // terminal chunk, so the body can never drain to a clean finish.
+                (1 to backlogChunks).foreach(_ => discard(serverConn.outbound.offer(spanOf(chunk1))))
                 respFiber.safe.get.map { resp =>
                     Latch.init(1).map { firstChunk =>
-                        Fiber.init(resp.fields.body.foreachChunk(_ => firstChunk.release)).map { consumer =>
-                            firstChunk.await.andThen {
-                                // Consumer got chunk1 and is parked on chunk2. Interrupting it unwinds the stream run, whose
-                                // finalizer closes the decoded channel, so the decoder's next delivery taints the connection.
-                                consumer.interrupt.unit.andThen {
-                                    consumer.getResult.map { _ =>
-                                        discard(serverConn.outbound.offer(spanOf(chunk2AndEnd)))
-                                        bodyOutcome.safe.get.map { reusable =>
-                                            assert(!reusable, "an interrupted streaming body must mark the connection non-reusable")
+                        Latch.init(1).map { holdConsumer =>
+                            // The consumer takes one chunk and then stops draining, which is what lets the decoded channel fill.
+                            Fiber.init(resp.fields.body.foreachChunk(_ => firstChunk.release.andThen(holdConsumer.await))).map {
+                                consumer =>
+                                    firstChunk.await.andThen {
+                                        // The decoder is parked on a put against a full channel, so the interrupt's finalizer closing
+                                        // that channel fails the put outright. The taint is forced by construction rather than by the
+                                        // finalizer winning a race against the next delivery, which is what made this leaf flaky.
+                                        consumer.interrupt.unit.andThen {
+                                            bodyOutcome.safe.get.map { reusable =>
+                                                assert(!reusable, "an interrupted streaming body must mark the connection non-reusable")
+                                            }
                                         }
                                     }
-                                }
                             }
                         }
                     }
@@ -212,16 +225,17 @@ class HttpClientBackendStreamingTest extends kyo.BaseHttpTest:
             val backend                    = HttpClientBackend.init(transport, 2, 60.seconds)
             val config                     = HttpClientConfig(timeout = 60.seconds)
             Fiber.init(backend.sendWithConfig(dripRoute, dripReq, config)(r => r)).map { f1 =>
-                serveOnce(serverConn1, Seq(streamHeaders, chunk1)).andThen {
+                serveOnce(serverConn1, streamHeaders +: Seq.fill(backlogChunks)(chunk1)).andThen {
                     f1.get.map { resp1 =>
                         Latch.init(1).map { firstChunk =>
-                            Fiber.init(resp1.fields.body.foreachChunk(_ => firstChunk.release)).map { consumer =>
-                                firstChunk.await.andThen {
-                                    // chunk1 reached the consumer, which is now parked awaiting chunk2.
-                                    consumer.interrupt.unit.andThen {
-                                        consumer.getResult.map { _ =>
-                                            // Finalizers ran; the next body fragment makes the decoder observe the closed channel -> discard.
-                                            Sync.Unsafe.defer(discard(serverConn1.outbound.offer(spanOf(chunk2AndEnd)))).andThen {
+                            Latch.init(1).map { holdConsumer =>
+                                Fiber.init(resp1.fields.body.foreachChunk(_ => firstChunk.release.andThen(holdConsumer.await))).map {
+                                    consumer =>
+                                        firstChunk.await.andThen {
+                                            // The consumer holds after its first chunk, so the decoder is parked on a put against a full
+                                            // channel and no terminal chunk is coming. Interrupting closes that channel under the parked
+                                            // put, so the discard is forced rather than racing the finalizer against the next delivery.
+                                            consumer.interrupt.unit.andThen {
                                                 clientConn1.onClosing.safe.get.andThen {
                                                     Sync.Unsafe.defer(clientConn1.isOpen).map { open =>
                                                         assert(!open, "a tainted streaming connection must be closed, not pooled")
@@ -238,7 +252,6 @@ class HttpClientBackendStreamingTest extends kyo.BaseHttpTest:
                                                 }
                                             }
                                         }
-                                    }
                                 }
                             }
                         }

--- a/kyo-i18n/README.md
+++ b/kyo-i18n/README.md
@@ -111,6 +111,7 @@ for
     start <- Locale.preferred(supported, Locale("en"))
     i18n  <- I18n.init(supported, start)(Path("resources") / "i18n")
 yield i18n
+end for
 // reads resources/i18n/en.ftl and resources/i18n/de.ftl
 ```
 

--- a/kyo-sql/shared/src/main/scala/kyo/internal/client/SqlConnectionPool.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/internal/client/SqlConnectionPool.scala
@@ -69,6 +69,23 @@ final private[kyo] class SqlConnectionPool[C <: Connection](
     // drains. Registered here so exactly one resolver claims each via `remove`, so no interrupted connection outlives the client.
     private val quarantined = ConcurrentHashMap.newKeySet[C]()
 
+    /** Reports the interrupt-reclaim counters alongside the transport dumps an end-of-run descriptor finding already prints.
+      *
+      * A leaked socket on its own does not say whether the pool still owed work on it. `decideExit` hands an interrupted lease to a
+      * detached carrier and quarantines the connection until that carrier resolves, so a descriptor still open while `quarantined` holds
+      * it is a state the reclaim design permits, whereas the same descriptor with nothing quarantined and no reclaim running means a
+      * carrier finished without closing it. Those two need different fixes and are indistinguishable from the transport dump alone.
+      * Counts only: this reports state and never a verdict, leaving the classification to whoever reads the finding.
+      */
+    private val diagRegistration =
+        kyo.internal.Diagnostics.register("SqlConnectionPool@" + java.lang.System.identityHashCode(this))(
+            dump = () =>
+                // Unsafe: a diagnostic dump is a bare `() => String` with no capability in scope, and these are read-only views of
+                // already-Unsafe atomics and a concurrent set, so the read cannot alter pool state.
+                import AllowUnsafe.embrace.danger
+                s"cancelsInFlight=${cancelsInFlight.get()} quarantined=${quarantined.size} drainPolls=${drainPolls.get()}"
+        )
+
     // --- Leases ---
 
     /** Runs `op` on a pooled connection under the statement policy: retry, per-statement timeout, and the query instruments.
@@ -211,6 +228,10 @@ final private[kyo] class SqlConnectionPool[C <: Connection](
                         quarantined.forEach { conn =>
                             if quarantined.remove(conn) then destroyAndFreeSlot(conn, logger)
                         }
+                        // Dropped last, after the sweep above has resolved every quarantined connection: while any remained the
+                        // counters were still worth reporting, and a pool that outlived its registration would report another pool's
+                        // state under this one's name.
+                        diagRegistration.close()
                     }
                 }(drain(gracePeriod))
             }

--- a/kyo-ui/js-wasm/src/test/scala/kyo/DomBackendReactiveRangesTest.scala
+++ b/kyo-ui/js-wasm/src/test/scala/kyo/DomBackendReactiveRangesTest.scala
@@ -152,11 +152,12 @@ class DomBackendReactiveRangesTest extends kyo.test.Test[Any]:
             _     <- assertEventually(Sync.defer(ready.installed && dom.document.getElementById("local-option-A") != null))
             _     <- rows.set(Chunk("A", "B"))
             _     <- nestedProp.set(true)
-            _     <- assertEventually(Sync.defer(dom.document.getElementById("local-option-B") != null))
-            _ <- assertEventually(Sync.defer {
-                dom.document.getElementById("local-nested-property").asInstanceOf[scalajs.Dynamic].indeterminate.asInstanceOf[Boolean]
-            })
-            topology <- Sync.defer {
+            // Each region above subscribes to the signal on its own, so one region having applied the update
+            // says nothing about the other seven. Waiting on a single representative and then reading the
+            // whole topology races the rest, which is why a loaded runner sees a count of 1 where 2 is
+            // expected. Settle on the entire tuple instead. This keeps the assertion's full strength: a
+            // region that never updates still fails, by exhausting the retry budget rather than by racing.
+            readTopology = Sync.defer {
                 def count(selector: String) = dom.document.querySelectorAll(selector).length
                 val property                = dom.document.getElementById("local-nested-property")
                 (
@@ -172,9 +173,12 @@ class DomBackendReactiveRangesTest extends kyo.test.Test[Any]:
                     count("span[data-kyo-reactive]")
                 )
             }
-            _ <- fiber.interrupt
-            _ <- fiber.getResult
-        yield assert(topology == (2, 2, 2, 2, 2, 2, 2, true, null, 0))
+            expected: (Int, Int, Int, Int, Int, Int, Int, Boolean, String, Int) = (2, 2, 2, 2, 2, 2, 2, true, null, 0)
+            _        <- assertEventually(readTopology.map(_ == expected))
+            topology <- readTopology
+            _        <- fiber.interrupt
+            _        <- fiber.getResult
+        yield assert(topology == expected)
     }
 
     "local mount updates directly nested logical ranges" in {

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
@@ -847,6 +847,12 @@ private[kyo] object ReactiveUI:
             expiryWake       <- Channel.init[Unit](1)
             expiryWorkers    <- AtomicInt.init(0)
             _                <- Scope.ensure(dragSessions.set(Map.empty))
+            // The worker clears its own count as it unwinds, which is right when it exits on its own but is not
+            // enough at scope close: interrupting a fiber and awaiting its result does not await the finalizer
+            // that clears the count, so the count can still read 1 after the scope has returned. Scope
+            // finalizers run last-registered-first, so registering this BEFORE the worker is started puts it
+            // after the worker's own teardown and makes "closed scope implies no worker" hold on every exit.
+            _ <- Scope.ensure(expiryWorkers.set(0))
             _ <- startOwnedFiber(
                 Abort.run[Any] {
                     Sync.ensure(expiryWorkers.set(0)) {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -134,8 +134,16 @@ if [ "$ARCH" != "native" ]; then
     hostarch=$(host_arch)
     if [ "$ARCH" != "$hostarch" ]; then
         echo "build.sh: emulated $ARCH run; expect substantial slowdown"
-        if [ -z "${BUILD_SKIP_BINFMT:-}" ] && [ ! -d /proc/sys/fs/binfmt_misc ]; then
-            echo "build.sh: binfmt_misc is not registered; install qemu-user-static and binfmt support, then retry" >&2
+        # Ask the container runtime to execute one binary of the target platform. The capability has to be
+        # checked where the containers run, which is not always where this script runs: with `podman machine`
+        # the binfmt_misc handlers live in the VM's kernel, and a macOS host has no /proc at all, so reading
+        # the host's own /proc/sys/fs/binfmt_misc answers "not registered" on every mac and refuses every
+        # cross-arch run on the machines most likely to need one. Running the thing is the only probe that
+        # cannot be wrong about which kernel it is asking. It costs an image pull the run is about to do
+        # anyway, since it uses the same image.
+        if [ -z "${BUILD_SKIP_BINFMT:-}" ] &&
+            ! podman run --rm --platform "$(podman_platform)" "$CONTAINER_IMAGE" true >/dev/null 2>&1; then
+            echo "build.sh: cannot execute $(podman_platform) binaries; register qemu-user-static binfmt handlers, then retry" >&2
             exit 1
         fi
     fi
@@ -178,6 +186,25 @@ container_provision() {
         # openssl-linked modules need -lssl -lcrypto).
         Native|all) native_pkgs="clang build-essential libssl-dev libcurl4-openssl-dev libidn2-dev libh2o-evloop-dev=2.2.5+dfsg2-8.1ubuntu3 libgc-dev" ;;
     esac
+    # Node 24, matching the workflow's setup-node pin. noble's apt `nodejs` is 18, and jsdom@30 declares
+    # engines >= 22, so a DOM-backed suite installs and then fails to load it, reporting "jsdom is not
+    # resolvable" no matter what the code under test does. Beyond jsdom, running JS/Wasm on a different V8
+    # major than CI makes any local result unfaithful. The apt packages stay as the source of npm and a
+    # fallback; /usr/local/bin precedes /usr/bin, so the tarball wins when present.
+    local node_setup=""
+    if [ -n "$node_pkgs" ]; then
+        node_setup='
+node_ok=0
+if command -v node >/dev/null 2>&1; then
+    node_major=$(node --version | tr -d "v" | cut -d. -f1)
+    if [ "${node_major:-0}" -ge 24 ] 2>/dev/null; then node_ok=1; fi
+fi
+if [ "$node_ok" != 1 ]; then
+    case $(uname -m) in aarch64) node_arch=linux-arm64 ;; *) node_arch=linux-x64 ;; esac
+    curl -fsSL "https://nodejs.org/dist/v24.16.0/node-v24.16.0-${node_arch}.tar.gz" \
+        | tar xz -C /usr/local --strip-components=1
+fi'
+    fi
     # BoringSSL build toolchain (cmake + Go + a C toolchain), only when STAGE_BORINGSSL=1 builds the vendored BoringSSL so kyo-net's
     # TLS tests run against real libssl/libcrypto instead of cancelling. Heavy, so off by default.
     [ "${STAGE_BORINGSSL:-}" = 1 ] && bssl_pkgs="cmake golang-go build-essential git clang libunwind-dev"
@@ -213,6 +240,7 @@ if command -v apt-get >/dev/null 2>&1; then
     apt-get update -qq >/dev/null
     apt-get install -y -qq -o Acquire::Retries=3 $apt_pkgs $node_pkgs $native_pkgs $bssl_pkgs $aeron_pkgs >/dev/null
 fi
+$node_setup
 export COURSIER_CACHE=/root/.cache/coursier
 if ! command -v cs >/dev/null 2>&1; then
     # Linux aarch64 launchers are published by VirtusLab's coursier-m1 releases, not
@@ -315,6 +343,20 @@ run_in_container() {
     else
         inner="./scripts/ci-test.sh '$platform' '$ACTION'"
     fi
+    # jsdom, on the same JS/Wasm condition the workflow's setup action applies. The DOM-backed kyo-ui suites
+    # resolve it lazily from the repository root and abort in their constructor when it is missing, and the
+    # container starts from a git archive, which never carries node_modules. Without this a DOM suite cannot
+    # run in a container at all: it fails identically whether or not the code under test is broken, which
+    # reads like a real failure. Gated rather than unconditional so a JVM or Native run keeps no dependency
+    # on the npm registry being reachable. Raw mode has no platform, so the sbt command itself is what says
+    # whether a JS or Wasm project is involved.
+    local stage_jsdom=0
+    if [ "$RAW_MODE" = yes ]; then
+        case "$RAW_SBT" in *JS*|*Wasm*) stage_jsdom=1 ;; esac
+    elif [ "$platform" = JS ] || [ "$platform" = Wasm ]; then
+        stage_jsdom=1
+    fi
+    envs+=(-e "STAGE_JSDOM=$stage_jsdom")
     local provision; provision=$(container_provision "$platform")
     podman "${args[@]}" "${envs[@]}" "$CONTAINER_IMAGE" \
         bash -c "set -e
@@ -322,7 +364,8 @@ $provision
 mkdir -p /work && cd /work && tar xf /build-input/src.tar \
     && if [ -s /build-input/changes.patch ]; then patch -p1 < /build-input/changes.patch; fi \
     && if [ \"\${STAGE_BORINGSSL:-}\" = 1 ]; then bash kyo-net/build/boringssl/build-boringssl.sh; fi \
-    && if [ \"\${STAGE_AERON:-}\" = 1 ]; then bash kyo-aeron/scripts/build-aeron.sh \"linux-\$(uname -m)\"; fi
+    && if [ \"\${STAGE_AERON:-}\" = 1 ]; then bash kyo-aeron/scripts/build-aeron.sh \"linux-\$(uname -m)\"; fi \
+    && if [ \"\${STAGE_JSDOM:-}\" = 1 ]; then npm install --no-save --no-fund --no-audit jsdom@^30; fi
 if $inner; then __rc=0; else __rc=\$?; fi
 if [ -d /output ]; then find . -type d \\( -name scoverage-report -o -name scoverage-data \\) -exec cp -r --parents {} /output/ \\; 2>/dev/null || true; fi
 exit \${__rc:-1}"


### PR DESCRIPTION
### Problem

Three suites fail on main, each reading state before the work it reflects has finished: a streaming test treating an interrupted fiber's result as proof its finalizer ran, a mount test waiting on two of eight independently subscribed regions before reading a topology covering all eight, and a drag subscription whose scope close awaits a worker result that lands before the finalizer clearing the worker count.

Reporting has the same gap: a leg whose JVM dies in native code fails with no test name and no crash report, and a click whose delivery probe vanished reads like a confirmed one.

### Solution

The streaming leaves hold the consumer with an undrained body, so the interrupt lands on the state under test. The mount test settles on the whole topology. The subscription's scope clears the worker count itself, registered before the worker starts so finalizer ordering places it last. Click delivery becomes three states, so an unconfirmed one still passes but says so. A failed leg prints any JVM crash report; the pool reports interrupt-reclaim counters.

### Notes

Assertion strength is unchanged: a region that never updates still fails, by exhausting its retry budget. The container runner installs the Node and jsdom the workflow provides and checks emulation where the containers run, so JS, Wasm, and cross-architecture defects are reproducible outside CI. The kyo-i18n README example is committed in the shape its doctest run produces.

