### PR TITLE
[kyo-flow] rebuild durable execution on a wait ledger and a claimed capability

### DIFF
--- a/kyo-flow/README.md
+++ b/kyo-flow/README.md
@@ -2,11 +2,13 @@
 
 Durable workflow engine for Kyo. Workflows are defined as composable, type-safe plans that the engine persists, coordinates across multiple executors, and recovers automatically after crashes.
 
-A `Flow` is a plan, not an execution. You describe what should happen (values to compute, inputs to wait for, side effects to perform, branches to take) and the engine handles the rest. Every step is checkpointed to a store before the next begins. If the process crashes, another executor claims the work and replays from the last checkpoint, skipping steps that already completed. Side effects in steps must be idempotent because they may re-execute on recovery.
+A `Flow` is a plan, not an execution. You describe what should happen (inputs to wait for, values to compute, side effects to perform, branches to take, collections to fan out over) and the engine handles persistence, crash recovery, and coordination. Each node in the plan carries a name, and that name is its durable key: the field its value is written under, the mark that says it finished, the row that says it is waiting. Every node is recorded before the next begins, so a crash means another executor claims the execution, replays the plan from the start, and skips every node whose record it finds. Side effects in step bodies must be idempotent, because the one node in flight when a process died is the one node that runs twice.
 
-The engine coordinates multiple executors via time-limited claim leases, supports compensation handlers for saga-style rollback, provides retry and timeout per step, emits a full event audit trail, and exposes an auto-generated REST API. Workflow structure can be rendered as Mermaid, DOT, BPMN, ELK, or JSON diagrams. The module compiles across JVM, JavaScript, and Scala Native.
+Two consequences of that model shape the whole API. First, waiting is not a status: an execution waiting for an input or serving out a durable sleep is still `Running`, and what it is waiting FOR lives on per-node wait rows, because a `race` of an input against a sleep waits for both at once. Second, anything that cannot happen instantly is a request rather than an act: cancelling an execution runs its compensation handlers first, so `cancel` answers with an outcome saying what the ask did and the terminal `Cancelled` lands at the end of the unwind.
 
-## Getting Started
+The engine coordinates multiple executors via time-limited claim leases, supports compensation handlers for saga-style rollback, provides retry and timeout per node attempt, emits a full event audit trail, and exposes an auto-generated REST API. Workflow structure can be rendered as Mermaid, DOT, BPMN, ELK, or JSON diagrams. The module cross-builds to JVM, JavaScript, Scala Native, and Wasm.
+
+## Getting started
 
 Add the dependency to your `build.sbt`:
 
@@ -18,376 +20,486 @@ libraryDependencies += "io.getkyo" %% "kyo-flow" % "<latest version>"
 ```scala
 import kyo.*
 
-case class Order(item: String, qty: Int, price: Int = 10) derives Schema
+case class Item(sku: String, qty: Int, price: Int) derives Schema
+case class Order(id: String, customer: String, items: Seq[Item]) derives Schema
+case class Approval(approved: Boolean, by: String) derives Schema
 
-def sendEmail(to: String, msg: String): Unit < Sync                      = ()
-def processOrder(id: String): Unit < Sync                                = ()
-def sendFollowUp(id: String): Unit < Sync                                = ()
-def notifyResult(decision: String): Unit < Sync                          = ()
-def checkStatus(url: String): String < Sync                              = "ready"
-def probe(endpoint: String): String < Sync                               = "healthy"
-def fetch(url: String): String < Sync                                    = ""
-def fetchData(url: String): String < Sync                                = ""
-def reserveInventory(order: Order): String < Sync                        = "resv-1"
-def cancelReservation(id: String): Unit < (Async & Abort[FlowException]) = ()
-def chargeCard(order: Order): String < Sync                              = "charge-1"
-def refundCard(id: String): Unit < (Async & Abort[FlowException])        = ()
-def ship(order: Order): Unit < Sync                                      = ()
-def riskyOperation(input: String): String < Sync                         = "ok"
+def reserveStock(item: Item): String < Async                                   = "resv-1"
+def releaseStock(reservationId: String): Unit < (Async & Abort[FlowException]) = ()
+def chargeCard(orderId: String, cents: Int): String < Async                    = "charge-1"
+def refundCharge(chargeId: String): Unit < (Async & Abort[FlowException])      = ()
+def ship(order: Order): Unit < Async                                           = ()
+def notifyCustomer(orderId: String, text: String): Unit < Async                = ()
+def carrierStatus(orderId: String): String < Async                             = "delivered"
 
-val validateFlow: Flow[Any, Any, Any]  = Flow.init("validate")
-val processFlow: Flow[Any, Any, Any]   = Flow.init("process")
-val pricingFlow: Flow[Any, Any, Any]   = Flow.init("pricing-base")
-val inventoryFlow: Flow[Any, Any, Any] = Flow.init("inventory")
-val shippingFlow: Flow[Any, Any, Any]  = Flow.init("shipping")
-val primaryFlow: Flow[Any, Any, Any]   = Flow.init("primary")
-val fallbackFlow: Flow[Any, Any, Any]  = Flow.init("fallback")
-val orderFlow: Flow[Any, Any, Any]     = Flow.init("order-flow")
-val paymentFlow: Flow[Any, Any, Any]   = Flow.init("payment")
+val sampleOrder: Order = Order("o-1017", "ada", Seq(Item("widget", 3, 400), Item("gasket", 1, 250)))
+
+val fulfilmentFlow: Flow[Any, Any, Any] = Flow.init("fulfilment")
+val shippingFlow: Flow[Any, Any, Any]   = Flow.init("shipping")
+val invoiceFlow: Flow[Any, Any, Any]    = Flow.init("invoice")
 ```
 -->
 
-The simplest workflow computes a value and stores it:
-
-```scala doctest:scope=env:greet
-val flow = Flow.init("hello")
-    .output("greeting")(_ => "Hello, World!")
-```
-
-`Flow.init` creates a named workflow. `.output("greeting")` computes a value, persists it under the name `"greeting"`, and makes it available to subsequent steps.
-
-Run a workflow locally for testing:
-
-```scala doctest:scope=env:greet
-val result = Flow.runLocal(flow, Record.empty)
-```
-
-## Outputs
-
-The function passed to `.output` receives a context record containing all fields produced so far. Here there are none, so we ignore it with `_`. When there are prior fields, each one is accessible by name with full type safety:
+Everything in this README works on one order-fulfilment workflow: an `Order` carrying line `Item`s, stock to reserve, a card to charge, an `Approval` to wait for when the total is large, and a shipment at the end. Here is the shape of it:
 
 ```scala
-val flow = Flow.init("pricing")
-    .output("price")(_ => 100)
-    .output("tax")(ctx => ctx.price * 0.08)
-    .output("total")(ctx => ctx.price + ctx.tax)
+val fulfilment =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
+        .outputCompensated("charge")(ctx => chargeCard(ctx.order.id, ctx.total))(ctx => refundCharge(ctx.charge))
+        .step("ship")(ctx => ship(ctx.order))
 ```
 
-`ctx.price` is statically typed as `Int`: accessing a field that doesn't exist is a compile error. This works through Kyo's `Record` type, which tracks fields as an intersection of `Name ~ Value` pairs. Each `.output` call adds a field to the record type:
+That value is a description. Nothing has run, nothing has been charged, and nothing has been written. Registering it with an engine and starting an execution is what makes it happen, and every one of those four nodes is recorded before the next one starts. The `charge` node also carries a second function, `ctx => refundCharge(ctx.charge)`: a compensation handler that undoes the charge if a later node fails. See [Undoing work when a later step fails](#undoing-work-when-a-later-step-fails).
+
+## Describing a workflow
+
+Reading a flow is reading a chain of named nodes. The names are the part to care about: each one is a durable key, so what you call a node decides what its field is called in the store, what its completion mark is, and what replay skips when it comes back. The constructs below differ in what they contribute to that record, which is why there are several rather than one.
+
+### Inputs
+
+An input is a value the workflow cannot compute for itself and must be handed from outside. The execution waits at that node until the value is delivered, and its type becomes part of the flow's `In` parameter, so a caller that does not supply it does not compile.
 
 ```scala
-// After .output("price"), the context type includes "price" ~ Int
-// After .output("tax"), it includes "price" ~ Int & "tax" ~ Double
-// After .output("total"), it includes all three fields
+val awaitingOrder =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
 ```
 
-The three type parameters on `Flow[In, Out, S]` track this automatically:
-- `In`: required inputs (accumulated via `.input`)
-- `Out`: produced outputs (accumulated via `.output`, `.loop`, `.dispatch`, etc.)
-- `S`: pending effect types from step computations
-
-## Inputs
-
-An input declares a value the workflow needs from the outside world. The execution suspends at the input node until the value is delivered externally via a signal:
-
-```scala doctest:scope=env:orderflow
-val flow = Flow.init("order")
-    .input[Order]("order")
-    .output("total")(ctx => ctx.order.qty * 100)
-    .output("receipt")(ctx => s"${ctx.order.item} x${ctx.order.qty} = ${ctx.total}")
-```
-
-Input types must have a `Schema` instance for serialization. Like outputs, each input adds a typed field to the context.
-
-For testing, pre-populate inputs with `runLocal`:
-
-```scala doctest:scope=env:orderflow
-val result = Flow.runLocal(flow, "order" ~ Order("Widget", 3))
-```
-
-The `~` operator creates a typed record field: `"order" ~ Order("Widget", 3)` is a `Record["order" ~ Order]`. Multiple fields combine with `&`: `"x" ~ 1 & "y" ~ "hello"`.
-
-In production, inputs arrive via the engine's signal API or the HTTP endpoint `POST /api/v1/executions/:eid/signal/order`.
-
-## Steps
-
-A step performs a side effect without producing a named value (HTTP calls, database writes, sending notifications):
+`Flow.init(name).input[V](inputName)` has a shorthand for the common case where the workflow and its first input share a name:
 
 ```scala
-val flow = Flow.init("notify")
-    .input[String]("email")
-    .output("message")(ctx => s"Welcome, ${ctx.email}!")
-    .step("send")(ctx => sendEmail(ctx.email, ctx.message))
+val orderShorthand = Flow.input[Order]("order")
 ```
 
-On replay after a crash, completed steps are skipped. Steps are tracked by their completion event in the audit trail, not by a stored value.
+> **Note:** `Flow.input[V](name)` is shorthand for `Flow.init(name).input[V](name)`. Its single argument names BOTH the workflow and the input, so a caller who wants them named differently uses the longer form, `Flow.init(workflowName).input[V](inputName)`.
 
-## Sleep
-
-Sleep pauses the execution for a duration. The pause is durable: if the process restarts, the engine calculates the remaining time and resumes when it expires.
+Input types need a `Schema` instance, since the delivered value is persisted. In production the value arrives through the engine's `signal` API or the HTTP endpoint `POST /api/v1/executions/{eid}/signal/order`. For a test, `runLocal` pre-populates them:
 
 ```scala
-val flow = Flow.init("delayed")
-    .input[String]("orderId")
-    .step("process")(ctx => processOrder(ctx.orderId))
-    .sleep("cooldown", 1.hour)
-    .step("followUp")(ctx => sendFollowUp(ctx.orderId))
+val flow   = Flow.init("fulfilment").input[Order]("order")
+val result = Flow.runLocal(flow, "order" ~ Order("o-1017", "ada", Seq(Item("widget", 3, 400))))
 ```
 
-Note: Parking (sleep, waiting for an input, or a lost claim) is not a failure. The engine signals it with a non-`Throwable` value (`FlowSuspension`), so a parked execution releases its in-memory state, never fires compensation handlers, and is resumed later from the store rather than being marked failed.
+The `~` operator builds a typed record field: `"order" ~ someOrder` has type `Record["order" ~ Order]`. Several fields combine with `&`: `"order" ~ someOrder & "priority" ~ true`.
 
-## Branching
+> **Caution:** `Flow.runLocal` polls until the execution reaches a terminal status, with no bound. A flow with an input that the supplied record does not carry never terminalises, so `runLocal` never returns. Supply every declared input, or drive the flow through an engine instead.
 
-Dispatch evaluates conditions in order and executes the first matching branch. It follows a builder pattern: start with `.dispatch[V]` specifying the result type, chain `.when` branches, and close with `.otherwise`:
+> **Note:** `signal` requires an EXACT type match against the declared input, not a subtype or assignability check: the engine tests `Tag[V] =:= inputMeta.tag`. Signalling with a type narrower, wider, or otherwise different from the one the `input` node declared is refused, even in a case that would normally widen or narrow safely.
+
+### Outputs
+
+An output is a value the flow computes and keeps. It is persisted under its name and is then readable by every node after it, by that name, with its real type.
 
 ```scala
-val flow = Flow.init("approval")
-    .input[Int]("amount")
-    .dispatch[String]("decision")
-    .when(ctx => ctx.amount > 1000, name = "review")(ctx => "needs review")
-    .when(ctx => ctx.amount > 100, name = "auto")(ctx => "auto-approved")
-    .otherwise(ctx => "instant", name = "default")
-    .step("notify")(ctx => notifyResult(ctx.decision))
+val priced =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("lines")(ctx => ctx.order.items.size)
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
+        .output("summary")(ctx => s"${ctx.lines} line(s), ${ctx.total} cents")
 ```
 
-The type parameter `[String]` is the type of the value all branches must produce. The result is persisted under the dispatch name (`"decision"`) and accessible downstream as `ctx.decision`. Calling `.otherwise` is required, and the compiler enforces this by making further chaining methods unavailable until the dispatch is closed.
-
-## Loops
-
-A loop iterates until the body returns `Loop.done(value)`. Each iteration can return `Loop.continue` to keep going or `Loop.done(result)` to finish. The final value is stored as a named output:
+`ctx.total` is statically an `Int`, and asking for a field no earlier node produced is a compile error. That works through Kyo's `Record` type, which tracks fields as an intersection of `Name ~ Value` pairs, and each node that produces a value adds one:
 
 ```scala
-val flow = Flow.init("poll")
-    .input[String]("url")
-    .loop("result") { ctx =>
-        checkStatus(ctx.url).map {
-            case "ready" => Loop.done("complete")
-            case _       => Loop.continue
+// After .output("lines"), the context type includes "lines" ~ Int
+// After .output("total"), it includes "lines" ~ Int & "total" ~ Int
+// After .output("summary"), it includes all three fields
+```
+
+The three type parameters on `Flow[In, Out, S]` carry that bookkeeping: `In` is the intersection of inputs the flow requires, `Out` is the intersection of values it produces, and `S` is the union of effects its node bodies use.
+
+### Steps
+
+A step is work with no value worth keeping: sending the shipment, writing an audit row, calling a notification service. It contributes a completion event rather than a field, and replay skips it once that event exists.
+
+```scala
+val shipping =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
+        .step("ship")(ctx => ship(ctx.order))
+        .step("notify")(ctx => notifyCustomer(ctx.order.id, s"shipped, ${ctx.total} cents"))
+```
+
+Both `output` and `step` run their body exactly where you put it in the chain. Reach for `output` when a later node needs the result, and for `step` when nothing does; a step that returns a value you then need again is a value the store never kept.
+
+### Sleep
+
+A sleep is a wait the store owns. The execution releases its in-memory state and comes back when the deadline passes, so a process restart in the middle costs nothing: the engine reads the original deadline and resumes at it.
+
+```scala
+val cooling =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .step("ship")(ctx => ship(ctx.order))
+        .sleep("delivery-window", 48.hours)
+        .step("ask-for-review")(ctx => notifyCustomer(ctx.order.id, "how did we do?"))
+```
+
+> **Note:** `sleep` declares neither `timeout` nor `retry`, unlike every other node builder, because it can honour neither. Bounding a wait is what racing the sleep against the thing being waited for is for; see [Running branches at the same time](#running-branches-at-the-same-time).
+
+A durable sleep, a wait for an input, and a lost claim are all suspensions rather than failures. No compensation handler fires, the status stays `Running`, and what the execution is waiting for lives on its wait rows.
+
+### Per-node knobs
+
+Every node that runs a body you supplied takes `description`, `timeout`, `retry`, and `tags`: `output`, `step`, `dispatch`, `loop`, `loopOn`, and `foreach`. `input` and `sleep` take `description` and `tags` only, because neither runs a body, and a bound or a retry has nothing to act on without one. `timeout` bounds one ATTEMPT rather than the node's whole lifetime, and `retry` re-asks an attempt that failed for an accidental reason.
+
+```scala
+val charging =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
+        .output(
+            "charge",
+            description = "authorise the card",
+            timeout = 10.seconds,
+            retry = Maybe(Schedule.exponentialBackoff(1.second, 2.0, 1.minute))
+        )(ctx => chargeCard(ctx.order.id, ctx.total))
+```
+
+Each attempt is timed independently, and when the schedule exhausts, the last error propagates. Those knobs are also a value, `Flow.Meta(description, tags, timeout, retry, version)`, which is how the stateful `loop` and `loopOn` overloads accept them: Scala lets only one overload of a name define default arguments, and the stateless overload is the one that does.
+
+> **Caution:** a `timeout` abandons the attempt rather than waiting for it. On the JVM and Native a body blocked in non-suspending code can still be running when the next attempt starts, so node bodies must be idempotent under overlap as well as under replay. See [Coordinating multiple executors](#coordinating-multiple-executors).
+
+### Subflows and sequencing
+
+A subflow embeds a whole flow inside another. The input mapper turns the parent's context into the child's input record, which is recorded under the subflow's path at entry, and the child's output record lands under the subflow's name.
+
+```scala
+val payment =
+    Flow.init("payment")
+        .input[String]("orderId")
+        .input[Int]("amountCents")
+        .output("chargeId")(ctx => chargeCard(ctx.orderId, ctx.amountCents))
+
+val withPayment =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
+        .subflow("payment", payment)(ctx => "orderId" ~ ctx.order.id & "amountCents" ~ ctx.total)
+        .step("ship")(ctx => ship(ctx.order))
+```
+
+The child's nodes are keyed under the instance path, so `payment`'s `chargeId` is durably `payment~chargeId`. Embedding the same child twice gives two sets of fields under two paths rather than one set that two instances fight over. Entering `payment` costs one field write per child input, before the child's first node; the child's own nodes then write exactly as they would at top level.
+
+> **Note:** entering a subflow records the child's inputs first. The mapper builds the child's input record, and each input is written under the child's path (`payment~orderId`, `payment~amountCents`) before the child's first node runs, once. A resumed subflow that finds its inputs recorded does not run the mapper again: the child runs against the inputs it was recorded with, plus its own durable fields, for the life of the execution. The mapper is effectful and can run more than once before its output lands (a crash between two of its input writes re-runs it for the ones still missing), so its side effects carry the same idempotency obligation a step body does, and nothing more.
+
+`andThen` sequences two flows without nesting them: the first runs to completion, then the second starts with access to everything the first produced.
+
+```scala
+val endToEnd = fulfilmentFlow.andThen(shippingFlow)
+```
+
+### Node names are durable keys
+
+The engine builds its own keys out of node names, using `~` to join a path and `#` to number a repetition: a subflow's node is `payment~chargeId`, a scheduled loop's third iteration is `delivery#2`, a fan-out's third item is `reservations~2`, and a dispatch's choice is `route#chosen`. Both characters are therefore reserved in a name you write, and a flow using either is refused at registration with `FlowReservedNameException`.
+
+Registration also refuses a flow in which two nodes claim one durable name, with `FlowDuplicateNameException`, because one name is one field and one completion mark: the second write would overwrite the first and replay would skip the second forever. Two cases are deliberately blessed rather than refused: an `input` that two parallel branches wait on, which is one wait and one field, and the branches of a `race`, which share their result name precisely so the union result is readable downstream.
+
+## Choosing, repeating, and fanning out
+
+Four constructs cover the shapes a workflow takes when it is not a straight line, and the useful way to tell them apart is not what they compute but what they write down. Recovery skips exactly what was recorded, so the choice between them is a choice about how much re-running a crash costs and how many store writes you pay for that.
+
+| Construct | What it checkpoints | What a crash mid-node re-runs | Store writes |
+|---|---|---|---|
+| `dispatch` | the branch it chose, before running it | the chosen branch's body | one field for the choice, one for the result |
+| `loop` | nothing until the body says stop | every iteration from the first | one field, at the end |
+| `loopOn` | every iteration | the iteration in flight | one field per iteration, its start and completion events, and the wait row and two events of the sleep between iterations |
+| `foreach` | every item | the items in flight | one field for the item count, one per item, and one for the assembled result |
+
+### Branching
+
+A dispatch evaluates conditions in order and runs the first branch that matches. It starts with `.dispatch[V]` naming the result type, chains `.when` branches, and is closed with `.otherwise`.
+
+```scala
+val routed =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
+        .dispatch[String]("route")
+        .when(ctx => ctx.total > 100000, name = "manual-review")(_ => "review")
+        .when(ctx => ctx.total > 10000, name = "supervisor")(_ => "supervisor")
+        .otherwise(_ => "auto-approve", name = "auto")
+        .step("record")(ctx => notifyCustomer(ctx.order.id, ctx.route))
+```
+
+The type parameter is what every branch must produce. The chosen value is persisted under the dispatch's name and read downstream as `ctx.route`, and the choice itself is recorded under `route#chosen` BEFORE the branch runs, so a recovered execution takes the same branch rather than re-evaluating conditions against a record that may have moved on.
+
+Closing with `.otherwise` is not a convention. Until you call it, `output`, `step`, `input`, and `sleep` are defined on the partial dispatch as compile errors, so an unclosed dispatch fails to compile with a message telling you what is missing.
+
+### Repeating without checkpoints
+
+`loop` repeats a body until it answers `Loop.done(value)`, and stores that value under the loop's name.
+
+```scala
+val untilAccepted =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .loop("accepted") { ctx =>
+            carrierStatus(ctx.order.id).map {
+                case "accepted" => Loop.done(true)
+                case _          => Loop.continue
+            }
         }
-    }
 ```
 
-Loops can carry state between iterations. The second argument to `.loop` is the initial state, and the body receives `(state, ctx)`:
+A loop can carry state between iterations. The second argument is the initial state and the body receives it beside the context:
 
 ```scala
-val flow = Flow.init("accumulate")
-    .input[Int]("target")
-    .loop("sum", 0) { (acc, ctx) =>
-        if acc >= ctx.target then Loop.done(acc)
-        else Loop.continue(acc + 1)
-    }
-```
-
-**Scheduled loops** (`loopOn`) insert durable sleeps between iterations using a `Schedule`. Each iteration is checkpointed independently, so recovery resumes from the last completed iteration:
-
-```scala
-val flow = Flow.init("monitor")
-    .input[String]("endpoint")
-    .loopOn("check", Schedule.fixed(5.minutes)) { ctx =>
-        probe(ctx.endpoint).map {
-            case "healthy" => Loop.continue
-            case status    => Loop.done(s"alert: $status")
+val counted =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .loop("attempts", 0) { (tries, ctx) =>
+            if tries >= ctx.order.items.size then Loop.done(tries)
+            else Loop.continue(tries + 1)
         }
-    }
 ```
 
-## ForEach
+> **Caution:** the whole loop is one durable node, and nothing is recorded until the body says stop. An execution that dies at iteration 40 of 50 begins again at iteration 1 when another executor recovers it, and every side effect those 40 iterations performed happens a second time. That is deliberate: a `loop` runs until its own body decides, so its iteration count is unbounded, and recording each one would write a field and an event per iteration for a loop that may converge over thousands. Use it for convergence over pure or idempotent-per-iteration work, and reach for one of the next two when the iterations do something you cannot afford twice.
 
-ForEach processes each element of a collection and stores all results as a `Chunk`:
+### Repeating with a checkpoint per iteration
+
+`loopOn` is a loop with a `Schedule` between iterations. The wait is durable, and every iteration is checkpointed: the state a continuing iteration carries and the value a finishing one produces are both recorded under the iteration's own key before the loop moves on.
 
 ```scala
-val flow = Flow.init("batch")
-    .input[Seq[String]]("urls")
-    .foreach("results")(ctx => ctx.urls)(url => fetch(url))
+val watching =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .loopOn("delivery", Schedule.fixed(30.minutes)) { ctx =>
+            carrierStatus(ctx.order.id).map {
+                case "delivered" => Loop.done("delivered")
+                case _           => Loop.continue
+            }
+        }
 ```
 
-## Composition
+An execution that dies mid-loop resumes at the iteration after the last one recorded, with that iteration's state. When you want the checkpointing and not the waiting, `Schedule.fixed(Duration.Zero)` is the schedule to pass: it is a `loop` whose iterations are durable, at the cost of the writes.
 
-### Sequential
+> **Caution:** a `loopOn` whose schedule runs out before the body returned `Loop.done` FAILS the execution with `FlowLoopExhaustedException`, naming the loop and the iterations it ran. It does not complete with the last state: the flow declared `N ~ V` and there is no `V` to write. Give the schedule more room than the body needs, or make the body decide.
 
-`andThen` sequences two flows: the first completes, then the second starts with access to all prior outputs.
+### Fanning out over a collection
+
+`foreach` is the shape to use when the work is genuinely N units. Each item's result is recorded under the item's own durable key as it lands, `reservations~0`, `reservations~1`, and so on, and the node's `Chunk[V]` is assembled from them when the last one arrives.
 
 ```scala
-val combined = validateFlow.andThen(processFlow)
+val reserving =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .foreach("reservations")(ctx => ctx.order.items)(item => reserveStock(item))
+        .step("ship")(ctx => ship(ctx.order))
 ```
 
-### Parallel
+An execution that dies with 40 of 50 items recorded resumes at item 41: the recorded items are read back rather than run again, so a fan-out that charges N cards charges each of them once however many attempts recovery takes. The item that was in flight when the process died is the one exception, and it is the same window every node has. The cost is N field writes for a fan-out of N, which is what buys the guarantee.
 
-`zip` runs two flows in parallel and merges their outputs. Both must complete:
+`timeout` bounds ONE item, since a bound over the whole fan-out cannot be sized for the single slow one; `retry` re-asks one item that failed for an accidental reason, leaving recorded items exactly as they are; `concurrency` bounds how many items are in flight, defaulting to unbounded. Results are ordered by the collection rather than by completion, whatever the bound is.
 
 ```scala
-val parallel = pricingFlow.zip(inventoryFlow)
+val bounded =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .foreach(
+            "reservations",
+            timeout = 5.seconds,
+            retry = Maybe(Schedule.fixed(1.second).take(3)),
+            concurrency = 4
+        )(ctx => ctx.order.items)(item => reserveStock(item))
 ```
 
-For more than two, use `gather`:
+> **Note:** items above a concurrency of 1 run in their own fibers. `Sync`, `Async` and `Abort` bodies need nothing for that, and neither does a body reading a context effect such as `Env`, which the kernel carries into a fiber. A body carrying `Var` or `Emit`, whose state has to be merged back, has no per-item state to merge here and should declare `concurrency = 1`.
+
+> **Caution:** the collection must be a deterministic function of the record. A resumed attempt recomputes it, because that is what names the items the recorded results belong to, and the count the fan-out started with is recorded beside them. A recomputed collection whose size disagrees fails the node with `FlowNondeterministicCollectionException`, naming the node, the count it recorded, and the size it recomputed.
+
+The node persists the whole `Chunk[V]` under the evidence for `Chunk[V]` rather than for `V`, so reading it back from a store is `store.getField[Chunk[String]](eid, "reservations")`, the same typed read every `FlowStore` implementation provides; asking for `getField[String]` answers `Absent` on the tag mismatch rather than failing.
+
+## Undoing work when a later step fails
+
+A workflow that reserved stock and charged a card, and then fails at the shipment, has to give both back. Compensation handlers are how a node says what undoing it means, and the engine runs them in reverse registration order when a later node fails.
 
 ```scala
-val all = Flow.gather(pricingFlow, inventoryFlow, shippingFlow)
+val saga =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
+        .foreachCompensated("reservations")(ctx => ctx.order.items)(item => reserveStock(item))((_, reservationId) =>
+            releaseStock(reservationId)
+        )
+        .outputCompensated("charge")(ctx => chargeCard(ctx.order.id, ctx.total))(ctx => refundCharge(ctx.charge))
+        .step("ship")(ctx => ship(ctx.order))
 ```
 
-### Racing
+If `ship` fails, the unwind refunds the charge, then releases each reservation. Handlers must be idempotent for the same reason node bodies must: an unwind interrupted part-way is resumed, and only the handlers whose completion was recorded are skipped.
 
-`race` runs two flows in parallel. The first to complete wins and the other is abandoned.
+Every node kind has a compensated variant: `outputCompensated`, `stepCompensated`, `loopCompensated`, `loopOnCompensated`, `foreachCompensated`, and `otherwiseCompensated` for a dispatch. Which record the handler receives is what differs, and it follows the shape of the node.
+
+A handler on `output`, `step`, `loop`, `loopOn`, or a dispatch is NODE level: it receives the record the node's own value is in, and undoes the one thing the node did. A loop's handler sees the value the loop converged on, so a loop that booked a shipment per iteration undoes the booking it ended with, and a loop cancelled between iterations produced no value and registers nothing. A dispatch's handler sees the branch that ran; the branch that did not run wrote nothing, so there is no per-branch question to answer.
+
+`foreachCompensated` is the exception, and it is per ITEM. The handler receives an item and what that item produced, and is registered as each item completes, so a run that charged three of five cards refunds three. A node-level handler would receive the node's stored value, and a fan-out's value exists only once every item has landed, which is to say it does not exist at the one moment unwinding matters. A resumed fan-out registers handlers for the items it read back as well as for the ones it ran, because an item recorded by an earlier attempt did its work just as much.
+
+> **Note:** handlers run in reverse order of REGISTRATION, and a fan-out's items register in the order they complete rather than the order they were listed. The order among one fan-out's items is therefore a scheduling fact and not a contract. Work that must be undone in a particular order is a batch, and its handler belongs on the node that owns the batch.
+
+> **Caution:** the one case that registers nothing is a detected nondeterministic collection. A fan-out whose recomputed collection changed size cannot say which item produced which recorded result, so it fails naming the mismatch instead of pairing them by a guess, and its own items are left as they are: their handlers never run. The unwind still runs every handler registered BEFORE the fan-out, and the already-recorded per-item fields stay in place as the evidence an operator remediates from.
+
+A handler carries the forward node's own effect row rather than a bare one, because undoing a database write needs the same database. The engine's runner discharges both directions, so a compensating flow is built exactly like an uncompensated one and nothing has to close over a live client before the flow value exists.
+
+> **Note:** handlers fire on `Throwable` failure and on cancellation, never on suspension. A flow waiting a week for an approval has run none of its handlers.
+
+While an unwind is in progress the execution's status is `Compensating(cause)`, and `Flow.Cause` is either `Failure(error, kind)` or `Cancellation`. The cause is durable, on the status and on the `CompensationStarted` event, which is what lets an unwind that crashed be resumed: a resumed attempt re-raises the cause its interrupted attempt recorded rather than replaying forward and hoping the failing node fails a second time.
+
+## Running branches at the same time
+
+Three combinators run flows concurrently, and they differ in what ends the join: `zip` and `gather` wait for every branch, `race` takes the first value.
+
+### zip and gather
+
+`zip` runs two flows in parallel and merges their outputs. Both must complete.
 
 ```scala
-val fastest = Flow.race(primaryFlow, fallbackFlow)
+val stockCheck =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("lines")(ctx => ctx.order.items.size)
+
+val priceCheck =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("total")(ctx => ctx.order.items.map(i => i.qty * i.price).sum)
+
+val checks = stockCheck.zip(priceCheck)
 ```
 
-### Subflows
-
-`subflow` embeds a child flow within a parent. The input mapper transforms the parent's context into the child's expected inputs:
+Both branches declare `input[Order]("order")`, which is the shared-input case registration blesses: one wait, one field, two readers. `gather` is the same join for two to five branches:
 
 ```scala
-val childFlow = Flow.init("payment-child")
-    .input[Int]("amount")
-    .output("confirmation")(ctx => s"paid:${ctx.amount}")
-
-val parent = Flow.init("parent")
-    .input[Order]("order")
-    .subflow("payment", childFlow)(ctx =>
-        "amount" ~ (ctx.order.qty * ctx.order.price)
-    )
-    .step("ship")(_ => ())
+val everything = Flow.gather(fulfilmentFlow, shippingFlow, invoiceFlow)
 ```
 
-## Error Handling
+### race
 
-### Retry and Timeout
-
-Any output or step can specify a per-attempt timeout and a retry schedule:
+`race` runs two flows in parallel and takes the first VALUE. The natural use is bounding a wait that has no bound of its own, by racing it against a sleep.
 
 ```scala
-val flow = Flow.init("resilient")
-    .input[String]("url")
-    .output(
-        "data",
-        timeout = 10.seconds,
-        retry = Maybe(Schedule.exponentialBackoff(1.second, 2.0, 1.minute))
-    )(ctx => fetchData(ctx.url))
+val awaitApproval =
+    Flow.init("approval")
+        .input[Approval]("approval")
+        .output("decision")(ctx => if ctx.approval.approved then "approved" else "declined")
+
+val approvalDeadline =
+    Flow.init("approval")
+        .sleep("grace", 24.hours)
+        .output("decision")(_ => "timed-out")
+
+val decided = Flow.race(awaitApproval, approvalDeadline)
 ```
 
-Each attempt is independently timed. When the schedule exhausts, the last error propagates.
+Both branches produce `decision`, which is what makes the union result readable downstream as `ctx.decision`, and it is the second case registration blesses rather than refuses.
 
-### Compensation
+This composition is also why `ExecutionDetail.waits` is a map rather than a single value. While the race is open the execution holds two wait rows at once, one `Wake.OnField("approval")` and one `Wake.At(deadline)`, and a single token could only ever answer one of them.
 
-Outputs and steps can register compensation handlers that fire in reverse order when a later step fails. This implements the saga pattern for distributed transactions:
+> **Note:** only a value decides a race. The first branch to produce one wins and the other is cancelled. A branch that FAILS while its sibling still waits decides nothing: the race keeps waiting on the survivors, and the failure stays recorded in the failing node's own events. Only when every branch has failed does the race fail, with the last failure as its verdict. That is what lets `race(notify-via-flaky-api, input("manual-ack"))` be rescued by the acknowledgement, which a failure-wins rule would have terminally failed while the answer it waits for was still deliverable.
+
+### Isolate
+
+All three combinators ask the call site for an `Isolate` for the combined effect row. Each branch runs in its own fiber, and the isolate is what carries a custom effect across that boundary: it is captured where the combined row is still visible, each branch runs against the captured state, and completed branches are restored into the caller's context.
+
+Pure rows and `Async` rows derive one automatically, and so do context effects such as `Env` and `Local`, and `Check`. `Var` and `Emit` need one in scope:
 
 ```scala
-val flow = Flow.init("saga")
-    .input[Order]("order")
-    .outputCompensated("reservation")(ctx =>
-        reserveInventory(ctx.order)
-    )(ctx =>
-        cancelReservation(ctx.reservation)
-    )
-    .outputCompensated("charge")(ctx =>
-        chargeCard(ctx.order)
-    )(ctx =>
-        refundCard(ctx.charge)
-    )
-    .step("ship")(ctx => ship(ctx.order))
+given Isolate[Var[Int], Any, Var[Int]] = Var.isolate.update[Int]
+
+val left  = Flow.init("fulfilment").input[Int]("a").output("b")(ctx => Var.get[Int].map(_ + ctx.a))
+val right = Flow.init("fulfilment").input[Int]("c").output("d")(ctx => Var.get[Int].map(_ + ctx.c))
+val both  = left.zip(right)
 ```
 
-If `ship` fails, compensations run in reverse: first `refundCard`, then `cancelReservation`. Compensations must be idempotent.
+> **Caution:** a row no isolate can be built for does not compose, and that refusal is deliberate rather than a gap to work around. kyo-prelude ships no `Isolate[Abort[E]]`, so a flow whose nodes raise their own `Abort[E]` cannot be joined by `zip`, `race`, or `gather` today. Handle the `Abort` inside the node body, with `Abort.recover` or `Abort.run`, so the branch's row no longer carries it.
 
-For error recovery within a step body, use Kyo's `Abort.recover`:
+The asymmetry with `foreach` is worth knowing: `foreach` derives its own identity isolate internally and asks the caller for nothing, and the price of that is the `Var`/`Emit` restriction on fan-out bodies, which has no compile-time guard.
+
+## Running a workflow
+
+The entry points below span a unit test, a development server, and a production cluster. They differ in what backs the store and whether HTTP is involved; the flow value is the same in all of them.
+
+### Locally, for tests
+
+`Flow.runLocal` builds an in-memory store and a one-worker engine, drives the flow to completion, and answers with the full output record.
 
 ```scala
-Flow.init("recover")
-    .input[String]("input")
-    .output("result")(ctx =>
-        Abort.recover[Throwable](_ => "fallback")(riskyOperation(ctx.input))
-    )
+val demo   = Flow.init("fulfilment").input[Order]("order").output("lines")(ctx => ctx.order.items.size)
+val record = Flow.runLocal(demo, "order" ~ Order("o-1017", "ada", Seq(Item("widget", 3, 400))))
 ```
 
-### Exception Types
+Subflow fields are assembled into the returned record, so a parent that embedded `payment` reads `record.payment` as the child's own record, its inputs included: `record.payment.orderId` is the value the mapper supplied.
 
-Engine operations fail with specific `FlowException` subtypes organized into sealed groups for pattern matching:
+### Over HTTP
 
-| Group | Exception | Meaning |
-|-------|-----------|---------|
-| `FlowWorkflowException` | `FlowWorkflowNotFoundException` | Workflow not in store |
-| | `FlowWorkflowNotRegisteredException` | Workflow not registered with engine |
-| `FlowExecutionStateException` | `FlowExecutionNotFoundException` | Execution not found |
-| | `FlowExecutionTerminalException` | Cannot signal terminal execution |
-| | `FlowDuplicateExecutionException` | Execution ID already exists |
-| `FlowSignalException` | `FlowSignalNotFoundException` | Input name doesn't exist |
-| | `FlowSignalTypeMismatchException` | Signal type doesn't match |
-| | `FlowInputAlreadyDeliveredException` | Input already delivered |
-
-API methods use precise Abort union types, so you can handle exactly the errors each method can produce.
-
-## Running Workflows
-
-### Local
-
-`Flow.runLocal` runs a flow in-memory, blocking until completion. Useful for tests:
+`Flow.runServer` starts an HTTP server exposing the REST API for every workflow you hand it.
 
 ```scala
-val simpleFlow = Flow.init("demo").input[Int]("x").output("doubled")(ctx => ctx.x * 2)
-val result     = Flow.runLocal(simpleFlow, "x" ~ 42)
+// In-memory store, for development
+val serverDev: HttpServer < (Async & Scope & Abort[HttpBindException | FlowDefinitionException | FlowStoreException]) =
+    Flow.runServer(fulfilmentFlow, shippingFlow)
+
+// Durable store, for production
+val serverProd: HttpServer < (Async & Scope & Abort[HttpBindException | FlowDefinitionException | FlowStoreException]) =
+    FlowStore.initMemory.map(store => Flow.runServer(store, fulfilmentFlow, shippingFlow))
 ```
 
-### Server
+> **Caution:** the zero-store overload uses `FlowStore.initMemory`, which is transient: every execution, field, and event is lost when the process exits. It is a development server. Production wants a store of your own; see [Backing it with your own store](#backing-it-with-your-own-store).
 
-`Flow.runServer` starts an HTTP server with REST endpoints for all registered workflows:
-
-```scala
-// In-memory store (development)
-val serverDev: HttpServer < (Async & Scope & Abort[HttpBindException]) = Flow.runServer(orderFlow, shippingFlow)
-
-// Durable store (production)
-val serverProd: HttpServer < (Async & Scope & Abort[HttpBindException]) =
-    FlowStore.initMemory.map(store => Flow.runServer(store, orderFlow, shippingFlow))
-```
-
-The server exposes:
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/v1/workflows` | List workflows |
-| GET | `/api/v1/workflows/:id` | Workflow metadata |
-| GET | `/api/v1/workflows/:id/diagram` | Workflow diagram |
-| POST | `/api/v1/workflows/:id/executions` | Start execution |
-| GET | `/api/v1/executions/:eid` | Execution status |
-| POST | `/api/v1/executions/:eid/signal/:name` | Deliver input |
-| GET | `/api/v1/executions/:eid/inputs` | Input delivery status |
-| GET | `/api/v1/executions/:eid/history` | Event history |
-| GET | `/api/v1/executions/:eid/diagram` | Diagram with progress |
-| POST | `/api/v1/executions/:eid/cancel` | Cancel execution |
-| POST | `/api/v1/executions/search` | Search executions |
-| POST | `/api/v1/executions/cancel` | Cancel matching executions |
-
-To compose with your own endpoints, use `Flow.runHandlers`:
+To mount the workflow endpoints beside your own, take the handlers instead of the server:
 
 ```scala
 FlowStore.initMemory.map { store =>
-    Flow.runHandlers(store, orderFlow).map { handlers =>
+    Flow.runHandlers(store, fulfilmentFlow).map { handlers =>
         HttpServer.init(handlers.toSeq*)
     }
 }
 ```
 
-### Engine
+> **Note:** `Flow.runHandlers` answers a pending `Chunk[HttpHandler[?, ?, ?]] < Any` rather than a bare `Chunk`, on purpose. A bare `Chunk` binds in a for-comprehension over `Chunk.flatMap`, which would quietly run the rest of the comprehension once per handler.
 
-`FlowEngine` provides the full programmatic API without HTTP:
+### The engine, without HTTP
+
+`FlowEngine` is the full programmatic surface. Creating one starts worker fibers that poll the store, claim ready executions under a lease, and interpret the flow node by node.
 
 ```scala doctest:scope=env:engine
-val engineEffect: FlowEngine < (Async & Scope) =
-    FlowStore.initMemory.map(store => FlowEngine.init(store, orderFlow, shippingFlow))
+val engineEffect: FlowEngine < (Async & Scope & Abort[FlowDefinitionException | FlowStoreException]) =
+    FlowStore.initMemory.map(store => FlowEngine.init(store, fulfilmentFlow, shippingFlow))
 ```
 
 ```scala doctest:scope=env:engine
 engineEffect.map { engine =>
     for
-        handle <- engine.workflows.start(Flow.Id.Workflow("order"))
-        _      <- handle.signal("order", Order("Widget", 3))
+        handle <- engine.workflows.start(Flow.Id.Workflow("fulfilment"))
+        _      <- handle.signal("order", sampleOrder)
         status <- handle.status
     yield status
 }
 ```
 
-The engine runs worker fibers that poll the store, claim executions via time-limited leases, and interpret the flow step by step. Configuration:
+Beyond `start` and `signal`, `workflows` also answers `list` (every registered workflow's metadata), `describe(workflowId)` (one workflow's metadata), and `executions(workflowId)` (every execution of that workflow, regardless of status), all of which the HTTP layer exposes as routes. `engine.executorId` identifies this particular engine instance; it is the value recorded on `ExecutionClaimed` and `ExecutionResumed` events when this engine is the one that claimed or resumed an execution.
+
+### Workflow ids: `init` versus `register`
+
+`FlowEngine.init(store, flows*)` and `Flow.runServer` derive each workflow's id from the flow's OWN `Flow.init` name, which is why the example above starts `Flow.Id.Workflow("fulfilment")`. `FlowEngine#register` takes the id explicitly, and it does not have to match:
+
+```scala doctest:scope=env:engine
+engineEffect.map { engine =>
+    engine.register(Flow.Id.Workflow("fulfilment-eu"), fulfilmentFlow)
+}
+```
+
+That flow is now addressable as `fulfilment-eu` and only as `fulfilment-eu`; the name inside its `Flow.init` is decorative for this registration. Registering the same flow value under two ids is how you run two independent populations of executions from one definition.
+
+Registration is also where a definition is checked. It refuses a flow with no name (`FlowUnnamedException`), one using a reserved character in a node name (`FlowReservedNameException`), and one in which two nodes claim a single durable name (`FlowDuplicateNameException`). Registration is the first point that has both the whole definition and an effect row, so a constructor could neither know that a later node will claim the same name nor report it as anything but a throw.
+
+### Tuning, and the runner
+
+Engine tuning is a `FlowEngine.Config`, or the same five values spelled out:
 
 ```scala
 FlowStore.initMemory.map { store =>
@@ -398,109 +510,355 @@ FlowStore.initMemory.map { store =>
         renewEvery = 10.seconds,
         batchSize = 8,
         pollTimeout = 30.seconds,
-        flows = Seq(orderFlow, shippingFlow)
+        flows = Seq(fulfilmentFlow, shippingFlow)
     )
 }
 ```
 
-## Monitoring
+`lease` is the one that decides crash-recovery latency: an execution whose executor died is offered to another only once its claim has expired.
+
+> **Caution:** a tuning the engine could not work under is REFUSED with `FlowInvalidConfigException` rather than clamped, and every bad setting is reported at once. A non-positive duration, a `workerCount` below 1, a `batchSize` below 1, and a `renewEvery` at or above `lease` all qualify. The last is the one that is actively harmful: the claim has already expired when the first renewal is presented, so the renewal is refused, the refusal interrupts the execution, and every node longer than the lease is interrupted, released, reclaimed, and re-run forever. Lowering `lease` without lowering `renewEvery` makes `init` fail rather than degrade.
+
+When node bodies use effects the engine does not handle itself, the runner parameter supplies the handlers. It wraps the whole flow execution, forward pass and unwind together, so a compensation handler carrying the same row is discharged by the same runner:
+
+```scala
+FlowStore.initMemory.map { store =>
+    val flow = Flow.init("fulfilment").output("warehouse")(_ => Env.use[String](region => s"warehouse-$region"))
+    FlowEngine.init(store, flow)([v] => (c: v < Env[String]) => Env.run("eu-west")(c))
+}
+```
+
+The same runner shape is accepted by `Flow.runLocal`, `Flow.runServer`, `Flow.runHandlers`, and `FlowEngine#register`.
+
+## Watching an execution
+
+Everything an operator asks about a running execution is answered from the store, which means it is answerable from any process, not only the one running the work.
 
 ### Status
 
-Executions transition through a status machine:
-
 ```
 Running ──→ Completed
-Running ──→ Failed (compensations run first if registered)
-Running ──→ WaitingForInput ──→ Running (on signal)
-Running ──→ Sleeping ──→ Running (on expiry)
+Running ──→ Failed
+Running ──→ Cancelled
 Running ──→ Compensating ──→ Failed
-Any non-terminal ──→ Cancelled
+Running ──→ Compensating ──→ Cancelled
 ```
+
+`Flow.Status` has exactly five cases: `Running`, `Completed`, `Failed(error, kind)`, `Compensating(cause)`, and `Cancelled`. The two `Compensating` rows are the shape a terminalisation takes when the execution registered compensation handlers, cancelling included; with no handlers registered, the transition is directly to `Cancelled` or `Failed`. Which terminal an unwind lands on is a total function of the cause: a cancellation ends `Cancelled`, a failure ends `Failed`.
+
+`Compensating ──→ Completed` is the one transition this module documents as impossible. A forward pass that reaches the end while resuming an unwind reached it in skip-only mode, having re-registered handlers and computed nothing, so answering with that record would complete an execution whose compensations are half run.
+
+A `Running` execution can be working or waiting: waiting for a signal, or waiting for a durable sleep to expire. Neither is a separate status. Running the handlers IS one, `Compensating(cause)`, written through the claim before the first handler fires, which is what lets an unwind interrupted half way resume as an unwind rather than replay forward. What the execution is waiting for is on `ExecutionDetail.waits: Dict[String, Flow.Wake]`, keyed by node path, whose values are `Flow.Wake.At(instant)` for a sleep and `Flow.Wake.OnField(name)` for an input.
 
 ```scala doctest:scope=env:monitor
 val eid: Flow.Id.Execution = Flow.Id.Execution("exec-123")
-val monitorEffect =
+val wfId: Flow.Id.Workflow = Flow.Id.Workflow("fulfilment")
+
+val describing =
     FlowStore.initMemory.map { store =>
-        FlowEngine.init(store, orderFlow).map { engine =>
+        FlowEngine.init(store, fulfilmentFlow).map { engine =>
             engine.executions.describe(eid).map { detail =>
-                val _status   = detail.status   // Flow.Status
-                val _progress = detail.progress // step-by-step node progress
-                val _inputs   = detail.inputs   // which inputs are delivered
+                val _status    = detail.status          // Flow.Status
+                val _progress  = detail.progress        // per-node progress
+                val _inputs    = detail.inputs          // which inputs are delivered
+                val _waits     = detail.waits           // Dict[String, Flow.Wake], what each waiting node waits for
+                val _cancelReq = detail.cancelRequested // asked to cancel, unwind not finished
             }
         }
     }
 ```
 
-### Events
+> **Caution:** `FlowEngine.Progress.NodeStatus`, the per-node rendering inside `detail.progress`, is a DIFFERENT vocabulary from `Flow.Status` and still carries `WaitingForInput`, `Sleeping(until)`, and `Compensated` alongside `Completed`, `Running`, `Pending`, and `Failed(error)`. Those are node-level facts about where an execution has got to, not execution-level statuses. A node reading `Sleeping` sits inside an execution whose status is `Running`.
 
-Every state change is recorded as a `Flow.Event`:
+`describe` on an execution whose definition this engine does not serve answers with empty inputs and empty progress beside a real state row, since both are derived from the definition.
 
-```scala doctest:scope=env:monitor
-FlowStore.initMemory.map { store =>
-    FlowEngine.init(store, orderFlow).map { engine =>
-        engine.executions.history(eid).map { page =>
-            val _events  = page.events  // Chunk[Flow.Event]
-            val _hasMore = page.hasMore // pagination
-        }
-    }
-}
-```
-
-Event kinds: `Created`, `StepStarted`, `StepCompleted`, `StepRetried`, `StepTimedOut`, `InputWaiting`, `InputReceived`, `SleepStarted`, `SleepCompleted`, `ExecutionResumed`, `ExecutionClaimed`, `ExecutionReleased`, `Completed`, `Failed`, `CompensationStarted`, `CompensationCompleted`, `CompensationFailed`, `Cancelled`.
-
-### Diagrams
-
-Render workflow structure or execution progress:
-
-```scala doctest:scope=env:monitor
-val wfId: Flow.Id.Workflow = Flow.Id.Workflow("order")
-FlowStore.initMemory.map { store =>
-    FlowEngine.init(store, orderFlow).map { engine =>
-        engine.workflows.diagram(wfId, Flow.DiagramFormat.Mermaid)
-        engine.executions.diagram(eid, Flow.DiagramFormat.Dot)
-    }
-}
-```
-
-Supported formats: `Mermaid`, `Dot`, `Bpmn`, `Elk`, `Json`. Also available directly on a flow definition:
+A failed execution records what KIND of failure ended it. A node's own domain failure extends `FlowDomainException`, the one open branch of the exception hierarchy, and reaches the engine as a typed failure rather than a panic; the persisted `Flow.Status.Failed` then carries its class name beside the message, so "how many executions failed for payment reasons" is a query over a field rather than a `LIKE` over free text. An escaped throwable carries no kind, since nothing declared one.
 
 ```scala
-Flow.renderMermaid(orderFlow)
+case class ChargeDeclined(orderId: String, cents: Int)(using Frame)
+    extends FlowDomainException(s"charge declined for $orderId: $cents cents over limit")
 ```
 
-## Custom Store
+### Searching executions
 
-The in-memory store (`FlowStore.initMemory`) is for development and testing. For production, implement `FlowStore` against a durable database:
+`executions.search` answers the operator's questions that are not about one known execution: what is still waiting for an approval, what failed for a payment reason, what somebody has asked to stop.
 
-```scala doctest:expect=skipped
-class PostgresFlowStore(pool: ConnectionPool) extends FlowStore:
-    def claimReady(): Unit   = ??? // SELECT ... FOR UPDATE SKIP LOCKED
-    def updateStatus(): Unit = ??? // UPDATE + INSERT in one transaction
-    // ... 15 abstract methods total
-end PostgresFlowStore
+```scala doctest:scope=env:monitor
+val searching =
+    FlowStore.initMemory.map { store =>
+        FlowEngine.init(store, fulfilmentFlow).map { engine =>
+            engine.executions.search(
+                wfId = Maybe(wfId),
+                filter = Maybe(FlowStore.ExecutionFilter.WaitingForInput(Maybe("approval")))
+            ).map { page =>
+                val _items = page.items // this page, most recently created first
+                val _total = page.total // how many MATCHED, not how many came back
+            }
+        }
+    }
 ```
 
-Key invariants:
-- `claimReady` never returns the same execution to two concurrent callers
-- `updateStatus` writes event + status atomically
-- `putFieldIfAbsent` is an atomic check-and-write (exactly-once)
-- `renewClaim` returns false if the claim was taken by another executor
-- Terminal status cannot revert to non-terminal
+`FlowStore.ExecutionFilter` is a deliberately different vocabulary from `Flow.Status`, because what an operator looks for includes facts that are not the lifecycle. Its arms are `Running`, `Compensating`, `Completed`, `Cancelled`, `Failed(kind)`, `Sleeping`, `WaitingForInput(name)`, `Cancelling`, and `Orphaned(servedHashes)`. A wait-kind arm matches when ANY of the execution's rows does.
 
-## Multi-Executor Coordination
+The filter is evaluated by the STORE, before it paginates. Filtering a returned page would answer "the matches among the first 25 rows" to a caller who asked for "the first 25 matches", and the two differ by however many non-matching rows the page happened to contain. `SearchResult.total` is the size of the matched set, which is what a caller sizing a page control or deciding whether to ask for more is reading; answering it costs reading every match, since the store's vocabulary has no count.
 
-Multiple engine instances on the same store coordinate automatically via claim leases:
+> **Note:** on `history`, `search`, and `parked`, a negative `limit` reads as UNBOUNDED rather than as an empty page. An empty page is the one answer a caller cannot tell from "nothing matched", and paired with "another page follows" it is what a paging loop never escapes.
+
+### Events
+
+Every state change is appended to the execution's history, in order.
+
+```scala doctest:scope=env:monitor
+val reading =
+    FlowStore.initMemory.map { store =>
+        FlowEngine.init(store, fulfilmentFlow).map { engine =>
+            engine.executions.history(eid).map { page =>
+                val _events  = page.events  // Chunk[Flow.Event]
+                val _hasMore = page.hasMore // pagination
+            }
+        }
+    }
+```
+
+`Flow.EventKind` has 23 cases: `Created`, `StepStarted`, `StepCompleted`, `StepFailed`, `StepRetried`, `StepTimedOut`, `InputWaiting`, `InputReceived`, `InputDischarged`, `InputSupplied`, `SleepStarted`, `SleepCompleted`, `BranchChosen`, `ExecutionResumed`, `ExecutionClaimed`, `ExecutionReleased`, `Completed`, `Failed`, `CompensationStarted`, `CompensationCompleted`, `CompensationFailed`, `NodeCompensated`, `Cancelled`.
+
+Three points repay a closer look. The three ways a value reaches an input stay apart in the history: `InputReceived` says a value arrived by `signal`, `InputSupplied` says a subflow's mapper supplied one at the instance's entry, and `InputDischarged` says a node consumed a signalled one, which an execution can sit a long way short of. `NodeCompensated` is per node, where `CompensationStarted`, `CompensationCompleted`, and `CompensationFailed` are per unwind, which is what lets an interrupted unwind tell the handlers that landed from the ones that did not. And `StepFailed(stepName, error, errorKind)` is what makes "which node failed" a read rather than a guess.
+
+### Engine health
+
+`FlowEngine#health` reports on the ENGINE, not on any execution: how many worker fibers are polling, how many the engine was configured with, and what the last failure to reach the store was.
+
+```scala doctest:scope=env:monitor
+val checking =
+    FlowStore.initMemory.map { store =>
+        FlowEngine.init(store, fulfilmentFlow).map { engine =>
+            engine.health.map { h =>
+                (h.isHealthy, h.workersAlive, h.workersConfigured, h.pollFailures, h.lastPollFailure)
+            }
+        }
+    }
+```
+
+This is what a process-level health endpoint should read. A worker that cannot reach the store records the failure and keeps polling rather than dying, so `isHealthy`, which is `workersAlive == workersConfigured`, is what catches a process that is up while nothing is being executed. `lastPollFailure` is present whether or not the worker that hit it recovered, so a store failing intermittently is visible rather than silent.
+
+## Cancelling
+
+Cancelling runs an execution's compensation handlers, so it cannot be instantaneous and is not modelled as if it were. `cancel` puts a request on the row and returns; an executor observes it at the next node boundary, starts no further node, runs the registered handlers in reverse, and only then writes the terminal `Cancelled`.
+
+```scala doctest:scope=env:monitor
+val cancelling =
+    FlowStore.initMemory.map { store =>
+        FlowEngine.init(store, fulfilmentFlow).map { engine =>
+            engine.executions.cancel(eid).map {
+                case FlowStore.CancelOutcome.Accepted                => "the unwind will run"
+                case FlowStore.CancelOutcome.AlreadyRequested        => "somebody asked first"
+                case FlowStore.CancelOutcome.AlreadyTerminal(status) => s"nothing to cancel, ended ${status.show}"
+            }
+        }
+    }
+```
+
+Those three answers are the only thing about a cancel that is observable on return, which is why the method does not answer `Unit`. `Accepted` means the request is now outstanding. `AlreadyRequested` means one already was. `AlreadyTerminal(status)` means there was nothing to cancel and carries what the execution ended as; it is an answer rather than a failure, because a caller that cancels something already finished got what it wanted and what it needs back is the terminal status. Requesting a cancel on an execution that does not exist answers `AlreadyTerminal(Cancelled)`, since a row that is not there cannot be running.
+
+The HTTP endpoint mirrors that exactly: `accepted` is 202, `already-requested` and `already-terminal` are both 200, and there is no 4xx.
+
+Between the request and the executor observing it, `Handle.status` still reads `Running`; from there to the terminal status an execution with handlers registered reads `Compensating(Cancellation)` while they run. The fact a caller wants in that window is `ExecutionDetail.cancelRequested`, and the filter that selects on it across a population is `ExecutionFilter.Cancelling`.
+
+`executions.cancelAll(wfId)`, and the wire's `CancelAllResponse.requested`, count REQUESTS issued, not executions cancelled. One counted may still be unwinding minutes later, and one that finished on its own before the request was observed was never asked at all. Each is counted exactly once: an execution somebody had already asked to cancel is not counted again.
+
+> **Note:** cancelling a held execution, one whose version no engine currently serves, stays outstanding until a matching definition is registered, because nothing observes the request until something serves its hash. That is the same rollback-as-recovery rule as the next section, seen from the cancel side.
+
+## Deploying a new version
+
+Changing a registered flow's structure changes its structural hash, and an execution belongs to the version it was STARTED under. In-flight executions of the old shape are therefore HELD rather than failed: no registered definition matches their hash, so no engine claims them, and they keep their fields, their history, and their place.
+
+```scala doctest:scope=env:monitor
+val held =
+    FlowStore.initMemory.map { store =>
+        FlowEngine.init(store, fulfilmentFlow).map { engine =>
+            engine.parked(wfId).map { states =>
+                states.map(state => (state.executionId, state.hash))
+            }
+        }
+    }
+```
+
+`FlowEngine.parked` is a query, not a status: nothing is written about being held in either direction. Being held is a fact about what THIS engine serves, it goes stale the moment an operator registers something, and an execution held under one engine may be running perfectly well under another. Each entry carries the execution's own `hash`, which is the version it was started under and the fact an operator needs: whether anything still serves that version is what registration decides. The store-side predicate behind it is `ExecutionFilter.Orphaned(servedHashes)`, which has no spelling in the HTTP filter vocabulary precisely because its parameter is one engine's own served set.
+
+Recovery is registration. Rolling the deployment back, or registering both the old and new definitions in the same process, makes the held executions claimable again and they resume on their own. Nothing evicts a registered version within a process, so serving both versions during a migration is a supported steady state rather than a trick.
+
+Failing held executions instead would be unrecoverable and would skip every compensation on the way out, because the handlers live in the definition they can no longer be matched to.
+
+## Seeing what you built
+
+A flow value can be drawn before it has ever run, and drawn again with an execution's progress painted onto it.
+
+```scala doctest:scope=env:monitor
+val drawing =
+    FlowStore.initMemory.map { store =>
+        FlowEngine.init(store, fulfilmentFlow).map { engine =>
+            engine.workflows.diagram(wfId, Flow.DiagramFormat.Mermaid).map { structure =>
+                engine.executions.diagram(eid, Flow.DiagramFormat.Dot).map(progress => (structure, progress))
+            }
+        }
+    }
+```
+
+Formats are `Mermaid`, `Dot`, `Bpmn`, `Elk`, and `Json`. A flow value renders directly too, with no engine involved:
+
+```scala
+val mermaid = Flow.renderMermaid(fulfilmentFlow)
+val dot     = Flow.renderDot(fulfilmentFlow)
+val json    = Flow.renderJson(fulfilmentFlow)
+```
+
+> **Caution:** `Flow.DiagramFormat.fromString` answers `Mermaid` for anything it does not recognise, so a typo in a format parameter produces a silently different diagram rather than an error.
+
+`Flow.lint` reports the name collisions registration would refuse, without needing an engine, which makes it usable in a unit test over a flow value:
+
+```scala
+val warnings = Flow.lint(fulfilmentFlow)
+```
+
+> **Note:** `lint` is public and returns `Seq[FlowLint.Warning]`, but `FlowLint` itself is `private[kyo]`. A caller outside this module can call `lint` and pattern-match or print the warnings it gets back, but cannot declare a variable of type `FlowLint.Warning`, since the type is not visible outside the module.
+
+It flags duplicate node names, with the count of nodes claiming each name and each one's call site, and dispatches with no conditional branch. The duplicate-name warnings are exactly the collisions registration refuses, no broader: a lint that warned about the canonical race, or about an input two branches wait on, would teach its author that correct code is wrong, and a lint a user learns to ignore protects nothing. Registration runs that check itself, along with the unnamed-flow and reserved-character checks, so linting is an early copy of a gate you cannot skip. The empty-dispatch warning is advice rather than a gate; registration accepts a dispatch with only an `otherwise`.
+
+## Failures, and how they are recorded
+
+The exception hierarchy is sealed and grouped so that `Abort` unions stay precise: a method that can only fail to find a workflow declares only that, and a caller handling `Abort[FlowSignalException]` sees the three signal failures and nothing else.
+
+| Group | Exception | Meaning |
+|-------|-----------|---------|
+| `FlowWorkflowException` | `FlowWorkflowNotFoundException` | Workflow not in store |
+| | `FlowWorkflowNotRegisteredException` | Workflow not registered with this engine |
+| `FlowDefinitionException` | `FlowDuplicateNameException` | Two nodes claim one durable name |
+| | `FlowReservedNameException` | A node name uses `~` or `#` |
+| | `FlowUnnamedException` | The flow has no name to be registered under |
+| `FlowExecutionStateException` | `FlowExecutionNotFoundException` | Execution not found |
+| | `FlowExecutionTerminalException` | Cannot signal a terminal execution |
+| | `FlowDuplicateExecutionException` | Execution id already exists |
+| `FlowSignalException` | `FlowSignalNotFoundException` | Input name is not in the definition |
+| | `FlowSignalTypeMismatchException` | Signal type is not EXACTLY the declared input's type (checked with `Tag[V] =:= inputMeta.tag`, not a subtype check) |
+| | `FlowInputAlreadyDeliveredException` | Input already delivered |
+| `FlowException` directly | `FlowStepTimeoutException` | A node exceeded the `timeout` its `Meta` declared |
+| | `FlowLoopExhaustedException` | A `loopOn`'s schedule ran out before the body produced a value |
+| | `FlowNondeterministicCollectionException` | A fan-out's collection recomputed to a different size on replay |
+| | `FlowInvalidConfigException` | `FlowEngine.init` was handed a tuning it cannot work under |
+| | `FlowExecutionFailedException` | `runLocal`'s flow ended `Failed` |
+| | `FlowCancelledException` | Raised at a node boundary once a cancel has been requested |
+
+`FlowDefinitionException` is itself a `FlowWorkflowException`, so `Abort.run[FlowWorkflowException]` catches registration refusals along with lookup failures.
+
+`FlowStepTimeoutException` is the one flow failure a node's retry schedule re-asks: a slow attempt is a measurement rather than a verdict, which is what declaring `timeout` and `retry` together is for. Once the schedule is exhausted, it terminalises the execution with its kind.
+
+`FlowDomainException` is the one OPEN branch, and it is what a node's own business failure extends. Without it a domain failure had nowhere typed to go, since a runner has to produce `Abort[FlowException]`, and turning a declined charge into a panic threw away the type on the way to a status that keeps a string. A failure extending it reaches the engine as a failure, and its class name lands in `Flow.Status.Failed.kind`, which is what makes `ExecutionFilter.Failed(kind)` a useful query.
+
+`FlowStoreException` is a separate, open hierarchy: the error channel every `FlowStore` method carries, so a store implementation reports a backend failure as a value rather than by panicking. A store that knows a failure is transient marks it with `FlowStoreException.Retryable`. The engine treats a store failure as transient in both places it can happen: a failure while polling is recorded on `health` and retried, and a failure while running an execution is recorded there too and leaves the execution exactly as claimable as it was, because a store the engine could not reach has said nothing about the work. That holds whatever the flow registered: a store failure is not a verdict, so it starts no unwind and runs no compensation handler, and the next attempt carries on from where this one stopped.
+
+For recovery inside a node body, use Kyo's `Abort.recover`:
+
+```scala
+val recovering =
+    Flow.init("fulfilment")
+        .input[Order]("order")
+        .output("charge")(ctx =>
+            Abort.recover[Throwable](_ => "unpaid")(chargeCard(ctx.order.id, 1))
+        )
+```
+
+## Coordinating multiple executors
+
+Several engines over one store coordinate without configuration. `claimReady` hands each ready execution to exactly one executor under a renewable, time-limited lease; if an executor dies, its lease expires and another picks the execution up.
 
 ```scala
 FlowStore.initMemory.map { store =>
     // Instance A
-    FlowEngine.init(store, workerCount = 2, lease = 30.seconds, flows = Seq(orderFlow))
-    // Instance B (same store, separate process)
-    FlowEngine.init(store, workerCount = 2, lease = 30.seconds, flows = Seq(orderFlow))
+    FlowEngine.init(store, workerCount = 2, lease = 30.seconds, flows = Seq(fulfilmentFlow))
+    // Instance B, same store, separate process
+    FlowEngine.init(store, workerCount = 2, lease = 30.seconds, flows = Seq(fulfilmentFlow))
 }
 ```
 
-If an executor crashes, its lease expires and another executor picks up the work.
+A node that was in flight when an executor died may run again on the executor that reclaims the lease, while a node already recorded as completed is skipped on replay. That is why node side effects must be idempotent, and the obligation has three faces worth naming separately.
 
-Coordination rests on `claimReady` handing each ready execution to exactly one executor under a renewable lease. A step that was in flight when an executor died may run again on the executor that reclaims the lease, but a step already recorded as completed is skipped on replay. This is why step side effects must be idempotent.
+**The store's guarantee is convergence, not exactly-once execution.** What the store converges on is one writer's view of an execution, not that a node's side effect ran once. A lapsed executor may already have charged a card before its write is refused by the claim fence: the lease expires, `claimReady` hands the execution to another executor under a new token, and every write the dead executor still had in flight is refused. The refusal protects the record, not the card. Idempotence therefore lives in the side effect itself.
+
+**Self-concurrency is part of the same demand.** A timed-out attempt is abandoned rather than awaited, so on the JVM and Native a node body blocked in non-suspending code can still be running when its own next attempt begins. Two attempts of one node can be in flight at once inside a single executor, and idempotence has to hold under that overlap, not only under re-execution after a crash.
+
+**A subflow's input mapper runs until the child's inputs are recorded, and not after.** Entering a subflow writes each of the child's inputs under its path, write-once, before the child's first node; a resumed subflow whose inputs are recorded re-enters the child without running the mapper, against the record. The obligation on the mapper is therefore the idempotency every effectful body carries, because it can run again after a crash between two of its input writes, and not determinism: the record, not the mapper, is what the child ran against.
+
+## Backing it with your own store
+
+`FlowStore.initMemory` loses everything when the process exits. Production means implementing `FlowStore` against a durable database, and the SPI is shaped so that the database, not the engine, is the thing that decides.
+
+```scala doctest:expect=skipped
+class PostgresFlowStore(pool: ConnectionPool) extends FlowStore:
+    def claimReady(): Unit = ??? // SELECT ... FOR UPDATE SKIP LOCKED, handing back a Claimed per row
+    def signal(): Unit     = ??? // UPDATE + INSERT in one transaction, refused on a terminal row
+    // ... the readers and the three administrative writes: 12 on FlowStore and 8 on Claimed, 20 in all
+end PostgresFlowStore
+```
+
+The trait splits in two: 12 on `FlowStore` and 8 on `Claimed` (six verbs and two accessors, `state` and `satisfied`), 20 in all. `FlowStore` carries `claimReady`, the three writes anybody may make (`createExecutionIfAbsent`, `signal`, `requestCancel`), the five readers (`getExecution`, `listExecutions`, `getField`, `getAllFields`, `getHistory`), and the three workflow-metadata methods (`putWorkflow`, which writes, and `getWorkflow` and `listWorkflows`, which read). Those three keep a `FlowEngine.WorkflowInfo` per registered workflow: its id, its `Flow.Meta`, its nodes, its inputs, its output names, and its structural hash. Every write made while RUNNING an execution is a method on `FlowStore.Claimed`, the handle `claimReady` hands back, which carries the generation the claim was granted under: two accessors, `state` and `satisfied`, and six verbs, `appendEvent`, `recordWait`, `renewClaim`, `updateStatus`, `recordProgress`, and `finish`. A write that carries no evidence of the claim it was made under cannot be refused by anything except the writer's own good manners, which is what this split removes.
+
+### The claim lease
+
+One rule decides every write through a `Claimed` handle, and it has two halves. A row's claim is either active, carrying a token and an expiry, or absent. A write is applied only if the claim is active, the presented token is the active claim's token, AND the claim has not expired against the store's own clock. The token alone refuses a superseded writer and says nothing about an executor whose lease expired while nobody else took the row, which still bears the highest token; the expiry alone says nothing about a writer whose row was taken while its lease still had time to run.
+
+`claimReady` replaces whatever claim a row has with an active one carrying a strictly greater token. `Claimed.finish` is the only verb that makes a claim absent, and that absence is what gives a row's wait rows their meaning: they are a finished attempt's statement of what the execution waits for, which is what readiness may gate on.
+
+> **Note:** an attempt that ends WITHOUT calling `finish` leaves the claim to expire, and that is correct rather than a leak. Readiness reads an active-and-expired claim as "the last attempt died mid-flight", returns the execution regardless of its wait rows, and lets the replay heal the ledger. Releasing there instead would bless a partial ledger as a finished attempt's statement, which is a permanent wedge rather than a slow recovery.
+
+### The nine invariants
+
+- **I1** `claimReady` never returns the same execution to two concurrent callers.
+- **I2** A transition writes its status, its event, and its ledger effect atomically, with no window in which a reader sees one without the others. This covers recording a wait, recording progress and clearing the row it discharges, and ending an attempt.
+- **I3** `signal` is an atomic check-and-write against both the field and the lifecycle: exactly one delivery of a name wins, and one arriving after the execution finished is refused.
+- **I4** A renewal succeeds only on an ACTIVE, UNEXPIRED claim whose token is the one presented. An expired claim is dead, and only a new `claimReady` generation revives the execution.
+- **I5** Terminal status cannot revert to non-terminal.
+- **I6** Read-your-writes consistency within a single caller.
+- **I7** `getHistory` returns events in append order.
+- **I8** `claimReady` returns an execution exactly when its lifecycle is not terminal, its claim is free or expired, the caller serves its version, and ANY of: a cancel request is outstanding, it has no outstanding wait rows, one of its rows is satisfied, or its claim is active and expired.
+- **I9** A claimed row records who holds it, until when, and under which generation. The executor id is recorded for reporting and is NEVER a write authority: two workers of one engine share one, so the token is what a write is judged against.
+
+Three details around them are the ones an implementor is likely to get wrong on the first pass.
+
+`claimReady` answering EMPTY is never proof that the timeout elapsed. Two things become ready with no write to wake anyone, a `Wake.At` row whose instant simply passed and a claim that simply expired, so an implementation must make one final attempt at the deadline. A caller reads an empty answer as a signal to re-read the served set and ask again with another blocking call, never as "nothing happened for the whole timeout".
+
+`recordWait` is put-if-absent on the ROW and always-append on the EVENT. A sleep re-recorded on a later attempt keeps its ORIGINAL deadline; a store that overwrote would push the deadline forward on every replay and turn a finite sleep into one that never fires.
+
+`recordProgress` is write-once per path, but the refusal is split by what the write carries. A VALUE-carrying write is refused by field presence. A VALUELESS one is refused only by its own recorded completion, because an input's discharge is by construction a valueless progress at a path the signalled value already occupies. A store must therefore keep a separate per-execution record of the paths at which a valueless progress landed; a field cannot serve as that mark.
+
+### Outcome vocabularies
+
+Each verb answers with what the store did rather than raising: `WriteOutcome` (`Applied`, `ClaimLost`), `StatusOutcome` (`Applied`, `ClaimLost`, `WrongSideOfTerminal`), `ProgressOutcome` (`Recorded`, `AlreadyRecorded`, `ClaimLost`), `SignalOutcome` (`Delivered`, `AlreadyDelivered`, `AlreadyTerminal`), and `CancelOutcome` (`Accepted`, `AlreadyRequested`, `AlreadyTerminal`). An attempt ends by handing `finish` a `Claimed.Outcome`: `Terminal(status, event)`, which retires every wait row, or `Suspended(waitingOn)`, which keeps exactly the named rows and retires the rest.
+
+The rows themselves are `FlowStore.ExecutionState`, carrying the lifecycle, the claim, the structural hash, the wait rows, and the cancel flag, so a caller listing a page of executions needs no per-row ledger read. Field values are `FlowStore.FieldData(value, tag)`, JSON text beside the erased tag of the declared type; use the companion's `FieldData.apply[V](value, tag: Tag[V])` to widen the `Tag[V]` the SPI hands you.
+
+### The conformance suite
+
+`FlowStoreTest` is an abstract test class in this module's test sources. An implementation extends it and supplies `makeStore`, and the suite then exercises the SPI contract against the real backend. It is organised invariant by invariant, I1 through I9, and then verb by verb: `claimReady`'s blocking and acceptance rules, `renewClaim`, `finish`, `requestCancel`, `listExecutions` with its filters and pagination, field operations, signal delivery, execution state, event history, and workflow metadata. Running it green is how a store demonstrates it upholds the invariants above, rather than by inspection.
+
+## The HTTP endpoints
+
+`Flow.runServer` and `Flow.runHandlers` expose these routes. They are what a dashboard, an operator tool, or a service in another language talks to.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workflows` | List workflows |
+| GET | `/api/v1/workflows/{id}` | Workflow metadata |
+| GET | `/api/v1/workflows/{id}/diagram` | Workflow diagram, `?format=` |
+| POST | `/api/v1/workflows/{id}/executions` | Start an execution |
+| GET | `/api/v1/executions/{eid}` | Status, waits, cancel flag, inputs, progress |
+| GET | `/api/v1/executions/{eid}/inputs` | Input delivery status |
+| GET | `/api/v1/executions/{eid}/history` | Event history |
+| GET | `/api/v1/executions/{eid}/diagram` | Diagram with progress overlay, `?format=` |
+| POST | `/api/v1/executions/{eid}/signal/{name}` | Deliver an input, JSON body decoded against the declared input schema |
+| POST | `/api/v1/executions/{eid}/cancel` | Request cancellation; 202 `accepted`, 200 `already-requested`, 200 `already-terminal` carrying the terminal status; no 4xx |
+| POST | `/api/v1/executions/cancel` | Request cancellation of matching executions, answering `requested`, the count of requests issued |
+| POST | `/api/v1/executions/search` | Search executions |
+
+The search body's `status` field takes the wire filter vocabulary: `running`, `completed`, `cancelled`, `cancelling`, `compensating`, `failed`, `failed:<kind>`, `sleeping`, `waiting`, and `waiting:<name>`. An unrecognised string is a 400 rather than "no filter", and so are a bare `failed:` and a bare `waiting:`, which would otherwise narrow to the empty kind and match nothing.
+
+`ExecutionFilter.Orphaned` has no spelling here, deliberately: its parameter is one engine's own served set, which is not something a client can name. An operator reaches that predicate through `FlowEngine.parked` instead.

--- a/kyo-flow/shared/src/main/scala/kyo/Flow.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/Flow.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import Flow.BranchInfo
 import Flow.Meta
 import Flow.internal.*
 import kyo.internal.*
@@ -9,8 +8,8 @@ import scala.compiletime.error
 
 /** A durable workflow definition.
   *
-  * A Flow is a plan, not an execution. You describe what should happen — inputs to wait for, values to compute, side effects to perform,
-  * branches to take — and the engine handles persistence, crash recovery, and coordination.
+  * A Flow is a plan, not an execution. You describe what should happen (inputs to wait for, values to compute, side effects to perform,
+  * branches to take) and the engine handles persistence, crash recovery, and coordination.
   *
   * The three type parameters track workflow structure at compile time:
   *   - `In` accumulates required inputs. Each `.input[V]("name")` refines `In` via `&` intersection, so the engine knows which signals the
@@ -20,14 +19,14 @@ import scala.compiletime.error
   *   - `S` collects effect types from step bodies (e.g., `Async` if a step makes HTTP calls).
   *
   * Start with `Flow.init("name")`, chain steps, then run it:
-  *   - `Flow.runServer(flow)` — HTTP server with in-memory store (development)
-  *   - `Flow.runServer(store, flow)` — HTTP server with a durable store (production)
-  *   - `Flow.runHandlers(store, flow)` — HTTP handlers to compose with your own server
-  *   - `FlowEngine.init(store, flow)` — programmatic engine without HTTP
-  *   - `Flow.runLocal(flow, inputs)` — in-memory, blocking, for tests
+  *   - `Flow.runServer(flow)`, an HTTP server with an in-memory store (development)
+  *   - `Flow.runServer(store, flow)`, an HTTP server with a durable store (production)
+  *   - `Flow.runHandlers(store, flow)`, HTTP handlers to compose with your own server
+  *   - `FlowEngine.init(store, flow)`, a programmatic engine without HTTP
+  *   - `Flow.runLocal(flow, inputs)`, in-memory and blocking, for tests
   *
   * Every step is persisted before the next begins. If the process crashes, another executor resumes from the last checkpoint. Steps that
-  * perform side effects (HTTP calls, database writes) must be idempotent — they may re-execute on recovery.
+  * perform side effects (HTTP calls, database writes) must be idempotent, because they may re-execute on recovery.
   *
   * Error handling uses Kyo's `Abort.recover` inside step bodies. Compensation handlers (`.outputCompensated`) fire in reverse order when a
   * later step fails.
@@ -36,11 +35,18 @@ import scala.compiletime.error
   *
   * ```text
   *   Running ──→ Completed
-  *   Running ──→ Failed (compensations run first if registered)
-  *   Running ──→ WaitingForInput ──→ Running (on signal)
-  *   Running ──→ Sleeping ──→ Running (on expiry)
-  *   Any non-terminal ──→ Cancelled
+  *   Running ──→ Compensating(cause) ──→ Failed | Cancelled
+  *   Running ──→ Failed (when nothing was registered to compensate)
+  *   Running ──→ Cancelled (when nothing was registered to compensate)
   * ```
+  *
+  * A cancel is a request rather than an act, and the executor observes it at a node boundary. An execution already in
+  * `Compensating(Failure(..))` is running the unwind its own failure started, and it ends as that verdict says: the request is not
+  * observed inside an unwind, so the edge out of `Compensating` is decided by the cause it began with.
+  *
+  * Waiting is not a status. An execution that is waiting for an input or serving out a sleep stays `Running`, and what it is waiting FOR
+  * is a wait row per waiting node, because a `race` of an input against a sleep waits for both at once. `executions.describe` answers the
+  * plural question; see [[kyo.Flow.Wake]].
   *
   * @tparam In
   *   Intersection of required input types (accumulated via `.input`)
@@ -60,8 +66,9 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
 
     /** Declare a named input that the execution must receive via `signal` before proceeding.
       *
-      * The flow parks at this node until a value is delivered. On replay, the stored value is read and the node is skipped.
-      * Field-producing: persists the value under `name` in the store.
+      * The node records a wait for the value and the execution stays `Running`, carrying a row that says what it is waiting for, until
+      * a `signal` delivers it. On replay, the stored value is read and the node is skipped. Field-producing: persists the value under
+      * `name` in the store.
       */
     def input[V](using
         Frame
@@ -75,7 +82,7 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
     /** Compute a named value from the current context and persist it to the store.
       *
       * The value becomes available to downstream steps via `ctx.name`. On replay, the stored value is read and the computation is skipped.
-      * Side effects in `fn` must be idempotent — if the executor crashes after computing but before recording, the step re-executes.
+      * Side effects in `fn` must be idempotent: if the executor crashes after computing but before recording, the step re-executes.
       * Field-producing: persists the value under `name` in the store.
       */
     def output[N <: String & Singleton, V, S2](
@@ -92,6 +99,11 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
       *
       * Compensations fire only on `Throwable` failures, not on suspension (sleep, waiting for input). Handlers must be idempotent. Use
       * `Abort.recover` inside `fn` for error recovery.
+      *
+      * The handler carries the forward step's own effects (`S2`), because a compensation undoes what the forward step did and therefore
+      * needs the same resource: a step that wrote a row needs the database to delete it. The engine's runner discharges both, so a
+      * compensating flow is built the same way an uncompensated one is, rather than closing over a live client the forward steps never
+      * needed and being unbuildable until that client exists.
       */
     def outputCompensated[N <: String & Singleton, V, S2](
         name: N,
@@ -100,7 +112,7 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
         retry: Maybe[Schedule] = Maybe.empty,
         tags: Seq[String] = Seq.empty
     )(fn: Record[Out] => V < S2)(
-        compensate: Record[Out & (N ~ V)] => Unit < (Async & Abort[FlowException])
+        compensate: Record[Out & (N ~ V)] => Unit < (S2 & Async & Abort[FlowException])
     )(using Frame, Tag[V], Schema[V]): Flow[In, Out & (N ~ V), S & S2] =
         AndThen(
             this,
@@ -122,7 +134,7 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
         AndThen(this, Step[Out, S2](name, fn, Meta(description, tags, timeout, retry), Maybe.empty))
     end step
 
-    /** Like `step`, but registers a compensation handler. */
+    /** Like `step`, but registers a compensation handler carrying the step's own effects. See [[outputCompensated]]. */
     def stepCompensated[S2](
         name: String,
         description: String = "",
@@ -130,7 +142,7 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
         retry: Maybe[Schedule] = Maybe.empty,
         tags: Seq[String] = Seq.empty
     )(fn: Record[Out] => Unit < S2)(
-        compensate: Record[Out] => Unit < (Async & Abort[FlowException])
+        compensate: Record[Out] => Unit < (S2 & Async & Abort[FlowException])
     )(using Frame): Flow[In, Out, S & S2] =
         AndThen(
             this,
@@ -139,18 +151,21 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
 
     /** Pause the execution for the given duration.
       *
-      * The flow parks durably — if the executor restarts, the sleep resumes from where it left off. On replay, the sleep is skipped when
-      * its `SleepCompleted` event exists. Event-tracked: no stored field.
+      * The wait is durable: the node records a row carrying the instant it is due and the execution stays `Running`, so if the executor
+      * restarts the sleep resumes from where it left off rather than starting over. On replay, the sleep is skipped when its
+      * `SleepCompleted` event exists. Event-tracked: no stored field.
+      *
+      * A durable sleep declares neither `timeout` nor `retry`, because it can honour neither. Bounding a wait is what racing the sleep
+      * against the thing being waited for is for, and the only failure a sleeping node can have is the store's, which is charged to the
+      * engine's health rather than to a node's budget.
       */
     def sleep(
         name: String,
         duration: Duration,
         description: String = "",
-        timeout: Duration = Duration.Infinity,
-        retry: Maybe[Schedule] = Maybe.empty,
         tags: Seq[String] = Seq.empty
     )(using Frame): Flow[In, Out, S] =
-        AndThen(this, Sleep(name, duration, Meta(description, tags, timeout, retry)))
+        AndThen(this, Sleep(name, duration, Meta(description, tags)))
 
     /** Start building a conditional dispatch (branching). Chain `.when(condition)(body)` calls and end with `.otherwise(default)`. */
     def dispatch[V](using Tag[V]): Flow.DispatchStarter[In, Out, S, V] =
@@ -158,6 +173,25 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
 
     /** Loop without state: execute `body` repeatedly. The body returns `Loop.continue` to iterate or `Loop.done(value)` to finish. The
       * final value is stored as the named output.
+      *
+      * #### What this loop does not checkpoint
+      *
+      * The whole loop is one durable node. Nothing is recorded until the body says stop, so an execution that dies at iteration 40 of 50
+      * begins again at iteration 1 when another executor recovers it, and every side effect those 40 iterations performed happens twice.
+      * That is deliberate rather than missing: a `loop` runs until its own body decides, so its iteration count is unbounded, and
+      * recording each one would write a field and an event per iteration for a loop that may converge over thousands.
+      *
+      * Two constructs do checkpoint per iteration, and choosing between them and this one is a durability choice rather than a scheduling
+      * one:
+      *   - [[loopOn]] records every iteration through its schedule, and a schedule of zero delays (`Schedule.fixed(Duration.Zero)`) buys
+      *     the checkpointing without any waiting.
+      *   - Work that is really N units is a [[foreach]] over those units, which records each item and resumes where it stopped.
+      *
+      * #### The knobs
+      *
+      * `timeout` bounds ONE iteration rather than the whole convergence, so a loop that legitimately converges over many iterations can
+      * still bound the single slow one. `retry` re-asks one iteration that failed for an accidental reason, leaving the iterations before
+      * it recorded as they were.
       */
     def loop[N <: String & Singleton, V: Tag: Schema, S2](
         name: N,
@@ -168,19 +202,12 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
     )(
         body: Record[Out] => Loop.Outcome[Unit, V] < S2
     )(using Frame, Tag[Unit], Schema[Unit]): Flow[In, Out & (N ~ V), S & S2] =
-        AndThen(
-            this,
-            LoopNode[Out, N, Unit, V, S2](
-                name,
-                (_, ctx) => body(ctx),
-                (),
-                Maybe.empty,
-                Meta(description, tags, timeout, retry)
-            )
-        )
+        loop[N, Unit, V, S2](name, (), Meta(description, tags, timeout, retry))((_, ctx) => body(ctx))
 
     /** Loop with 1 state value: execute `body` repeatedly starting from `init`. The body returns `Loop.continue(newState)` to iterate or
       * `Loop.done(value)` to finish. The final value is stored as the named output.
+      *
+      * Iterations are not checkpointed. See the stateless [[loop]] for what that costs and for the two constructs that do checkpoint.
       */
     def loop[N <: String & Singleton, A: Tag: Schema, V: Tag: Schema, S2](
         name: N,
@@ -188,18 +215,44 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
     )(
         body: (A, Record[Out]) => Loop.Outcome[A, V] < S2
     )(using Frame): Flow[In, Out & (N ~ V), S & S2] =
-        AndThen(
-            this,
-            LoopNode[Out, N, A, V, S2](name, body, init, Maybe.empty, Meta())
-        )
+        loop[N, A, V, S2](name, init, Meta())(body)
+
+    /** Loop with 1 state value under a declared `description`, `timeout`, `retry` and `tags`.
+      *
+      * The knobs arrive as a [[Meta]] rather than as four defaulted parameters because Scala allows only one overload of a name to define
+      * default arguments, and the stateless [[loop]] is that overload. `timeout` and `retry` govern one iteration, as they do there.
+      */
+    def loop[N <: String & Singleton, A: Tag: Schema, V: Tag: Schema, S2](
+        name: N,
+        init: A,
+        meta: Meta
+    )(
+        body: (A, Record[Out]) => Loop.Outcome[A, V] < S2
+    )(using Frame): Flow[In, Out & (N ~ V), S & S2] =
+        AndThen(this, LoopNode[Out, N, A, V, S2](name, body, init, Maybe.empty, meta, Maybe.empty))
 
     /** Loop with 2 state values: execute `body` repeatedly starting from `init1` and `init2`. The body returns `Loop.continue(newA, newB)`
       * to iterate or `Loop.done(value)` to finish. The final value is stored as the named output.
+      *
+      * Iterations are not checkpointed. See the stateless [[loop]] for what that costs and for the two constructs that do checkpoint.
       */
     def loop[N <: String & Singleton, A: Tag: Schema, B: Tag: Schema, V: Tag: Schema, S2](
         name: N,
         init1: A,
         init2: B
+    )(
+        body: (A, B, Record[Out]) => Loop.Outcome2[A, B, V] < S2
+    )(using Frame, Tag[(A, B)], Schema[(A, B)]): Flow[In, Out & (N ~ V), S & S2] =
+        loop[N, A, B, V, S2](name, init1, init2, Meta())(body)
+
+    /** Loop with 2 state values under a declared `description`, `timeout`, `retry` and `tags`. See the one-state [[loop]] overload for why
+      * the knobs arrive as a [[Meta]].
+      */
+    def loop[N <: String & Singleton, A: Tag: Schema, B: Tag: Schema, V: Tag: Schema, S2](
+        name: N,
+        init1: A,
+        init2: B,
+        meta: Meta
     )(
         body: (A, B, Record[Out]) => Loop.Outcome2[A, B, V] < S2
     )(using Frame, Tag[(A, B)], Schema[(A, B)]): Flow[In, Out & (N ~ V), S & S2] =
@@ -210,11 +263,102 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
                 (state, ctx) => body(state._1, state._2, ctx),
                 (init1, init2),
                 Maybe.empty,
-                Meta()
+                meta,
+                Maybe.empty
             )
         )
 
-    /** Process each element of a collection and store all results as a `Chunk[V]` output. */
+    /** Like the stateless [[loop]], but registers a compensation handler that runs (in reverse order) if a later step fails.
+      *
+      * The handler is NODE level and receives the record the loop's own value is in, which is the value the loop converged on: a loop that
+      * booked a shipment per iteration undoes the booking it ended with. It is pushed only once the loop produced that value, so a loop
+      * that was cancelled between iterations has nothing to undo and registers nothing. See [[outputCompensated]] for the effect row the
+      * handler carries.
+      */
+    def loopCompensated[N <: String & Singleton, V: Tag: Schema, S2](
+        name: N,
+        description: String = "",
+        timeout: Duration = Duration.Infinity,
+        retry: Maybe[Schedule] = Maybe.empty,
+        tags: Seq[String] = Seq.empty
+    )(
+        body: Record[Out] => Loop.Outcome[Unit, V] < S2
+    )(
+        compensate: Record[Out & (N ~ V)] => Unit < (S2 & Async & Abort[FlowException])
+    )(using Frame, Tag[Unit], Schema[Unit]): Flow[In, Out & (N ~ V), S & S2] =
+        loopCompensated[N, Unit, V, S2](name, (), Meta(description, tags, timeout, retry))((_, ctx) => body(ctx))(compensate)
+
+    /** Like the one-state [[loop]], but registers a node-level compensation handler. See [[loopCompensated]]. */
+    def loopCompensated[N <: String & Singleton, A: Tag: Schema, V: Tag: Schema, S2](
+        name: N,
+        init: A,
+        meta: Meta
+    )(
+        body: (A, Record[Out]) => Loop.Outcome[A, V] < S2
+    )(
+        compensate: Record[Out & (N ~ V)] => Unit < (S2 & Async & Abort[FlowException])
+    )(using Frame): Flow[In, Out & (N ~ V), S & S2] =
+        AndThen(this, LoopNode[Out, N, A, V, S2](name, body, init, Maybe.empty, meta, Maybe(handlerOf(compensate))))
+
+    /** Like the two-state [[loop]], but registers a node-level compensation handler. See [[loopCompensated]]. */
+    def loopCompensated[N <: String & Singleton, A: Tag: Schema, B: Tag: Schema, V: Tag: Schema, S2](
+        name: N,
+        init1: A,
+        init2: B,
+        meta: Meta
+    )(
+        body: (A, B, Record[Out]) => Loop.Outcome2[A, B, V] < S2
+    )(
+        compensate: Record[Out & (N ~ V)] => Unit < (S2 & Async & Abort[FlowException])
+    )(using Frame, Tag[(A, B)], Schema[(A, B)]): Flow[In, Out & (N ~ V), S & S2] =
+        AndThen(
+            this,
+            LoopNode[Out, N, (A, B), V, S2](
+                name,
+                (state, ctx) => body(state._1, state._2, ctx),
+                (init1, init2),
+                Maybe.empty,
+                meta,
+                Maybe(handlerOf(compensate))
+            )
+        )
+
+    /** Process each element of a collection and store all results as a `Chunk[V]` output, in collection order.
+      *
+      * #### The item is the durable unit
+      *
+      * Each item's result is recorded under the item's own durable name as it completes, `charges~0`, `charges~1` and so on, and the
+      * node's own `Chunk[V]` is assembled from them and written when the last one lands. An execution that dies with 40 of 50 items
+      * recorded resumes at item 41: the items already recorded are read back instead of run again, so a fan-out that charges N cards
+      * charges each of them once however many attempts recovery takes. The item that was in flight when the process died is the one
+      * exception, and it is the same window every step has: it re-runs, which is what its body is required to be idempotent for. What
+      * this costs is N field writes for a fan-out of N, which is the price of the guarantee.
+      *
+      * #### What the collection owes
+      *
+      * The collection must be a deterministic function of the record. An attempt that re-enters a fan-out recomputes it wherever it
+      * still needs the items, because that is what names the items the recorded results belong to, and the count the fan-out started
+      * with is recorded beside them: a recomputed collection whose size disagrees with that count fails the node with
+      * [[kyo.FlowNondeterministicCollectionException]], naming the node, the count it recorded and the size it recomputed. It is the
+      * obligation a step body already carries one level down, and here it is checked rather than assumed.
+      *
+      * #### The knobs
+      *
+      * `timeout` bounds ONE item and `retry` re-asks one item that failed for an accidental reason, leaving the items already recorded
+      * exactly as they are. A bound over the whole fan-out cannot be sized for the single slow item, which is the one thing a caller
+      * bounds.
+      *
+      * `concurrency` bounds how many items are in flight at once. It defaults to unbounded, so the items of a fan-out run in parallel
+      * unless the caller says otherwise; a value of 1 processes them one at a time. Results are ordered by the collection rather than by
+      * completion, whatever the bound is.
+      *
+      * Items above a bound of 1 run in their own fibers. `Sync`, `Async` and `Abort` bodies need nothing for that, and neither does a
+      * body reading a context effect such as `Env`, which the kernel carries into a fiber. A body carrying an effect whose state has to
+      * be merged back, `Var` or `Emit`, has no per-item state to merge here and should declare `concurrency = 1`.
+      *
+      * The node persists the whole `Chunk[V]`, under the evidence for `Chunk[V]` rather than for `V`, so `store.getField[Chunk[V]]` reads
+      * back what the fan-out produced.
+      */
     def foreach[N <: String & Singleton, E, V, S2](
         name: N,
         description: String = "",
@@ -226,8 +370,58 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
         collection: Record[Out] => Seq[E] < S2
     )(
         body: E => V < S2
-    )(using Frame, Tag[V], Schema[V]): Flow[In, Out & (N ~ Chunk[V]), S & S2] =
-        AndThen(this, ForEach(name, concurrency, collection, body, Meta(description, tags, timeout, retry)))
+    )(using
+        Frame,
+        Tag[V],
+        Schema[V],
+        Tag[Chunk[V]]
+    ): Flow[In, Out & (N ~ Chunk[V]), S & S2] =
+        // The evidence is captured HERE, where `V` is still concrete. The node is erased before the interpreter sees it, and
+        // neither `Tag[Chunk[V]]` nor the item's own `Tag[V]` can be rebuilt from a tag that has been erased to `Tag[Any]`.
+        AndThen(this, ForEach(name, concurrency, collection, body, Meta(description, tags, timeout, retry), Maybe.empty))
+
+    /** Like [[foreach]], but registers a compensation handler per ITEM, which runs (in reverse order) if a later step fails.
+      *
+      * The handler receives an item and what that item produced, and it is registered as each item completes, so a fan-out that failed
+      * part-way unwinds over exactly the items that ran: a run that charged three of five cards refunds three. That is why the handler
+      * belongs to the item rather than to the node. A node-level handler receives the node's stored value, and a fan-out's value exists
+      * only once every item has landed, so it would have nothing to hand a handler at the one moment unwinding matters.
+      *
+      * A resumed fan-out registers a handler for the items it read back as well as for the ones it ran, because an item recorded by an
+      * earlier attempt did its work just as much. The one case that registers nothing is a detected nondeterministic collection: a
+      * fan-out whose recomputed collection changed size cannot say which item produced which recorded result, so it fails naming the
+      * mismatch instead of pairing them, and the items that ran are reported by that failure rather than undone by a guess.
+      *
+      * Handlers run in reverse order of registration, as every compensation does, and a fan-out's items register in the order they
+      * complete rather than the order they were listed. So the order among ONE fan-out's items is a scheduling fact and not something
+      * to depend on, which is the same independence between items that makes a per-item handler the right shape in the first place. A
+      * fan-out whose items must be undone in a particular order is a batch, and its handler belongs on the node that owns the batch.
+      *
+      * See [[outputCompensated]] for the effect row the handler carries and why it is the body's own.
+      */
+    def foreachCompensated[N <: String & Singleton, E, V, S2](
+        name: N,
+        description: String = "",
+        timeout: Duration = Duration.Infinity,
+        retry: Maybe[Schedule] = Maybe.empty,
+        tags: Seq[String] = Seq.empty,
+        concurrency: Int = Int.MaxValue
+    )(
+        collection: Record[Out] => Seq[E] < S2
+    )(
+        body: E => V < S2
+    )(
+        compensate: (E, V) => Unit < (S2 & Async & Abort[FlowException])
+    )(using
+        Frame,
+        Tag[V],
+        Schema[V],
+        Tag[Chunk[V]]
+    ): Flow[In, Out & (N ~ Chunk[V]), S & S2] =
+        AndThen(
+            this,
+            ForEach(name, concurrency, collection, body, Meta(description, tags, timeout, retry), Maybe(itemHandlerOf(compensate)))
+        )
 
     /** Execute a child flow as a sub-workflow. The `inputMapper` transforms the current context into the child's input record. The child's
       * output record is stored as a named field.
@@ -245,6 +439,24 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
 
     /** Loop on a schedule without state. Between iterations, the flow durably sleeps for the delay returned by `Schedule.next`. The body
       * returns `Loop.continue` to iterate or `Loop.done(value)` to finish.
+      *
+      * #### What a schedule buys beyond waiting
+      *
+      * Every iteration is checkpointed: the state a continuing iteration carries and the value a finishing one produces are both recorded
+      * under the iteration's own durable name before the loop moves on. An execution that dies mid-loop resumes at the iteration after the
+      * last one recorded, with that iteration's state, rather than starting over as the unscheduled [[loop]] does. A schedule of zero
+      * delays (`Schedule.fixed(Duration.Zero)`) is how to get the checkpointing with no waiting at all.
+      *
+      * #### When the schedule runs out
+      *
+      * A schedule with no delay left ends the execution as `Failed`, naming the loop and the iterations it ran. A flow declaring `N ~ V`
+      * promises a `V`, and a loop whose schedule is spent has none: the last state it carried is the loop's own state type, and nothing is
+      * written under the loop's name. Give the schedule more room than the body needs, or make the body return `Loop.done`.
+      *
+      * #### The knobs
+      *
+      * `timeout` bounds ONE iteration and `retry` re-asks one iteration that failed for an accidental reason, both of them the iteration's
+      * own body rather than the loop's whole convergence.
       */
     def loopOn[N <: String & Singleton, V: Tag: Schema, S2](
         name: N,
@@ -256,12 +468,11 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
     )(
         body: Record[Out] => Loop.Outcome[Unit, V] < S2
     )(using Frame, Tag[Unit], Schema[Unit]): Flow[In, Out & (N ~ V), S & S2] =
-        AndThen(
-            this,
-            LoopNode[Out, N, Unit, V, S2](name, (_, ctx) => body(ctx), (), Maybe(schedule), Meta(description, tags, timeout, retry))
-        )
+        loopOn[N, Unit, V, S2](name, schedule, (), Meta(description, tags, timeout, retry))((_, ctx) => body(ctx))
 
-    /** Loop on a schedule with 1 state value. Between iterations, the flow durably sleeps for the delay from `Schedule.next`. */
+    /** Loop on a schedule with 1 state value. Between iterations, the flow durably sleeps for the delay from `Schedule.next`, and the state
+      * the next iteration starts from is recorded with the iteration that produced it.
+      */
     def loopOn[N <: String & Singleton, A: Tag: Schema, V: Tag: Schema, S2](
         name: N,
         schedule: Schedule,
@@ -269,10 +480,22 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
     )(
         body: (A, Record[Out]) => Loop.Outcome[A, V] < S2
     )(using Frame): Flow[In, Out & (N ~ V), S & S2] =
-        AndThen(
-            this,
-            LoopNode[Out, N, A, V, S2](name, body, init, Maybe(schedule), Meta())
-        )
+        loopOn[N, A, V, S2](name, schedule, init, Meta())(body)
+
+    /** Loop on a schedule with 1 state value under a declared `description`, `timeout`, `retry` and `tags`.
+      *
+      * The knobs arrive as a [[Meta]] rather than as four defaulted parameters because Scala allows only one overload of a name to define
+      * default arguments, and the stateless [[loopOn]] is that overload.
+      */
+    def loopOn[N <: String & Singleton, A: Tag: Schema, V: Tag: Schema, S2](
+        name: N,
+        schedule: Schedule,
+        init: A,
+        meta: Meta
+    )(
+        body: (A, Record[Out]) => Loop.Outcome[A, V] < S2
+    )(using Frame): Flow[In, Out & (N ~ V), S & S2] =
+        AndThen(this, LoopNode[Out, N, A, V, S2](name, body, init, Maybe(schedule), meta, Maybe.empty))
 
     /** Loop on a schedule with 2 state values. Between iterations, the flow durably sleeps for the delay from `Schedule.next`. */
     def loopOn[N <: String & Singleton, A: Tag: Schema, B: Tag: Schema, V: Tag: Schema, S2](
@@ -283,14 +506,95 @@ sealed abstract class Flow[In, Out, S] derives CanEqual:
     )(
         body: (A, B, Record[Out]) => Loop.Outcome2[A, B, V] < S2
     )(using Frame, Tag[(A, B)], Schema[(A, B)]): Flow[In, Out & (N ~ V), S & S2] =
+        loopOn[N, A, B, V, S2](name, schedule, init1, init2, Meta())(body)
+
+    /** Loop on a schedule with 2 state values under a declared `description`, `timeout`, `retry` and `tags`. See the one-state [[loopOn]]
+      * overload for why the knobs arrive as a [[Meta]].
+      */
+    def loopOn[N <: String & Singleton, A: Tag: Schema, B: Tag: Schema, V: Tag: Schema, S2](
+        name: N,
+        schedule: Schedule,
+        init1: A,
+        init2: B,
+        meta: Meta
+    )(
+        body: (A, B, Record[Out]) => Loop.Outcome2[A, B, V] < S2
+    )(using Frame, Tag[(A, B)], Schema[(A, B)]): Flow[In, Out & (N ~ V), S & S2] =
         AndThen(
             this,
-            LoopNode[Out, N, (A, B), V, S2](name, (state, ctx) => body(state._1, state._2, ctx), (init1, init2), Maybe(schedule), Meta())
+            LoopNode[Out, N, (A, B), V, S2](
+                name,
+                (state, ctx) => body(state._1, state._2, ctx),
+                (init1, init2),
+                Maybe(schedule),
+                meta,
+                Maybe.empty
+            )
+        )
+
+    /** Like the stateless [[loopOn]], but registers a node-level compensation handler. See [[loopCompensated]]. */
+    def loopOnCompensated[N <: String & Singleton, V: Tag: Schema, S2](
+        name: N,
+        schedule: Schedule,
+        description: String = "",
+        timeout: Duration = Duration.Infinity,
+        retry: Maybe[Schedule] = Maybe.empty,
+        tags: Seq[String] = Seq.empty
+    )(
+        body: Record[Out] => Loop.Outcome[Unit, V] < S2
+    )(
+        compensate: Record[Out & (N ~ V)] => Unit < (S2 & Async & Abort[FlowException])
+    )(using Frame, Tag[Unit], Schema[Unit]): Flow[In, Out & (N ~ V), S & S2] =
+        loopOnCompensated[N, Unit, V, S2](name, schedule, (), Meta(description, tags, timeout, retry))((_, ctx) => body(ctx))(compensate)
+
+    /** Like the one-state [[loopOn]], but registers a node-level compensation handler. See [[loopCompensated]]. */
+    def loopOnCompensated[N <: String & Singleton, A: Tag: Schema, V: Tag: Schema, S2](
+        name: N,
+        schedule: Schedule,
+        init: A,
+        meta: Meta
+    )(
+        body: (A, Record[Out]) => Loop.Outcome[A, V] < S2
+    )(
+        compensate: Record[Out & (N ~ V)] => Unit < (S2 & Async & Abort[FlowException])
+    )(using Frame): Flow[In, Out & (N ~ V), S & S2] =
+        AndThen(this, LoopNode[Out, N, A, V, S2](name, body, init, Maybe(schedule), meta, Maybe(handlerOf(compensate))))
+
+    /** Like the two-state [[loopOn]], but registers a node-level compensation handler. See [[loopCompensated]]. */
+    def loopOnCompensated[N <: String & Singleton, A: Tag: Schema, B: Tag: Schema, V: Tag: Schema, S2](
+        name: N,
+        schedule: Schedule,
+        init1: A,
+        init2: B,
+        meta: Meta
+    )(
+        body: (A, B, Record[Out]) => Loop.Outcome2[A, B, V] < S2
+    )(
+        compensate: Record[Out & (N ~ V)] => Unit < (S2 & Async & Abort[FlowException])
+    )(using Frame, Tag[(A, B)], Schema[(A, B)]): Flow[In, Out & (N ~ V), S & S2] =
+        AndThen(
+            this,
+            LoopNode[Out, N, (A, B), V, S2](
+                name,
+                (state, ctx) => body(state._1, state._2, ctx),
+                (init1, init2),
+                Maybe(schedule),
+                meta,
+                Maybe(handlerOf(compensate))
+            )
         )
 
     // --- Composition ---
 
-    /** Execute two flows in parallel and merge their outputs. Both must complete. */
+    /** Execute two flows in parallel and merge their outputs. Both must complete.
+      *
+      * Each branch runs in its own fiber, and the `Isolate` is what carries a custom effect row across that boundary: it is
+      * captured here, at the only site where the combined row is still visible, each branch runs against the captured state, and
+      * completed branches are restored into the caller's context. Pure and `Async` rows derive an isolate automatically. A
+      * stateful row needs one in scope, such as `Var.isolate.update`, and a row no isolate can be built for does not compose,
+      * deliberately: refusing at the call site is what keeps a branch from suspending inside a fiber that cannot handle its
+      * effects. A body that needs such an effect can handle it inside its own step instead.
+      */
     def zip[In2, Out2, S2](other: Flow[In2, Out2, S2])(using
         Frame,
         Isolate[S & S2, Abort[FlowException] & Async, S & S2]
@@ -320,9 +624,7 @@ object Flow:
         version: String = "",
         tags: Seq[String] = Seq.empty
     )(using Frame): Flow[Any, Any, Any] =
-        require(name != null && name.nonEmpty, "Flow name must not be null or empty")
         internal.Init(name, Meta(description = description, version = version, tags = tags))
-    end init
 
     /** Start building a flow with a named input. Shorthand for `Flow.init(name).input[V](inputName)`. */
     def input[V](using
@@ -344,35 +646,47 @@ object Flow:
       * Flow.runServer(orderFlow, shippingFlow)
       * ```
       */
-    def runServer(flows: Flow[?, ?, ?]*)(using Frame): HttpServer < (Async & Scope & Abort[HttpBindException]) =
+    def runServer(flows: Flow[?, ?, ?]*)(using
+        Frame
+    ): HttpServer < (Async & Scope & Abort[HttpBindException | FlowDefinitionException | FlowStoreException]) =
         FlowStore.initMemory.map(store => runServer(store, flows*))
 
     def runServer[S](flows: Flow[?, ?, S]*)(
         runner: [V] => V < S => V < (Async & Scope & Abort[FlowException])
-    )(using Frame): HttpServer < (Async & Scope & Abort[HttpBindException]) =
+    )(using Frame): HttpServer < (Async & Scope & Abort[HttpBindException | FlowDefinitionException | FlowStoreException]) =
         FlowStore.initMemory.map(store => runServer(store, flows*)(runner))
 
     /** Start an HTTP server backed by a specific store. */
-    def runServer(store: FlowStore, flows: Flow[?, ?, ?]*)(using Frame): HttpServer < (Async & Scope & Abort[HttpBindException]) =
+    def runServer(store: FlowStore, flows: Flow[?, ?, ?]*)(using
+        Frame
+    ): HttpServer < (Async & Scope & Abort[HttpBindException | FlowDefinitionException | FlowStoreException]) =
         runHandlers(store, flows*).map(h => HttpServer.init(h.toSeq*))
 
     def runServer[S](store: FlowStore, flows: Flow[?, ?, S]*)(
         runner: [V] => V < S => V < (Async & Scope & Abort[FlowException])
-    )(using Frame): HttpServer < (Async & Scope & Abort[HttpBindException]) =
+    )(using Frame): HttpServer < (Async & Scope & Abort[HttpBindException | FlowDefinitionException | FlowStoreException]) =
         runHandlers(store, flows*)(runner).map(h => HttpServer.init(h.toSeq*))
 
     /** Get HTTP handlers without starting a server. Compose with your own endpoints. */
-    def runHandlers(store: FlowStore, flows: Flow[?, ?, ?]*)(using Frame): Chunk[HttpHandler[?, ?, ?]] < (Async & Scope) =
+    def runHandlers(store: FlowStore, flows: Flow[?, ?, ?]*)(using
+        Frame
+    ): Chunk[HttpHandler[?, ?, ?]] < (Async & Scope & Abort[FlowDefinitionException | FlowStoreException]) =
         FlowEngine.initImpl(store, flows = flows).map(engine => kyo.internal.FlowApi.handlers(engine))
 
     def runHandlers[S](store: FlowStore, flows: Flow[?, ?, S]*)(
         runner: [V] => V < S => V < (Async & Scope & Abort[FlowException])
-    )(using Frame): Chunk[HttpHandler[?, ?, ?]] < (Async & Scope) =
+    )(using Frame): Chunk[HttpHandler[?, ?, ?]] < (Async & Scope & Abort[FlowDefinitionException | FlowStoreException]) =
         FlowEngine.initImpl(store, flows = flows, runner = Maybe(FlowRunner[S](runner)))
             .map(engine => kyo.internal.FlowApi.handlers(engine))
 
-    /** Get HTTP handlers from an existing engine. */
-    def runHandlers(engine: FlowEngine)(using Frame): Chunk[HttpHandler[?, ?, ?]] =
+    /** Get HTTP handlers from an existing engine.
+      *
+      * Answers a pending value, like its two siblings above, rather than a bare `Chunk`. The three are written next to each other in the
+      * same for-comprehension, and a bare `Chunk` binds there over `Chunk`'s own `flatMap`: `handlers <- Flow.runHandlers(engine)` would
+      * give one handler per iteration and run the rest of the comprehension once per handler, quietly changing what the program does. A
+      * type error catches that only when the body's types disagree, which is not the case for a body generic in its element.
+      */
+    def runHandlers(engine: FlowEngine)(using Frame): Chunk[HttpHandler[?, ?, ?]] < Any =
         kyo.internal.FlowApi.handlers(engine)
 
     /** Execute a flow locally with an in-memory store. Blocks until the flow completes and returns the full output record.
@@ -383,7 +697,7 @@ object Flow:
     def runLocal[In, Out](
         flow: Flow[In, Out, ?],
         inputs: Record[In] = Record.empty
-    )(using Frame): Record[In & Out] < (Async & Scope & Abort[FlowException]) =
+    )(using Frame): Record[In & Out] < (Async & Scope & Abort[FlowException | FlowStoreException]) =
         runLocalImpl(flow, inputs, Maybe.empty)
 
     /** Execute a flow locally with a runner that handles custom effects.
@@ -400,27 +714,27 @@ object Flow:
         inputs: Record[In]
     )(runner: [V] => V < S => V < (Async & Scope & Abort[FlowException]))(using
         Frame
-    ): Record[In & Out] < (Async & Scope & Abort[FlowException]) =
+    ): Record[In & Out] < (Async & Scope & Abort[FlowException | FlowStoreException]) =
         runLocalImpl(flow, inputs, Maybe(FlowRunner[S](runner)))
 
     private def runLocalImpl[In, Out](
         flow: Flow[In, Out, ?],
         inputs: Record[In],
         runner: Maybe[FlowRunner]
-    )(using Frame): Record[In & Out] < (Async & Scope & Abort[FlowException]) =
+    )(using Frame): Record[In & Out] < (Async & Scope & Abort[FlowException | FlowStoreException]) =
         FlowStore.initMemory.map { store =>
-            FlowEngine.initImpl(store, workerCount = 1, pollTimeout = 100.millis).map { engine =>
+            FlowEngine.initImpl(store, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis)).map { engine =>
                 val wfId = Flow.Id.Workflow("_local")
                 engine.registerImpl(wfId, flow, runner).map { _ =>
                     engine.workflows.start(wfId, inputs.asInstanceOf[Record[Any]]).map { handle =>
                         val eid = handle.executionId
-                        def await: Record[In & Out] < (Async & Abort[FlowException]) =
+                        def await: Record[In & Out] < (Async & Abort[FlowException | FlowStoreException]) =
                             Async.sleep(10.millis).map { _ =>
                                 store.getExecution(eid).map {
                                     case Present(state) if state.status == Flow.Status.Completed =>
                                         store.getAllFields(eid).map { fields =>
                                             val schema = WorkflowSchema.of(flow)
-                                            val dict = fields.foldLeft(Dict.empty[String, Any]) { (acc, name, fd) =>
+                                            val decoded = fields.foldLeft(Dict.empty[String, Any]) { (acc, name, fd) =>
                                                 schema.fromStoreName(name) match
                                                     case Present(entry) =>
                                                         entry.decode(fd) match
@@ -428,11 +742,19 @@ object Flow:
                                                             case _          => acc
                                                     case _ => acc
                                             }
-                                            new Record[In & Out](dict)
+                                            // A subflow's own field is promised by the returned record's type and persisted by
+                                            // nobody: the node writes nothing under its name and the child's nodes write under its
+                                            // path, which is what makes two instances of one subflow two sets of fields. So the
+                                            // reader that hands back a `Record[In & Out]` is the one that puts them together, and
+                                            // it asks the schema, which carries an assembly entry per subflow instance.
+                                            val assembled = schema.subflows.foldLeft(decoded) { (acc, subflow) =>
+                                                acc.update(subflow.name, subflow.assemble(decoded))
+                                            }
+                                            new Record[In & Out](assembled)
                                         }
                                     case Present(state) =>
                                         state.status match
-                                            case Flow.Status.Failed(err) =>
+                                            case Flow.Status.Failed(err, _) =>
                                                 Abort.fail(FlowExecutionFailedException(eid.value, err))
                                             case Flow.Status.Cancelled =>
                                                 Abort.fail(FlowCancelledException(eid.value))
@@ -449,7 +771,14 @@ object Flow:
 
     // --- Combinators ---
 
-    /** Race two flows — the first to complete wins, the other is cancelled. Output type is the union of both flows' outputs. */
+    /** Race two flows: the first to complete wins, the other is cancelled. Output type is the union of both flows' outputs.
+      *
+      * Each branch runs in its own fiber, and the `Isolate` is what carries a custom effect row across that boundary: it is
+      * captured here, at the only site where the combined row is still visible, and the winning branch's effects are restored
+      * into the caller's context while the cancelled branch's are discarded with it. Pure and `Async` rows derive an isolate
+      * automatically; a stateful row needs one in scope, such as `Var.isolate.update`, and a row no isolate can be built for
+      * does not compose, deliberately. A body that needs such an effect can handle it inside its own step instead.
+      */
     def race[In1, Out1, S1, In2, Out2, S2](left: Flow[In1, Out1, S1], right: Flow[In2, Out2, S2])(
         using
         Frame,
@@ -457,7 +786,13 @@ object Flow:
     ): Flow[In1 & In2, Out1 | Out2, S1 & S2] =
         internal.Race(left, right)
 
-    /** Execute multiple flows in parallel and merge all their outputs. All branches must complete. */
+    /** Execute multiple flows in parallel and merge all their outputs. All branches must complete.
+      *
+      * The branches run in their own fibers, and the `Isolate` carries a custom effect row across that boundary the same way
+      * [[zip]]'s does: captured here, restored per completed branch. Pure and `Async` rows derive an isolate automatically; a
+      * stateful row needs one in scope, and a row no isolate can be built for does not compose, deliberately. A body that needs
+      * such an effect can handle it inside its own step instead.
+      */
     def gather[In1, Out1, S1, In2, Out2, S2](f1: Flow[In1, Out1, S1], f2: Flow[In2, Out2, S2])(
         using
         Frame,
@@ -546,8 +881,9 @@ object Flow:
     /** Per-node metadata for flow steps.
       *
       * @param timeout
-      *   Per-attempt timeout. If a single attempt exceeds this duration, it fails with a timeout error. Also used as in-flight fencing: how
-      *   long a new executor waits for a competing executor's in-progress step before re-executing.
+      *   Per-attempt timeout. If a single attempt exceeds this duration, it fails with a timeout error. It bounds this executor's own
+      *   attempt only: a node whose previous executor died mid-step is re-executed by the executor that reclaims the lease, never waited
+      *   on, because an execution is handed out only once no other executor holds a live lease on it.
       * @param retry
       *   Retry schedule for transient failures. When present, the engine retries the step computation according to the schedule's delays.
       *   When the schedule exhausts, the last error propagates. Each attempt is independently timed by `timeout`.
@@ -561,7 +897,8 @@ object Flow:
     ) derives Schema
     object Meta
 
-    case class BranchInfo(name: String, frame: Frame, meta: Meta)
+    /** What a dispatch's branch tells a walk about itself, carried to [[kyo.internal.FlowVisitor.onDispatch]] and nowhere else. */
+    private[kyo] case class BranchInfo(name: String, frame: Frame, meta: Meta)
 
     // --- Diagram format ---
 
@@ -582,46 +919,89 @@ object Flow:
                 case _         => DiagramFormat.Mermaid
     end DiagramFormat
 
+    // --- Wake ---
+
+    /** What a waiting node is waiting FOR, as the store records it on that node's wait row.
+      *
+      * A row exists because a node is waiting for something, so the only cases are things a node can wait for. There is no case for "the
+      * lifecycle is runnable" and none for "the execution is over": those are the lifecycle status, which readiness reads directly, and a
+      * row could never carry one, leaving a predicate somewhere to agree that it does not.
+      *
+      * Both conditions are judged by the STORE against its own state, never by the caller: the store is the clock for a sleep, and it is
+      * the one that holds the fields for an input.
+      *
+      * @see
+      *   [[kyo.FlowStore.recordWait]] which writes a row, and [[kyo.FlowStore.ExecutionState.waits]] which reads them back
+      */
+    enum Wake derives CanEqual, Schema:
+
+        /** A durable sleep, satisfied once the store's clock has passed `instant`. */
+        case At(instant: Instant)
+
+        /** A wait for an input, satisfied once the field `name` is present on the execution. */
+        case OnField(name: String)
+    end Wake
+
     // --- Status ---
 
+    /** Why an execution is unwinding, carried by [[Status.Compensating]] and by [[Event.CompensationStarted]].
+      *
+      * An unwind that crashes has to be re-enterable, and re-entering means knowing what it was unwinding FROM. Without that the only
+      * recovery left is to replay forward and hope the failing step fails again, which for a transient failure means the execution
+      * continues and COMPLETES with some of its compensations already run and the work they undid still undone.
+      *
+      * Two arms rather than an empty-message convention on one: a cancellation and a failure with no message are different facts, and the
+      * terminal status the unwind ends with is a total function of this value.
+      */
+    enum Cause derives CanEqual, Schema:
+
+        /** The forward pass failed. `kind` is [[FlowException.kind]] where the engine had one, as on [[Status.Failed]]. */
+        case Failure(error: String, kind: Maybe[String] = Maybe.empty)
+
+        /** Somebody asked for the execution to be cancelled. */
+        case Cancellation
+    end Cause
+
+    /** The persisted LIFECYCLE of an execution, and nothing else.
+      *
+      * `Running` spans working and waiting: what an execution is waiting FOR is plural (a `race` of an input against a sleep waits for
+      * both at once) and lives on the execution's wait rows, where a reader finds it through [[kyo.FlowEngine.executions.describe]].
+      * A single token could only answer one of two simultaneous waits, and any tiebreak hides the other.
+      */
     enum Status derives CanEqual, Schema:
         case Running
-        case WaitingForInput(name: String)
-        case Sleeping(name: String, until: Instant)
         case Completed
-        case Failed(error: String)
-        case Compensating
+
+        /** The execution failed. `kind` names what kind of failure it was, from [[FlowException.kind]] where the engine had one.
+          *
+          * The persisted shape of a failure is what an operator queries, and a message alone makes "how many failed for payment reasons"
+          * a LIKE over free text. A step's own [[FlowDomainException]] therefore lands its class name here, next to the message.
+          */
+        case Failed(error: String, kind: Maybe[String] = Maybe.empty)
+
+        /** The execution is running its compensation handlers, undoing what `cause` interrupted. */
+        case Compensating(cause: Cause)
         case Cancelled
 
         def show: String = this match
-            case Running               => "running"
-            case WaitingForInput(name) => s"waiting:$name"
-            case Sleeping(name, until) => s"sleeping:$name"
-            case Completed             => "completed"
-            case Failed(error)         => s"failed:$error"
-            case Compensating          => "compensating"
-            case Cancelled             => "cancelled"
+            case Running          => "running"
+            case Completed        => "completed"
+            case Failed(error, _) => s"failed:$error"
+            case Compensating(_)  => "compensating"
+            case Cancelled        => "cancelled"
 
         def isTerminal: Boolean = this match
-            case Completed | Failed(_) | Cancelled => true
-            case _                                 => false
-
-        def isSleeping: Boolean = this match
-            case _: Sleeping => true
-            case _           => false
-
-        def isWaitingForInput: Boolean = this match
-            case _: WaitingForInput => true
-            case _                  => false
+            case Completed | Failed(_, _) | Cancelled => true
+            case _                                    => false
     end Status
 
     // --- Event ---
 
     enum EventKind derives Schema:
-        case Created, StepStarted, StepCompleted, StepRetried, StepTimedOut,
-            InputWaiting, InputReceived, SleepStarted, SleepCompleted,
-            ExecutionResumed, ExecutionClaimed, ExecutionReleased,
-            Completed, Failed, CompensationStarted, CompensationCompleted, CompensationFailed, Cancelled
+        case Created, StepStarted, StepCompleted, StepFailed, StepRetried, StepTimedOut,
+            InputWaiting, InputReceived, InputDischarged, InputSupplied, SleepStarted, SleepCompleted,
+            BranchChosen, ExecutionResumed, ExecutionClaimed, ExecutionReleased,
+            Completed, Failed, CompensationStarted, CompensationCompleted, CompensationFailed, NodeCompensated, Cancelled
     end EventKind
 
     enum Event derives Schema:
@@ -648,11 +1028,67 @@ object Flow:
             timestamp: Instant
         )
         case SleepCompleted(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, stepName: String, timestamp: Instant)
+
+        /** A dispatch entered a branch, recorded before the branch ran. See [[kyo.internal.FlowInterpreter.onChoice]].
+          *
+          * Replay reads the choice from the field the same write left behind, never from this event: history is what an operator reads
+          * to see which way a row went, and deciding control flow from it would make an execution's future depend on how much of its
+          * history a store chose to return.
+          */
+        case BranchChosen(
+            flowId: Flow.Id.Workflow,
+            executionId: Flow.Id.Execution,
+            dispatchName: String,
+            branchName: String,
+            timestamp: Instant
+        )
         case Completed(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, timestamp: Instant)
         case Failed(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, error: String, timestamp: Instant)
-        case CompensationStarted(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, timestamp: Instant)
+
+        /** The unwind began, carrying what it is unwinding from.
+          *
+          * The cause is on the event AND on [[Status.Compensating]], because the two have different readers: replay decides control flow
+          * from the durable status, and an operator reads the history. A cause in only one of them leaves the other unable to answer.
+          */
+        case CompensationStarted(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, cause: Cause, timestamp: Instant)
         case CompensationCompleted(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, timestamp: Instant)
         case CompensationFailed(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, error: String, timestamp: Instant)
+
+        /** One node's compensation handler ran to completion.
+          *
+          * Per NODE, where [[CompensationStarted]], [[CompensationCompleted]] and [[CompensationFailed]] are per UNWIND. An unwind that
+          * is interrupted part-way leaves some handlers run and some not, and only a per-node record can tell them apart, which is what
+          * a recovered execution reads to re-run exactly the handlers that never landed.
+          */
+        case NodeCompensated(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, nodeName: String, timestamp: Instant)
+
+        /** One node's work ended in a failure the attempt did not recover from, recorded under the node's own name.
+          *
+          * **The record exists so a reader does not have to guess which node failed.** The lifecycle carries the message and the
+          * kind but no name, and deriving the name from what is missing (a `StepStarted` with no `StepCompleted`) names the wrong node
+          * for an interrupted step, for a branch abandoned when its sibling failed, and for the earlier attempt of a step that was
+          * re-run after a crash. A progress view built on that guess reports a failure on a node that did not fail, which is the
+          * instrument lying about the thing it exists to measure.
+          *
+          * Written for a failure of the WORK: a declared [[FlowException]] carries its `kind`, and an escaped throwable carries none,
+          * because the class name of something that escaped is not a category anybody declared. A store failure writes nothing here,
+          * since it is not a verdict on the step and the execution stays exactly as claimable as it was, and neither does an interrupt,
+          * since an attempt that was told to stop has reached no verdict at all.
+          *
+          * A later `StepCompleted` on the same name supersedes it: a step that failed on one attempt and succeeded on the next is
+          * completed, and the reader takes the last word rather than the first.
+          *
+          * `errorKind` rather than `kind`, which every event already answers with its own [[EventKind]]. It is the same value
+          * [[Status.Failed.kind]] carries, so "which node failed, and for what kind of reason" is one read of the history.
+          */
+        case StepFailed(
+            flowId: Flow.Id.Workflow,
+            executionId: Flow.Id.Execution,
+            stepName: String,
+            error: String,
+            errorKind: Maybe[String],
+            timestamp: Instant
+        )
         case StepRetried(
             flowId: Flow.Id.Workflow,
             executionId: Flow.Id.Execution,
@@ -668,6 +1104,27 @@ object Flow:
         case ExecutionReleased(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, executorId: Flow.Id.Executor, timestamp: Instant)
         case Cancelled(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, timestamp: Instant)
 
+        /** An input node found its value and went on, which is the transition that clears the wait row it had written.
+          *
+          * The node's own completion, and distinct from [[InputReceived]], which is the value ARRIVING through `signal` on the other
+          * side. A delivery and a consumption are two facts, and one event cannot stand for both: the value can arrive long before an
+          * executor replays far enough to use it, and it can arrive for a node the execution never reaches.
+          */
+        case InputDischarged(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, inputName: String, timestamp: Instant)
+
+        /** A subflow's input mapper supplied a child input's value, recorded at entry before the child's first node ran.
+          *
+          * The third way a value reaches an input, and the three stay distinguishable in history: a start seed leaves the field and
+          * no input event at all, a `signal` leaves [[InputWaiting]], [[InputReceived]] and [[InputDischarged]], and a mapper leaves
+          * exactly one of these. `inputName` is the child input's durable path (`review~amount`), which is where the value was
+          * written; the field and this event are one transition, so a reader of the history and replay reading the field never
+          * disagree about whether the child ran against a recorded value.
+          *
+          * Not [[InputDischarged]], which is the node's own consumption of a value it waited for. A mapper-fed input never parks, so
+          * it has no wait row to clear, and writing a discharge here would put a consumption record before the node was reached.
+          */
+        case InputSupplied(flowId: Flow.Id.Workflow, executionId: Flow.Id.Execution, inputName: String, timestamp: Instant)
+
         def kind: EventKind = this match
             case _: Created               => EventKind.Created
             case _: StepStarted           => EventKind.StepStarted
@@ -676,27 +1133,37 @@ object Flow:
             case _: InputReceived         => EventKind.InputReceived
             case _: SleepStarted          => EventKind.SleepStarted
             case _: SleepCompleted        => EventKind.SleepCompleted
+            case _: BranchChosen          => EventKind.BranchChosen
             case _: Completed             => EventKind.Completed
             case _: Failed                => EventKind.Failed
             case _: CompensationStarted   => EventKind.CompensationStarted
             case _: CompensationCompleted => EventKind.CompensationCompleted
             case _: CompensationFailed    => EventKind.CompensationFailed
+            case _: NodeCompensated       => EventKind.NodeCompensated
+            case _: StepFailed            => EventKind.StepFailed
             case _: StepRetried           => EventKind.StepRetried
             case _: StepTimedOut          => EventKind.StepTimedOut
             case _: ExecutionResumed      => EventKind.ExecutionResumed
             case _: ExecutionClaimed      => EventKind.ExecutionClaimed
             case _: ExecutionReleased     => EventKind.ExecutionReleased
             case _: Cancelled             => EventKind.Cancelled
+            case _: InputDischarged       => EventKind.InputDischarged
+            case _: InputSupplied         => EventKind.InputSupplied
 
         def detail: String = this match
             case StepStarted(_, _, name, _, _)           => name
             case StepCompleted(_, _, name, _)            => name
             case InputWaiting(_, _, name, _)             => name
             case InputReceived(_, _, name, _)            => name
+            case InputDischarged(_, _, name, _)          => name
+            case InputSupplied(_, _, name, _)            => name
             case SleepStarted(_, _, name, _, _)          => name
             case SleepCompleted(_, _, name, _)           => name
+            case NodeCompensated(_, _, name, _)          => name
+            case BranchChosen(_, _, name, branch, _)     => s"$name ($branch)"
             case Failed(_, _, error, _)                  => error
             case CompensationFailed(_, _, error, _)      => error
+            case StepFailed(_, _, name, error, _, _)     => s"$name ($error)"
             case StepRetried(_, _, name, error, n, _, _) => s"$name (attempt $n: $error)"
             case StepTimedOut(_, _, name, _, _)          => name
             case _                                       => ""
@@ -753,16 +1220,43 @@ object Flow:
             frame: Frame,
             schema: Schema[V]
         ): Flow[In, Out & (N ~ V), Sf & Sc & S2] =
+            build(body, name, Maybe.empty)(using frame, schema)
+
+        /** Like [[otherwise]], but registers a compensation handler for the dispatch as a whole.
+          *
+          * The handler is NODE level, and on a dispatch that is exactly right: one branch runs and produces one value, so the handler
+          * receives the record that value is in and undoes whatever the branch that ran did. The branch that did not run wrote nothing,
+          * so there is no per-branch question to answer. A dispatch branch that charges a premium fee is otherwise as unrecoverable as
+          * a step that charges one without a handler.
+          *
+          * Handlers run in reverse order when a later step fails, and only on failure, never on suspension. See [[outputCompensated]]
+          * for the effect row the handler carries.
+          */
+        def otherwiseCompensated[S2](body: Record[Out] => V < S2, name: String, description: String = "")(
+            compensate: Record[Out & (N ~ V)] => Unit < (Sc & S2 & Async & Abort[FlowException])
+        )(
+            using
+            frame: Frame,
+            schema: Schema[V]
+        ): Flow[In, Out & (N ~ V), Sf & Sc & S2] =
+            build(body, name, Maybe(internal.handlerOf(compensate)))(using frame, schema)
+
+        private def build[S2](
+            body: Record[Out] => V < S2,
+            name: String,
+            compensate: Maybe[internal.Handler[S2 & Sc]]
+        )(using frame: Frame, schema: Schema[V]): Flow[In, Out & (N ~ V), Sf & Sc & S2] =
             val dispatch = internal.Dispatch[Out, N, V, S2, Sc](
                 this.name,
                 branches,
                 name,
                 body,
                 frame,
-                meta
+                meta,
+                compensate
             )(using dispatchFrame, vtag, schema)
             internal.AndThen(flow, dispatch)(using dispatchFrame)
-        end otherwise
+        end build
 
         inline def output[N2 <: String & Singleton, V2, S2](name: N2, meta: Meta = Meta())(fn: Record[Out] => V2 < S2)(
             using
@@ -798,15 +1292,36 @@ object Flow:
 
     // --- Run (interpreter loop) ---
 
+    /** An exception's message, or its rendering when it carries none, so a durable field never holds a null. */
+    private def messageOf(error: Throwable): String =
+        Maybe(error.getMessage).getOrElse(error.toString)
+
+    /** Interprets one attempt at a flow.
+      *
+      * @param completedEvents
+      *   the durable names this execution has already completed, so a replay re-registers their handlers and runs nothing again
+      * @param compensatedNodes
+      *   the nodes whose compensation handler has already run, read from the same history. An unwind that was interrupted part-way left
+      *   some handlers run and some not, and re-running the ones that landed is what an idempotency contract cannot save a caller from:
+      *   a refund issued twice is two refunds.
+      * @param resumeCause
+      *   the verdict an interrupted attempt recorded when it entered its unwind, present exactly when this attempt is resuming one. The
+      *   forward pass then re-registers handlers and stops, and this cause is what the unwind re-raises. Without it a resumed
+      *   `Compensating` execution can only replay forward and hope the failing step fails again, and a transient failure that succeeds
+      *   the second time COMPLETES an execution whose compensations have half run, which is the one transition the module's own
+      *   documentation says cannot happen.
+      */
     private[kyo] def run[In, Out, S <: Sync](
         flow: Flow[In, Out, ?],
         inputs: Record[Any] = Record.empty,
-        completedEvents: Set[String] = Set.empty
+        completedEvents: Set[String] = Set.empty,
+        compensatedNodes: Set[String] = Set.empty,
+        resumeCause: Maybe[Cause] = Maybe.empty
     )(
         interpreter: FlowInterpreter[S]
     )(using Frame): Record[In & Out] < S =
 
-        case class Compensation(ctx: Record[Any], handler: Record[Any] => Any, branchId: Maybe[Int])
+        case class Compensation(name: String, ctx: Record[Any], handler: Record[Any] => Any)
 
         def addField(ctx: Record[Any], name: String, value: Any): Record[Any] =
             new Record[Any](ctx.toDict ++ Dict(name -> value))
@@ -814,37 +1329,33 @@ object Flow:
         AtomicRef.init[Chunk[Compensation]](Chunk.empty).map { compsRef =>
 
             def pushComp(
-                branchId: Maybe[Int],
+                name: String,
                 ctx: Record[Any],
                 handler: Record[Any] => Any
             ): Unit < Sync =
-                compsRef.getAndUpdate(Compensation(ctx, handler, branchId) +: _).unit
+                compsRef.getAndUpdate(Compensation(name, ctx, handler) +: _).unit
 
-            def snapshotComps(): Chunk[Compensation] < Sync = compsRef.get
-
-            def restoreCompsForBranch(snapshot: Chunk[Compensation], branchId: Int): Unit < Sync =
-                compsRef.getAndUpdate { current =>
-                    snapshot ++ current.filter(_.branchId != Maybe(branchId))
-                }.unit
-
-            def filterComps(winnerCtx: Record[Any]): Unit < Sync =
-                val allKeys = winnerCtx.toDict.foldLeft(Set.empty[String])((acc, k, _) => acc + k)
-                compsRef.getAndUpdate { current =>
-                    current.filter { comp =>
-                        val entryKeys = comp.ctx.toDict.foldLeft(Set.empty[String])((acc, k, _) => acc + k)
-                        entryKeys.subsetOf(allKeys)
-                    }
-                }.unit
-            end filterComps
-
+            /** Runs the handlers this attempt registered, in reverse order of registration, skipping the ones already recorded.
+              *
+              * **Every registered handler runs, including a race loser's.** A branch that lost a race is not a branch that did
+              * nothing: it can have completed a step, written its field and registered the handler that undoes it, and only then lost,
+              * because a race is decided by the first branch to SUCCEED. Whatever it reserved is reserved for real, so dropping its
+              * handler leaves the reservation standing with nothing left to undo it.
+              *
+              * A handler that THREW is not recorded, so a later attempt runs it again and the unwind carries on to the next one either
+              * way. An unwind that stops at its first failing handler leaves every handler below it un-run, which is the opposite of
+              * what an unwind is for.
+              */
             def runComps(): Unit < S =
                 compsRef.use { comps =>
                     Kyo.foreachDiscard(comps.toSeq) { comp =>
-                        Abort.run[Throwable](comp.handler(comp.ctx)).map {
-                            case Result.Panic(ex)   => interpreter.onCompensationFailed(ex)
-                            case Result.Failure(ex) => interpreter.onCompensationFailed(ex)
-                            case _                  => ()
-                        }
+                        if compensatedNodes.contains(comp.name) then ()
+                        else
+                            Abort.run[Throwable](comp.handler(comp.ctx)).map {
+                                case Result.Panic(ex)   => interpreter.onCompensationFailed(ex)
+                                case Result.Failure(ex) => interpreter.onCompensationFailed(ex)
+                                case _                  => interpreter.onCompensated(comp.name)
+                            }
                     }
                 }
 
@@ -856,286 +1367,512 @@ object Flow:
             def eventCompleted(name: String): Boolean =
                 completedEvents.contains(name)
 
-            // branchId tracks which Recover branch compensations belong to
-            // nextBranch is a running counter threaded through recursive calls
-            def loop(flow: Flow[?, ?, ?], ctx: Record[Any], branchId: Maybe[Int] = Maybe.empty, nextBranch: Int = 0): Record[Any] < S =
+            // Everything the store already holds for this execution, keyed the way the store keys it: by composition path.
+            val durable = inputs.toDict
+
+            /** What a child flow starts from: the inputs this entry supplied, plus everything the store holds under its path.
+              *
+              * The mapper supplies only the inputs the entry still owed, so without the second half a resumed subflow re-enters with
+              * an empty record and re-executes every node it already completed. The fields are re-keyed to the bare names the child's
+              * nodes and record type are written in, because a path names a node durably while a record names it structurally.
+              *
+              * **The durable half wins**, which is what makes the record the truth of what the child ran against: `Dict.concat`
+              * gives its argument precedence and the argument here is the store's view. An entry that owed nothing passes an empty
+              * mapped record, so such a child starts from the store alone, its recorded inputs included.
+              */
+            def childRecord(childPath: String, mapped: Record[Any]): Record[Any] =
+                val prefix = s"$childPath${NodePath.Separator}"
+                val inherited = durable.foldLeft(Dict.empty[String, Any]) { (acc, name, value) =>
+                    if name.startsWith(prefix) then acc.update(name.substring(prefix.length), value) else acc
+                }
+                new Record[Any](mapped.toDict ++ inherited)
+            end childRecord
+
+            // path is the composition path the node sits under, empty at the flow's own top level
+            def loop(
+                flow: Flow[?, ?, ?],
+                ctx: Record[Any],
+                path: String = ""
+            ): Record[Any] < S =
                 flow match
                     case _: Init => ctx
 
                     case n: Output[?, ?, ?, ?, ?] @unchecked =>
-                        val e = n.erased
+                        val e         = n.erased
+                        val qualified = NodePath.qualify(path, n.name)
                         if fieldCompleted(ctx, n.name) then
                             e.compensate match
-                                case Present(handler) => pushComp(branchId, ctx, handler).andThen(ctx)
+                                case Present(handler) => pushComp(qualified, ctx, handler).andThen(ctx)
                                 case _                => ctx
                         else
                             val computation = Sync.defer(e.fn(ctx))
-                            interpreter.onOutput(n.name, computation, n.frame, n.meta)(using e.tag, e.schema)
+                            interpreter.onOutput(qualified, computation, n.frame, n.meta)(using e.tag, e.schema)
                                 .map { v =>
                                     val result = addField(ctx, n.name, v)
                                     e.compensate match
-                                        case Present(handler) => pushComp(branchId, result, handler).andThen(result)
+                                        case Present(handler) => pushComp(qualified, result, handler).andThen(result)
                                         case _                => result
                                     end match
                                 }
                         end if
 
                     case n: Step[?, ?] @unchecked =>
-                        val e = n.erased
-                        if eventCompleted(n.name) then
+                        val e         = n.erased
+                        val qualified = NodePath.qualify(path, n.name)
+                        if eventCompleted(qualified) then
                             e.compensate match
-                                case Present(handler) => pushComp(branchId, ctx, handler).andThen(ctx)
+                                case Present(handler) => pushComp(qualified, ctx, handler).andThen(ctx)
                                 case _                => ctx
                         else
                             val computation = Sync.defer(e.fn(ctx))
-                            interpreter.onStep(n.name, computation, n.frame, n.meta).map { _ =>
+                            interpreter.onStep(qualified, computation, n.frame, n.meta).map { _ =>
                                 e.compensate match
-                                    case Present(handler) => pushComp(branchId, ctx, handler).andThen(ctx)
+                                    case Present(handler) => pushComp(qualified, ctx, handler).andThen(ctx)
                                     case _                => ctx
                             }
                         end if
 
                     case n: Input[?, ?] @unchecked =>
-                        if fieldCompleted(ctx, n.name) then ctx
+                        // The satisfied branch records the node's own discharge, which is what clears the wait row the parked branch
+                        // wrote. Nothing else records it: a satisfied input proceeds with the value in hand and writes no progress of
+                        // its own, so a row written here would be outstanding forever and keep the execution permanently ready.
+                        if fieldCompleted(ctx, n.name) then
+                            interpreter.onInputDischarged(NodePath.qualify(path, n.name), n.frame, n.meta).andThen(ctx)
                         else
-                            interpreter.onInput(n.name, n.frame, n.meta)(using n.erased.tag, n.erased.schema)
+                            interpreter.onInput(NodePath.qualify(path, n.name), n.frame, n.meta)(using n.erased.tag, n.erased.schema)
                                 .map(v => addField(ctx, n.name, v))
 
                     case n: Sleep =>
-                        if eventCompleted(n.name) then ctx
+                        if eventCompleted(NodePath.qualify(path, n.name)) then ctx
                         else
-                            interpreter.onSleep(n.name, n.duration, n.frame, n.meta)
+                            interpreter.onSleep(NodePath.qualify(path, n.name), n.duration, n.frame, n.meta)
                                 .andThen(ctx)
 
                     case n: Dispatch[?, ?, ?, ?, ?] @unchecked =>
-                        if fieldCompleted(ctx, n.name) then ctx
+                        val d               = n.erased
+                        val nameStr: String = n.name
+                        val durableName     = NodePath.qualify(path, nameStr)
+
+                        // The handler undoes what the branch that ran did, so it is registered on the replay path too: a dispatch
+                        // whose field is already stored ran its branch under an earlier attempt of this same execution.
+                        def compensated(result: Record[Any] < S): Record[Any] < S =
+                            d.compensate match
+                                case Present(handler) =>
+                                    result.map(updated => pushComp(durableName, updated, handler).andThen(updated))
+                                case _ => result
+
+                        def run(body: Record[Any] => Any < Any): Record[Any] < S =
+                            val computation = Sync.defer(body(ctx))
+                            interpreter.onOutput(durableName, computation, n.frame, n.meta)(using d.tag, d.schema)
+                                .map(v => addField(ctx, nameStr, v))
+                        end run
+
+                        // The choice is recorded BEFORE the branch runs, which is what makes the record the truth of what ran.
+                        def enter(branch: String, body: Record[Any] => Any < Any): Record[Any] < S =
+                            interpreter.onChoice(durableName, branch, n.frame, n.meta).andThen(run(body))
+
+                        def ask(idx: Int): Record[Any] < S =
+                            if idx >= n.branches.length then enter(d.defaultName, d.default)
+                            else
+                                val b = n.branches(idx)
+                                Sync.defer(b.cond(ctx)).map {
+                                    case true  => enter(b.name, b.body)
+                                    case false => ask(idx + 1)
+                                }
+
+                        // Replay re-enters the recorded branch and asks no condition, because the record is what ran and running a
+                        // second branch beside it is worse than either branch alone. A recorded name this definition does not carry
+                        // cannot arrive here: every branch name, the default's included, is part of the structural hash, so an
+                        // execution whose branches changed is parked rather than resumed.
+                        def reenter(branch: String, idx: Int): Record[Any] < S =
+                            if idx >= n.branches.length then
+                                if branch == d.defaultName then run(d.default)
+                                else
+                                    Abort.panic(new IllegalStateException(
+                                        s"dispatch '$nameStr' recorded branch '$branch', which this definition does not declare"
+                                    ))
+                            else
+                                val b = n.branches(idx)
+                                if b.name == branch then run(b.body) else reenter(branch, idx + 1)
+
+                        if fieldCompleted(ctx, nameStr) then compensated(ctx)
                         else
-                            def dispatchBody: Any < Any =
-                                def tryBranches(idx: Int): Any < Any =
-                                    if idx >= n.branches.length then
-                                        n.erased.default(ctx)
-                                    else
-                                        val b = n.branches(idx)
-                                        b.cond(ctx).map {
-                                            case true  => b.body(ctx)
-                                            case false => tryBranches(idx + 1)
-                                        }
-                                tryBranches(0)
-                            end dispatchBody
-                            val computation = Sync.defer(dispatchBody)
-                            interpreter.onOutput(n.name, computation, n.frame, n.meta)(using n.erased.tag, n.erased.schema)
-                                .map(v => addField(ctx, n.name, v))
+                            compensated {
+                                interpreter.getField[String](FlowInterpreter.chosenKey(durableName)).map {
+                                    case Present(branch) => reenter(branch, 0)
+                                    case _               => ask(0)
+                                }
+                            }
+                        end if
 
                     case n: LoopNode[?, ?, ?, ?, ?] @unchecked =>
-                        if fieldCompleted(ctx, n.name) then ctx
-                        else
-                            val r       = n.erased
-                            val nameStr = r.name: String
+                        val r               = n.erased
+                        val nameStr: String = r.name
+                        val durableName     = NodePath.qualify(path, nameStr)
 
-                            import kyo.kernel.Loop.{Continue, Continue2}
+                        import kyo.kernel.Loop.Continue
+                        import kyo.kernel.Loop.Continue2
 
-                            def extractDoneValue(outcome: Any): Maybe[Any] =
-                                outcome match
-                                    case _: Continue[?] @unchecked     => Maybe.empty
-                                    case _: Continue2[?, ?] @unchecked => Maybe.empty
-                                    case done                          => Maybe(done)
+                        // The handler is registered only once the loop produced its value: a loop that stopped between iterations
+                        // wrote nothing under its name and has nothing to undo.
+                        def compensated(result: Record[Any] < S): Record[Any] < S =
+                            r.compensate match
+                                case Present(handler) =>
+                                    result.map { updated =>
+                                        if fieldCompleted(updated, nameStr) then
+                                            pushComp(durableName, updated, handler).andThen(updated)
+                                        else updated
+                                    }
+                                case _ => result
 
-                            def extractContinueState(outcome: Any): Maybe[Any] =
-                                outcome match
-                                    case c: Continue2[?, ?] @unchecked => Maybe((c._1, c._2))
-                                    case c: Continue[?] @unchecked     => Maybe(c._1)
-                                    case _                             => Maybe.empty
+                        // `Loop.done(v)` erases to `v` itself, so an outcome that is not a continue IS the loop's value.
+                        def continueState(outcome: Any): Maybe[Any] =
+                            outcome match
+                                case c: Continue2[?, ?] @unchecked => Maybe((c._1, c._2))
+                                case c: Continue[?] @unchecked     => Maybe(c._1)
+                                case _                             => Maybe.empty
 
-                            r.schedule match
-                                case Absent =>
-                                    // Non-scheduled: all iterations in one computation
-                                    def loopBody: Any < Any =
-                                        def iterate(state: Any, current: Record[Any]): Any < Any =
-                                            r.body(state, current).map { outcome =>
-                                                extractDoneValue(outcome) match
-                                                    case Present(done) => done
-                                                    case _ =>
-                                                        extractContinueState(outcome) match
-                                                            case Present(newState) => iterate(newState, current)
-                                                            case _                 => outcome
+                        // The BODY runs inside the node's bracket, so the iteration is what `timeout` bounds, what `retry` re-asks,
+                        // and what the claim check guards. Nothing is recorded here, because what an iteration records depends on
+                        // what it returned and a scheduled loop and an unscheduled one record differently.
+                        def runIteration(state: Any): Any < S =
+                            interpreter.onIteration(durableName, Sync.defer(r.body(state, ctx)), n.frame, n.meta)
+
+                        // The knobs are stripped from the writes below. They govern an iteration's body, and writing down a value
+                        // already in hand has nothing to bound and nothing to re-ask.
+                        val writeMeta = Meta(n.meta.description, n.meta.tags)
+
+                        def storeValue(value: Any): Record[Any] < S =
+                            interpreter.onOutput(durableName, value, n.frame, writeMeta)(using r.tag, r.schema)
+                                .andThen(addField(ctx, nameStr, value))
+
+                        // Unscheduled: iterations are bracketed and none of them is recorded. That pairing is deliberate. An
+                        // unscheduled loop's iteration count is unbounded, so a checkpoint per iteration is unbounded history,
+                        // which is the cost `loop`'s own scaladoc states and declines to pay.
+                        def unscheduled: Record[Any] < S =
+                            def iterate(state: Any): Record[Any] < S =
+                                runIteration(state).map { outcome =>
+                                    continueState(outcome) match
+                                        case Present(next) => iterate(next)
+                                        case _             => storeValue(outcome)
+                                }
+                            iterate(r.initialState)
+                        end unscheduled
+
+                        // Scheduled: a continuing iteration records the state the NEXT one starts from, under the iteration's own
+                        // durable name and under the state's own evidence, so a resume picks up where it stopped carrying what it
+                        // was carrying. A finishing iteration records nothing there: the loop's own field is its record, and one
+                        // write rather than two leaves no window in which the loop is done and cannot say so.
+                        def scheduled(schedule: Schedule): Record[Any] < S =
+                            def resume(state: Any, iterNum: Int, sched: Schedule): Record[Any] < S =
+                                interpreter.checkCancelled.map {
+                                    // Cancelled: stop where the loop stands. Nothing is written under the node's name, so no
+                                    // compensation is registered for a value that does not exist.
+                                    case true => ctx
+                                    case false =>
+                                        val iterName = IterationName.step(durableName, iterNum)
+                                        if eventCompleted(iterName) then
+                                            interpreter.getField[Any](iterName)(using r.stateTag, r.stateSchema).map {
+                                                case Present(recorded) => afterIteration(recorded, iterNum, sched)
+                                                // The checkpoint's event landed without its field, so this iteration runs again
+                                                // from the state the last recorded one carried.
+                                                case _ => execute(state, iterNum, sched)
                                             }
-                                        iterate(r.initialState, ctx)
-                                    end loopBody
-                                    val computation = Sync.defer(loopBody)
-                                    interpreter.onOutput(nameStr, computation, n.frame, n.meta)(using r.tag, r.schema)
-                                        .map(v => addField(ctx, nameStr, v))
+                                        else execute(state, iterNum, sched)
+                                        end if
+                                }
 
-                                case Present(schedule) =>
-                                    // Scheduled: iterate at S level with durable sleep between iterations
+                            def execute(state: Any, iterNum: Int, sched: Schedule): Record[Any] < S =
+                                runIteration(state).map { outcome =>
+                                    continueState(outcome) match
+                                        case Present(next) =>
+                                            interpreter.onOutput(IterationName.step(durableName, iterNum), next, n.frame, writeMeta)(using
+                                                r.stateTag,
+                                                r.stateSchema
+                                            ).andThen(afterIteration(next, iterNum, sched))
+                                        case _ => storeValue(outcome)
+                                }
 
-                                    def iterate(
-                                        state: Any,
-                                        current: Record[Any],
-                                        iterNum: Int,
-                                        sched: Schedule
-                                    ): Record[Any] < S =
-                                        interpreter.checkCancelled.map {
-                                            case true => current // cancelled — stop iterating
-                                            case false =>
-                                                val iterName  = IterationName.step(nameStr, iterNum)
-                                                val sleepName = IterationName.sleep(nameStr, iterNum)
-                                                if eventCompleted(iterName) then
-                                                    // Resuming from checkpoint — this iteration was already recorded
-                                                    // If a field was stored the iteration completed with a final value; otherwise it was a continue
-                                                    interpreter.getField[Any](iterName)(using r.tag, r.schema).map {
-                                                        case Present(result) =>
-                                                            // Done iteration — result is stored, this is the final value
-                                                            addField(current, nameStr, result)
-                                                        case _ =>
-                                                            // Continue iteration (was stored as step, no field value)
-                                                            if eventCompleted(sleepName) then
-                                                                // Sleep also done — advance schedule and continue
-                                                                Clock.nowWith { now =>
-                                                                    sched.next(now) match
-                                                                        case Present((_, nextSched)) =>
-                                                                            iterate(state, current, iterNum + 1, nextSched)
-                                                                        case _ => current
-                                                                }
-                                                            else
-                                                                // Sleep was not completed — re-execute from this point
-                                                                Clock.nowWith { now =>
-                                                                    sched.next(now) match
-                                                                        case Present((delay, nextSched)) =>
-                                                                            interpreter.onSleep(sleepName, delay, n.frame, n.meta)
-                                                                                .map(_ =>
-                                                                                    iterate(state, current, iterNum + 1, nextSched)
-                                                                                )
-                                                                        case _ => current
-                                                                }
-                                                            end if
-                                                    }
-                                                else executeIteration(state, current, iterNum, sched)
-                                                end if
-                                        } // end case false (not cancelled)
-                                    end iterate
+                            def afterIteration(next: Any, iterNum: Int, sched: Schedule): Record[Any] < S =
+                                val sleepName = IterationName.sleep(durableName, iterNum)
+                                Clock.nowWith { now =>
+                                    sched.next(now) match
+                                        case Present((delay, nextSched)) =>
+                                            val slept: Unit < S =
+                                                if eventCompleted(sleepName) then ()
+                                                else interpreter.onSleep(sleepName, delay, n.frame, n.meta)
+                                            slept.andThen(resume(next, iterNum + 1, nextSched))
+                                        // The schedule has no delay left and the body never produced a value. Nothing is written
+                                        // under the loop's name: the state it carried is the loop's state type and the name is
+                                        // typed for its value, and writing one where the other is declared is sound only where
+                                        // the two coincide. The execution fails, naming the loop and what it ran, as a DECLARED
+                                        // failure rather than an escaped one, so the status it reaches carries the kind an
+                                        // operator groups by. Running out of schedule is a verdict, so nothing re-asks it.
+                                        case _ =>
+                                            interpreter.onFailure(durableName, FlowLoopExhaustedException(nameStr, iterNum + 1))
+                                }
+                            end afterIteration
 
-                                    def executeIteration(
-                                        state: Any,
-                                        current: Record[Any],
-                                        iterNum: Int,
-                                        sched: Schedule
-                                    ): Record[Any] < S =
-                                        val iterName  = s"$nameStr#$iterNum"
-                                        val sleepName = s"$nameStr##$iterNum"
-                                        // Compute the outcome first, then decide what to persist
-                                        Sync.defer(r.body(state, current)).map { rawOutcome =>
-                                            extractContinueState(rawOutcome) match
-                                                case Present(newState) =>
-                                                    // Continue — mark iteration, then sleep
-                                                    interpreter.onStep(iterName, Kyo.unit, n.frame, n.meta).map { _ =>
-                                                        Clock.nowWith { now =>
-                                                            sched.next(now) match
-                                                                case Present((delay, nextSched)) =>
-                                                                    interpreter.onSleep(sleepName, delay, n.frame, n.meta)
-                                                                        .andThen(iterate(newState, current, iterNum + 1, nextSched))
-                                                                case _ =>
-                                                                    val updated = addField(current, nameStr, ())
-                                                                    interpreter.onOutput(nameStr, Kyo.unit, n.frame, n.meta)(using
-                                                                        r.tag,
-                                                                        r.schema
-                                                                    )
-                                                                        .andThen(updated)
-                                                        }
-                                                    }
-                                                case _ =>
-                                                    // Done — store final result
-                                                    interpreter.onOutput(iterName, rawOutcome, n.frame, n.meta)(using r.tag, r.schema)
-                                                        .andThen {
-                                                            val updated = addField(current, nameStr, rawOutcome)
-                                                            interpreter.onOutput(nameStr, rawOutcome, n.frame, n.meta)(using
-                                                                r.tag,
-                                                                r.schema
-                                                            )
-                                                                .andThen(updated)
-                                                        }
-                                        }
-                                    end executeIteration
+                            resume(r.initialState, 0, schedule)
+                        end scheduled
 
-                                    iterate(r.initialState, ctx, 0, schedule)
-                            end match
+                        if fieldCompleted(ctx, nameStr) then compensated(ctx)
+                        else
+                            compensated {
+                                r.schedule match
+                                    case Absent            => unscheduled
+                                    case Present(schedule) => scheduled(schedule)
+                            }
+                        end if
 
                     case n: ForEach[?, ?, ?, ?, ?] @unchecked =>
-                        if fieldCompleted(ctx, n.name) then ctx
-                        else
-                            val nameStr: String = n.name
-                            def foreachBody: Any < Any =
-                                n.erased.collection(ctx).map { items =>
-                                    val seq = items.asInstanceOf[Seq[Any]]
-                                    Kyo.foldLeft(seq)(Chunk.empty[Any]) { (acc, item) =>
-                                        n.erased.body(item).map(acc :+ _)
-                                    }
-                                }
-                            end foreachBody
-                            given Schema[Any] = n.erased.schema
-                            val seqSchema     = summon[Schema[Seq[Any]]].asInstanceOf[Schema[Any]]
-                            val computation   = Sync.defer(foreachBody)
-                            interpreter.onOutput(nameStr, computation, n.frame, n.meta)(using Tag[Any], seqSchema)
-                                .map { stored =>
-                                    val chunk = stored match
-                                        case c: Chunk[?] => c
-                                        case s: Seq[?]   => Chunk.from(s)
-                                        case other       => Chunk(other)
-                                    addField(ctx, nameStr, chunk)
-                                }
+                        val r               = n.erased
+                        val nameStr: String = n.name
+                        val durableName     = NodePath.qualify(path, nameStr)
 
-                    case n: Race[?, ?, ?, ?, ?, ?] @unchecked =>
-                        snapshotComps().map { snapshot =>
-                            val leftResult  = loop(n.left, ctx, branchId, nextBranch)
-                            val rightResult = loop(n.right, ctx, branchId, nextBranch)
-                            interpreter.onRace(leftResult, rightResult, n.erased.isolate).map { winnerCtx =>
-                                filterComps(winnerCtx).andThen(winnerCtx)
+                        // Items above a bound of 1 run in their own fibers. Nothing is isolated across that boundary because
+                        // the AST is erased at `S`: the row is `Any` here, so the isolate is the identity, and what carries an
+                        // item's effects is the fiber itself, which is why the DSL says a body needing state merged back
+                        // should ask for one item at a time.
+                        given itemIsolate: Isolate[Any, Abort[FlowException] & Async, Any] = Isolate.derive
+
+                        // The knobs are stripped from the writes that record a value already in hand. They govern an ITEM's body,
+                        // which is the unit a fan-out brackets: a bound over the whole fan-out cannot be sized for the single slow
+                        // item, and a retry of the whole fan-out re-runs the items that already landed.
+                        val writeMeta = Meta(n.meta.description, n.meta.tags)
+
+                        // The collection is the only thing that says which item produced which recorded result, so a size that
+                        // disagrees with what the fan-out recorded leaves every pairing unknowable. The node fails. Re-running the
+                        // fan-out whole instead would write onto paths that already carry the previous attempt's results, hand each
+                        // handler a value from a run it did not belong to, and re-fire every item's side effects on the way.
+                        def mismatch(recorded: Int, recomputed: Int): Record[Any] < S =
+                            interpreter.onFailure(durableName, FlowNondeterministicCollectionException(durableName, recorded, recomputed))
+
+                        // The record an entry carries decides one thing, whether a race kept the branch the entry belongs to, and
+                        // an item's handler is applied to the item and its result rather than to a record. So the entry carries the
+                        // record the fan-out started from: the node's own field does not exist while its items are still landing,
+                        // and that is the whole point of registering a handler per item rather than per node.
+                        def pushItemComp(index: Int, item: Any, value: Any): Unit < Sync =
+                            r.compensate match
+                                case Present(handler) =>
+                                    pushComp(itemKey(durableName, index), ctx, (_: Record[Any]) => handler(item, value))
+                                case _ => ()
+
+                        // One item's durable transition, whole: read back what an earlier attempt recorded, or run the body under
+                        // the node's own policy and record it. The handler is registered either way, because an item recorded by an
+                        // earlier attempt did its work just as much as one that ran here.
+                        def itemResult(index: Int, item: Any, replaying: Boolean): Any < S =
+                            val key = itemKey(durableName, index)
+                            def compute: Any < S =
+                                interpreter.onOutput(key, Sync.defer(r.body(item)), n.frame, n.meta)(using r.itemTag, r.itemSchema)
+                            // The count is written before any item is, so a fan-out with no count recorded has no item recorded
+                            // either and the read would answer absent for every one of them.
+                            val value: Any < S =
+                                if !replaying then compute
+                                else
+                                    interpreter.getField[Any](key)(using r.itemTag, r.itemSchema).map {
+                                        case Present(recorded) => recorded
+                                        case _                 => compute
+                                    }
+                            value.map(v => pushItemComp(index, item, v).andThen(v))
+                        end itemResult
+
+                        def runItems(items: Seq[Any], replaying: Boolean): Record[Any] < S =
+                            // Every item's whole transition runs inside the fan-out's own bound, so a result is recorded as its item
+                            // completes rather than after the last one. The row is erased the way an item's body already is: what
+                            // these computations carry are the effects a fiber carries anyway.
+                            val results: Chunk[Any] < S =
+                                Async.foreachIndexed(items, r.concurrency) { (index, item) =>
+                                    itemResult(index, item, replaying).asInstanceOf[Any < Any]
+                                }.asInstanceOf[Chunk[Any] < S]
+                            results.map { values =>
+                                interpreter.onOutput(durableName, values, n.frame, writeMeta)(using r.tag, r.schema)
+                                    .andThen(addField(ctx, nameStr, values))
                             }
-                        }
+                        end runItems
+
+                        // A fan-out that has not written its own field yet. The count is what an attempt that resumes it checks the
+                        // collection against, and it is recorded before the first item so that an absent count means an untouched
+                        // fan-out.
+                        //
+                        // The collection runs outside the claim check the count's write makes, the way a dispatch's conditions run
+                        // outside the check its choice makes. Nothing needs it bracketed: a collection is required to be a
+                        // deterministic function of the record and is recomputed by every attempt that re-enters the node, so it is
+                        // not a computation a claim could protect from running twice. What the claim guards is every write below.
+                        def start: Record[Any] < S =
+                            interpreter.getField[Int](countKey(durableName)).map { recorded =>
+                                Sync.defer(r.collection(ctx)).map { items =>
+                                    recorded match
+                                        case Present(count) if count != items.size => mismatch(count, items.size)
+                                        case Present(_)                            => runItems(items, replaying = true)
+                                        case _ =>
+                                            interpreter.onOutput(countKey(durableName), items.size, n.frame, writeMeta)
+                                                .andThen(runItems(items, replaying = false))
+                                }
+                            }
+
+                        // The fan-out completed under an earlier attempt, so nothing is left to record. What is left is to register
+                        // the handlers again, the way every other compensated node does on replay, and pairing them with their items
+                        // is the one thing the collection is still needed for. The node's own field says how many items ran, which is
+                        // what the recomputed collection is checked against here: past the last item the count field has no reader.
+                        def replayCompleted(results: Seq[Any]): Record[Any] < S =
+                            Sync.defer(r.collection(ctx)).map { items =>
+                                if items.size != results.size then mismatch(results.size, items.size)
+                                else Kyo.foreachDiscard(items.indices)(i => pushItemComp(i, items(i), results(i))).andThen(ctx)
+                            }
+
+                        if !fieldCompleted(ctx, nameStr) then start
+                        else
+                            (r.compensate, ctx.toDict.get(nameStr)) match
+                                case (Present(_), Present(results: Seq[Any] @unchecked)) => replayCompleted(results)
+                                case _                                                   => ctx
+                        end if
+
+                    // A race keeps every handler both branches registered, the loser's included. A branch that lost is not a branch
+                    // that did nothing: a race is decided by the first branch to SUCCEED, so a loser can have completed a step,
+                    // written its field and registered the handler that undoes it, and only then lost. Filtering the handlers by
+                    // whether the pushing context's keys are a subset of the winner's is wrong in both directions at once, and drops
+                    // exactly the handlers whose branch did the most work: a compensated output hands its handler its own value in
+                    // scope, and that key is never in the winner's set.
+                    case n: Race[?, ?, ?, ?, ?, ?] @unchecked =>
+                        val leftResult  = loop(n.left, ctx, path)
+                        val rightResult = loop(n.right, ctx, path)
+                        interpreter.onRace(leftResult, rightResult, n.erased.isolate)
 
                     case n: Subflow[?, ?, ?, ?, ?, ?] @unchecked =>
                         if fieldCompleted(ctx, n.name) then ctx
                         else
-                            val nameStr = n.name: String
-                            n.erased.inputMapper(ctx)
-                                .map(inputRecord => loop(n.childFlow, inputRecord, branchId, nextBranch))
+                            val nameStr   = n.name: String
+                            val childPath = NodePath.qualify(path, nameStr)
+                            // The inputs this entry still owes the store: the ones the record does not already hold. An input the
+                            // store holds is what the child ran against and is never written again and never compared with the
+                            // mapper's answer, which is the same rule a recorded dispatch branch follows.
+                            val owed = n.erased.childInputs.filter(input =>
+                                durable.get(NodePath.qualify(childPath, input.name)) match
+                                    case Present(_) => false
+                                    case _          => true
+                            )
+
+                            /** One owed input recorded from the mapper's record, answering what the child will run against.
+                              *
+                              * A refusal is not a failure. Two arms of a `race` may embed one subflow name, so both entries write
+                              * the same path and the store answers the second already-recorded; the race exemption's rule is that
+                              * the first write decides the field, so this reads that value back and hands it to the child rather
+                              * than running it against a value nothing kept. The read cannot answer absent for a path the store
+                              * just refused as occupied, and if it ever did the mapper's own value is the honest fallback.
+                              */
+                            def record(acc: Dict[String, Any], input: ChildInput): Dict[String, Any] < S =
+                                val qualified = NodePath.qualify(childPath, input.name)
+                                acc.get(input.name) match
+                                    case Present(value) =>
+                                        interpreter.onInputSupplied(qualified, value, input.frame, input.meta)(using
+                                            input.tag,
+                                            input.schema
+                                        ).map {
+                                            case true => acc
+                                            case false =>
+                                                interpreter.getField[Any](qualified)(using input.tag, input.schema).map {
+                                                    case Present(recorded) => acc.update(input.name, recorded)
+                                                    case _                 => acc
+                                                }
+                                        }
+                                    // The mapper handed back no value under a name the child declares, which its own type forbids.
+                                    // Nothing is written for it, and the child's input node decides what to do with an absent
+                                    // field the way it decides for any other.
+                                    case _ => acc
+                                end match
+                            end record
+
+                            // The mapper runs only for an entry that owes the store something, which is the first entry and a
+                            // re-entry after a crash between two of its input writes. An entry that finds every declared input
+                            // recorded re-enters the child against the record without asking the mapper at all, exactly as a
+                            // dispatch re-enters its recorded branch without re-asking its conditions. It runs before the hook's
+                            // own guard, the accepted precedent a dispatch's conditions and a fan-out's collection already set.
+                            val mapped: Record[Any] < S =
+                                if owed.isEmpty then Record.empty
+                                else
+                                    n.erased.inputMapper(ctx).map { inputRecord =>
+                                        Kyo.foldLeft(owed)(inputRecord.toDict)(record).map(new Record[Any](_))
+                                    }
+
+                            mapped
+                                .map(inputRecord =>
+                                    loop(n.childFlow, childRecord(childPath, inputRecord), childPath)
+                                )
                                 .map(childResult => addField(ctx, nameStr, childResult))
 
                     case n: AndThen[?, ?, ?, ?, ?, ?] @unchecked =>
-                        loop(n.first, ctx, branchId, nextBranch).map(ctx2 => loop(n.second, ctx2, branchId, nextBranch))
+                        loop(n.first, ctx, path).map(ctx2 => loop(n.second, ctx2, path))
 
                     case n: Zip[?, ?, ?, ?, ?, ?] @unchecked =>
-                        val l = loop(n.left, ctx, branchId, nextBranch)
-                        val r = loop(n.right, ctx, branchId, nextBranch)
+                        val l = loop(n.left, ctx, path)
+                        val r = loop(n.right, ctx, path)
                         interpreter.onZip(l, r, ctx, n.erased.isolate)
 
                     case n: Gather[?, ?, ?] @unchecked =>
                         if n.flows.isEmpty then ctx
                         else
-                            n.flows.toSeq.map(f => loop(f, ctx, branchId, nextBranch))
+                            n.flows.toSeq.map(f => loop(f, ctx, path))
                                 .reduce((l, r) => interpreter.onZip(l, r, ctx, n.erased.isolate))
 
             val rawResult = loop(flow, new Record[Any](inputs.toDict))
+
+            /** Re-raises what ended the flow, after its compensations have run.
+              *
+              * A [[FlowException]] goes back out on the typed channel it was raised on, which is what makes a step's own
+              * [[FlowDomainException]] survive as a failure rather than arriving at the engine as a panic and losing everything but its
+              * message. Anything else is not a declared failure of this flow and stays a panic.
+              */
+            def unwindFrom(cause: Flow.Cause, reraise: Nothing < S): Nothing < S =
+                compsRef.use { comps =>
+                    if comps.nonEmpty then
+                        interpreter.onCompensationStart(cause)
+                            .andThen(runComps())
+                            .andThen(interpreter.onCompensationComplete)
+                            .andThen(reraise)
+                    else reraise
+                }
+
+            /** What ended the walk, and whether it was a verdict on the flow at all.
+              *
+              * **Two endings are not verdicts and unwind nothing.** A [[FlowStoreException]] says the store could not be reached,
+              * which is a fact about the infrastructure and says nothing about the work; an [[Interrupted]] says this attempt was
+              * told to stop. Neither has decided that what already ran should be undone, so neither may write a status, run a
+              * handler or append an event: they go straight back out, and the execution is left exactly as claimable as it was, for
+              * the next attempt to carry on from where this one stopped.
+              *
+              * Entering the unwind for either is enough to lose the execution. The first handler's registration turns a transient
+              * blip into `Compensating(Failure(<the store's own message>))` written through the claim with every handler run behind
+              * it, and the next attempt reads that row as an unwind to resume and terminalises the saga `Failed` on an outage it did
+              * not cause. Classifying the ending correctly further down the engine does not undo that, because by then the row and
+              * the handlers have already moved.
+              */
+            def unwind(ex: Throwable): Nothing < S =
+                ex match
+                    case _: FlowStoreException | _: Interrupted => interpreter.onUnwind(ex)
+                    case _                                      =>
+                        // The verdict that started the unwind is recorded with it, because a resumed `Compensating` execution has to
+                        // re-enter the unwind rather than replay forward into the step that failed. A resumed one carries the verdict
+                        // its interrupted attempt already recorded, so nothing is re-derived from an exception that no longer exists.
+                        val cause = ex match
+                            case e: FlowResumedUnwindException => e.cause
+                            case _: FlowCancelledException     => Flow.Cause.Cancellation
+                            case e: FlowException              => Flow.Cause.Failure(messageOf(e), Maybe(e.kind))
+                            case e                             => Flow.Cause.Failure(messageOf(e), Maybe.empty)
+                        unwindFrom(cause, interpreter.onUnwind(ex))
+            end unwind
+
             Abort.run[Throwable](rawResult).map {
                 case Result.Success(record) =>
-                    record.asInstanceOf[Record[In & Out]]
-                case Result.Failure(ex) =>
-                    compsRef.use { comps =>
-                        if comps.nonEmpty then
-                            interpreter.onCompensationStart
-                                .andThen(runComps())
-                                .andThen(interpreter.onCompensationComplete)
-                                .andThen(Abort.panic(ex))
-                        else Abort.panic(ex)
-                    }
-                case Result.Panic(ex) =>
-                    compsRef.use { comps =>
-                        if comps.nonEmpty then
-                            interpreter.onCompensationStart
-                                .andThen(runComps())
-                                .andThen(interpreter.onCompensationComplete)
-                                .andThen(Abort.panic(ex))
-                        else Abort.panic(ex)
-                    }
+                    // A forward pass that reached the end while RESUMING an unwind reached it in skip-only mode: every node it walked
+                    // was already complete, so it re-registered handlers and computed nothing. Answering with that record would take a
+                    // `Compensating` execution to `Completed` with its compensations half run, which is the transition this module
+                    // documents as impossible.
+                    resumeCause match
+                        case Present(cause) => unwindFrom(cause, interpreter.onUnwind(FlowResumedUnwindException(cause)))
+                        case _              => record.asInstanceOf[Record[In & Out]]
+                case Result.Failure(ex) => unwind(ex)
+                case Result.Panic(ex)   => unwind(ex)
             }
         }
     end run
@@ -1143,6 +1880,50 @@ object Flow:
     // --- Internal AST ---
 
     private[kyo] object internal:
+
+        /** A compensation handler as the interpreter applies it, over the erased record.
+          *
+          * [[Record]]'s type parameter is invariant by design, so a handler declared over the record the node's value is in cannot be
+          * seen as one over `Record[Any]` by subtyping, and the erased AST the interpreter walks has nothing else to hand it. Nodes
+          * whose handler is declared at the DSL site therefore store it in this shape.
+          */
+        type Handler[S] = Record[Any] => Unit < (S & Async & Abort[FlowException])
+
+        /** Stores a DSL-declared compensation handler in the shape the interpreter applies. See [[Handler]] for why a cast is what
+          * that takes.
+          */
+        def handlerOf[C, S](handler: Record[C] => Unit < (S & Async & Abort[FlowException])): Handler[S] =
+            handler.asInstanceOf[Handler[S]]
+
+        /** A fan-out's per-item compensation handler as the interpreter applies it, over the erased item and its erased result.
+          *
+          * A fan-out's unit of work is the item, so its handler takes an item and what that item produced rather than the record a
+          * node-level handler takes. The record holds the whole `Chunk`, which exists only once the last item has landed, and a
+          * fan-out that failed part-way is the one case where unwinding matters and that value is not there.
+          */
+        type ItemHandler[S] = (Any, Any) => Unit < (S & Async & Abort[FlowException])
+
+        /** Stores a DSL-declared per-item handler in the shape the interpreter applies. See [[Handler]] for why a cast is what that
+          * takes.
+          */
+        def itemHandlerOf[E, V, S](handler: (E, V) => Unit < (S & Async & Abort[FlowException])): ItemHandler[S] =
+            handler.asInstanceOf[ItemHandler[S]]
+
+        /** The durable key a fan-out's item at `index` records its result under.
+          *
+          * An item is a composition step the way a subflow instance is, one level down, so its key is built the same way: item 2 of
+          * `charges` is `charges~2`. See [[kyo.internal.NodePath]].
+          */
+        def itemKey(foreach: String, index: Int): String = NodePath.qualify(foreach, index.toString)
+
+        /** The durable key a fan-out records how many items it had under.
+          *
+          * It rides the fan-out's own path, the namespace its items are keyed in, where `count` can be neither an item's index nor a
+          * name a user chose: registration refuses the separator in a node name, and a subflow instance sharing the fan-out's name is
+          * a duplicate the same refusal catches. It cannot ride `#` instead, because a progress walk reads every `name#...` as an
+          * iteration of `name` and would draw the fan-out as done the moment its count landed.
+          */
+        def countKey(foreach: String): String = NodePath.qualify(foreach, "count")
 
         final case class BranchData[Ctx, V, S](
             name: String,
@@ -1161,7 +1942,7 @@ object Flow:
             name: N & String,
             fn: Record[Ctx] => V < S,
             meta: Meta,
-            compensate: Maybe[Record[CompCtx] => Unit < (Async & Abort[FlowException])]
+            compensate: Maybe[Record[CompCtx] => Unit < (S & Async & Abort[FlowException])]
         )(using val frame: Frame, val tag: Tag[V], val schema: Schema[V]) extends Flow[Any, N ~ V, S]:
             private[kyo] def erased: Output[Any, Any, Nothing, Any, Any] = this.asInstanceOf[Output[Any, Any, Nothing, Any, Any]]
         end Output
@@ -1170,7 +1951,7 @@ object Flow:
             name: String,
             fn: Record[Ctx] => Unit < S,
             meta: Meta,
-            compensate: Maybe[Record[Ctx] => Unit < (Async & Abort[FlowException])]
+            compensate: Maybe[Record[Ctx] => Unit < (S & Async & Abort[FlowException])]
         )(using val frame: Frame) extends Flow[Any, Any, S]:
             private[kyo] def erased: Step[Any, Any] = this.asInstanceOf[Step[Any, Any]]
         end Step
@@ -1193,7 +1974,8 @@ object Flow:
             defaultName: String,
             default: Record[Ctx] => V < S,
             defaultFrame: Frame,
-            meta: Meta
+            meta: Meta,
+            compensate: Maybe[Handler[S & Sb]]
         )(using val frame: Frame, val tag: Tag[V], val schema: Schema[V]) extends Flow[Any, N ~ V, S & Sb]:
             private[kyo] def erased: Dispatch[Any, Nothing, Any, Any, Any] = this.asInstanceOf[Dispatch[Any, Nothing, Any, Any, Any]]
         end Dispatch
@@ -1203,9 +1985,18 @@ object Flow:
             body: (State, Record[Ctx]) => Any < S, // returns Loop.Outcome[State, V] (erased at S boundary)
             initialState: State,
             schedule: Maybe[Schedule],
-            meta: Meta
-        )(using val frame: Frame, val tag: Tag[V], val schema: Schema[V], val stateTag: Tag[State], val stateSchema: Schema[State])
-            extends Flow[Any, N ~ V, S]:
+            meta: Meta,
+            compensate: Maybe[Handler[S]]
+        )(using
+            val frame: Frame,
+            val tag: Tag[V],
+            val schema: Schema[V],
+            // A scheduled loop checkpoints the state its next iteration starts from, under the iteration's own durable name and
+            // under the state's own evidence. That is why the state's tag is part of the flow's version identity: replay decodes
+            // the checkpoint back through it.
+            val stateTag: Tag[State],
+            val stateSchema: Schema[State]
+        ) extends Flow[Any, N ~ V, S]:
             private[kyo] def erased: LoopNode[Any, Nothing, Any, Any, Any] = this.asInstanceOf[LoopNode[Any, Nothing, Any, Any, Any]]
         end LoopNode
 
@@ -1214,8 +2005,19 @@ object Flow:
             concurrency: Int,
             collection: Record[Ctx] => Seq[E] < S,
             body: E => V < S,
-            meta: Meta
-        )(using val frame: Frame, val tag: Tag[V], val schema: Schema[V]) extends Flow[Any, N ~ Chunk[V], S]:
+            meta: Meta,
+            compensate: Maybe[ItemHandler[S]]
+        )(using
+            val frame: Frame,
+            // The node persists the whole collection, so its evidence is for `Chunk[V]` and is captured at the DSL site: `V` is
+            // erased to `Any` by the time the interpreter sees the node, and `Tag[Chunk[Any]]` is not the tag a caller reads with.
+            val tag: Tag[Chunk[V]],
+            val schema: Schema[Chunk[V]],
+            // An item's own evidence, captured at the same site and for the same reason. Each item's result is a durable field of
+            // its own, written and read back under the element type the caller declared rather than under the collection's.
+            val itemTag: Tag[V],
+            val itemSchema: Schema[V]
+        ) extends Flow[Any, N ~ Chunk[V], S]:
             private[kyo] def erased: ForEach[Any, Nothing, Any, Any, Any] = this.asInstanceOf[ForEach[Any, Nothing, Any, Any, Any]]
         end ForEach
 
@@ -1227,6 +2029,15 @@ object Flow:
             private[kyo] def erased: Race[Any, Any, Any, Any, Any, Any] = this.asInstanceOf[Race[Any, Any, Any, Any, Any, Any]]
         end Race
 
+        /** One input a subflow's child declares directly, carrying everything recording its value takes.
+          *
+          * The evidence is captured at the input node, because that is the only place the input's own `V` still exists: the
+          * interpreter walks an AST erased at `Any` and the value the mapper supplied is written under the input's declared type,
+          * which is also the type the schema decodes it back through. The tag is erased the way [[kyo.internal.FlowLint.inputMetas]]
+          * erases a top-level input's, so a mapper-supplied field and a start-seeded one are stored identically.
+          */
+        final case class ChildInput(name: String, tag: Tag[Any], schema: Schema[Any], frame: Frame, meta: Meta)
+
         final case class Subflow[In, Ctx, N <: String & Singleton, In2, Out2, S](
             name: N & String,
             childFlow: Flow[In2, Out2, ?],
@@ -1235,6 +2046,29 @@ object Flow:
         )(using val frame: Frame) extends Flow[In, Ctx & (N ~ Record[Out2]), S]:
             private[kyo] def erased: Subflow[Any, Any, Nothing, Any, Any, Any] =
                 this.asInstanceOf[Subflow[Any, Any, Nothing, Any, Any, Any]]
+
+            /** The inputs the child declares DIRECTLY, in walk order and without repeats, which entering this instance records.
+              *
+              * Direct, because a grandchild's inputs belong to the nested instance's own entry: the collector leaves `onSubflow` at
+              * its `empty` default, so the walk contributes an inner child's inputs at `outer~inner~ia` when `inner` is entered
+              * rather than flattening them under `outer`.
+              *
+              * Without repeats, because a name can be declared twice in one child: two arms of a `race` may share a written name by
+              * the race exemption, and one write per declared occurrence would answer the second already-recorded for no reason.
+              * Walk order is kept so the writes land in the order the child declares them, which is what makes a partial seed after
+              * a crash a prefix rather than an arbitrary subset.
+              *
+              * Computed once per node rather than per entry: the answer depends on the child's AST alone, which is immutable, and an
+              * execution that resumes a hundred times walks it once.
+              */
+            private[kyo] lazy val childInputs: Chunk[ChildInput] =
+                val collected = FlowFold(childFlow)(new FlowVisitorCollect[Chunk[ChildInput]](Chunk.empty, _ ++ _):
+                    override def onInput[V](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V]) =
+                        Chunk(ChildInput(name, Tag[V].erased, summon[Schema[V]].asInstanceOf[Schema[Any]], frame, meta)))
+                collected.foldLeft((Chunk.empty[ChildInput], Set.empty[String])) { case ((acc, seen), input) =>
+                    if seen.contains(input.name) then (acc, seen) else (acc.append(input), seen + input.name)
+                }._1
+            end childInputs
         end Subflow
 
         final case class AndThen[In1, Out1, In2, Out2, S1, S2](

--- a/kyo-flow/shared/src/main/scala/kyo/FlowEngine.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/FlowEngine.scala
@@ -10,13 +10,13 @@ import kyo.kernel.Isolate
   * steps are persisted before the next begins, so if a process crashes, another engine on the same store resumes from where it left off.
   *
   * The two main API surfaces are `workflows` (start new executions, list registered workflows, render diagrams) and `executions` (deliver
-  * input signals, check status, cancel, search, view history). Starting an execution returns a `Handle` — a lightweight reference that
+  * input signals, check status, cancel, search, view history). Starting an execution returns a `Handle`, a lightweight reference that
   * wraps the execution ID and delegates to the engine.
   *
   * Multiple engines can share the same store for horizontal scaling. The store's atomic `claimReady` ensures each execution is processed by
-  * exactly one engine at a time. If an engine dies, its leases expire and other engines pick up the orphaned executions. This means
-  * completed steps are never re-executed, but an in-flight step (started but not completed) may re-execute on a new engine — so
-  * side-effecting steps must be idempotent.
+  * exactly one engine at a time. If an engine dies, its leases expire and the executions it was carrying become claimable again, so
+  * another engine picks them up. This means completed steps are never re-executed, but an in-flight step (started but not completed) may
+  * re-execute on a new engine, so side-effecting steps must be idempotent.
   *
   * Executions park when they hit an `.input` node (waiting for a signal) or a `.sleep` node (waiting for time to pass). Parked executions
   * release all in-memory state; only the store holds their state. When the signal arrives or the sleep expires, the next `claimReady` poll
@@ -33,9 +33,23 @@ import kyo.kernel.Isolate
   */
 final class FlowEngine private (
     private[kyo] val store: FlowStore,
-    private[kyo] val defs: AtomicRef[Dict[Flow.Id.Workflow, FlowDefinition]],
-    val executorId: Flow.Id.Executor
+    private[kyo] val defs: AtomicRef[FlowEngine.Definitions],
+    val executorId: Flow.Id.Executor,
+    private[kyo] val liveness: FlowEngine.Liveness,
+    private[kyo] val supervisions: AtomicRef[Maybe[Set[Fiber[Unit, Any]]]]
 )(using Frame):
+
+    import FlowEngine.Attempt
+    import FlowEngine.Definitions
+
+    /** What the engine's workers are doing: how many are polling, and what the last poll failure was.
+      *
+      * The reachable answer to "is this engine actually working". A worker that cannot reach the store keeps polling and records the
+      * failure here rather than dying, so a health check reads `workersAlive` against `workersConfigured` and the process does not report
+      * itself healthy while nothing is being executed.
+      */
+    def health(using Frame): FlowEngine.Health < Sync =
+        liveness.snapshot
 
     // --- Workflows ---
 
@@ -50,90 +64,143 @@ final class FlowEngine private (
         def start(
             workflowId: Flow.Id.Workflow,
             inputs: Record[Any] = Record.empty
-        )(using Frame): FlowEngine.Handle < (Async & Abort[FlowWorkflowNotRegisteredException | FlowSignalTypeMismatchException]) =
-            defs.use(_.get(workflowId)).map {
-                case Absent => Abort.fail(FlowWorkflowNotRegisteredException(workflowId.value))
+        )(using
+            Frame
+        ): FlowEngine.Handle < (Async & Abort[FlowWorkflowNotRegisteredException | FlowSignalTypeMismatchException | FlowStoreException]) =
+            defs.use(_.latest.get(workflowId)).map {
+                case Absent        => Abort.fail(FlowWorkflowNotRegisteredException(workflowId.value))
                 case Present(defn) =>
-                    for
-                        eid <- Flow.Id.Execution.random
-                        now <- Clock.now
-                        _ <-
-                            store.createExecution(
+                    // Encoded first, so a start that is going to be refused writes nothing at all. Creation then carries the seeds,
+                    // which is what keeps a crash from leaving an execution that holds some of its declared inputs and not others.
+                    seedFields(defn, inputs).map { seeds =>
+                        for
+                            eid <- Flow.Id.Execution.random
+                            now <- Clock.now
+                            created <- store.createExecutionIfAbsent(
                                 eid,
                                 Flow.Status.Running,
                                 Flow.Event.Created(workflowId, eid, now),
-                                defn.meta.structuralHash
+                                defn.meta.structuralHash,
+                                seeds
                             )
-                        _ <-
-                            Kyo.foreachDiscard(defn.inputs) { inputMeta =>
-                                inputs.toDict.get(inputMeta.name) match
-                                    case Present(value) =>
-                                        val valid =
-                                            try
-                                                discard(inputMeta.schema.encodeString[Json](value)); true
-                                            catch case _: Throwable => false
-                                        if !valid then
-                                            Abort.fail(FlowSignalTypeMismatchException(
-                                                inputMeta.name,
-                                                inputMeta.tag.show,
-                                                value.getClass.getSimpleName
-                                            ))
-                                        else
-                                            store.putField[Any](eid, inputMeta.name, value)(using
-                                                inputMeta.tag,
-                                                inputMeta.schema
-                                            )
-                                        end if
-                                    case _ => ()
-                            }
-                    yield new FlowEngine.Handle(eid, FlowEngine.this)
+                            _ <- requireCreated(created, eid)
+                        yield new FlowEngine.Handle(eid, FlowEngine.this)
+                    }
             }
 
         /** Create an execution with a specific ID. Fails with FlowDuplicateExecutionException if the ID already exists. */
         def start(
             workflowId: Flow.Id.Workflow,
             executionId: Flow.Id.Execution
-        )(using Frame): Unit < (Async & Abort[FlowWorkflowNotRegisteredException | FlowDuplicateExecutionException]) =
-            defs.use(_.get(workflowId)).map {
+        )(using
+            Frame
+        ): Unit < (Async & Abort[FlowWorkflowNotRegisteredException | FlowDuplicateExecutionException | FlowStoreException]) =
+            defs.use(_.latest.get(workflowId)).map {
                 case Absent => Abort.fail(FlowWorkflowNotRegisteredException(workflowId.value))
                 case Present(defn) =>
-                    store.getExecution(executionId).map {
-                        case Present(_) => Abort.fail(FlowDuplicateExecutionException(executionId.value))
-                        case _ =>
-                            Clock.nowWith { now =>
-                                store.createExecution(
-                                    executionId,
-                                    Flow.Status.Running,
-                                    Flow.Event.Created(workflowId, executionId, now),
-                                    defn.meta.structuralHash
-                                )
-                            }
+                    Clock.nowWith { now =>
+                        // The store decides, in one operation. A read followed by a write let two concurrent starts on one id both
+                        // pass the check, and the loser's create then reset a running execution's history.
+                        store.createExecutionIfAbsent(
+                            executionId,
+                            Flow.Status.Running,
+                            Flow.Event.Created(workflowId, executionId, now),
+                            defn.meta.structuralHash,
+                            Dict.empty
+                        ).map {
+                            case true  => ()
+                            case false => Abort.fail(FlowDuplicateExecutionException(executionId.value))
+                        }
                     }
             }
 
+        /** The start-supplied values for the definition's declared inputs, encoded, refusing the whole start on the first that cannot be.
+          *
+          * Validation runs before anything is written, which is what makes a refused start leave no execution behind.
+          *
+          * **The width of the catch is forced, and it is not correct, it is honest.** Encoding has no total form: `Schema.encodeString`
+          * answers a `String` or throws, so the only way to learn that a supplied value does not match its declared input is to attempt
+          * the write and see what comes back. What comes back is not the same thing everywhere. On the JVM a mismatched value raises
+          * `ClassCastException` from the generated writer, which a typed catch could name; on JS and Wasm the same cast is UNDEFINED
+          * BEHAVIOR, and the linker raises `UndefinedBehaviorError` instead. A narrower catch is therefore not a narrower contract
+          * here, it is a contract that holds on one platform and lets the host die on two.
+          *
+          * **It is caught as a `Result`, and that is load-bearing rather than a matter of taste.** `UndefinedBehaviorError` extends
+          * `VirtualMachineError`, so `NonFatal` rejects it, and every catch built on `NonFatal`, `Abort.catching` included, lets it
+          * through to kill the host. `Result.catching` is a plain `try`/`catch` around one expression, so it is the only form here that
+          * reaches the failure on all four platforms while still answering with a value.
+          *
+          * **What bounds it is the call, not the catch.** The guarded expression is one synchronous, pure encode with no suspension
+          * point inside it, so in practice nothing but the encoder's own failure passes through, and the whole start is refused before
+          * anything is written either way. The residual is real and is pinned rather than hidden: a schema whose write throws something
+          * of its own is reported to the caller as a type mismatch, which the leaf named for that says out loud.
+          *
+          * **The closure is upstream.** A total encode in kyo-schema (`Result[EncodeException, String]`, or a generated writer that
+          * converts rather than casts) makes the failure a value on every platform, after which this reads it and the catch disappears.
+          */
+        private def seedFields(defn: FlowDefinition, inputs: Record[Any])(using
+            Frame
+        ): Dict[String, FlowStore.FieldData] < Abort[FlowSignalTypeMismatchException] =
+            val supplied = inputs.toDict
+            Kyo.foldLeft(Chunk.from(defn.inputs))(Dict.empty[String, FlowStore.FieldData]) { (acc, inputMeta) =>
+                supplied.get(inputMeta.name) match
+                    case Present(value) =>
+                        Result.catching[Throwable](inputMeta.schema.encodeString[Json](value)) match
+                            case Result.Success(text) =>
+                                acc.update(inputMeta.name, new FlowStore.FieldData(text, inputMeta.tag))
+                            case _ =>
+                                Abort.fail(FlowSignalTypeMismatchException(
+                                    inputMeta.name,
+                                    inputMeta.tag.show,
+                                    value.getClass.getSimpleName
+                                ))
+                    case _ => acc
+            }
+        end seedFields
+
+        /** Refuses to hand back a handle for an execution this call did not create.
+          *
+          * [[FlowStore.createExecutionIfAbsent]] answers whether THIS call created the row, and a false says the id was already
+          * taken. The handle would then address SOMEBODY ELSE'S execution: every later `signal`, `cancel` and `describe` through it
+          * would reach a stranger's, while the execution the caller asked for does not exist and never will.
+          *
+          * It is raised rather than returned on a typed channel because there is no answer a caller could act on. The id was
+          * generated here, so a collision is a defect in the id source or in the store, not something the call did wrong; the
+          * start-with-a-given-id overload, where the caller chose the id, answers [[FlowDuplicateExecutionException]] instead.
+          */
+        private def requireCreated(created: Boolean, executionId: Flow.Id.Execution)(using
+            Frame
+        ): Unit < Abort[FlowStoreException] =
+            if created then ()
+            else
+                Abort.panic(new IllegalStateException(
+                    s"the store already holds an execution under the freshly generated id ${executionId.value}, so no handle " +
+                        "can be returned for the execution this call was asked to start"
+                ))
+
         /** List all registered workflows with their metadata. */
-        def list(using Frame): Seq[FlowEngine.WorkflowInfo] < Async =
+        def list(using Frame): Seq[FlowEngine.WorkflowInfo] < (Async & Abort[FlowStoreException]) =
             store.listWorkflows
 
         /** Get metadata for a registered workflow. Fails with FlowWorkflowNotFoundException if not registered. */
         def describe(workflowId: Flow.Id.Workflow)(using
             Frame
-        ): FlowEngine.WorkflowInfo < (Async & Abort[FlowWorkflowNotFoundException]) =
+        ): FlowEngine.WorkflowInfo < (Async & Abort[FlowWorkflowNotFoundException | FlowStoreException]) =
             store.getWorkflow(workflowId).map {
                 case Absent     => Abort.fail(FlowWorkflowNotFoundException(workflowId.value))
                 case Present(m) => m
             }
 
         /** List all executions of a workflow, regardless of status. */
-        def executions(workflowId: Flow.Id.Workflow)(using Frame): Chunk[FlowStore.ExecutionState] < Async =
-            store.listExecutions(workflowId, Maybe.empty, Int.MaxValue, 0)
+        def executions(workflowId: Flow.Id.Workflow)(using Frame): Chunk[FlowStore.ExecutionState] < (Async & Abort[FlowStoreException]) =
+            store.listExecutions(workflowId, Maybe.empty, Maybe.empty, 0)
 
         /** Render the workflow's structure as a diagram. */
         def diagram(
             workflowId: Flow.Id.Workflow,
             format: Flow.DiagramFormat = Flow.DiagramFormat.Mermaid
-        )(using Frame): String < (Async & Abort[FlowWorkflowNotRegisteredException]) =
-            defs.use(_.get(workflowId)).map {
+        )(using Frame): String < (Async & Abort[FlowWorkflowNotRegisteredException | FlowStoreException]) =
+            defs.use(_.latest.get(workflowId)).map {
                 case Absent => Abort.fail(FlowWorkflowNotRegisteredException(workflowId.value))
                 case Present(defn) =>
                     FlowRender.render(defn.flow, format)
@@ -149,7 +216,9 @@ final class FlowEngine private (
         /** Deliver a typed value to a named input of a running execution.
           *
           * Fails if the execution is terminal, the input name doesn't exist in the workflow definition, the type doesn't match, or the
-          * input was already delivered. Delivery is atomic (exactly-once via putFieldIfAbsent).
+          * input was already delivered. **Delivery is exactly-once and the store judges it**: the field and the `InputReceived` event
+          * are one transition, refused against an execution that is already over, so a value cannot land on an execution that finished
+          * while the delivery was in flight and leave the caller told it succeeded.
           */
         def signal[V: Tag: Schema](
             executionId: Flow.Id.Execution,
@@ -157,13 +226,15 @@ final class FlowEngine private (
             value: V
         )(using
             Frame
-        ): Unit < (Async & Abort[FlowExecutionStateException | FlowWorkflowNotRegisteredException | FlowSignalException]) =
+        ): Unit < (Async & Abort[
+            FlowExecutionStateException | FlowWorkflowNotRegisteredException | FlowSignalException | FlowStoreException
+        ]) =
             store.getExecution(executionId).map {
                 case Absent => Abort.fail(FlowExecutionNotFoundException(executionId.value))
                 case Present(state) if state.status.isTerminal =>
                     Abort.fail(FlowExecutionTerminalException(executionId.value, state.status))
                 case Present(state) =>
-                    defs.use(_.get(state.flowId)).map {
+                    defs.use(_.of(state.flowId, state.hash)).map {
                         case Absent => Abort.fail(FlowWorkflowNotRegisteredException(state.flowId.value))
                         case Present(defn) =>
                             Maybe.fromOption(defn.inputs.find(_.name == name)) match
@@ -173,15 +244,21 @@ final class FlowEngine private (
                                     if !(Tag[V] =:= inputMeta.tag) then
                                         Abort.fail(FlowSignalTypeMismatchException(name, inputMeta.tag.show, Tag[V].show))
                                     else
-                                        store.putFieldIfAbsent[V](executionId, name, value).map {
-                                            case true =>
-                                                Clock.nowWith(ts =>
-                                                    store.appendEvent(
-                                                        executionId,
-                                                        Flow.Event.InputReceived(state.flowId, executionId, name, ts)
-                                                    )
-                                                )
-                                            case false => Abort.fail(FlowInputAlreadyDeliveredException(executionId.value, name))
+                                        Clock.nowWith { ts =>
+                                            store.signal[V](
+                                                executionId,
+                                                name,
+                                                value,
+                                                Flow.Event.InputReceived(state.flowId, executionId, name, ts)
+                                            )
+                                        }.map {
+                                            case FlowStore.SignalOutcome.Delivered => ()
+                                            case FlowStore.SignalOutcome.AlreadyDelivered =>
+                                                Abort.fail(FlowInputAlreadyDeliveredException(executionId.value, name))
+                                            // The read above found the execution running and the store found it over, which is the
+                                            // window a check-then-write leaves open and the store closes by judging both facts at once.
+                                            case FlowStore.SignalOutcome.AlreadyTerminal(status) =>
+                                                Abort.fail(FlowExecutionTerminalException(executionId.value, status))
                                         }
                     }
             }
@@ -189,50 +266,77 @@ final class FlowEngine private (
         /** Get full execution detail including status, progress, and pending input information. */
         def describe(executionId: Flow.Id.Execution)(using
             Frame
-        ): FlowEngine.ExecutionDetail < (Async & Abort[FlowExecutionNotFoundException]) =
+        ): FlowEngine.ExecutionDetail < (Async & Abort[FlowExecutionNotFoundException | FlowStoreException]) =
             store.getExecution(executionId).map {
                 case Absent => Abort.fail(FlowExecutionNotFoundException(executionId.value))
                 case Present(state) =>
-                    defs.use(_.get(state.flowId)).map {
+                    defs.use(_.of(state.flowId, state.hash)).map {
                         case Absent =>
                             FlowEngine.ExecutionDetail(state, Seq.empty, FlowEngine.Progress.empty)
                         case Present(defn) =>
                             for
                                 fields  <- store.getAllFields(executionId)
-                                history <- store.getHistory(executionId, Int.MaxValue, 0)
+                                history <- store.getHistory(executionId, Maybe.empty, 0)
                                 completed       = deriveCompleted(history)
+                                compensated     = deriveCompensated(history)
+                                failed          = deriveFailed(history)
                                 deliveredInputs = deliveredInputNames(defn, fields)
-                                progress        = FlowEngine.Progress.build(defn.flow, completed ++ deliveredInputs, state.status)
+                                progress = FlowEngine.Progress.build(
+                                    defn.flow,
+                                    completed ++ deliveredInputs,
+                                    state.status,
+                                    state.waits,
+                                    compensated,
+                                    failed
+                                )
                                 inputInfos = defn.inputs.map { im =>
-                                    FlowEngine.InputInfo(im.name, im.tag.show, delivered = fields.contains(im.name))
+                                    FlowEngine.InputStatus(im.name, im.tag.show, delivered = fields.contains(im.name))
                                 }
                             yield FlowEngine.ExecutionDetail(state, inputInfos, progress)
                     }
             }
 
-        /** Cancel a running execution. No-op if already terminal. In-flight steps complete; no new steps start. */
-        def cancel(executionId: Flow.Id.Execution)(using Frame): Unit < Async =
-            store.getExecution(executionId).map {
-                case Absent                                    => ()
-                case Present(state) if state.status.isTerminal => ()
-                case Present(state) =>
-                    Clock.nowWith { now =>
-                        store.updateStatus(executionId, Flow.Status.Cancelled, Flow.Event.Cancelled(state.flowId, executionId, now))
-                    }
-            }
+        /** Ask for a running execution to be cancelled, and say what the ask did.
+          *
+          * **The request returns before the execution stops, and that is the contract.** Cancelling runs the execution's
+          * compensations, so the terminal `Cancelled` is written at the END of an unwind: an executor observes the request at the next
+          * node boundary, no further step starts, the handlers run in reverse, and only then does the status change. Until then the
+          * execution reads as cancelling, which [[FlowStore.ExecutionState.cancelRequested]] carries and
+          * [[FlowStore.ExecutionFilter.Cancelling]] selects on.
+          *
+          * **Which is exactly why the answer is not `Unit`.** Nothing about a cancel is observable on return except this value, so
+          * collapsing the three answers leaves no caller able to tell an accepted request from a no-op against an execution that was
+          * already over. [[FlowStore.CancelOutcome.Accepted]] means the request is now outstanding and the unwind will run,
+          * [[FlowStore.CancelOutcome.AlreadyRequested]] means somebody asked first and it still stands, and
+          * [[FlowStore.CancelOutcome.AlreadyTerminal]] means there was nothing to cancel and carries what the execution ended as. The
+          * last is an answer and not a failure: a caller that cancels something already finished got what it wanted, and what it
+          * needs back is the terminal status rather than an error.
+          */
+        def cancel(executionId: Flow.Id.Execution)(using Frame): FlowStore.CancelOutcome < (Async & Abort[FlowStoreException]) =
+            store.requestCancel(executionId)
 
-        /** Cancel all non-terminal executions, optionally filtered by workflow. Returns the count cancelled. */
-        def cancelAll(wfId: Maybe[Flow.Id.Workflow] = Maybe.empty)(using Frame): Int < Async =
-            val wfIds: Seq[Flow.Id.Workflow] < Sync = wfId match
+        /** Ask for every non-terminal execution to be cancelled, optionally filtered by workflow. Returns how many requests this call
+          * put on.
+          *
+          * **Requests issued, not executions cancelled, and the difference is the whole meaning of the number.** Cancelling runs an
+          * execution's compensations, so an execution counted here has been ASKED to stop and may still be unwinding minutes later,
+          * and one that finished on its own before the request was observed was never asked at all. A count named for completed work,
+          * returned by a method whose work is deferred, tells an operator the sweep is over when it has just begun.
+          *
+          * Counted exactly once each: an execution somebody had already asked to cancel is not counted again, and one that reached a
+          * terminal status in between is not counted at all.
+          */
+        def cancelAll(wfId: Maybe[Flow.Id.Workflow] = Maybe.empty)(using Frame): Int < (Async & Abort[FlowStoreException]) =
+            val wfIds: Seq[Flow.Id.Workflow] < (Async & Abort[FlowStoreException]) = wfId match
                 case Present(id) => Seq(id)
-                case _           => defs.use(_.keys.toArray.toSeq)
+                case _           => sweptWorkflowIds
             wfIds.map { ids =>
                 Kyo.foreach(ids) { id =>
-                    store.listExecutions(id, Maybe.empty, Int.MaxValue, 0).map { execs =>
+                    store.listExecutions(id, Maybe.empty, Maybe.empty, 0).map { execs =>
                         Kyo.foreach(execs.filter(!_.status.isTerminal).toSeq) { ex =>
-                            Clock.nowWith { now =>
-                                store.updateStatus(ex.executionId, Flow.Status.Cancelled, Flow.Event.Cancelled(id, ex.executionId, now))
-                                    .andThen(1)
+                            store.requestCancel(ex.executionId).map {
+                                case FlowStore.CancelOutcome.Accepted => 1
+                                case _                                => 0
                             }
                         }.map(_.sum)
                     }
@@ -240,67 +344,100 @@ final class FlowEngine private (
             }
         end cancelAll
 
-        /** Get paginated event history for an execution. Events are in append order. */
-        def history(executionId: Flow.Id.Execution, limit: Int = 50, offset: Int = 0)(using Frame): FlowStore.HistoryPage < Async =
-            store.getHistory(executionId, limit, offset)
+        /** Get paginated event history for an execution. Events are in append order.
+          *
+          * A negative `limit` reads as unbounded rather than as an empty page, the contract [[FlowStore.getHistory]] states and every
+          * implementation keeps, because an empty page that still claims another follows is the pair a paging caller loops on forever.
+          * `offset` is expected non-negative; the HTTP surface refuses a negative one rather than passing it down.
+          */
+        def history(executionId: Flow.Id.Execution, limit: Int = 50, offset: Int = 0)(using
+            Frame
+        ): FlowStore.HistoryPage < (Async & Abort[FlowStoreException]) =
+            store.getHistory(executionId, Maybe(limit), offset)
 
         /** List all inputs for an execution, showing which have been delivered and which are still pending. */
         def inputs(executionId: Flow.Id.Execution)(using
             Frame
-        ): Seq[FlowEngine.InputInfo] < (Async & Abort[FlowExecutionNotFoundException | FlowWorkflowNotRegisteredException]) =
+        ): Seq[FlowEngine.InputStatus] < (Async & Abort[
+            FlowExecutionNotFoundException | FlowWorkflowNotRegisteredException | FlowStoreException
+        ]) =
             store.getExecution(executionId).map {
                 case Absent => Abort.fail(FlowExecutionNotFoundException(executionId.value))
                 case Present(state) =>
-                    defs.use(_.get(state.flowId)).map {
+                    defs.use(_.of(state.flowId, state.hash)).map {
                         case Absent => Abort.fail(FlowWorkflowNotRegisteredException(state.flowId.value))
                         case Present(defn) =>
                             store.getAllFields(executionId).map { fields =>
                                 defn.inputs.map { im =>
-                                    FlowEngine.InputInfo(im.name, im.tag.show, delivered = fields.contains(im.name))
+                                    FlowEngine.InputStatus(im.name, im.tag.show, delivered = fields.contains(im.name))
                                 }
                             }
                     }
             }
 
-        /** Search executions across workflows with optional status filter and pagination. */
+        /** Search executions, most recently created first, with an optional filter the store evaluates before it selects.
+          *
+          * **The page is cut once, here, over the matches from every workflow the sweep covers.** Asking each workflow for
+          * `(limit, offset)` and then paging the merged answer applies the offset twice, so six executions across two workflows paged
+          * at two from an offset of two answer nothing at all; and truncating each workflow before the merge evicts rows that belong
+          * in the global page whenever one workflow's executions are newer than another's, which is wrong on the first page too.
+          *
+          * **`total` is how many matched, not how many came back**, because a field named `total` beside `items`, returned from a
+          * method taking `limit` and `offset`, is the size of the set being paged through, and a caller that divides it by its page
+          * size or compares it against what it has collected reads it that way. Answering it costs reading every match: the store's
+          * vocabulary has no count, so the matches are what is counted.
+          *
+          * A negative `limit` reads as unbounded rather than as an empty page, the contract [[FlowStore.listExecutions]] states for
+          * the same value, because an empty page is the one answer a caller cannot tell from "nothing matched".
+          */
         def search(
             wfId: Maybe[Flow.Id.Workflow] = Maybe.empty,
-            status: Maybe[Flow.Status] = Maybe.empty,
+            filter: Maybe[FlowStore.ExecutionFilter] = Maybe.empty,
             limit: Int = 25,
             offset: Int = 0
-        )(using Frame): FlowEngine.SearchResult < Async =
-            val results = wfId match
-                case Present(id) => store.listExecutions(id, status, limit, offset)
+        )(using Frame): FlowEngine.SearchResult < (Async & Abort[FlowStoreException]) =
+            val matched: Chunk[FlowStore.ExecutionState] < (Async & Abort[FlowStoreException]) = wfId match
+                case Present(id) => store.listExecutions(id, filter, Maybe.empty, 0)
                 case _ =>
-                    defs.use(_.keys.toArray.toSeq).map { ids =>
-                        Kyo.foreach(ids)(id =>
-                            store.listExecutions(id, status, limit, offset)
-                        ).map { chunks =>
-                            Chunk.from(
-                                chunks.foldLeft(Chunk.empty[FlowStore.ExecutionState])(_ ++ _)
-                                    .toSeq.sortBy(_.created)(using Ordering[Instant]).reverse
-                                    .drop(offset).take(limit)
-                            )
+                    sweptWorkflowIds.map { ids =>
+                        Kyo.foreach(ids)(id => store.listExecutions(id, filter, Maybe.empty, 0)).map { chunks =>
+                            chunks.foldLeft(Chunk.empty[FlowStore.ExecutionState])(_ ++ _)
                         }
                     }
-            results.map(r => FlowEngine.SearchResult(r.toSeq, r.length))
+            matched.map { all =>
+                // Sorted descending in one pass rather than ascending-and-reversed, so the sort is stable over rows sharing a
+                // `created` instant and leaves an already-ordered answer from the store exactly as it found it.
+                val ordered = all.toSeq.sortBy(_.created)(using Ordering[Instant].reverse)
+                val dropped = ordered.drop(offset)
+                val page    = if limit < 0 then dropped else dropped.take(limit)
+                FlowEngine.SearchResult(page, all.length)
+            }
         end search
 
         /** Render the execution's flow diagram with progress overlay (completed nodes highlighted). */
         def diagram(executionId: Flow.Id.Execution, format: Flow.DiagramFormat = Flow.DiagramFormat.Mermaid)(using
             Frame
-        ): String < (Async & Abort[FlowExecutionNotFoundException | FlowWorkflowNotRegisteredException]) =
+        ): String < (Async & Abort[FlowExecutionNotFoundException | FlowWorkflowNotRegisteredException | FlowStoreException]) =
             store.getExecution(executionId).map {
                 case Absent => Abort.fail(FlowExecutionNotFoundException(executionId.value))
                 case Present(state) =>
-                    defs.use(_.get(state.flowId)).map {
+                    defs.use(_.of(state.flowId, state.hash)).map {
                         case Absent => Abort.fail(FlowWorkflowNotRegisteredException(state.flowId.value))
                         case Present(defn) =>
                             store.getAllFields(executionId).map { fields =>
-                                store.getHistory(executionId, Int.MaxValue, 0).map { history =>
+                                store.getHistory(executionId, Maybe.empty, 0).map { history =>
                                     val completed       = deriveCompleted(history)
+                                    val compensated     = deriveCompensated(history)
+                                    val failed          = deriveFailed(history)
                                     val deliveredInputs = deliveredInputNames(defn, fields)
-                                    val progress        = FlowEngine.Progress.build(defn.flow, completed ++ deliveredInputs, state.status)
+                                    val progress = FlowEngine.Progress.build(
+                                        defn.flow,
+                                        completed ++ deliveredInputs,
+                                        state.status,
+                                        state.waits,
+                                        compensated,
+                                        failed
+                                    )
                                     FlowRender.render(defn.flow, format, Maybe(progress))
                                 }
                             }
@@ -311,8 +448,14 @@ final class FlowEngine private (
 
     // --- Registration ---
 
-    /** Register a workflow whose step bodies use only effects the engine already handles. */
-    def register(id: Flow.Id.Workflow, flow: Flow[?, ?, ?])(using Frame): Unit < Async =
+    /** Register a workflow whose step bodies use only effects the engine already handles.
+      *
+      * Refuses a definition that cannot be executed durably: one with no name, one using a reserved character in a node name, and one in
+      * which two nodes claim a single durable name. See [[FlowDefinitionException]] for what each means and what the answer to it is.
+      */
+    def register(id: Flow.Id.Workflow, flow: Flow[?, ?, ?])(using
+        Frame
+    ): Unit < (Async & Abort[FlowDefinitionException | FlowStoreException]) =
         registerImpl(id, flow, Maybe.empty)
 
     /** Register a workflow whose step bodies use custom effects.
@@ -325,134 +468,474 @@ final class FlowEngine private (
       */
     def register[S](id: Flow.Id.Workflow, flow: Flow[?, ?, S])(
         runner: [V] => V < S => V < (Async & Scope & Abort[FlowException])
-    )(using Frame): Unit < Async =
+    )(using Frame): Unit < (Async & Abort[FlowDefinitionException | FlowStoreException]) =
         registerImpl(id, flow, Maybe(FlowRunner[S](runner)))
 
-    private[kyo] def registerImpl(id: Flow.Id.Workflow, flow: Flow[?, ?, ?], runner: Maybe[FlowRunner])(using Frame): Unit < Async =
-        val meta   = FlowEngine.WorkflowInfo.of(id.value, flow)
-        val schema = WorkflowSchema.of(flow)
-        val inputs = kyo.internal.FlowLint.inputMetas(flow)
-        val defn   = FlowDefinition(id, flow, runner, inputs, meta, schema)
-        defs.getAndUpdate(_.update(id, defn)).unit.andThen(store.putWorkflow(meta))
+    private[kyo] def registerImpl(id: Flow.Id.Workflow, flow: Flow[?, ?, ?], runner: Maybe[FlowRunner])(using
+        Frame
+    ): Unit < (Async & Abort[FlowDefinitionException | FlowStoreException]) =
+        validate(id, flow).andThen {
+            val meta   = FlowEngine.WorkflowInfo.of(id.value, flow)
+            val schema = WorkflowSchema.of(flow)
+            val inputs = kyo.internal.FlowLint.inputMetas(flow)
+            val defn   = FlowDefinition(id, flow, runner, inputs, meta, schema)
+            // The definition goes into the map BEFORE the store hears about it, because `putWorkflow` wakes the pollers and a woken
+            // poll asks this map what it serves. Nothing else is needed to recover an execution held for this version: readiness
+            // gates on the served set, so registering the version is what makes the row claimable.
+            defs.getAndUpdate(_.register(id, defn)).unit
+                .andThen(store.putWorkflow(meta))
+        }
     end registerImpl
+
+    /** Decides whether a definition can be executed durably at all, and refuses it here if it cannot.
+      *
+      * Registration is where these belong because it is the first place with both the whole definition and an effect row. A constructor
+      * sees one node at a time, so it can neither know that a later node will claim the same name nor report what it does know as anything
+      * but a throw, which is the untyped refusal this replaces.
+      *
+      * The checks are ordered by how much of the definition each one trusts. A flow with no name has no identity to be refused under; a
+      * reserved character makes a name unusable on its own terms; only then is it worth asking how the names relate to each other.
+      */
+    private def validate(id: Flow.Id.Workflow, flow: Flow[?, ?, ?])(using Frame): Unit < Abort[FlowDefinitionException] =
+        FlowLint.flowName(flow) match
+            case Present(name) if name.nonEmpty =>
+                val reserved = FlowLint.reservedNames(flow)
+                if reserved.nonEmpty then Abort.fail(FlowReservedNameException(id.value, reserved))
+                else
+                    val conflicts = FlowLint.nameConflicts(flow)
+                    if conflicts.nonEmpty then Abort.fail(FlowDuplicateNameException(id.value, conflicts))
+                    else ()
+                end if
+            case _ => Abort.fail(FlowUnnamedException())
+
+    /** The workflow's non-terminal executions whose version this engine does not serve, each with its own hash and cancel flag.
+      *
+      * **A report, not a status.** Nothing is written about being held in either direction: an execution is held exactly while no
+      * registered definition matches its structural hash, which is a fact about what this engine serves and goes stale the moment an
+      * operator registers something. A written status would have to be un-written by whoever noticed, and an execution held under one
+      * engine may be running perfectly well under another.
+      *
+      * **Held rather than failed, and the difference is what an operator can do about it.** A structural change to a deployed flow
+      * leaves its in-flight executions matched to a definition that is no longer the one registered under their workflow id, and replaying
+      * them against the new one would run a different flow. A held execution keeps its fields, its history and its place, and runs again on
+      * its own once a definition with its hash is registered, which makes rolling the deployment back the recovery. Failing it instead is
+      * unrecoverable and skips every compensation on the way out, because the handlers live in the definition it can no longer be matched
+      * to.
+      *
+      * Each entry carries the execution's own `hash`, which is the fact an operator needs: an execution held here declares the version it
+      * was started under, and whether any engine still serves that version is what registration decides.
+      *
+      * The predicate is evaluated by the store, before it paginates: computing it here over a fetched page would return pages the
+      * predicate then ate.
+      *
+      * A negative `limit` reads as unbounded rather than as an empty page, the contract [[FlowStore.listExecutions]] states and every
+      * implementation keeps. `offset` is expected non-negative.
+      */
+    def parked(
+        workflowId: Flow.Id.Workflow,
+        limit: Int = Int.MaxValue,
+        offset: Int = 0
+    )(using Frame): Chunk[FlowStore.ExecutionState] < (Async & Abort[FlowStoreException]) =
+        defs.use(_.servedHashes(workflowId)).map { hashes =>
+            store.listExecutions(workflowId, Maybe(FlowStore.ExecutionFilter.Orphaned(hashes)), Maybe(limit), offset)
+        }
 
     // --- Internal ---
 
-    private def withEvent[A, S2](eid: Flow.Id.Execution, event: Instant => Flow.Event)(body: => A < S2)(using Frame): A < (S2 & Async) =
-        Clock.nowWith(ts => store.appendEvent(eid, event(ts))).andThen(body)
+    /** Every workflow a sweep over "everything" has to cover: the ones the store holds, plus the ones this engine registered.
+      *
+      * **Not the engine's own registry, which is the wrong population to be blind to.** An execution written by another engine, or
+      * left behind by a workflow this process no longer registers, belongs to a workflow the store knows about and this engine does not
+      * serve. Such an execution is also unclaimable here, since readiness gates on the served set, so it makes no progress and emits no
+      * events, which makes it exactly the one an operator is hunting; enumerating the registry that does not contain it is how it
+      * becomes invisible to every surface at once.
+      *
+      * The engine's own ids are unioned in rather than trusted away, so a workflow this process registered is still swept if the
+      * store's workflow table has not caught up with the registration.
+      */
+    private def sweptWorkflowIds(using Frame): Seq[Flow.Id.Workflow] < (Async & Abort[FlowStoreException]) =
+        store.listWorkflows.map { held =>
+            defs.use(_.workflowIds).map { registered =>
+                (held.map(w => Flow.Id.Workflow(w.id)) ++ registered).distinct
+            }
+        }
 
+    /** Appends one event under the claim, answering whether the claim still held.
+      *
+      * Every event the engine writes about an attempt is a claimed write like every other, so an executor whose row was taken cannot
+      * narrate its own progress into an execution somebody else is running. Two workers of one engine share an executor id, which is
+      * why an owner-matched append is not even a store no-op for the loser.
+      */
+    private def claimedEvent(claimed: FlowStore.Claimed, event: Instant => Flow.Event)(using
+        Frame
+    ): Boolean < (Async & Abort[FlowStoreException]) =
+        Clock.nowWith(ts => claimed.appendEvent(event(ts))).map {
+            case FlowStore.WriteOutcome.Applied   => true
+            case FlowStore.WriteOutcome.ClaimLost => false
+        }
+
+    /** One worker's poll loop, wrapped so that a failure reaching the store retries instead of killing the fiber.
+      *
+      * A store failure raised while EXECUTING reaches no verdict: it is charged to health, nothing is written about the execution and
+      * the claim is left to lapse ([[finish]]'s `Infra` arm). A failure raised while CLAIMING has no such home, and left to escape it
+      * kills the worker fiber with nothing logged and no status changed, leaving a process that answers its health check while no
+      * execution ever progresses again. Every failure here is a failure to reach the store, which is the transient kind, so the loop
+      * pauses for the poll timeout and goes around again.
+      */
     private[kyo] def worker(
         lease: Duration,
         renewEvery: Duration,
         batchSize: Int,
         pollTimeout: Duration
-    )(using Frame): Unit < (Async & Scope) =
-        defs.use(_.keys.toArray.toSet).map { wfIds =>
-            if wfIds.isEmpty then Async.sleep(pollTimeout).andThen(worker(lease, renewEvery, batchSize, pollTimeout))
-            else
-                store.claimReady(wfIds, executorId, lease, batchSize, pollTimeout).map { batch =>
-                    Kyo.foreachDiscard(batch) { state =>
-                        val eid = state.executionId
-                        store.renewClaim(eid, executorId, lease).map {
-                            case false => ()
-                            case true =>
-                                withEvent(eid, ts => Flow.Event.ExecutionClaimed(state.flowId, eid, executorId, ts)) {
-                                    Fiber.init {
-                                        def renew: Unit < Async =
-                                            Async.sleep(renewEvery).map { _ =>
-                                                store.renewClaim(eid, executorId, lease).map {
-                                                    case true  => renew
-                                                    case false => ()
-                                                }
-                                            }
-                                        renew
-                                    }.map { renewFiber =>
-                                        Sync.ensure(renewFiber.interrupt) {
-                                            Abort.recover[Throwable] { ex =>
-                                                Clock.nowWith { ts =>
-                                                    store.updateStatus(
-                                                        eid,
-                                                        Flow.Status.Failed(ex.getMessage),
-                                                        Flow.Event.Failed(state.flowId, eid, ex.getMessage, ts)
-                                                    )
-                                                }
-                                            }(executeOne(eid)).andThen {
-                                                withEvent(
-                                                    eid,
-                                                    ts => Flow.Event.ExecutionReleased(state.flowId, eid, executorId, ts)
-                                                ) {
-                                                    store.releaseClaim(eid, executorId)
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                        }
-                    }.andThen(worker(lease, renewEvery, batchSize, pollTimeout))
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        // The loop goes around HERE, in the continuation of the handler, and never inside `pollOnce`. A poll that
+        // recursed into the next one from inside `Abort.run` would leave that handler open across every cycle, so a
+        // loop that is meant to run for the process's life would nest one more handler per poll, forever.
+        Abort.run[Throwable](pollOnce(lease, renewEvery, batchSize, pollTimeout)).map {
+            case Result.Success(_) => worker(lease, renewEvery, batchSize, pollTimeout)
+            // An interrupt is the engine going away, not a store that cannot be reached, so it stops the loop rather
+            // than being counted against the store's health and slept off. It has to be picked out by hand because
+            // `Interrupted` is an ordinary exception: `Result.Panic` carries every throwable `NonFatal` admits, and
+            // nothing else here tells it apart from a defect worth another attempt. The worker's own interruption is
+            // already stopped at its safepoint; what reaches this arm is one raised inside the poll, by a race or a
+            // timeout the store ran internally.
+            case Result.Panic(interrupted: Interrupted) => Abort.panic(interrupted)
+            case failed                                 =>
+                // Both channels, because a store is free to panic even though the SPI gives it somewhere typed to put
+                // a failure: an implementation is third-party code, and a defect in one poll must not permanently stop
+                // the only loop that moves executions forward while the process still answers its health check.
+                val error = failed match
+                    case Result.Failure(e) => e
+                    case Result.Panic(e)   => e
+                    case _                 => new IllegalStateException("worker poll failed with no error")
+                liveness.recordFailure(error).andThen {
+                    Log.error(s"kyo.flow: executor ${executorId.value} could not poll the store, retrying", error)
+                        .andThen(Async.sleep(pollTimeout))
+                        .andThen(worker(lease, renewEvery, batchSize, pollTimeout))
                 }
         }
 
-    private def executeOne(eid: Flow.Id.Execution)(using Frame): Unit < Async =
-        store.getExecution(eid).map {
-            case Present(state) if state.status.isTerminal => ()
-            case Present(state) =>
-                withEvent(eid, ts => Flow.Event.ExecutionResumed(state.flowId, eid, executorId, ts)) {
-                    defs.use(_.get(state.flowId)).map {
-                        case Present(defn) if state.hash == defn.meta.structuralHash =>
-                            Abort.run[Throwable] {
-                                for
-                                    _ <- (state.status match
-                                        case Flow.Status.Sleeping(name, _) =>
-                                            Clock.nowWith(ts =>
-                                                store.updateStatus(
-                                                    eid,
-                                                    Flow.Status.Running,
-                                                    Flow.Event.SleepCompleted(state.flowId, eid, name, ts)
-                                                )
-                                            )
-                                        case _ => ()
-                                    ): Unit < Async
-                                    fields  <- store.getAllFields(eid)
-                                    history <- store.getHistory(eid, Int.MaxValue, 0)
-                                    record    = rebuildRecord(fields, defn.schema)
-                                    completed = deriveCompleted(history)
-                                    interp    = new StoreInterpreter(store, eid, state.flowId, executorId, defn)
-                                    flowExec = Flow.run(defn.flow, record, completed)(interp)
-                                        .map(_.asInstanceOf[Record[Any]])
-                                    wrappedExec = defn.runner match
-                                        case Present(r) => r.erased(flowExec)
-                                        case _          => flowExec
-                                    result <- Abort.run[FlowSuspension] {
-                                        Abort.run[FlowException] {
-                                            wrappedExec
-                                        }
-                                    }
-                                    _ <- handleResult(eid, state.flowId, result)
-                                yield ()
-                            }.map {
-                                case Result.Panic(ex) =>
-                                    Clock.nowWith { ts =>
-                                        store.updateStatus(
-                                            eid,
-                                            Flow.Status.Failed(ex.getMessage),
-                                            Flow.Event.Failed(state.flowId, eid, ex.getMessage, ts)
-                                        )
-                                    }
-                                case _ => ()
-                            }
-                        case _ =>
-                            // Workflow definition not found or hash mismatch — fail the execution
-                            Clock.nowWith { ts =>
-                                store.updateStatus(
-                                    eid,
-                                    Flow.Status.Failed("Workflow definition not found or version mismatch"),
-                                    Flow.Event.Failed(state.flowId, eid, "Workflow definition not found or version mismatch", ts)
-                                )
-                            }
+    private def pollOnce(
+        lease: Duration,
+        renewEvery: Duration,
+        batchSize: Int,
+        pollTimeout: Duration
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        defs.use(identity).map { registered =>
+            val served = registered.served
+            if served.isEmpty then Async.sleep(pollTimeout)
+            else
+                // The served set is re-read on every poll, which is what an early empty answer is for: the store returns
+                // one when a definition is registered, and it means poll again with the wider set rather than that the
+                // timeout elapsed. Nothing here needs to tell the two apart, because an empty batch walks nothing and
+                // the loop's next ask is another BLOCKING claim, so one registration buys one re-attempt, never a spin.
+                store.claimReady(served, executorId, lease, batchSize, pollTimeout).map { batch =>
+                    // The walk CONFIRMS each claim and starts the execution, then moves on. Awaiting the execution here
+                    // would make the batch serial: everything past the first would sit claimed with no renewal fiber
+                    // until its turn came, so a first member that runs for an hour starves the rest for an hour and lets
+                    // their leases lapse while they queue. Each execution already has a fiber and a renewal of its own,
+                    // so its supervision belongs beside them rather than in front of the next execution.
+                    //
+                    // The confirmation stays HERE rather than moving into the fiber, and the difference is observable.
+                    // A claim can lapse between being granted and being confirmed, and the row is then claimable by
+                    // whoever polls next, this executor included. Asking from the fiber puts that question in a race
+                    // with this worker's own next poll: the poll re-claims the row under a fresh lease, and the fiber
+                    // would then be renewing a generation the row no longer carries. The renewal answers that correctly
+                    // because it is judged against the token rather than against the executor id, and asking here
+                    // answers it before the next poll can be made either way.
+                    Kyo.foreachDiscard(batch) { claimed =>
+                        // The definition is in hand before the attempt starts, and it is the one the execution was STARTED
+                        // under: readiness handed this row over because its `(workflow, hash)` is in the set above, and the
+                        // map only grows within a process, so the lookup cannot miss. A row that somehow arrives unserved is
+                        // left exactly as a refused renewal leaves one, claimed until its lease lapses.
+                        registered.of(claimed.state.flowId, claimed.state.hash) match
+                            case Absent => ()
+                            case Present(defn) =>
+                                claimed.renewClaim(lease).map {
+                                    // Nothing is written and nothing is released: a release presented on a lapsed claim is
+                                    // refused by the same rule that refused the renewal, and the row is already claimable.
+                                    case false => ()
+                                    case true  => superviseDetached(claimed, defn, lease, renewEvery)
+                                }
+                        end match
                     }
-                } // end withEvent ExecutionResumed
-            case _ => ()
+                }
+            end if
         }
+
+    /** Spawns one attempt's supervision, tracked for the engine's shutdown and forgotten the moment it ends.
+      *
+      * **An attempt's fibers must not outlive the attempt in the engine's bookkeeping.** [[Fiber.init]] is
+      * `Scope.acquireRelease(...)(_.interrupt)`, and a scope's finalizer store only ever grows: nothing removes an entry when the
+      * fiber it would interrupt has already finished. Spawning the supervision under the engine's own scope therefore leaves one dead
+      * entry per attempt, for the life of a process that is meant to run for the life of the process, and an execution that parks and
+      * resumes a thousand times pays a thousand of them. Each entry retains its closure and the finished fiber's result.
+      *
+      * So the supervision is spawned detached and tracked here instead, where an ending removes it. The registry is what shutdown
+      * interrupts, which is the one thing the scope entry was for; [[Absent]] is the engine's scope having closed, and a supervision
+      * that arrives after that is interrupted at once rather than being tracked by a registry nobody will read again. Registering
+      * BEFORE arranging the removal is what keeps a fiber that finishes immediately from leaving its entry behind: `onComplete` on a
+      * finished fiber runs its callback now.
+      */
+    private def superviseDetached(
+        claimed: FlowStore.Claimed,
+        defn: FlowDefinition,
+        lease: Duration,
+        renewEvery: Duration
+    )(using Frame): Unit < Sync =
+        Fiber.initUnscoped(supervise(claimed, defn, lease, renewEvery)).map { fiber =>
+            supervisions.updateAndGet {
+                case Present(live) => Present(live + fiber)
+                case _             => Absent
+            }.map {
+                case Present(_) => fiber.onComplete(_ => supervisions.updateAndGet(_.map(_ - fiber)).unit)
+                case _          => fiber.interrupt.unit
+            }
+        }
+
+    /** Interrupts every attempt this engine is still carrying, and refuses to track another.
+      *
+      * Registered on the engine's scope, so closing it stops the executions the engine was running. Nothing is written about any of
+      * them: an interrupted attempt reaches no verdict, and each supervision's own scope interrupts the execution and renewal fibers
+      * below it on the way out.
+      */
+    private[kyo] def stopSupervisions(using Frame): Unit < Async =
+        supervisions.getAndSet(Absent).map {
+            case Present(live) => Kyo.foreachDiscard(live.toSeq)(_.interrupt.unit)
+            case _             => ()
+        }
+
+    /** Runs one confirmed execution to its outcome and gives the claim back, on a fiber of its own.
+      *
+      * Every store failure here is answered rather than raised, for the reason [[finish]] answers its own: this runs detached from the
+      * poll loop, so a raised failure would reach nobody, and it is a failure to reach the store rather than a verdict on the work. It is
+      * charged to health, where a failing store is visible, and the execution is left exactly as claimable as it was.
+      *
+      * **The execution and renewal fibers belong to the attempt, so they are spawned in a scope of the attempt's own.** Left to the
+      * engine's scope they would be two more entries per attempt that nothing removes, and there is no reason for them to live that
+      * long: both are finished by the time this returns, one because its result was awaited and the other because it was interrupted.
+      * Closing the scope here is also what carries an interrupt down: a supervision the engine stops takes both of them with it.
+      */
+    private def supervise(
+        claimed: FlowStore.Claimed,
+        defn: FlowDefinition,
+        lease: Duration,
+        renewEvery: Duration
+    )(using Frame): Unit < Async =
+        Scope.run(superviseScoped(claimed, defn, lease, renewEvery))
+
+    private def superviseScoped(
+        claimed: FlowStore.Claimed,
+        defn: FlowDefinition,
+        lease: Duration,
+        renewEvery: Duration
+    )(using Frame): Unit < (Async & Scope) =
+        val state = claimed.state
+        val eid   = state.executionId
+        val run: Unit < (Async & Scope & Abort[FlowStoreException]) =
+            claimedEvent(claimed, ts => Flow.Event.ExecutionClaimed(state.flowId, eid, executorId, ts)).andThen {
+                // The execution runs in its own fiber so the renewal can STOP it. The lease is what
+                // authorises this executor to work on the execution at all, so a refused renewal means
+                // the claim is already someone else's and everything done from that moment is work on
+                // an execution this executor does not hold. Noticing is not enough: a step's `timeout`
+                // defaults to `Duration.Infinity`, and the next node boundary sits at the far side of
+                // the step, so a step that does not return on its own would never reach one.
+                Fiber.init(executeOne(claimed, defn)).map { execFiber =>
+                    Fiber.init {
+                        // A renewal that could not reach the store has not lost the claim; it has
+                        // failed to ask. Exiting on the first failure would leave the execution
+                        // running with nothing renewing it, so its lease lapses while it works and
+                        // another executor takes it over. A failure is charged to health and the
+                        // claim is asked for again on the next tick, with the recursion in the
+                        // handler's continuation so a loop meant to run for the execution's life does
+                        // not nest one more handler per tick.
+                        def renew: Unit < Async =
+                            Async.sleep(renewEvery).andThen {
+                                Abort.run[Throwable](claimed.renewClaim(lease)).map {
+                                    case Result.Success(true)  => renew
+                                    case Result.Success(false) => execFiber.interrupt.unit
+                                    // The renewal fiber's own interrupt, which the engine raises when
+                                    // it closes: it stops the loop rather than being counted against
+                                    // the store and asked again, exactly as the worker loop treats one.
+                                    case Result.Panic(interrupted: Interrupted) => Abort.panic(interrupted)
+                                    case failedRenewal =>
+                                        val error = failedRenewal match
+                                            case Result.Failure(e) => e
+                                            case Result.Panic(e)   => e
+                                            case _ =>
+                                                new IllegalStateException("renewing the claim failed with no error")
+                                        liveness.recordFailure(error).andThen(renew)
+                                }
+                            }
+                        renew
+                    }.map { renewFiber =>
+                        Sync.ensure(renewFiber.interrupt) {
+                            // The attempt's outcome is classified rather than discarded. An interrupt
+                            // never travels through the handlers inside `executeOne`, so this is the
+                            // only place an interrupted attempt is told apart from a panicked one,
+                            // and telling them apart is what keeps a shutdown from terminalising
+                            // every execution the engine was carrying.
+                            Abort.run[Throwable](execFiber.get).map { outcome =>
+                                finish(claimed, attemptOf(outcome))
+                            }
+                        }
+                    }
+                }
+            }
+        // Both channels, for the reason the worker loop states about its own: a store is third-party code and is free to
+        // panic even though the SPI gives it somewhere typed to put a failure, and a defect in one execution's supervision
+        // must not disappear without a trace now that it no longer travels back to the poll.
+        Abort.run[Throwable](run).map {
+            case Result.Success(_) => ()
+            // The engine going away, not a store that could not be reached. It ends this execution's supervision rather
+            // than being counted against the store's health, exactly as the worker loop treats one.
+            case Result.Panic(interrupted: Interrupted) => Abort.panic(interrupted)
+            case refused =>
+                val error = refused match
+                    case Result.Failure(e) => e
+                    case Result.Panic(e)   => e
+                    case _                 => new IllegalStateException("supervising a claimed execution failed with no error")
+                liveness.recordFailure(error).andThen(
+                    Log.error(s"kyo.flow: executor ${executorId.value} could not supervise ${eid.value}", error)
+                )
+        }
+    end superviseScoped
+
+    /** Runs one attempt at an execution and says what happened, without writing anything about it.
+      *
+      * Classifying rather than concluding is the point. Infrastructure failure and domain verdict must not share one channel: on one
+      * channel a store outage is recorded as the workflow having failed, and every site that writes a terminal status is a site free
+      * to disagree with the others about what deserves one. [[finish]] is the only thing that writes.
+      *
+      * The handler is `Abort.run[Throwable]` and not `Abort.recover`, which re-raises panics rather than catching them. That
+      * difference is what keeps a deterministic panic on the resume path from leaving the execution at Running, to be reclaimed and
+      * panic again on every poll with nothing recorded anywhere.
+      */
+    private def executeOne(claimed: FlowStore.Claimed, defn: FlowDefinition)(using Frame): Attempt < Async =
+        Abort.run[Throwable](attemptOne(claimed, defn)).map(attemptOf)
+
+    /** The attempt itself, run up to the point where its outcome is known.
+      *
+      * The row it works from is the claim's own snapshot, so a claimed batch costs no reads at all rather than one per row.
+      */
+    private def attemptOne(
+        claimed: FlowStore.Claimed,
+        defn: FlowDefinition
+    )(using Frame): Attempt < (Async & Abort[FlowStoreException]) =
+        val state = claimed.state
+        val eid   = state.executionId
+        // Nothing for this executor to do or to say: the row was already finished before the attempt began. It holds a claim
+        // it learned nothing under, so it neither releases it nor retires a row, and the claim lapses like any other ending
+        // with no verdict.
+        if state.status.isTerminal then Attempt.NoWork
+        else
+            claimedEvent(claimed, ts => Flow.Event.ExecutionResumed(state.flowId, eid, executorId, ts)).map {
+                case false => Attempt.ClaimLost
+                case true =>
+                    for
+                        _       <- dischargeSleeps(claimed)
+                        fields  <- store.getAllFields(eid)
+                        history <- store.getHistory(eid, Maybe.empty, 0)
+                        record      = rebuildRecord(fields, defn.schema)
+                        completed   = deriveCompleted(history)
+                        compensated = deriveCompensated(history)
+                        retried     = deriveRetries(history)
+                        // A `Compensating` lifecycle means a previous attempt was interrupted mid-unwind, and the cause it
+                        // recorded is what this one re-enters on. Replaying forward instead would re-run the step that
+                        // failed, and a step that succeeds the second time completes an execution whose compensations have
+                        // half run.
+                        resume = state.status match
+                            case Flow.Status.Compensating(cause) => Maybe(cause)
+                            case _                               => Maybe.empty
+                        interp = new StoreInterpreter(store, claimed, executorId, defn, retried, resume)
+                        flowExec = Flow.run(defn.flow, record, completed, compensated, resume)(interp)
+                            .map(_.asInstanceOf[Record[Any]])
+                        result <- Abort.run[FlowSuspension] {
+                            Abort.run[FlowException] {
+                                // A runner PRODUCES a scope, because the effects it handles may acquire resources, and the
+                                // scope is closed here rather than inherited: a step's file or connection belongs to the
+                                // attempt that opened it, and leaving it to the engine's own scope keeps it open until the
+                                // process shuts down.
+                                defn.runner match
+                                    case Present(r) => Scope.run(r.erased(flowExec))
+                                    case _          => flowExec
+                            }
+                        }
+                    yield classifyFlowResult(result)
+            }
+        end if
+    end attemptOne
+
+    /** Discharges every sleep the STORE judged due, before the replay reaches the node that recorded it.
+      *
+      * The satisfied set rides on the claim, so the engine discharges exactly what readiness woke it for. Judging it here against the
+      * engine's own clock instead would put the two ends of one decision on two clocks: against a store whose clock runs ahead,
+      * readiness returns the execution, the engine finds nothing due, re-parks, and the poll re-claims at full speed until the engine
+      * catches up. A row satisfied for some other reason is left alone, and the node it belongs to re-records a wait that keeps its
+      * original deadline.
+      */
+    private def dischargeSleeps(claimed: FlowStore.Claimed)(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        val state = claimed.state
+        val due = claimed.satisfied.toSeq.filter { path =>
+            state.waits.get(path) match
+                case Present(_: Flow.Wake.At) => true
+                case _                        => false
+        }
+        Clock.nowWith { now =>
+            Kyo.foreachDiscard(due) { path =>
+                claimed.recordProgress(
+                    path,
+                    Flow.Event.SleepCompleted(state.flowId, state.executionId, path, now)
+                )
+            }
+        }
+    end dischargeSleeps
+
+    /** What an attempt's raw outcome was, in the vocabulary [[finish]] reads.
+      *
+      * Read at two places, and the second is the one that matters: an interrupt never travels through the handlers inside
+      * `executeOne`, because interruption short-circuits evaluation at a safepoint rather than being delivered into an
+      * in-computation `Abort.run[Throwable]`. It arrives as the attempt FIBER's own outcome, so reading that outcome is the only
+      * way an interrupted attempt is told apart from a panicked one.
+      */
+    private def attemptOf(outcome: Result[Throwable, Attempt]): Attempt =
+        outcome match
+            case Result.Success(attempt) => attempt
+            case Result.Failure(error)   => classify(error)
+            case Result.Panic(error)     => classify(error)
+            case _                       => Attempt.Panicked(new IllegalStateException("the attempt produced no outcome"))
+
+    /** Which arm an error that ended an attempt belongs to.
+      *
+      * The two that are not a verdict on the work are worth naming. A [[FlowStoreException]] is a fact about the store, so it is
+      * infrastructure and leaves the execution as claimable as it was. An [[Interrupted]] is a designed way for an attempt to end,
+      * by the engine closing or by the renewal fiber stopping an executor whose lease lapsed, and it is an ordinary throwable that
+      * is no [[FlowException]], so without an arm of its own a shutdown terminalises every execution the engine was carrying.
+      *
+      * The two unwind arms come first because both are [[FlowException]]s and neither is a domain verdict. A cancellation reached the
+      * end of its unwind, so the terminal status is `Cancelled` rather than a `Failed` carrying the cancel exception's own name; a
+      * resumed unwind re-raises the verdict its interrupted attempt recorded, which is the only thing that still knows the original
+      * failure's message and kind.
+      */
+    private def classify(error: Throwable): Attempt =
+        error match
+            case e: FlowResumedUnwindException => Attempt.Unwound(e.cause)
+            case _: FlowCancelledException     => Attempt.Unwound(Flow.Cause.Cancellation)
+            case e: FlowStoreException         => Attempt.Infra(e)
+            case _: Interrupted                => Attempt.Interrupted
+            case e: FlowException              => Attempt.DomainFailed(e)
+            case e                             => Attempt.Panicked(e)
+
+    /** What the flow's own result says, once its suspension and failure channels have been handled. */
+    private def classifyFlowResult(result: Result[FlowSuspension, Result[FlowException, Record[Any]]]): Attempt =
+        result match
+            case Result.Success(Result.Success(_))                => Attempt.Completed
+            case Result.Failure(FlowSuspension.Parked(waitingOn)) => Attempt.Suspended(waitingOn)
+            case Result.Failure(FlowSuspension.ClaimLost)         => Attempt.ClaimLost
+            case Result.Success(Result.Failure(error))            => classify(error)
+            case Result.Success(Result.Panic(error))              => classify(error)
+            case Result.Panic(error)                              => classify(error)
+            case _ => Attempt.Panicked(new IllegalStateException("the flow produced no outcome"))
 
     private def rebuildRecord(fields: Dict[String, FlowStore.FieldData], schema: WorkflowSchema): Record[Any] =
         val dict = fields.foldLeft(Dict.empty[String, Any]) { (acc, name, fd) =>
@@ -468,64 +951,266 @@ final class FlowEngine private (
 
     private def deriveCompleted(history: FlowStore.HistoryPage): Set[String] =
         history.events.foldLeft(Set.empty[String]) {
-            case (acc, Flow.Event.StepCompleted(_, _, name, _))  => acc + name
-            case (acc, Flow.Event.SleepCompleted(_, _, name, _)) => acc + name
-            case (acc, _)                                        => acc
+            case (acc, Flow.Event.StepCompleted(_, _, name, _))   => acc + name
+            case (acc, Flow.Event.SleepCompleted(_, _, name, _))  => acc + name
+            case (acc, Flow.Event.InputDischarged(_, _, name, _)) => acc + name
+            case (acc, Flow.Event.InputSupplied(_, _, name, _))   => acc + name
+            case (acc, _)                                         => acc
+        }
+
+    /** Each node that failed and has not completed since, with the message it failed on.
+      *
+      * **The last word wins, which is what the fold is for.** A node that failed on one attempt and succeeded on the next carries
+      * both records, in that order, and it is completed; taking the first would report a failure on a node whose work is done. History
+      * is in append order (I7), so walking it forward and letting a completion erase a failure gives exactly "failed, with nothing
+      * later saying otherwise".
+      */
+    private def deriveFailed(history: FlowStore.HistoryPage): Map[String, String] =
+        history.events.foldLeft(Map.empty[String, String]) {
+            case (acc, Flow.Event.StepFailed(_, _, name, error, _, _)) => acc + (name -> error)
+            case (acc, Flow.Event.StepCompleted(_, _, name, _))        => acc - name
+            case (acc, _)                                              => acc
+        }
+
+    /** The nodes whose compensation handler already ran, so a resumed unwind runs only the ones that never landed. */
+    private def deriveCompensated(history: FlowStore.HistoryPage): Set[String] =
+        history.events.foldLeft(Set.empty[String]) {
+            case (acc, Flow.Event.NodeCompensated(_, _, name, _)) => acc + name
+            case (acc, _)                                         => acc
+        }
+
+    /** Where each node's retry schedule already stood, counted from the retries it durably recorded.
+      *
+      * Reading the position back is what keeps the policy bounded. An executor that entered at attempt 1 would let a step failing
+      * deterministically burn its whole schedule once per resume without ever exhausting it, which turns a bounded retry policy into
+      * an unbounded one exactly when the system is already unhealthy.
+      */
+    private def deriveRetries(history: FlowStore.HistoryPage): Map[String, Int] =
+        history.events.foldLeft(Map.empty[String, Int]) {
+            case (acc, Flow.Event.StepRetried(_, _, name, _, _, _, _)) => acc + (name -> (acc.getOrElse(name, 0) + 1))
+            case (acc, _)                                              => acc
         }
 
     private def deliveredInputNames(defn: FlowDefinition, fields: Dict[String, FlowStore.FieldData]): Set[String] =
         defn.inputs.filter(im => fields.contains(im.name)).map(_.name).toSet
 
-    private def handleResult(
-        eid: Flow.Id.Execution,
-        flowId: Flow.Id.Workflow,
-        result: Result[FlowSuspension, Result[FlowException, Record[Any]]]
-    )(using Frame): Unit < Async =
-        result match
-            case Result.Failure(_: FlowSuspension) => ()
-            case _ =>
-                store.getExecution(eid).map {
-                    case Present(s) if s.status == Flow.Status.Cancelled => ()
-                    case _ =>
-                        Clock.nowWith { ts =>
-                            val (status, event) = result match
-                                case Result.Success(Result.Success(_)) =>
-                                    (Flow.Status.Completed, Flow.Event.Completed(flowId, eid, ts))
-                                case Result.Success(Result.Failure(err)) =>
-                                    (Flow.Status.Failed(err.getMessage), Flow.Event.Failed(flowId, eid, err.getMessage, ts))
-                                case Result.Success(Result.Panic(ex)) =>
-                                    (Flow.Status.Failed(ex.getMessage), Flow.Event.Failed(flowId, eid, ex.getMessage, ts))
-                                case Result.Panic(ex) =>
-                                    (Flow.Status.Failed(ex.getMessage), Flow.Event.Failed(flowId, eid, ex.getMessage, ts))
-                                case _ =>
-                                    (Flow.Status.Failed("unknown"), Flow.Event.Failed(flowId, eid, "unknown", ts))
-                            store.updateStatus(eid, status, event)
-                        }
-                }
+    /** The one place an attempt's outcome becomes a store transition.
+      *
+      * A terminal `Failed` written from several sites is several sites disagreeing about what deserves one, which puts a store outage
+      * and a business rejection in the same cell and makes the first as irreversible as the second. Every arm's transition is readable
+      * here, and the arms that write nothing say so in a line each rather than by an accident of shape somewhere else.
+      *
+      * **The release is part of the outcome rather than an epilogue after it.** Every arm that reaches a verdict says it through
+      * `Claimed.finish`, which writes what happened, settles the wait ledger and makes the claim absent in ONE transition. The arms
+      * that reach no verdict (`Infra`, `ClaimLost`, `Interrupted`, `NoWork`) call it not at all and leave the claim to lapse: their
+      * ledger describes waits nobody confirmed, and an absent claim is exactly what readiness reads as "these rows are a finished
+      * attempt's statement", so releasing there would turn a healable expiry into a permanent wedge.
+      *
+      * The release EVENT rides the same gate, appended through the claim just before the ending, so an executor whose row was taken
+      * cannot write its own release into an execution somebody else is running.
+      */
+    private def finish(claimed: FlowStore.Claimed, attempt: Attempt)(using Frame): Unit < Async =
+        val state  = claimed.state
+        val eid    = state.executionId
+        val flowId = state.flowId
+
+        def end(outcome: FlowStore.Claimed.Outcome): Unit < (Async & Abort[FlowStoreException]) =
+            claimedEvent(claimed, ts => Flow.Event.ExecutionReleased(flowId, eid, executorId, ts)).map {
+                case false => ()
+                case true =>
+                    claimed.finish(outcome).map {
+                        case FlowStore.StatusOutcome.Applied   => ()
+                        case FlowStore.StatusOutcome.ClaimLost => ()
+                        case FlowStore.StatusOutcome.WrongSideOfTerminal =>
+                            Abort.panic(new IllegalStateException(
+                                s"the attempt at ${eid.value} ended with a status on the wrong side of the lifecycle partition"
+                            ))
+                    }
+            }
+
+        def terminal(status: Flow.Status, event: Instant => Flow.Event): Unit < (Async & Abort[FlowStoreException]) =
+            Clock.nowWith(ts => end(FlowStore.Claimed.Outcome.Terminal(status, event(ts))))
+
+        // A failure the flow raised on its typed channel is recorded with its kind, so a persisted failure can be grouped
+        // by what it was rather than matched on the message text. A panic has no declared kind: it is whatever escaped,
+        // and the class name of an escaped throwable is not a category a caller declared.
+        def failed(message: String, kind: Maybe[String]): Unit < (Async & Abort[FlowStoreException]) =
+            terminal(Flow.Status.Failed(message, kind), ts => Flow.Event.Failed(flowId, eid, message, ts))
+
+        val transition: Unit < (Async & Abort[FlowStoreException]) =
+            attempt match
+                case Attempt.Completed           => terminal(Flow.Status.Completed, ts => Flow.Event.Completed(flowId, eid, ts))
+                case Attempt.DomainFailed(error) => failed(error.getMessage, Maybe(error.kind))
+                case Attempt.Panicked(error)     => failed(error.getMessage, Maybe.empty)
+                // The unwind ran, and what it ends as is a total function of the verdict it ran for: a cancellation
+                // terminalises `Cancelled`, a failure keeps the message and the kind the forward pass produced. That is what
+                // lets a cancel run its compensations at all, since an unwind that began at a cancel request would otherwise
+                // have nothing to write but `Failed`.
+                case Attempt.Unwound(Flow.Cause.Cancellation) =>
+                    terminal(Flow.Status.Cancelled, ts => Flow.Event.Cancelled(flowId, eid, ts))
+                case Attempt.Unwound(Flow.Cause.Failure(message, kind)) => failed(message, kind)
+                // The parks were recorded by the nodes that made them while the attempt ran, and the ending keeps exactly
+                // those: everything else the execution holds a row for is a branch it is no longer waiting on.
+                case Attempt.Suspended(waitingOn) => end(FlowStore.Claimed.Outcome.Suspended(waitingOn))
+                // Not a verdict on the work: the store is what failed. It is charged to health, and the execution is left
+                // exactly as claimable as it was, for the next poll to try again.
+                case Attempt.Infra(error) =>
+                    liveness.recordFailure(error).andThen(
+                        Log.error(
+                            s"kyo.flow: executor ${executorId.value} could not reach the store while running ${eid.value}",
+                            error
+                        )
+                    )
+                // Nothing at all: not a status, not an event, not a release. The row belongs to somebody else now, and the
+                // new owner needs no help from the executor that stopped owning it.
+                case Attempt.ClaimLost => ()
+                // Also nothing, and not for ClaimLost's reason. There the fence would refuse the write; here the claim may
+                // be perfectly valid and nothing would refuse anything. An executor told to stop has reached no verdict,
+                // and only saying so keeps a shutdown from terminalising every execution the engine was carrying.
+                case Attempt.Interrupted => ()
+                // And nothing here either, for a third reason: there was no work to do. Releasing would say the rows are a
+                // finished attempt's statement, which this attempt is in no position to make, and it would say it on the
+                // strength of having found the row already over.
+                case Attempt.NoWork => ()
+
+        // Recording an outcome is a store write like any other, so a store that cannot take it is charged to health and the
+        // execution is left where the next poll finds it, rather than killing the poll loop carrying the rest of the batch.
+        Abort.run[Throwable](transition).map {
+            case Result.Success(_) => ()
+            // A store stopped mid-write, not a store that could not be reached. It ends this execution's supervision rather than
+            // being counted against the store's health, exactly as the worker and renewal loops treat one.
+            case Result.Panic(interrupted: Interrupted) => Abort.panic(interrupted)
+            case refused =>
+                val error = refused match
+                    case Result.Failure(e) => e
+                    case Result.Panic(e)   => e
+                    case _                 => new IllegalStateException("recording the attempt's outcome failed with no error")
+                liveness.recordFailure(error).andThen(
+                    Log.error(s"kyo.flow: executor ${executorId.value} could not record the outcome of ${eid.value}", error)
+                )
+        }
+    end finish
 
 end FlowEngine
 
 object FlowEngine:
 
+    /** What an engine serves: every version registered in this process, plus which one a fresh start runs.
+      *
+      * Keyed by `(workflowId, structuralHash)` because an execution belongs to the version it was STARTED under: a `signal` for an input
+      * the current definition renamed must still resolve against the one the execution declares, or the value can never be delivered.
+      *
+      * Registration is the retention policy and nothing evicts. Within a process the map only grows, an operator who wants a version gone
+      * restarts without registering it, and a verb that removed a version an in-flight execution still needed would manufacture exactly the
+      * orphan the version gate exists to avoid. What an operator needs instead is the information, and it is on
+      * [[FlowEngine.parked]] (which executions this engine does NOT serve) and on each execution's own hash.
+      *
+      * @param latest
+      *   the definition registered LAST for each workflow id, which is what `workflows.start` runs. Refusing an ambiguous start would
+      *   punish an operator for registering a second version so their in-flight executions keep running.
+      */
+    private[kyo] case class Definitions(
+        byVersion: Dict[(Flow.Id.Workflow, String), FlowDefinition],
+        latest: Dict[Flow.Id.Workflow, FlowDefinition]
+    ):
+        def of(workflowId: Flow.Id.Workflow, hash: String): Maybe[FlowDefinition] = byVersion.get((workflowId, hash))
+
+        def register(workflowId: Flow.Id.Workflow, defn: FlowDefinition): Definitions =
+            Definitions(byVersion.update((workflowId, defn.meta.structuralHash), defn), latest.update(workflowId, defn))
+
+        /** Every `(workflow, version)` pair this engine can interpret, which is what readiness gates on. */
+        def served: Set[(Flow.Id.Workflow, String)] =
+            byVersion.foldLeft(Set.empty[(Flow.Id.Workflow, String)])((acc, key, _) => acc + key)
+
+        /** The versions of one workflow this engine serves. */
+        def servedHashes(workflowId: Flow.Id.Workflow): Set[String] =
+            byVersion.foldLeft(Set.empty[String])((acc, key, _) => if key._1 == workflowId then acc + key._2 else acc)
+
+        def workflowIds: Seq[Flow.Id.Workflow] =
+            latest.foldLeft(Seq.empty[Flow.Id.Workflow])((acc, id, _) => acc :+ id)
+    end Definitions
+
+    private[kyo] object Definitions:
+        val empty: Definitions = Definitions(Dict.empty, Dict.empty)
+
+    /** What one attempt at an execution did, said before anything is written about it.
+      *
+      * It exists so that infrastructure failure and domain verdict never share a channel, where a store outage would be recorded as
+      * the workflow having failed, and so that no two sites can write a terminal status while disagreeing about what deserves one.
+      * [[FlowEngine.executeOne]] classifies into these arms and one transition function reads them, so what an outcome does to the
+      * store is written down once.
+      */
+    private[kyo] enum Attempt derives CanEqual:
+
+        /** The flow finished. */
+        case Completed
+
+        /** It parked, and these are the parks that ended the attempt. */
+        case Suspended(waitingOn: Set[String])
+
+        /** A verdict on the work: terminal, and it carries its kind. */
+        case DomainFailed(error: FlowException)
+
+        /** Not a declared failure of this flow: terminal, with no kind to record. */
+        case Panicked(error: Throwable)
+
+        /** The unwind ran to its end, and what it ends as is a total function of the cause it ran for.
+          *
+          * `Failure` keeps the message and kind the forward pass produced; `Cancellation` terminalises `Cancelled`. It is separate
+          * from [[DomainFailed]] because a cancellation is not a verdict on the work and must not land as a `Failed` carrying the
+          * cancel exception's own class name, and because a RESUMED unwind has no exception left to read a kind off: the cause its
+          * interrupted attempt recorded is the only thing that still knows.
+          */
+        case Unwound(cause: Flow.Cause)
+
+        /** There was nothing to run: the row was already terminal when the attempt reached it.
+          *
+          * It writes nothing and releases nothing, unlike an empty [[Suspended]], which would say the ledger is a finished attempt's
+          * statement of what the execution waits for. This attempt learned nothing about the rows and holds a claim it took no work
+          * under, so the claim lapses like every other ending with no verdict.
+          */
+        case NoWork
+
+        /** The store failed. Not terminal, recorded on health, execution left exactly as claimable as it was. */
+        case Infra(error: FlowStoreException)
+
+        /** This executor no longer owns the row, so it has nothing to say about it. */
+        case ClaimLost
+
+        /** This executor was told to stop while its claim may still be valid. */
+        case Interrupted
+
+    end Attempt
+
     // --- Factory ---
 
     /** Create an engine with worker fibers that poll the store for ready executions.
       *
-      * Each flow must have been built with `Flow.init("name")` so the engine can derive the workflow ID. Flows without a name cause an
-      * `IllegalArgumentException`.
+      * Each flow must have been built with `Flow.init("name")`, since the engine derives the workflow ID from that name and it is the
+      * workflow's durable identity. A flow with no name, or one no engine could execute durably, is refused with a
+      * [[FlowDefinitionException]] on the same typed channel a store failure travels.
       */
     def init(
         store: FlowStore,
         flows: Flow[?, ?, ?]*
-    )(using Frame): FlowEngine < (Async & Scope) =
-        init(store, flows = flows)
+    )(using Frame): FlowEngine < (Async & Scope & Abort[FlowDefinitionException | FlowStoreException]) =
+        initImpl(store, flows = flows)
 
     def init[S](
         store: FlowStore,
         flows: Flow[?, ?, S]*
-    )(runner: [V] => V < S => V < (Async & Scope & Abort[FlowException]))(using Frame): FlowEngine < (Async & Scope) =
+    )(runner: [V] => V < S => V < (Async & Scope & Abort[FlowException]))(using
+        Frame
+    ): FlowEngine < (Async & Scope & Abort[FlowDefinitionException | FlowStoreException]) =
         initImpl(store, flows = flows, runner = Maybe(FlowRunner[S](runner)))
 
+    /** Create an engine with the tuning spelled out.
+      *
+      * A tuning the engine could not work under is refused with a [[FlowInvalidConfigException]] naming every setting at fault, which
+      * is why this overload carries a channel the untuned ones above do not: they supply the tuning themselves and cannot be handed a
+      * bad one. Returning an engine that answers its health check while claiming nothing, or one whose every renewal is refused
+      * because the claim expires first, is what the checks exist to prevent.
+      */
     def init(
         store: FlowStore,
         workerCount: Int = 2,
@@ -534,36 +1219,213 @@ object FlowEngine:
         batchSize: Int = 4,
         pollTimeout: Duration = 30.seconds,
         flows: Seq[Flow[?, ?, ?]] = Seq.empty
-    )(using Frame): FlowEngine < (Async & Scope) =
-        initImpl(store, workerCount, lease, renewEvery, batchSize, pollTimeout, flows, Maybe.empty)
+    )(using Frame): FlowEngine < (Async & Scope & Abort[FlowInvalidConfigException | FlowDefinitionException | FlowStoreException]) =
+        init(store, Config(workerCount, lease, renewEvery, batchSize, pollTimeout), flows*)
+
+    /** Create a tuned engine.
+      *
+      * The tuning is one [[FlowEngine.Config]] value rather than a parameter list, so it composes with the runner overload below. Every
+      * workflow whose steps touch a resource has a non-trivial effect row and therefore needs a runner, and `lease` is the knob that sets
+      * how long crash recovery waits, so the two have to be available together.
+      *
+      * A tuning the engine could not work under is refused with a [[FlowInvalidConfigException]] listing every setting at fault.
+      */
+    def init(
+        store: FlowStore,
+        config: Config,
+        flows: Flow[?, ?, ?]*
+    )(using Frame): FlowEngine < (Async & Scope & Abort[FlowInvalidConfigException | FlowDefinitionException | FlowStoreException]) =
+        accept(config).andThen(initImpl(store, config, flows, Maybe.empty))
+
+    /** Create a tuned engine whose step bodies use custom effects. */
+    def init[S](
+        store: FlowStore,
+        config: Config,
+        flows: Flow[?, ?, S]*
+    )(runner: [V] => V < S => V < (Async & Scope & Abort[FlowException]))(using
+        Frame
+    ): FlowEngine < (Async & Scope & Abort[FlowInvalidConfigException | FlowDefinitionException | FlowStoreException]) =
+        accept(config).andThen(initImpl(store, config, flows, Maybe(FlowRunner[S](runner))))
+
+    /** Refuses a tuning the engine could not work under, before anything is built.
+      *
+      * It guards the factories that take a tuning FROM A CALLER rather than [[initImpl]], which every factory funnels through,
+      * because the untuned ones supply a tuning of their own and cannot be handed a bad one. A channel carrying a failure its caller
+      * has no way to produce is a caller made to handle something that never happens, which is what the module's precise error unions
+      * exist to avoid.
+      */
+    private def accept(config: Config)(using Frame): Unit < Abort[FlowInvalidConfigException] =
+        Abort.when(config.problems.nonEmpty)(FlowInvalidConfigException(config.problems))
 
     private[kyo] def initImpl(
         store: FlowStore,
+        config: Config = Config(),
+        flows: Seq[Flow[?, ?, ?]] = Seq.empty,
+        runner: Maybe[FlowRunner] = Maybe.empty
+    )(using Frame): FlowEngine < (Async & Scope & Abort[FlowDefinitionException | FlowStoreException]) =
+        import config.*
+        for
+            defs         <- AtomicRef.init(Definitions.empty)
+            eid          <- Flow.Id.Executor.random
+            liveness     <- Liveness.init(workerCount)
+            supervisions <- AtomicRef.init(Maybe(Set.empty[Fiber[Unit, Any]]))
+            engine = new FlowEngine(store, defs, eid, liveness, supervisions)
+            // A flow with no name is refused by registration rather than here, on the typed channel every other refusal
+            // of a definition travels. The name this reads and the name registration checks come from the same fold, so
+            // the two cannot disagree about which flows have one.
+            _ <- Kyo.foreachDiscard(flows) { flow =>
+                engine.registerImpl(Flow.Id.Workflow(FlowLint.flowName(flow).getOrElse("")), flow, runner)
+            }
+            _ <- Kyo.foreachDiscard(1 to workerCount) { _ =>
+                // Counted before the fiber starts and uncounted when it ends, so `health` answers for every worker the
+                // engine was asked for from the moment `init` returns. Counting inside the fiber would report zero
+                // until the scheduler got to it, which is a health check that fails on a healthy engine.
+                liveness.workerStarted.andThen(
+                    Fiber.init(
+                        Sync.ensure(liveness.workerStopped)(engine.worker(lease, renewEvery, batchSize, pollTimeout))
+                    )
+                )
+            }
+            // A scope drains its finalizers LAST REGISTERED FIRST, so registering this after the workers means it runs BEFORE they
+            // are interrupted: the attempts are stopped while the poll loops are still live and free to claim another row.
+            //
+            // That order is safe, and the registry's `Absent` is what makes it so rather than a narrow race being covered. Once
+            // `stopSupervisions` has taken the set, every later supervision finds the registry closed and interrupts itself on the
+            // spot, so a worker that claims a row in the window between this finalizer and its own leaves nothing running behind it.
+            // Registering the other way round would not remove the window either, since a worker is only interrupted at its next
+            // safepoint and can spawn on the way there.
+            _ <- Scope.ensure(engine.stopSupervisions)
+        yield engine
+        end for
+    end initImpl
+
+    /** What [[FlowEngine.health]] answers: how many workers are polling, how many were asked for, and the last poll failure.
+      *
+      * `workersAlive < workersConfigured` is the condition a health check fails on: the engine is up but is not processing everything it
+      * was configured to. `lastPollFailure` is the message of the most recent failure to reach the store, present whether or not the
+      * worker that hit it recovered, so a store that is failing intermittently is visible rather than silent.
+      *
+      * @param workersAlive
+      *   worker fibers currently running
+      * @param workersConfigured
+      *   worker fibers the engine was created with
+      * @param pollFailures
+      *   how many times a poll has failed since the engine started
+      * @param lastPollFailure
+      *   the message of the most recent poll failure
+      */
+    case class Health(
+        workersAlive: Int,
+        workersConfigured: Int,
+        pollFailures: Long,
+        lastPollFailure: Maybe[String]
+    ) derives CanEqual:
+        /** Every worker the engine was configured with is polling. */
+        def isHealthy: Boolean = workersAlive == workersConfigured
+    end Health
+
+    /** The engine's own view of its workers, written by the workers and read by [[FlowEngine.health]]. */
+    final private[kyo] class Liveness(
+        configured: Int,
+        alive: AtomicInt,
+        failures: AtomicLong,
+        lastFailure: AtomicRef[Maybe[String]]
+    ):
+        def workerStarted(using Frame): Unit < Sync = alive.incrementAndGet.unit
+        def workerStopped(using Frame): Unit < Sync = alive.decrementAndGet.unit
+
+        def recordFailure(error: Throwable)(using Frame): Unit < Sync =
+            failures.incrementAndGet.andThen(lastFailure.set(Maybe(Maybe(error.getMessage).getOrElse(error.toString))))
+
+        def snapshot(using Frame): Health < Sync =
+            for
+                a <- alive.get
+                f <- failures.get
+                l <- lastFailure.get
+            yield Health(a, configured, f, l)
+    end Liveness
+
+    private[kyo] object Liveness:
+        def init(configured: Int)(using Frame): Liveness < Sync =
+            for
+                alive       <- AtomicInt.init(0)
+                failures    <- AtomicLong.init(0L)
+                lastFailure <- AtomicRef.init(Maybe.empty[String])
+            yield new Liveness(configured, alive, failures, lastFailure)
+    end Liveness
+
+    /** Engine tuning: how many workers poll, how long a claim lives, and how the poll loop is paced.
+      *
+      * One value rather than a parameter list, so a caller configures the engine the same way whether or not the flows need a runner.
+      * `lease` is the one that decides crash-recovery latency: an execution whose executor died is offered to another only once its claim
+      * has expired, so it is the first knob anyone running this in production reaches for.
+      *
+      * @param workerCount
+      *   how many worker fibers poll the store for ready executions
+      * @param lease
+      *   how long a claim on an execution lasts before another executor may take it
+      * @param renewEvery
+      *   how often a worker renews the claim of an execution it is running
+      * @param batchSize
+      *   how many executions one poll claims at once
+      * @param pollTimeout
+      *   how long a poll waits for a ready execution before going around again
+      */
+    case class Config(
         workerCount: Int = 2,
         lease: Duration = 30.seconds,
         renewEvery: Duration = 10.seconds,
         batchSize: Int = 4,
-        pollTimeout: Duration = 30.seconds,
-        flows: Seq[Flow[?, ?, ?]] = Seq.empty,
-        runner: Maybe[FlowRunner] = Maybe.empty
-    )(using Frame): FlowEngine < (Async & Scope) =
-        for
-            defs <- AtomicRef.init(Dict.empty[Flow.Id.Workflow, FlowDefinition])
-            eid  <- Flow.Id.Executor.random
-            engine = new FlowEngine(store, defs, eid)
-            _ <- Kyo.foreachDiscard(flows) { flow =>
-                val name = FlowFold(flow)(new FlowVisitorCollect[Maybe[String]](Maybe.empty, (a, b) => a.orElse(b)):
-                    override def onInit(name: String, frame: Frame, meta: Flow.Meta) = Maybe(
-                        name
-                    )).getOrElse(
-                    throw new IllegalArgumentException("Flow must have a name — use Flow.init(\"name\") to create named workflows")
-                )
-                engine.registerImpl(Flow.Id.Workflow(name), flow, runner)
-            }
-            _ <- Kyo.foreachDiscard(1 to workerCount) { _ =>
-                Fiber.init(engine.worker(lease, renewEvery, batchSize, pollTimeout))
-            }
-        yield engine
+        pollTimeout: Duration = 30.seconds
+    ) derives CanEqual:
+
+        /** Every setting here the engine could not work under, empty for a tuning it accepts.
+          *
+          * What [[FlowEngine.init]] refuses on, reported all at once so a caller does not pay a process start per problem. A duration is
+          * asked to be POSITIVE rather than merely non-negative because [[kyo.Duration]] has no negative values: `-1.seconds` is
+          * `Duration.Zero`, so zero is where a caller asking for a negative one arrives.
+          */
+        private[kyo] def problems: Seq[FlowConfigProblem] =
+            def refuse(bad: Boolean, setting: String, value: String, reason: String): Seq[FlowConfigProblem] =
+                if bad then Seq(FlowConfigProblem(setting, value, reason)) else Seq.empty
+            refuse(
+                workerCount < 1,
+                "workerCount",
+                workerCount.toString,
+                "no fiber would poll the store, so no execution would ever be claimed"
+            ) ++ refuse(
+                batchSize < 1,
+                "batchSize",
+                batchSize.toString,
+                "a poll would ask for no executions, so it would find none however many are ready"
+            ) ++ refuse(
+                lease <= Duration.Zero,
+                "lease",
+                lease.show,
+                "a claim would be expired the moment it was granted, so the row is reclaimable while it is being worked on"
+            ) ++ refuse(
+                renewEvery <= Duration.Zero,
+                "renewEvery",
+                renewEvery.show,
+                "the renewal loop would not pause, so it would re-ask the store as fast as the scheduler allows"
+            ) ++ refuse(
+                pollTimeout <= Duration.Zero,
+                "pollTimeout",
+                pollTimeout.show,
+                "a poll would not wait for work, so an idle worker would spin"
+            ) ++ refuse(
+                lease > Duration.Zero && renewEvery > Duration.Zero && renewEvery >= lease,
+                "renewEvery",
+                s"${renewEvery.show} against a lease of ${lease.show}",
+                "the claim expires before its first renewal, and a refused renewal interrupts the execution, so every step " +
+                    "longer than the lease is interrupted, released, reclaimed and re-run forever"
+            )
+        end problems
+    end Config
+
+    object Config:
+        /** The tuning the untuned `init` overloads use. */
+        val default: Config = Config()
 
     // --- Handle ---
 
@@ -573,41 +1435,82 @@ object FlowEngine:
     final class Handle(val executionId: Flow.Id.Execution, engine: FlowEngine):
         def signal[V: Tag: Schema](name: String, value: V)(using
             Frame
-        ): Unit < (Async & Abort[FlowExecutionStateException | FlowWorkflowNotRegisteredException | FlowSignalException]) =
+        ): Unit < (Async & Abort[
+            FlowExecutionStateException | FlowWorkflowNotRegisteredException | FlowSignalException | FlowStoreException
+        ]) =
             engine.executions.signal[V](executionId, name, value)
 
-        def status(using Frame): Flow.Status < (Async & Abort[FlowExecutionNotFoundException]) =
+        /** The execution's persisted lifecycle.
+          *
+          * `Running` spans working AND waiting: an execution waiting for an input or serving out a sleep is running, and what it is
+          * waiting for is plural, so no single token could answer it without hiding one of two simultaneous waits. Use [[describe]] for
+          * that question; it answers with the wait rows and the outstanding cancel request beside the lifecycle.
+          */
+        def status(using Frame): Flow.Status < (Async & Abort[FlowExecutionNotFoundException | FlowStoreException]) =
             engine.executions.describe(executionId).map(_.status)
 
-        def describe(using Frame): ExecutionDetail < (Async & Abort[FlowExecutionNotFoundException]) =
+        def describe(using Frame): ExecutionDetail < (Async & Abort[FlowExecutionNotFoundException | FlowStoreException]) =
             engine.executions.describe(executionId)
 
-        def cancel(using Frame): Unit < Async =
+        /** Ask for this execution to be cancelled, and say what the ask did.
+          *
+          * The three answers reach the holder of a handle for the reason they reach any other caller: the cancel is a request, so this
+          * value is the only thing about it that is observable on return. See [[FlowEngine.executions.cancel]].
+          */
+        def cancel(using Frame): FlowStore.CancelOutcome < (Async & Abort[FlowStoreException]) =
             engine.executions.cancel(executionId)
 
-        def history(limit: Int = 50, offset: Int = 0)(using Frame): FlowStore.HistoryPage < Async =
+        /** This execution's event history, in append order. A negative `limit` reads as unbounded, per
+          * [[FlowEngine.executions.history]].
+          */
+        def history(limit: Int = 50, offset: Int = 0)(using Frame): FlowStore.HistoryPage < (Async & Abort[FlowStoreException]) =
             engine.executions.history(executionId, limit, offset)
     end Handle
 
     // --- Types ---
 
-    /** Status of a single input: name, expected type tag, and whether it has been delivered. */
-    case class InputInfo(name: String, tag: String, delivered: Boolean) derives CanEqual
+    /** One input's delivery state on a running execution: its name, the type it expects, and whether a value has arrived.
+      *
+      * A fact about an EXECUTION, which is what separates it from [[FlowEngine.WorkflowInfo.InputInfo]], the input a definition
+      * declares. Naming both `InputInfo` would leave the two told apart only by their enclosing scope, so a reader with one in hand
+      * could not tell which question it answers.
+      */
+    case class InputStatus(name: String, tag: String, delivered: Boolean) derives CanEqual
 
     /** Full detail of an execution: store state, input delivery status, and step-by-step progress. Returned by `executions.describe` and
       * `Handle.describe`.
       */
     case class ExecutionDetail(
         state: FlowStore.ExecutionState,
-        inputs: Seq[InputInfo],
+        inputs: Seq[InputStatus],
         progress: FlowEngine.Progress
     ):
         def executionId: Flow.Id.Execution = state.executionId
         def flowId: Flow.Id.Workflow       = state.flowId
-        def status: Flow.Status            = state.status
+
+        /** The persisted lifecycle. See [[FlowEngine.Handle.status]] for why waiting is not one of its cases. */
+        def status: Flow.Status = state.status
+
+        /** What each waiting node is waiting for, keyed by the node's composition path. Plural, and empty for an execution that is
+          * working rather than waiting.
+          */
+        def waits: Dict[String, Flow.Wake] = state.waits
+
+        /** Whether somebody has asked for this execution to be cancelled and the unwind has not finished yet.
+          *
+          * Cancellation is a request rather than an act, so a caller who cancels and then looks sees it here while the compensations run.
+          */
+        def cancelRequested: Boolean = state.cancelRequested
     end ExecutionDetail
 
-    /** Paginated search result with items and total count. */
+    /** One page of a search, and how many executions the search matched in all.
+      *
+      * @param items
+      *   the executions on this page, most recently created first
+      * @param total
+      *   how many matched, which is the size of the set being paged through and not the length of `items`. A caller sizing a page
+      *   control, or deciding whether to ask for more, is reading this number as the match count.
+      */
     case class SearchResult(items: Seq[FlowStore.ExecutionState], total: Int) derives CanEqual
 
     /** Metadata for a registered workflow: inputs, outputs, structural hash, and node information. Returned by `workflows.describe` and
@@ -641,13 +1544,24 @@ object FlowEngine:
                     Seq(NodeInfo(name, "step", Tag[Unit].erased, frame.snippetShort, meta))
                 override def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta) =
                     Seq(NodeInfo(name, "sleep", Tag[Unit].erased, frame.snippetShort, meta))
-                override def onDispatch(name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
-                    Seq(NodeInfo(name, "dispatch", Tag[Any], frame.snippetShort, meta))
-                override def onLoop(name: String, frame: Frame, meta: Flow.Meta) =
-                    Seq(NodeInfo(name, "loop", Tag[Any], frame.snippetShort, meta))
-                override def onForEach(name: String, concurrency: Int, frame: Frame, meta: Flow.Meta) =
-                    Seq(NodeInfo(name, "foreach", Tag[Any], frame.snippetShort, meta))
-                override def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta) =
+                // Each of these persists a value, so each reports the type it persists, exactly as an input and an output do. That
+                // takes evidence on the visitor's arm: without it the only reportable tag is `Tag[Any]`, which tells a caller
+                // reading the workflow's description nothing about what a dispatch, a loop or a foreach actually stores.
+                override def onDispatch[V](name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using
+                    Tag[V],
+                    Schema[V]
+                ) =
+                    Seq(NodeInfo(name, "dispatch", Tag[V].erased, frame.snippetShort, meta))
+                override def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using
+                    Tag[V],
+                    Schema[V],
+                    Tag[State],
+                    Schema[State]
+                ) =
+                    Seq(NodeInfo(name, "loop", Tag[V].erased, frame.snippetShort, meta))
+                override def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+                    Seq(NodeInfo(name, "foreach", Tag[V].erased, frame.snippetShort, meta))
+                override def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Seq[NodeInfo], frame: Frame, meta: Flow.Meta) =
                     Seq(NodeInfo(name, "subflow", Tag[Any], frame.snippetShort, meta)))
             val inputs = inputMetas.map(m => WorkflowInfo.InputInfo(m.name, m.tag))
             WorkflowInfo(
@@ -664,7 +1578,7 @@ object FlowEngine:
     // --- Progress ---
 
     /** Step-by-step progress of an execution: each flow node's name, type, and current status (Completed, Running, Pending,
-      * WaitingForInput, Sleeping, Failed). Used for monitoring dashboards and diagram overlays.
+      * WaitingForInput, Compensated, Sleeping, Failed). Used for monitoring dashboards and diagram overlays.
       */
     case class Progress(nodes: Seq[Progress.NodeProgress]) derives CanEqual:
         def nodeByName(name: String): Maybe[Progress.NodeProgress] =
@@ -683,16 +1597,68 @@ object FlowEngine:
 
         enum NodeStatus derives CanEqual:
             case Completed, Running, Pending, WaitingForInput
+
+            /** This node ran, and its compensation handler has since run too.
+              *
+              * What an operator watching an unwind needs: which handlers have already landed, and therefore where the unwind has
+              * reached. It is durable rather than inferred, coming from the per-handler completion record the unwind writes, so a
+              * resumed unwind reports the same thing the interrupted one did.
+              */
+            case Compensated
             case Sleeping(until: Instant)
             case Failed(error: String)
+
+            /** The one-line rendering a monitoring surface shows, in the same shape [[Flow.Status.show]] uses. */
+            def show: String = this match
+                case Completed       => "completed"
+                case Running         => "running"
+                case Pending         => "pending"
+                case WaitingForInput => "waiting"
+                case Compensated     => "compensated"
+                case Sleeping(until) => s"sleeping:$until"
+                case Failed(error)   => s"failed:$error"
         end NodeStatus
 
-        private[kyo] def build(flow: Flow[?, ?, ?], completedSteps: Set[String], currentStatus: Flow.Status): Progress =
+        /** The per-node view: what is done, what has been compensated, what is active, and what every waiting node is waiting for.
+          *
+          * The waits come as rows rather than as one token on the status, which is what lets this mark EVERY waiting node. A `race` of an
+          * input against a sleep has two waiting nodes at once, and a single cell had room to say so about one of them.
+          *
+          * **Every arm here reports something the execution durably recorded**, and nothing is painted on that it did not. Marking an
+          * unwinding execution's active node as failed fabricates a node-level fact from an execution-level one: the unwind is a fact
+          * about the flow, which the lifecycle already carries, and the node-level fact worth having is which handlers have run, which
+          * `compensated` supplies. A cancel request gets no node-level arm for the same reason: it is a fact about the execution, on
+          * its row, and `describe` reports it there.
+          *
+          * **The one node that records nothing is derived from the ones around it rather than read.** A subflow writes nothing under
+          * its own name, because its children write under their qualified paths and the arm that runs one calls no verb for itself, so
+          * a rule that reads the recorded set can only ever call it unfinished: it takes the active marker from the node that is
+          * running and then sits at `pending` for good, which is `completedCount` never reaching `totalCount` on any workflow with a
+          * subflow in it. The derivation still rests on recorded facts, one level out: what the child's own nodes recorded. A child's
+          * INPUT is among them, because entering an instance records each of the child's inputs under its own path before the child's
+          * first node runs, so the input is read from its record like any other node.
+          *
+          * **A failed node comes from `failed`, never from where it sits in the walk.** Painting the first node that is neither
+          * completed nor waiting is right for a straight line and wrong the moment a flow is not one: a `zip` branch that failed
+          * beside a sibling that completed, or a failure after a node that never started, both put the paint on the wrong node. Such a
+          * rule can also say nothing until the execution terminalises, so the whole unwind goes unreported without the one fact an
+          * operator watching it needs. An execution whose history predates the record is painted nowhere rather than somewhere: no
+          * node claims a failure that nothing recorded.
+          */
+        private[kyo] def build(
+            flow: Flow[?, ?, ?],
+            completedSteps: Set[String],
+            currentStatus: Flow.Status,
+            waits: Dict[String, Flow.Wake],
+            compensated: Set[String] = Set.empty,
+            failed: Map[String, String] = Map.empty
+        ): Progress =
             import Progress.{NodeProgress, NodeType, NodeStatus}
-            def isCompleted(name: String, nodeType: NodeType): Boolean =
-                completedSteps.contains(name) ||
-                    ((nodeType == NodeType.Loop || nodeType == NodeType.ForEach) &&
-                        completedSteps.exists(IterationName.isIteration(_, name)))
+            // A node is done when the node's OWN completion was recorded, never when a part of it was. Counting any recorded
+            // iteration draws a loop on iteration 1 of 50 as finished and gives `Running` to the node after it, which has not
+            // started; and it cannot help a fan-out at all, which records one event under its own name.
+            def isCompleted(name: String): Boolean =
+                completedSteps.contains(name)
             val rawNodes = FlowFold(flow)(new FlowVisitor[Chunk[NodeProgress]]:
                 def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
                     Chunk(NodeProgress(name, NodeType.Input, NodeStatus.Pending, frame.snippetShort))
@@ -702,43 +1668,130 @@ object FlowEngine:
                     Chunk(NodeProgress(name, NodeType.Step, NodeStatus.Pending, frame.snippetShort))
                 def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta) =
                     Chunk(NodeProgress(name, NodeType.Sleep, NodeStatus.Pending, frame.snippetShort))
-                def onDispatch(name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
+                def onDispatch[V](name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
                     Chunk(NodeProgress(name, NodeType.Dispatch, NodeStatus.Pending, frame.snippetShort))
-                def onLoop(name: String, frame: Frame, meta: Flow.Meta) =
+                def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V], Tag[State], Schema[State]) =
                     Chunk(NodeProgress(name, NodeType.Loop, NodeStatus.Pending, frame.snippetShort))
-                def onForEach(name: String, concurrency: Int, frame: Frame, meta: Flow.Meta) =
+                def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
                     Chunk(NodeProgress(name, NodeType.ForEach, NodeStatus.Pending, frame.snippetShort))
                 def onRace(left: Chunk[NodeProgress], right: Chunk[NodeProgress], frame: Frame) = left ++ right
-                def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta) =
-                    Chunk(NodeProgress(name, NodeType.Subflow, NodeStatus.Pending, frame.snippetShort))
+                // The child's nodes appear under the instance's path, because that is what the store knows them by and because a
+                // subflow embedded twice would otherwise contribute two entries a renderer cannot tell apart.
+                def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Chunk[NodeProgress], frame: Frame, meta: Flow.Meta) =
+                    Chunk(NodeProgress(name, NodeType.Subflow, NodeStatus.Pending, frame.snippetShort)) ++
+                        child.map(n => n.copy(name = NodePath.qualify(name, n.name)))
                 def onAndThen(first: Chunk[NodeProgress], second: Chunk[NodeProgress], frame: Frame) = first ++ second
                 def onZip(left: Chunk[NodeProgress], right: Chunk[NodeProgress], frame: Frame)       = left ++ right
                 def onGather(flows: Seq[Chunk[NodeProgress]], frame: Frame) = flows.foldLeft(Chunk.empty[NodeProgress])(_ ++ _)
                 def onInit(name: String, frame: Frame, meta: Flow.Meta)     = Chunk.empty)
+            // A failure is recorded under the path that failed, and a loop's iteration (`sum#3`) and a fan-out's item (`charges~3`)
+            // are paths no node carries: the node is their parent. Resolving against the nodes this flow actually has, rather than
+            // by stripping a suffix, is what keeps a subflow's child apart from a fan-out's item, since `review~step` and
+            // `charges~3` are the same shape and only one of them is a node. It is the completion side's asymmetry the other way
+            // up: one iteration completing does not complete the loop, and one iteration failing does fail it.
+            val nodeNames = rawNodes.foldLeft(Set.empty[String])((acc, node) => acc + node.name)
+            @scala.annotation.tailrec
+            def owner(path: String): Maybe[String] =
+                if nodeNames.contains(path) then Maybe(path)
+                else
+                    val cut = path.lastIndexWhere(c => c == '#' || c == NodePath.Separator)
+                    if cut <= 0 then Maybe.empty else owner(path.substring(0, cut))
+            // Sorted so that two items of one fan-out failing paint their parent with the same message on every platform, rather
+            // than with whichever the map happened to yield first.
+            val failedByNode = failed.toSeq.sortBy(_._1).foldLeft(Map.empty[String, String]) { case (acc, (path, message)) =>
+                owner(path) match
+                    case Present(node) => acc + (node -> message)
+                    case _             => acc
+            }
+            // One node kind records nothing of its own, so its status is derived below rather than read here.
+            //
+            // A subflow is the name its children hang under: the arm that runs one calls no interpreter verb for the instance itself
+            // and writes nothing under that name, by design, since the child's nodes write under `instance~name`. It could never be
+            // completed by a rule that reads the recorded set.
+            //
+            // Leaving it in this walk costs the surface twice over. It takes the active marker whenever it comes first, so an operator
+            // watching a running execution sees a subflow `running` and the node actually executing `pending`; and once the execution
+            // finishes it reads `pending` forever, so `completedCount` never reaches `totalCount` on any workflow with a subflow in
+            // it. It takes no marker here and holds its place until the derivation fills it in.
+            //
+            // A child's INPUT is not derived: a mapper's output is persisted, under the input's own path and before the child's first
+            // node runs, so the node is read from its record like any other and an unrecorded one is genuinely the point the
+            // execution has reached.
+            def isDerived(node: NodeProgress): Boolean =
+                node.nodeType == NodeType.Subflow
             @scala.annotation.tailrec
             def assignStatuses(idx: Int, foundActive: Boolean, acc: Chunk[NodeProgress]): Chunk[NodeProgress] =
                 if idx >= rawNodes.length then acc
                 else
                     val node = rawNodes(idx)
-                    if isCompleted(node.name, node.nodeType) then
+                    if isDerived(node) then assignStatuses(idx + 1, foundActive, acc :+ node)
+                    // Asked before completion, because a compensated node is a completed one whose handler has since run, and the
+                    // handler is the later fact. Neither counts as the active node the walk is looking for.
+                    else if failedByNode.contains(node.name) then
+                        assignStatuses(idx + 1, foundActive, acc :+ node.copy(status = NodeStatus.Failed(failedByNode(node.name))))
+                    else if compensated.contains(node.name) then
+                        assignStatuses(idx + 1, foundActive, acc :+ node.copy(status = NodeStatus.Compensated))
+                    else if isCompleted(node.name) then
                         assignStatuses(idx + 1, foundActive, acc :+ node.copy(status = NodeStatus.Completed))
                     else
-                        currentStatus match
-                            case Flow.Status.WaitingForInput(n) if n == node.name =>
+                        waits.get(node.name) match
+                            case Present(Flow.Wake.OnField(_)) =>
                                 assignStatuses(idx + 1, true, acc :+ node.copy(status = NodeStatus.WaitingForInput))
-                            case Flow.Status.Sleeping(n, until) if n == node.name =>
+                            case Present(Flow.Wake.At(until)) =>
                                 assignStatuses(idx + 1, true, acc :+ node.copy(status = NodeStatus.Sleeping(until)))
-                            case Flow.Status.Failed(error) if !foundActive =>
-                                assignStatuses(idx + 1, true, acc :+ node.copy(status = NodeStatus.Failed(error)))
-                            case Flow.Status.Compensating if !foundActive =>
-                                assignStatuses(idx + 1, true, acc :+ node.copy(status = NodeStatus.Failed("compensating")))
-                            case Flow.Status.Running if !foundActive =>
-                                assignStatuses(idx + 1, true, acc :+ node.copy(status = NodeStatus.Running))
-                            case _ =>
-                                assignStatuses(idx + 1, foundActive, acc :+ node.copy(status = NodeStatus.Pending))
+                            case Absent =>
+                                currentStatus match
+                                    case Flow.Status.Running if !foundActive =>
+                                        assignStatuses(idx + 1, true, acc :+ node.copy(status = NodeStatus.Running))
+                                    case _ =>
+                                        assignStatuses(idx + 1, foundActive, acc :+ node.copy(status = NodeStatus.Pending))
                     end if
             end assignStatuses
-            Progress(assignStatuses(0, false, Chunk.empty).toSeq)
+            val walked = assignStatuses(0, false, Chunk.empty)
+            def under(nodes: Chunk[NodeProgress], instance: String): Chunk[NodeProgress] =
+                val prefix = s"$instance${NodePath.Separator}"
+                nodes.filter(_.name.startsWith(prefix))
+            // A recorded failure keeps its place ahead of the derivation, here as everywhere else: it is a fact the execution wrote,
+            // and only the resolver decides which node owns it.
+            def recordedFailure(node: NodeProgress): Maybe[NodeProgress] =
+                if failedByNode.contains(node.name) then Maybe(node.copy(status = NodeStatus.Failed(failedByNode(node.name))))
+                else Maybe.empty
+            // The nodes a subflow contributed, which are the ones qualified under its path. Nested subflows are skipped rather than
+            // ordered around: every node that does real work is a leaf of this tree, so an instance reads the same answer whether it
+            // is asked before or after the one beneath it.
+            //
+            // A child whose nodes are ALL inputs still contributes, because entering an instance records the child's inputs. Deriving
+            // such an instance from the lifecycle instead, on the grounds that nothing under it could be recorded, counts a
+            // `Completed` execution as having entered every instance it declares, which gets a race's losing arm wrong by calling an
+            // instance the loser never reached `Completed`. Reading the record instead, an inputs-only child reports exactly what it
+            // recorded and an un-entered one reports `Pending` because nothing was written under it.
+            def contributed(instance: String): Chunk[NodeStatus] =
+                under(walked, instance).collect {
+                    case child if child.nodeType != NodeType.Subflow => child.status
+                }
+            // What a subflow is, said in its children's terms: done when they are all done, undone when their handlers have since
+            // run, and where the execution is while any of them is running or waiting. A subflow with nothing under it has nothing to
+            // report, which is the empty case.
+            //
+            // There is deliberately no failed arm: a child that failed leaves its instance Pending. Adding one would put the same
+            // message on two nodes, and a reader asking which node failed would get two answers, which is exactly what the resolver's
+            // exact-match-first rule above exists to prevent by giving a recorded failure one owner and one only.
+            def derived(children: Chunk[NodeStatus]): NodeStatus =
+                if children.isEmpty then NodeStatus.Pending
+                else if children.forall(_ == NodeStatus.Completed) then NodeStatus.Completed
+                else if children.forall(s => s == NodeStatus.Completed || s == NodeStatus.Compensated) then NodeStatus.Compensated
+                else if children.exists {
+                        case NodeStatus.Running | NodeStatus.WaitingForInput | NodeStatus.Sleeping(_) => true
+                        case _                                                                        => false
+                    }
+                then NodeStatus.Running
+                else NodeStatus.Pending
+            Progress(
+                walked.map { node =>
+                    if node.nodeType != NodeType.Subflow then node
+                    else recordedFailure(node).getOrElse(node.copy(status = derived(contributed(node.name))))
+                }.toSeq
+            )
         end build
     end Progress
 

--- a/kyo-flow/shared/src/main/scala/kyo/FlowException.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/FlowException.scala
@@ -7,9 +7,11 @@ package kyo
   * `NoStackTrace`) and capture the call site via `Frame` for diagnostics.
   *
   * The hierarchy has intermediate sealed types for natural groupings:
-  *   - `FlowWorkflowException` — workflow lookup failures
-  *   - `FlowExecutionStateException` — execution state/lifecycle failures
-  *   - `FlowSignalException` — input signal delivery failures
+  *   - `FlowWorkflowException`, workflow lookup failures
+  *   - `FlowDefinitionException`, a definition refused at registration
+  *   - `FlowExecutionStateException`, execution state/lifecycle failures
+  *   - `FlowSignalException`, input signal delivery failures
+  *   - `FlowDomainException`, the open branch, extended by a step's own domain failures
   *
   * Catch them with `Abort.run[FlowException]` (all errors), `Abort.run[FlowSignalException]` (signal errors only), etc. The HTTP API
   * translates them to appropriate status codes (404 for not-found, 409 for conflict, 400 for bad request).
@@ -20,7 +22,11 @@ package kyo
   *   [[kyo.Flow]] The workflow definition DSL
   */
 sealed abstract class FlowException(message: String, cause: String | Throwable = "")(using Frame)
-    extends KyoException(message, cause)
+    extends KyoException(message, cause):
+
+    /** The name this failure is recorded under in [[Flow.Status.Failed.kind]], so a persisted failure can be grouped by what it was. */
+    def kind: String = getClass.getSimpleName
+end FlowException
 
 // --- Workflow errors ---
 
@@ -35,6 +41,162 @@ case class FlowWorkflowNotFoundException(workflowId: String)(using Frame)
 /** Thrown when starting an execution for a workflow that hasn't been registered with this engine. */
 case class FlowWorkflowNotRegisteredException(workflowId: String)(using Frame)
     extends FlowWorkflowException(s"Workflow '$workflowId' not registered")
+
+// --- Definition errors ---
+
+/** A definition refused at registration, because nothing it could do afterwards would be right.
+  *
+  * The failures here are properties of the flow VALUE rather than of the store or of an execution, so they are decided once, when the
+  * definition is handed to an engine, and never again. Registration is the only place with both the whole definition and an effect row to
+  * report on: a constructor sees one node at a time and can only throw.
+  *
+  * @see
+  *   [[FlowDuplicateNameException]] two nodes writing one durable name
+  * @see
+  *   [[FlowReservedNameException]] a node name using a character the engine reserves
+  * @see
+  *   [[FlowUnnamedException]] a flow with no name to be registered under
+  */
+sealed abstract class FlowDefinitionException(message: String)(using Frame)
+    extends FlowWorkflowException(message)
+
+/** One durable name claimed by more than one node, with where each claim is and how the two are composed.
+  *
+  * Carried by [[FlowDuplicateNameException]] so a caller can act on the collision rather than parse a message for it. A claim is a write in
+  * at least one of the two nodes: a name only read by both is no conflict, and a name one node writes while another reads it is, because
+  * the write lands on the field the read already occupies.
+  *
+  * @param name
+  *   the name the nodes share
+  * @param composition
+  *   how the two nodes reach each other: in sequence, or through a named combinator's branches
+  * @param locations
+  *   the call site of each node, in the order the fold reached them
+  */
+case class FlowNameConflict(name: String, composition: String, locations: Seq[String]) derives CanEqual:
+    /** The one-line rendering [[FlowDuplicateNameException]] lists this conflict under. */
+    def show: String = s"'$name', shared $composition, at ${locations.mkString(" and ")}"
+
+/** Thrown when registering a flow in which one durable name is written by more than one node.
+  *
+  * A node's name IS its durable key: its field, its completion mark and its schema entry all use it. Two nodes writing one name therefore
+  * share one field and one completion mark, so the second's value overwrites the first's and replay, which decides what is already done
+  * from the set of completed names, skips the second forever after any suspension. Neither node is addressable and the record is not
+  * readable, so there is no contract under which the flow means what it looks like.
+  *
+  * What is NOT refused is as load-bearing as what is. A name only READ, an `input` two branches wait on, is one wait and one field with
+  * nothing ambiguous about it. A name written by the branches of a `race` is the canonical race rather than a collision: the result type is
+  * the union of the two branches, readable downstream only through a field both carry, and replay depends on the shared key to keep its
+  * winner. What guards that one narrow case is the store's write-once progress record, not this refusal.
+  *
+  * @param workflowId
+  *   the workflow the definition was offered under
+  * @param conflicts
+  *   every collision found, one entry per name
+  */
+case class FlowDuplicateNameException(workflowId: String, conflicts: Seq[FlowNameConflict])(using Frame)
+    extends FlowDefinitionException(FlowDuplicateNameException.describe(workflowId, conflicts))
+
+object FlowDuplicateNameException:
+
+    /** The remediation is part of the message because the obvious reading of "duplicate name" sends a user to rename their steps, and for
+      * branches that run the same work that is the wrong fix: the branches are supposed to share a name, and what they need is a distinct
+      * durable path each.
+      */
+    private[kyo] def describe(workflowId: String, conflicts: Seq[FlowNameConflict]): String =
+        val listed   = conflicts.map(c => s"\n  ${c.show}").mkString
+        val parallel = conflicts.exists(_.composition.contains("branches"))
+        val remedy =
+            if parallel then
+                "\nGive each branch a durable path of its own: wrap it in a subflow with its own name, or, when the parallelism is " +
+                    "over runtime data rather than over distinct flows, use foreach, whose items are identified one per item."
+            else
+                "\nGive the nodes different names: each name is one field and one completion mark, so the second write overwrites " +
+                    "the first and replay skips the second."
+        val counted =
+            if conflicts.size == 1 then "one durable name is claimed by more than one node"
+            else s"${conflicts.size} durable names are claimed by more than one node"
+        s"Workflow '$workflowId' cannot be registered, $counted:$listed$remedy"
+    end describe
+end FlowDuplicateNameException
+
+/** Thrown when registering a flow with a node name that uses a character the engine reserves.
+  *
+  * Two characters are reserved, because the engine builds durable keys with both. `#` separates a scheduled loop's iterations, recorded as
+  * `loop#0` and `loop#1`, and a dispatch's chosen branch, recorded as `name#chosen`. `~` joins a subflow instance to a node inside it, so a
+  * node called `step` inside instance `review` is durably `review~step`. A user name carrying either can collide with a key the engine
+  * generates, which is a corruption no test of the flow itself would show.
+  *
+  * @param workflowId
+  *   the workflow the definition was offered under
+  * @param names
+  *   every node name that uses a reserved character
+  */
+case class FlowReservedNameException(workflowId: String, names: Seq[String])(using Frame)
+    extends FlowDefinitionException(
+        s"Workflow '$workflowId' cannot be registered, ${names.map(n => s"'$n'").mkString(", ")} " +
+            "use a reserved character: '#', which the engine uses to build the durable keys of loop iterations and dispatch " +
+            "choices, or '~', which joins a subflow instance to the nodes inside it"
+    )
+
+/** Thrown when registering a flow that has no name.
+  *
+  * The name is the workflow's durable identity, so a flow without one cannot be started, resumed or found. It arrives here rather than from
+  * the constructor because registration is the first point with an effect row: a caller handling `Abort[FlowDefinitionException]` sees this
+  * refusal the same way it sees every other, instead of an untyped throw no union names.
+  */
+case class FlowUnnamedException()(using Frame)
+    extends FlowDefinitionException(
+        "A flow must be named before it is registered: use Flow.init(\"name\"), since the name is the workflow's durable identity"
+    )
+
+// --- Engine configuration errors ---
+
+/** One tuning value the engine cannot work under, with what it was given and what it would do.
+  *
+  * Carried by [[FlowInvalidConfigException]] so a caller can act on the setting rather than parse a message for it, the same reason
+  * [[FlowNameConflict]] is a value beside its exception.
+  *
+  * @param setting
+  *   the [[FlowEngine.Config]] field that cannot be used
+  * @param value
+  *   what that field was given, rendered
+  * @param reason
+  *   what the engine would do under it
+  */
+case class FlowConfigProblem(setting: String, value: String, reason: String) derives CanEqual:
+    /** The one-line rendering [[FlowInvalidConfigException]] lists this problem under. */
+    def show: String = s"$setting = $value: $reason"
+
+/** Thrown when an engine is asked for with a tuning under which it could never do its work.
+  *
+  * The values are refused at `FlowEngine.init` rather than clamped, because every one of them is a caller saying something specific that
+  * the engine cannot honour, and a silently corrected tuning is an engine running under settings its operator never chose. What they have
+  * in common is that the engine would keep answering its health check while making no progress: no worker to poll with, no room in a
+  * batch to claim into, or a lease that is over before it is written.
+  *
+  * The renewal interval is the one that is harmful rather than merely inert. A `renewEvery` no shorter than `lease` means the claim has
+  * already expired when the first renewal is presented, so the renewal is refused, the refusal interrupts the execution, and every step
+  * longer than the lease is interrupted, released, reclaimed and re-run forever, writing several history events per turn.
+  *
+  * Every problem is reported at once rather than the first one found, because a caller who fixes them one at a time pays a process start
+  * per problem.
+  *
+  * @param problems
+  *   every tuning that cannot be used, one entry per setting
+  */
+case class FlowInvalidConfigException(problems: Seq[FlowConfigProblem])(using Frame)
+    extends FlowException(FlowInvalidConfigException.describe(problems))
+
+object FlowInvalidConfigException:
+    private[kyo] def describe(problems: Seq[FlowConfigProblem]): String =
+        val listed = problems.map(p => s"\n  ${p.show}").mkString
+        val counted =
+            if problems.size == 1 then "one setting cannot be used"
+            else s"${problems.size} settings cannot be used"
+        s"The engine cannot be created, $counted:$listed"
+    end describe
+end FlowInvalidConfigException
 
 // --- Execution state errors ---
 
@@ -68,9 +230,134 @@ case class FlowSignalNotFoundException(inputName: String, executionId: String)(u
 case class FlowSignalTypeMismatchException(inputName: String, expected: String, got: String)(using Frame)
     extends FlowSignalException(s"Type mismatch for input '$inputName': expected $expected, got $got")
 
-/** Thrown when delivering an input that was already delivered (signals are exactly-once via putFieldIfAbsent). */
+/** Thrown when delivering an input that was already delivered.
+  *
+  * Delivery is exactly-once, and the store is what decides: [[FlowStore.signal]] writes the field and its arrival in one transition
+  * and answers [[FlowStore.SignalOutcome.AlreadyDelivered]] to every later delivery of the same name. What makes the promise true is
+  * that store-judged transition rather than a check the caller runs first.
+  */
 case class FlowInputAlreadyDeliveredException(executionId: String, inputName: String)(using Frame)
     extends FlowSignalException(s"Input '$inputName' was already delivered in execution '$executionId'")
+
+/** A failure of the store behind an execution: the database was unreachable, a statement was rejected, a row would not decode.
+  *
+  * The error channel every [[FlowStore]] method carries, and the reason it exists: a store implementation talks to something that fails,
+  * and without a channel its only way to report a failure is to panic, which throws away a typed and often classified error at the SPI
+  * boundary. A deadlock on the claim UPDATE makes it concrete: the database says "retry this", the store knows that, and there is no way
+  * to tell the engine.
+  *
+  * Open, because the failures a store can have are the failures of whatever it is built on, and only the implementation can name them. A
+  * store over kyo-sql wraps `SqlException`; one over a file wraps an IO failure.
+  *
+  * The engine treats a failure of the poll loop as transient and keeps polling, recording it on [[FlowEngine.health]] (see
+  * [[FlowEngine.worker]]), and it treats a failure raised while an execution is being run the same way. A store that could not be
+  * reached has said nothing about the work, so the attempt is charged to health and the execution is left exactly as claimable as it
+  * was, for the next poll to try again, rather than terminalising an execution on an outage it did not cause.
+  *
+  * @see
+  *   [[FlowStoreException.Retryable]] the marker a store puts on a failure the caller may safely retry
+  */
+abstract class FlowStoreException(message: String, cause: String | Throwable = "")(using Frame)
+    extends KyoException(message, cause):
+
+    /** The store's own name for this failure, so one store failure can be told from another by what it is.
+      *
+      * A store names its failures, and the class it gives one is the only description of it worth keeping: what a deadlock is called by
+      * the store that raised it is how a deadlock is recognised again. Without it a store failure carries nothing but a message, and
+      * telling two apart means matching their text.
+      */
+    def kind: String = getClass.getSimpleName
+end FlowStoreException
+
+object FlowStoreException:
+
+    /** Property marker: this failure is transient and the operation may be retried unchanged.
+      *
+      * A store puts it on the failures its backend classifies that way (a deadlock, a serialization failure, a lost connection), so the
+      * engine can tell "try again" from "this will fail the same way forever" without knowing what a backend's error codes mean.
+      */
+    trait Retryable
+
+end FlowStoreException
+
+// --- Step errors ---
+
+/** Raised when a step does not finish within the `timeout` its [[Flow.Meta]] declared.
+  *
+  * A timeout is a policy the caller declared on the node itself, so the failure that enforces it is a declared failure of this flow and
+  * carries a kind like any other: "how many executions timed out" is then a query over [[Flow.Status.Failed.kind]] rather than a LIKE
+  * over message text. It reaches the engine as a failure and not as a panic, for the reason [[FlowDomainException]] states in as many
+  * words about turning a typed error into one.
+  *
+  * It is also the one flow failure a step's retry schedule re-asks. Declaring `timeout` and `retry` together is what the two `Meta`
+  * fields are for: a slow attempt is a measurement rather than a verdict, and the schedule exists to take another one. Once the
+  * schedule is exhausted the timeout terminalises the execution with its kind.
+  *
+  * @param stepName
+  *   the node whose `timeout` was exceeded
+  * @param timeout
+  *   the bound that was declared and exceeded
+  */
+case class FlowStepTimeoutException(stepName: String, timeout: Duration)(using Frame)
+    extends FlowException(s"Step '$stepName' timed out after ${timeout.show}")
+
+/** Raised when a scheduled loop's schedule runs out before its body produced a value.
+  *
+  * A flow declaring `N ~ V` promises a `V`, and a `loopOn` whose schedule is spent has none to store, so running out is a failure of the
+  * flow rather than a success. Nothing is written under the loop's name: the last state is the loop's `A` and the name is typed `V`, and
+  * writing one where the other is declared is sound only where the two coincide. It carries a kind like any other declared failure, so
+  * "how many executions ran their loop out" is a query over [[Flow.Status.Failed.kind]] rather than a LIKE over message text.
+  *
+  * @param loopName
+  *   the scheduled loop whose schedule was exhausted
+  * @param iterations
+  *   how many iterations ran before the schedule had no delay left
+  */
+case class FlowLoopExhaustedException(loopName: String, iterations: Int)(using Frame)
+    extends FlowException(s"Loop '$loopName' exhausted its schedule after $iterations iteration(s) without producing a value")
+
+/** Raised when a fan-out's collection answers a different size on the attempt that resumes it.
+  *
+  * A `foreach` records each item's result under the item's own durable name and the count it started with beside them, which is what lets
+  * a resumed fan-out skip the items that already ran. That identity is positional, so it holds only while the collection is a
+  * deterministic function of the record, and a collection that answers a different size has broken it: the results recorded under the old
+  * positions belong to items the new collection may no longer contain.
+  *
+  * The node fails rather than running the fan-out again. Re-running it would write onto paths that already carry the previous attempt's
+  * results, hand each per-item compensation handler a value from a run it did not belong to, and re-fire every item's side effects on the
+  * way, which is both of the outcomes the recorded count exists to prevent. It carries a kind like any other declared failure, so "how
+  * many executions had a collection change under them" is a query over [[Flow.Status.Failed.kind]] rather than a search over message text.
+  *
+  * @param nodeName
+  *   the fan-out whose collection changed, by its durable name
+  * @param recorded
+  *   how many items the fan-out recorded when it started
+  * @param recomputed
+  *   how many the collection answered on the attempt that resumed it
+  */
+case class FlowNondeterministicCollectionException(nodeName: String, recorded: Int, recomputed: Int)(using Frame)
+    extends FlowException(
+        s"Foreach '$nodeName' recorded $recorded item(s) and its collection recomputed to $recomputed on replay; " +
+            "a fan-out's collection must be a deterministic function of the record"
+    )
+
+/** The base a step's own domain failure extends, and the one branch of this hierarchy that is open.
+  *
+  * A step's runner has to produce `Abort[FlowException]`, so without an open branch a domain failure has nowhere typed to go: declining a
+  * charge, rejecting an order, a business rule saying no. Those are not engine errors, and turning them into panics throws away the type
+  * on the way to a status that keeps a string.
+  *
+  * A failure extending this reaches the engine as a failure rather than a panic, and the status it produces carries its class name as
+  * [[Flow.Status.Failed.kind]], so "how many executions failed for payment reasons" is a query over a field rather than a LIKE over an
+  * error message.
+  *
+  * {{{
+  * case class ChargeDeclined(orderId: String, cents: Long)(using Frame)
+  *     extends FlowDomainException(s"charge declined for \$orderId: \$cents cents over limit")
+  * }}}
+  */
+abstract class FlowDomainException(message: String, cause: String | Throwable = "")(using Frame)
+    extends FlowException(message, cause)
 
 // --- Execution lifecycle ---
 
@@ -78,6 +365,20 @@ case class FlowInputAlreadyDeliveredException(executionId: String, inputName: St
 case class FlowExecutionFailedException(executionId: String, error: String)(using Frame)
     extends FlowException(s"Flow execution '$executionId' failed: $error")
 
-/** Thrown when the engine detects a cancelled execution during input resolution. */
+/** Raised at a node boundary when somebody has asked for the execution to be cancelled.
+  *
+  * A cancel is a REQUEST rather than a terminal write: raising it here is what stops the forward pass at the next boundary and takes the
+  * execution into its unwind, and only when the handlers have run does the terminal `Cancelled` land.
+  */
 case class FlowCancelledException(executionId: String)(using Frame)
     extends FlowException(s"Flow execution '$executionId' was cancelled")
+
+/** The verdict a resumed unwind re-raises, carrying what the interrupted attempt recorded when it entered the unwind.
+  *
+  * An execution that crashed mid-unwind knows only that it was unwinding, not what from, unless the transition into `Compensating` wrote
+  * the cause down. It does, so a resumed attempt raises this at the first node the forward pass would otherwise RUN, and the terminal
+  * status is then a total function of the cause rather than of whether the failing step failed a second time. This never leaves the
+  * engine: the transition that ends the attempt reads the cause off it and writes the pair the interrupted attempt was going to write.
+  */
+private[kyo] case class FlowResumedUnwindException(cause: Flow.Cause)(using Frame)
+    extends FlowException(s"resuming an unwind recorded as ${cause}")

--- a/kyo-flow/shared/src/main/scala/kyo/FlowStore.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/FlowStore.scala
@@ -5,30 +5,68 @@ import kyo.internal.*
 /** Persistence layer for durable workflow execution state.
   *
   * Most users only need `FlowStore.initMemory` (for development/testing) or pass a store to `Flow.runServer`. Implementing this trait is
-  * for integrating a durable database like PostgreSQL — you provide the 15 abstract methods and get crash recovery, multi-executor
+  * for integrating a durable database like PostgreSQL: you provide the abstract methods, 12 on `FlowStore` and 8 on
+  * [[FlowStore.Claimed]] (six verbs and two accessors, `state` and `satisfied`), 20 in all, and get crash recovery, multi-executor
   * coordination, and exactly-once field writes for free.
   *
   * Each FlowStore instance is a stateless client over a shared backing database. All coordination (claiming executions, preventing
   * duplicates, ensuring ordering) happens through atomic operations in the database. The in-memory implementation uses `AtomicRef` as the
-  * database and `Signal.Ref` for notification.
+  * database and two channels to wake blocked pollers, one carrying ordinary writes and one carrying registrations, which
+  * [[FlowStore.claimReady]] treats differently.
+  *
+  * **The trait splits in two, and which half a verb is on says who may call it.** `FlowStore` carries the readers and the three
+  * administrative writes anybody may make ([[FlowStore.createExecutionIfAbsent]], [[FlowStore.signal]], [[FlowStore.requestCancel]]).
+  * Every write made while RUNNING an execution is a method on [[FlowStore.Claimed]], the handle [[FlowStore.claimReady]] hands back, and
+  * the store judges each one against the claim it was presented under. A write that carries no evidence of the claim it was made under
+  * cannot be refused by anything except the writer's own good manners, which is what this split removes.
   *
   * The key concept is the **claim lease**: `claimReady` atomically finds ready executions and assigns them to an executor with a
-  * time-limited lease. If the executor dies, the lease expires and `claimReady` hands the execution to another executor. The engine renews
-  * leases periodically to keep long-running steps alive.
+  * time-limited lease and a generation token. If the executor dies, the lease expires and `claimReady` hands the execution to another
+  * executor under a NEW token, and every write the dead executor still had in flight is refused. The engine renews leases periodically to
+  * keep long-running steps alive.
+  *
+  * Every method carries [[FlowStoreException]] as its error channel, so an implementation reports a failure of its backend as a value
+  * rather than by panicking. What the engine does with one: a failure while polling is treated as transient, recorded on
+  * [[FlowEngine.health]], and retried; a failure while running an execution is recorded there too and leaves the execution exactly as
+  * claimable as it was, because a store the engine could not reach is not a verdict on the work. Nothing about such a failure is written
+  * to the execution, and the claim is left to lapse rather than released, so the next poll after the lease recovers it. A store that
+  * knows a failure is transient marks it [[FlowStoreException.Retryable]].
   *
   * Invariants every implementation must uphold:
   *   - I1: claimReady never returns the same execution to two concurrent callers
-  *   - I2: updateStatus writes event + status atomically (no window where one is updated without the other)
-  *   - I3: putFieldIfAbsent is an atomic check-and-write (exactly one concurrent writer wins)
-  *   - I4: renewClaim returns false if the claim was taken by another executor
+  *   - I2: a transition writes its status, its event and its ledger effect atomically, with no window in which a reader sees one without
+  *     the others. It binds more than the status writes: the transitions are recording a wait ([[FlowStore.Claimed.recordWait]]),
+  *     recording progress and clearing the row it discharges ([[FlowStore.Claimed.recordProgress]]), and ending an attempt by retiring
+  *     the rows the execution no longer waits on and consuming the claim ([[FlowStore.Claimed.finish]]). A store that clears a row in a
+  *     second write leaves a crash window in which a satisfied row keeps the execution permanently ready, which is the poll spin the
+  *     ledger exists to close.
+  *   - I3: [[FlowStore.signal]] is an atomic check-and-write against both the field and the lifecycle: exactly one concurrent delivery of
+  *     a name wins and every later one is answered [[FlowStore.SignalOutcome.AlreadyDelivered]], and a delivery that arrives when the
+  *     execution is already terminal is answered [[FlowStore.SignalOutcome.AlreadyTerminal]] and writes nothing. Reading the status and
+  *     then writing is not enough: an execution that terminates between the two accepts a value nobody will ever consume while the
+  *     caller is told it succeeded.
+  *   - I4: a renewal succeeds only on an ACTIVE, UNEXPIRED claim whose token is the one presented. Expiry is half of that and
+  *     supersession is the other half, and naming only supersession is the hole an implementor copies: a claim whose lease ran out while
+  *     nobody else took the row still bears the highest token, so an implementation that checked the token alone would let a lapsed
+  *     executor renew late and resume writing. An expired claim is dead, and only a new [[FlowStore.claimReady]] generation revives the
+  *     execution.
   *   - I5: terminal status (Completed/Failed/Cancelled) cannot revert to a non-terminal status
   *   - I6: read-your-writes consistency within a single caller
   *   - I7: getHistory returns events in append order
-  *   - I8: claimReady returns only genuinely progressable executions (not terminal, not future-sleeping, not waiting without field)
-  *   - I9: returned executions have executor = caller's ID and claimExpiry = now + lease
+  *   - I8: claimReady returns an execution exactly when its lifecycle is not terminal, its claim is free or expired, the caller serves its
+  *     version, and ANY of: a cancel request is outstanding, it has no outstanding wait rows, one of its rows is satisfied, or its claim
+  *     is active and expired. See [[FlowStore.claimReady]] for what each clause is for.
+  *   - I9: a claimed row RECORDS who holds it, until when, and under which generation. `claimReady` stamps the caller's executor id and a
+  *     deadline one lease past its own now, and issues a token strictly greater than any that row has carried. The executor id is
+  *     recorded so the reporting surfaces can say who is working on an execution; it is NOT a write authority, and no implementation may
+  *     judge a write by it. Two workers of one engine share an executor id, so an executor whose lease lapsed while its sibling reclaimed
+  *     the row would find a live claim bearing its own name and could not tell the dead generation from the new one. The token is what a
+  *     write is judged against.
   *
   * @see
   *   [[kyo.FlowEngine]] The engine that coordinates store operations
+  * @see
+  *   [[kyo.FlowStore.Claimed]] The capability a claimed execution is written through
   * @see
   *   [[kyo.FlowStore.ExecutionState]] The execution state row
   * @see
@@ -38,107 +76,185 @@ abstract class FlowStore:
 
     // --- Coordination: atomic find-and-claim ---
 
-    /** Atomically find ready executions and claim them. Blocks up to timeout if nothing ready. Returns exclusively — no two concurrent
-      * callers get the same execution.
+    /** Atomically find ready executions and claim them. Returns exclusively: no two concurrent callers get the same execution.
+      *
+      * **Readiness is one total function over everything it depends on**, and the store evaluates all of it. An execution is returned
+      * when all four hold:
+      *
+      *   1. its lifecycle is not terminal, and
+      *   1. its claim is free or expired, and
+      *   1. the caller SERVES its version, that is, `(flowId, hash)` is in `served`, and
+      *   1. any of: a cancel request is outstanding; it has no outstanding wait rows; at least one row's [[Flow.Wake]] is satisfied; or
+      *      its claim is active and expired.
+      *
+      * A row is satisfied by, and only by: [[Flow.Wake.At]] once the STORE's clock has passed the instant, and [[Flow.Wake.OnField]] once
+      * that field is present. Both judged by the store against its own state, never by the caller. Which rows the store judged satisfied
+      * rides back on [[FlowStore.Claimed.satisfied]], so the caller discharges exactly what the store woke it for rather than re-deciding
+      * against a clock of its own.
+      *
+      * **The third clause stands alone rather than qualifying one arm of the fourth.** Inside the disjunction it leaks twice, because an
+      * execution with no rows, or with a cancel request, would then be handed to a caller that cannot resolve its definition and so can
+      * neither run it nor unwind it, while holding a perfectly valid claim.
+      *
+      * **The cancel arm is load-bearing**: without it a suspended execution with a cancel request has no satisfied wait and no executor,
+      * so nothing ever claims it and its compensations never run.
+      *
+      * **The active-and-expired arm is what keeps a crash from wedging an execution permanently.** Rows gate wake-up only when they are
+      * a finished attempt's blessed statement of what the execution waits for, and only the transition that ends an attempt makes a claim
+      * ABSENT. An active claim that has expired means the last attempt died mid-flight, so its rows may describe waits the execution is no
+      * longer in, and no attempt could ever retire them if readiness demanded their satisfaction first: retirement needs the claim the
+      * rule would refuse to grant. Return the execution; its replay re-records the real waits and its ending retires the stale ones.
+      *
+      * **A claim a caller does not receive must not be a claim.** Either the call hands the row over or it leaves the row as it found
+      * it: the rows a call returns are exactly the rows whose token it just took. A store that stamps a fresh deadline on a row and then
+      * withholds it makes that execution invisible to the whole system for a full lease while its row looks perfectly healthy.
+      *
+      * Blocks up to `timeout` if nothing is ready, and re-asks as the store's state changes. It answers EARLY AND EMPTY on one change
+      * only, a definition being registered: what a caller serves is fixed for the life of the call, so a registration cannot make
+      * anything ready for THIS call and the useful answer is to hand control back for a poll with the wider set. Without it an
+      * execution held for a version nobody served waits out a whole poll timeout after the definition it needs arrives.
+      *
+      * **The deadline makes one final attempt and answers what it claimed; an empty answer at the deadline means the row was not
+      * ready on that attempt.** Two things become ready with no write to wake anyone: a [[Flow.Wake.At]] row whose instant simply
+      * passed, and a claim that simply expired. An implementation that answered empty on the strength of having run out of time would
+      * hide either of them until somebody polled again, which is a whole poll cycle of latency on the two paths that have no writer to
+      * announce them, and it would make the answer depend on whether the wait or the clock won a race.
+      *
+      * **An empty answer is therefore never proof that `timeout` elapsed**, and a caller must not read it as one. It is a signal to
+      * poll again: re-read what the answer may have changed, which is the served set, and ask again with another BLOCKING call. One
+      * wake drives one re-attempt, so an empty answer cannot turn into a spin. Nothing else wakes a blocked call empty: an ordinary
+      * write that leaves nothing ready is re-asked inside the call, which keeps waiting.
       */
     def claimReady(
-        workflowIds: Set[Flow.Id.Workflow],
+        served: Set[(Flow.Id.Workflow, String)],
         executorId: Flow.Id.Executor,
         lease: Duration,
         limit: Int,
         timeout: Duration
-    )(using Frame): Seq[FlowStore.ExecutionState] < Async
+    )(using Frame): Seq[FlowStore.Claimed] < (Async & Abort[FlowStoreException])
 
-    /** Extend the lease. Returns false if the claim was lost (expired or taken by another executor). */
-    def renewClaim(
-        executionId: Flow.Id.Execution,
-        executorId: Flow.Id.Executor,
-        lease: Duration
-    )(using Frame): Boolean < Async
+    // --- Execution state ---
 
-    /** Release the claim. No-op if not the owner. */
-    def releaseClaim(
-        executionId: Flow.Id.Execution,
-        executorId: Flow.Id.Executor
-    )(using Frame): Unit < Async
-
-    // --- Execution state: atomic event + status ---
-
-    /** Create a new execution with an initial status, event, and structural hash for version enforcement. */
-    def createExecution(
+    /** Create an execution if that id is free, and answer whether this call is the one that created it.
+      *
+      * The row, its `Created` event, its structural hash and every field the start supplied are one transition, so a crash cannot leave an
+      * execution half-seeded: an input written as a separate call after creation is a value the execution may or may not have, and replay
+      * cannot tell a missing seed from an input nobody has delivered yet.
+      *
+      * **An id already taken leaves everything exactly as it was** and answers false. The check and the write are one operation for the
+      * same reason: a read followed by a write lets two concurrent starts on one explicit id both pass the check, and a second create that
+      * reset the row would wipe a running execution's history, which replay reads to decide what is already done.
+      *
+      * `fields` are already encoded, because a start seeds inputs of several declared types at once and one call cannot carry a type
+      * parameter per field. [[getAllFields]] answers in the same shape.
+      */
+    def createExecutionIfAbsent(
         executionId: Flow.Id.Execution,
         status: Flow.Status,
         event: Flow.Event,
-        hash: String
-    )(using Frame): Unit < Async
+        hash: String,
+        fields: Dict[String, FlowStore.FieldData]
+    )(using Frame): Boolean < (Async & Abort[FlowStoreException])
 
-    /** Write an event AND update execution status atomically. Does not modify the structural hash. */
-    def updateStatus(
+    /** Deliver a value to a named input, and record its arrival, in one transition.
+      *
+      * **The store judges terminality, because it is the only place that holds both facts at once.** A caller that reads the status,
+      * finds it non-terminal and then writes has a window in which the execution finishes in between, and what lands there is a value
+      * nobody will ever consume on an execution that is over, with the caller told it succeeded.
+      *
+      * The answer says WHICH refusal, because the two are different instructions to a caller: [[FlowStore.SignalOutcome.Delivered]] wrote
+      * the field and the event, [[FlowStore.SignalOutcome.AlreadyDelivered]] means stop retrying this name, and
+      * [[FlowStore.SignalOutcome.AlreadyTerminal]] means stop entirely and read the result. A `Boolean` collapses the last two into one
+      * "no", which is the answer a caller can do least with.
+      *
+      * An input name this execution's definition does not declare, and a value whose type does not match the declared one, are defects in
+      * the CALL rather than states of the execution, so they are refused by the engine on its own typed channel before this verb is
+      * reached: a caller retrying either unchanged would fail identically forever.
+      */
+    def signal[V: Tag: Schema](
         executionId: Flow.Id.Execution,
-        status: Flow.Status,
+        name: String,
+        value: V,
         event: Flow.Event
-    )(using Frame): Unit < Async
+    )(using Frame): FlowStore.SignalOutcome < (Async & Abort[FlowStoreException])
+
+    /** Ask for an execution to be cancelled, and answer what the ask did.
+      *
+      * **A request rather than an act.** The terminal status is written after the work stops, because cancelling runs the execution's
+      * compensations: an executor observes the request at a node boundary, unwinds, and terminalises at the end of the unwind. So the
+      * request has to be carried on the row in between, which is what [[FlowStore.ExecutionState.cancelRequested]] is, and readiness
+      * returns a cancel-requested execution regardless of what it is waiting for, since a suspended execution nobody claims never runs
+      * its handlers.
+      *
+      * The answer says which of three things happened rather than collapsing them into a `Boolean`:
+      * [[FlowStore.CancelOutcome.Accepted]] means the flag is now set, [[FlowStore.CancelOutcome.AlreadyRequested]] means somebody asked
+      * first, and [[FlowStore.CancelOutcome.AlreadyTerminal]] means there is nothing to cancel and carries what the execution ended as.
+      * The first two are the difference between "your cancel is in flight" and "someone already asked"; the third is the difference
+      * between a caller that should wait and one that should read the terminal result.
+      *
+      * Requesting a cancel on an execution that does not exist is answered [[FlowStore.CancelOutcome.AlreadyTerminal]] carrying
+      * [[Flow.Status.Cancelled]], because a row that is not there cannot be running.
+      */
+    def requestCancel(
+        executionId: Flow.Id.Execution
+    )(using Frame): FlowStore.CancelOutcome < (Async & Abort[FlowStoreException])
 
     /** Read execution state. */
     def getExecution(
         executionId: Flow.Id.Execution
-    )(using Frame): Maybe[FlowStore.ExecutionState] < Async
+    )(using Frame): Maybe[FlowStore.ExecutionState] < (Async & Abort[FlowStoreException])
 
-    /** List executions for a workflow, optionally filtered by status. */
+    /** List executions for a workflow, optionally filtered.
+      *
+      * **The filter is evaluated BEFORE pagination**, which is the whole reason it is a parameter rather than something a caller applies
+      * to the answer: filtering a returned page answers "the matches among the first 25 rows" to a caller who asked for "the first 25
+      * matches", and the two differ by however many non-matching rows the page happened to contain.
+      *
+      * `limit` bounds how many rows come back; `Absent` means every match. A negative `Present` count is not a meaningful limit, and
+      * every implementation answers it the same as `Absent` rather than as an empty page: a caller cannot tell that answer from a
+      * workflow that genuinely has nothing matching. `offset` is non-negative.
+      */
     def listExecutions(
         flowId: Flow.Id.Workflow,
-        status: Maybe[Flow.Status],
-        limit: Int,
+        filter: Maybe[FlowStore.ExecutionFilter],
+        limit: Maybe[Int],
         offset: Int
-    )(using Frame): Chunk[FlowStore.ExecutionState] < Async
+    )(using Frame): Chunk[FlowStore.ExecutionState] < (Async & Abort[FlowStoreException])
 
     // --- Fields ---
-
-    /** Write a typed field. Overwrites if exists. */
-    def putField[V: Tag: Schema](
-        executionId: Flow.Id.Execution,
-        name: String,
-        value: V
-    )(using Frame): Unit < Async
-
-    /** Atomic check-and-write. Returns true if written (was absent), false if already existed. */
-    def putFieldIfAbsent[V: Tag: Schema](
-        executionId: Flow.Id.Execution,
-        name: String,
-        value: V
-    )(using Frame): Boolean < Async
 
     /** Read a typed field. Returns Absent if missing or type tag mismatch. */
     def getField[V: Tag: Schema](
         executionId: Flow.Id.Execution,
         name: String
-    )(using Frame): Maybe[V] < Async
+    )(using Frame): Maybe[V] < (Async & Abort[FlowStoreException])
 
     /** Read all fields for an execution as raw FieldData. */
     def getAllFields(
         executionId: Flow.Id.Execution
-    )(using Frame): Dict[String, FlowStore.FieldData] < Async
+    )(using Frame): Dict[String, FlowStore.FieldData] < (Async & Abort[FlowStoreException])
 
     // --- Events ---
 
-    /** Append an event without changing execution status. */
-    def appendEvent(
-        executionId: Flow.Id.Execution,
-        event: Flow.Event
-    )(using Frame): Unit < Async
-
-    /** Read paginated event history. */
+    /** Read paginated event history.
+      *
+      * `limit` bounds how many events come back; `Absent` means every event. `Absent` rather than an `Int.MaxValue` sentinel for the
+      * same request, which would leave every implementation guarding the obvious way of answering `hasMore`: fetching `limit + 1` rows
+      * overflows to `Int.MinValue` at that sentinel. A negative `Present` count is not a meaningful limit, and every implementation
+      * answers it the same as `Absent`, never as an empty page that still claims another follows: that pair is the one answer a paging
+      * caller loops on forever. `offset` is non-negative.
+      */
     def getHistory(
         executionId: Flow.Id.Execution,
-        limit: Int,
+        limit: Maybe[Int],
         offset: Int
-    )(using Frame): FlowStore.HistoryPage < Async
+    )(using Frame): FlowStore.HistoryPage < (Async & Abort[FlowStoreException])
 
     // --- Workflows ---
 
-    def putWorkflow(meta: FlowEngine.WorkflowInfo)(using Frame): Unit < Async
-    def getWorkflow(id: Flow.Id.Workflow)(using Frame): Maybe[FlowEngine.WorkflowInfo] < Async
-    def listWorkflows(using Frame): Seq[FlowEngine.WorkflowInfo] < Async
+    def putWorkflow(meta: FlowEngine.WorkflowInfo)(using Frame): Unit < (Async & Abort[FlowStoreException])
+    def getWorkflow(id: Flow.Id.Workflow)(using Frame): Maybe[FlowEngine.WorkflowInfo] < (Async & Abort[FlowStoreException])
+    def listWorkflows(using Frame): Seq[FlowEngine.WorkflowInfo] < (Async & Abort[FlowStoreException])
 
 end FlowStore
 
@@ -154,16 +270,278 @@ object FlowStore:
     def initMemory(using Frame): FlowStore < (Sync & Scope) =
         AtomicRef.init(MemoryData.empty).map { ref =>
             Channel.init[Unit](1).map { channel =>
-                new MemoryFlowStore(ref, channel)
+                Channel.init[Unit](1).map { registrations =>
+                    new MemoryFlowStore(ref, channel, registrations)
+                }
             }
         }
 
+    // --- The claimed capability ---
+
+    /** The capability to write to one execution, handed over by [[FlowStore.claimReady]] and carrying the generation it was granted under.
+      *
+      * **One rule decides every write made through this handle, and it has two halves.** A row's claim is either ACTIVE, carrying a
+      * token and an expiry, or ABSENT. A write is applied only if the row's claim is active, the presented token equals the active
+      * claim's token, and the active claim has not expired against the store's own clock. `claimReady` replaces whatever claim the row
+      * has with an active one carrying a token strictly greater than any the row has carried; [[Claimed.finish]] makes the claim absent,
+      * and it is the only verb that does; expiry leaves the claim active and expired, which is what lets `claimReady` replace it.
+      *
+      * Both halves, never either. The token alone refuses a SUPERSEDED writer, one whose row somebody else claimed, and says nothing
+      * about an executor whose lease expired while nobody else claimed the row, which still holds the highest token. The expiry alone
+      * says nothing about a writer whose row was taken while its lease still had time to run.
+      *
+      * **Applied means the whole transition, including the event.** A refused write leaves NOTHING: no status change, no field, no
+      * history row, no cleared or retired wait. History is where a half-refusal does the most damage, because it is append-only and the
+      * operator surfaces treat it as authoritative for failure, so an execution its owner completed must not carry a `Failed` event
+      * written by an executor that no longer held it.
+      *
+      * **An attempt that ends without calling `finish` leaves the claim to expire.** That is not a leak: readiness reads an ACTIVE AND
+      * EXPIRED claim as "the last attempt died mid-flight", returns the execution regardless of its rows, and lets the replay heal the
+      * ledger. Releasing there instead would bless a partial ledger as a finished attempt's statement, which is a permanent wedge rather
+      * than a slow recovery.
+      *
+      * A store author implements this trait beside [[FlowStore]] and hands instances back from `claimReady`. The handle carries the
+      * claimed row's snapshot so the caller can resolve the execution's definition without a read of its own.
+      */
+    trait Claimed:
+
+        /** The claimed row as it stood when the claim was granted.
+          *
+          * A snapshot, deliberately: it carries the id, the `flowId` and the structural hash the caller resolves the definition with, so
+          * a batch of claimed rows costs no reads at all. It cannot see a change that arrived after the claim, which is why a cancel
+          * request is observed by reading the row fresh through [[FlowStore.getExecution]] at a node boundary rather than from here.
+          */
+        def state: ExecutionState
+
+        /** The paths of the wait rows the store judged satisfied when it granted this claim.
+          *
+          * Empty when the execution was returned for a reason that is not a row (no rows at all, a cancel request, or a claim that
+          * expired mid-flight). The caller discharges from this rather than re-judging the rows against a clock of its own: the store is
+          * the clock, and an engine whose clock runs behind a third-party store's would otherwise refuse to discharge what readiness
+          * woke it for, re-park, and be handed the execution again at full speed until it caught up.
+          */
+        def satisfied: Set[String]
+
+        /** Append an event without changing anything else. */
+        def appendEvent(event: Flow.Event)(using Frame): WriteOutcome < (Async & Abort[FlowStoreException])
+
+        /** Record that the node at `path` is waiting for `wake`, and append the event that says so, in one transition.
+          *
+          * **Put-if-absent in shape, and that is load-bearing rather than a convenience.** A row that already exists is left exactly as
+          * it is: a sleep re-recorded on a later attempt keeps its ORIGINAL deadline, and a store that overwrote would push the deadline
+          * forward on every replay and turn a finite sleep into one that never fires. The EVENT is appended either way, because a
+          * replayed re-record is something an operator reading the history should see; only the row is left alone.
+          *
+          * **Recording a wait does not release the claim, and the two must stay separate.** Rows are per node, so a composition
+          * waiting on two conditions at once is two rows; each parking branch calls this while the claim is still held, and the
+          * transition that ENDS the attempt releases once. A verb that released on the first branch's suspension would make the second
+          * branch's row unwritable by its own acceptance rule, so `race(input, sleep)` would record one row instead of two and lose
+          * either the timeout or the wake depending on which branch parked first.
+          */
+        def recordWait(path: String, wake: Flow.Wake, event: Flow.Event)(using
+            Frame
+        ): WriteOutcome < (Async & Abort[FlowStoreException])
+
+        /** Extend the lease on this claim. Answers false once the claim is gone, by expiry or by supersession (I4). */
+        def renewClaim(lease: Duration)(using Frame): Boolean < (Async & Abort[FlowStoreException])
+
+        /** Move the execution's LIFECYCLE mid-attempt, with the event that says so, in one transition.
+          *
+          * The one lifecycle transition an attempt makes while it is still running, which is entering [[Flow.Status.Compensating]] with
+          * the cause that started the unwind. It refuses a TERMINAL status, and [[finish]] refuses a non-terminal one: the two verbs
+          * partition the lifecycle, because a terminal write that bypassed `finish` would bypass the retirement and the claim
+          * consumption that make terminality safe.
+          */
+        def updateStatus(status: Flow.Status, event: Flow.Event)(using
+            Frame
+        ): StatusOutcome < (Async & Abort[FlowStoreException])
+
+        /** Record a node's progress: write its field under `path`, append its completion event, and clear the wait rows under that path,
+          * in one transition.
+          *
+          * **One transition, all three parts or none.** A field and its completion event written separately leave, on a store that
+          * fails between them, a value durably present and a history saying the step never finished; replay decides from the FIELD and
+          * the operator surface decides from HISTORY, so that step never runs again and the surface reports it unfinished forever. The
+          * clearing rides here for the same reason: a satisfied row that is never removed keeps the execution ready after its branch has
+          * moved on. Clearing a path with no row is a no-op, which is what makes the discharge idempotent across replays.
+          *
+          * **Absent means no field is written, never an absent marker.** A node with no value of its own (a step, or an input being
+          * marked discharged) records its completion and its clearing and touches no field. For the input case a marker would clobber
+          * the value that was signalled.
+          *
+          * **Write-once per path, with the refusal split by what the write carries.** A VALUE-CARRYING write is refused when the path
+          * already carries a field. A VALUELESS one is refused only by its own recorded completion and never by field presence, because
+          * an input's discharge is by construction a valueless progress at a path the signalled value already occupies, and refusing it
+          * on field presence would silently delete the discharge event and the row clearing. A refused write is answered
+          * [[ProgressOutcome.AlreadyRecorded]] and writes nothing at all.
+          *
+          * No legitimate node writes its own path twice: iterations, fan-out items and a dispatch's choice all key distinct paths. What
+          * the rule buys is the one race the design blesses, two live branches of a `race` completing a shared output name: the first
+          * writer decides the field and the loser is answered already-recorded, which is the same answer replay derives from the field's
+          * presence, settled by the store instead of by whichever write the scheduler happened to land last.
+          *
+          * A store must therefore record, per execution, the paths at which a valueless progress has been recorded. A field cannot serve
+          * as that mark, since a valueless write is exactly the one that writes no field.
+          */
+        def recordProgress[V](path: String, value: Maybe[V], event: Flow.Event)(using
+            Tag[V],
+            Schema[V],
+            Frame
+        ): ProgressOutcome < (Async & Abort[FlowStoreException])
+
+        /** The valueless progress, for a node whose completion carries no value of its own.
+          *
+          * Delegates to the canonical write with an absent value. The type parameter it picks is arbitrary and unobservable, because an
+          * absent value writes no field and the tag is only ever read beside one.
+          */
+        final def recordProgress(path: String, event: Flow.Event)(using
+            Frame
+        ): ProgressOutcome < (Async & Abort[FlowStoreException]) =
+            recordProgress[String](path, Maybe.empty, event)
+
+        /** End this attempt: write what happened, settle the wait ledger, and make the claim absent, in one transition.
+          *
+          * The only verb that makes a claim absent, which is what gives the absence its meaning: when a row's claim is absent, its rows
+          * are a finished attempt's blessed statement of what the execution is waiting for, and readiness may gate on them.
+          *
+          * [[Claimed.Outcome.Terminal]] writes the terminal status and its event and retires EVERY row, because a terminal execution
+          * waits for nothing. It refuses a non-terminal status, for the reason [[updateStatus]] refuses a terminal one.
+          * [[Claimed.Outcome.Suspended]] writes no status, keeps exactly the rows named in `waitingOn`, and retires the rest: a race's
+          * losing branch, a `zip` branch abandoned when its sibling failed, a straggler interrupted between writing its row and being
+          * cancelled. None of them was discharged, so no progress write clears them, and a row that outlives the branch that wrote it
+          * keeps the execution ready the moment it happens to be satisfiable.
+          */
+        def finish(outcome: Claimed.Outcome)(using Frame): StatusOutcome < (Async & Abort[FlowStoreException])
+
+    end Claimed
+
+    object Claimed:
+
+        /** What an attempt writes as it ends. Every outcome makes the claim absent in the same transition. */
+        enum Outcome derives CanEqual:
+
+            /** The execution is over. Writes the pair and retires every row. */
+            case Terminal(status: Flow.Status, event: Flow.Event)
+
+            /** It parked. Writes no status and keeps exactly the paths the attempt ended parked on. */
+            case Suspended(waitingOn: Set[String])
+        end Outcome
+    end Claimed
+
+    /** What the store did with a write presented through a claim. */
+    enum WriteOutcome derives CanEqual:
+
+        /** The claim was active, unexpired and this generation, and the whole transition landed. */
+        case Applied
+
+        /** The row's claim is absent, expired, or a later generation's. Nothing was written. */
+        case ClaimLost
+    end WriteOutcome
+
+    /** What the store did with a write that moves the lifecycle: [[Claimed.updateStatus]] or [[Claimed.finish]]. */
+    enum StatusOutcome derives CanEqual:
+
+        /** The claim held and the status was on this verb's side of the partition. The whole transition landed. */
+        case Applied
+
+        /** The row's claim is absent, expired, or a later generation's. Nothing was written. */
+        case ClaimLost
+
+        /** The status is on the other verb's side of the lifecycle partition: a terminal status handed to
+          * [[Claimed.updateStatus]], or a non-terminal one handed to [[Claimed.finish]]. Nothing was written.
+          */
+        case WrongSideOfTerminal
+    end StatusOutcome
+
+    /** What the store did with a [[Claimed.recordProgress]] write. */
+    enum ProgressOutcome derives CanEqual:
+
+        /** The field, the completion event and the clearing all landed. */
+        case Recorded
+
+        /** This path already carries what the write would record, so the first writer stands. Nothing was written. */
+        case AlreadyRecorded
+
+        /** The row's claim is absent, expired, or a later generation's. Nothing was written. */
+        case ClaimLost
+    end ProgressOutcome
+
+    /** What [[FlowStore.signal]] did with a delivery. */
+    enum SignalOutcome derives CanEqual:
+
+        /** The field was written and its arrival recorded, in one transition. */
+        case Delivered
+
+        /** This input already has a value, so the caller should stop retrying this name. */
+        case AlreadyDelivered
+
+        /** The execution is over, so the caller should stop entirely and read the result it ended with. */
+        case AlreadyTerminal(status: Flow.Status)
+    end SignalOutcome
+
+    /** What [[FlowStore.requestCancel]] did with an ask. */
+    enum CancelOutcome derives CanEqual:
+
+        /** The request is now outstanding on the row, and the next attempt observes it and unwinds. */
+        case Accepted
+
+        /** Somebody asked first and the request is still outstanding. */
+        case AlreadyRequested
+
+        /** There is nothing to cancel, and this is what the execution ended as. */
+        case AlreadyTerminal(status: Flow.Status)
+    end CancelOutcome
+
     // --- Types ---
 
-    /** A context field entry: serialized value + runtime type tag. */
+    /** A context field entry: serialized value + runtime type tag.
+      *
+      * The tag is stored erased, because a store holds fields of every type a workflow declares and one row type cannot be parameterised
+      * per field. A store implementing [[FlowStore.Claimed.recordProgress]] is handed a `Tag[V]`, which is not a `Tag[Any]` (`Tag` is
+      * invariant), so the companion's [[FieldData.apply]] does the widening once here rather than leaving every implementation to write
+      * the cast for it.
+      *
+      * **A field is written once and then stands.** The two writers are the start's seeded inputs, which land with the row itself, and
+      * [[FlowStore.Claimed.recordProgress]], which is refused when the path already carries one; a delivery through
+      * [[FlowStore.signal]] is refused the same way. So a reader that has seen a value for a name has seen the value that name will
+      * have, which is the fact replay rests on when it decides a node is already done from the field alone.
+      *
+      * @param value
+      *   the value encoded as JSON text
+      * @param tag
+      *   the erased tag of the value's declared type, compared against the reader's on the way out
+      */
     case class FieldData(value: String, tag: Tag[Any]) derives Schema
 
-    /** Execution state row. */
+    object FieldData:
+        /** Builds a field entry from the `Tag[V]` the SPI hands an implementation, erasing it here.
+          *
+          * Named at the JVM level because it erases to the same signature as the case class's own `apply`, which takes the already-erased
+          * tag.
+          */
+        @scala.annotation.targetName("applyErasingTag")
+        def apply[V](value: String, tag: Tag[V]): FieldData = new FieldData(value, tag.erased)
+    end FieldData
+
+    /** Execution state row.
+      *
+      * The wait rows and the cancel request ride the row every reader already holds, rather than needing a read of their own: a caller
+      * listing a page of executions would otherwise issue one ledger read per row.
+      *
+      * @param status
+      *   the persisted LIFECYCLE, and nothing else. `Running` spans working and waiting; what an execution is waiting FOR is `waits`.
+      * @param executor
+      *   who holds the claim, recorded so a reporting surface can say who is working on an execution. It is not a write authority: two
+      *   workers of one engine share an id, so a write is judged against `claimToken` and never against this.
+      * @param claimToken
+      *   the generation the active claim was granted under, present exactly when the claim is active. Each `claimReady` issues one
+      *   strictly greater than any this row has carried, and [[FlowStore.Claimed.finish]] is what makes it absent again.
+      * @param waits
+      *   the execution's outstanding wait rows, keyed by the composition path of the node that is waiting
+      * @param cancelRequested
+      *   whether somebody has asked for this execution to be cancelled. A request rather than an act: the executor observes it at a node
+      *   boundary, unwinds, and terminalises some time later, so this is what a caller who cancelled and then looked sees.
+      */
     case class ExecutionState(
         executionId: Flow.Id.Execution,
         flowId: Flow.Id.Workflow,
@@ -172,8 +550,94 @@ object FlowStore:
         claimExpiry: Maybe[Instant] = Maybe.empty,
         hash: String,
         created: Instant,
-        updated: Instant
-    ) derives CanEqual, Schema
+        updated: Instant,
+        waits: Dict[String, Flow.Wake] = Dict.empty,
+        cancelRequested: Boolean = false,
+        claimToken: Maybe[Long] = Maybe.empty
+    ) derives CanEqual, Schema:
+
+        /** Structural, because the generated comparison is not structural on the one field that carries a collection.
+          *
+          * **Two rows describing the same execution are equal.** That is what `CanEqual` on this type advertises and what a store's
+          * own conformance test rests on: read a row, do something that should change nothing, read again, compare. A generated
+          * `equals` would compare `waits` with the `Dict`'s own `==`, and under its threshold a `Dict` is a span over an array, so
+          * two ledgers holding the same rows are equal only when they happen to share that array. A store that rebuilds the row,
+          * which is every store over a database, never shares it, so the comparison would answer false for a reason that has nothing
+          * to do with the store. [[Dict.is]] is the structural test and this uses it.
+          *
+          * `hashCode` goes with it, and is order-independent over the ledger's entries for the same reason `is` is: two ledgers that
+          * differ only in the order their rows were added are equal, so they must hash alike.
+          */
+        override def equals(other: Any): Boolean =
+            other match
+                case that: ExecutionState =>
+                    executionId == that.executionId &&
+                    flowId == that.flowId &&
+                    status == that.status &&
+                    executor == that.executor &&
+                    claimExpiry == that.claimExpiry &&
+                    hash == that.hash &&
+                    created == that.created &&
+                    updated == that.updated &&
+                    cancelRequested == that.cancelRequested &&
+                    claimToken == that.claimToken &&
+                    waits.is(that.waits)
+                case _ => false
+
+        override def hashCode: Int =
+            // Summed rather than folded in sequence, so the ledger's iteration order cannot reach the answer.
+            val ledger = waits.foldLeft(0)((acc, path, wake) => acc + (path.hashCode * 31 + wake.hashCode))
+            var result = executionId.hashCode
+            result = result * 31 + flowId.hashCode
+            result = result * 31 + status.hashCode
+            result = result * 31 + executor.hashCode
+            result = result * 31 + claimExpiry.hashCode
+            result = result * 31 + hash.hashCode
+            result = result * 31 + created.hashCode
+            result = result * 31 + updated.hashCode
+            result = result * 31 + cancelRequested.hashCode
+            result = result * 31 + claimToken.hashCode
+            result * 31 + ledger
+        end hashCode
+    end ExecutionState
+
+    /** What [[FlowStore.listExecutions]] can be asked for, evaluated by the store before it paginates.
+      *
+      * Separate vocabulary from [[Flow.Status]] on purpose, because the two answer different questions. A status is what one execution IS;
+      * a filter is what a caller is looking for, and what an operator looks for includes facts that are not the lifecycle: what an
+      * execution is waiting on, whether somebody has asked for it to stop, and whether any engine still serves its version.
+      *
+      * A wait-kind arm matches when ANY of the execution's rows does, so plurality is matches-any rather than a tiebreak.
+      */
+    enum ExecutionFilter derives CanEqual:
+        case Running
+        case Compensating
+        case Completed
+        case Cancelled
+
+        /** Failed executions, narrowed to one [[Flow.Status.Failed.kind]] when a kind is given. */
+        case Failed(kind: Maybe[String] = Maybe.empty)
+
+        /** Executions holding at least one sleep row.
+          *
+          * Payload-free, and the asymmetry with [[WaitingForInput]] is deliberate: input names are the CALLER's vocabulary, since `signal`
+          * takes them, while a sleep's name is the flow author's internal business.
+          */
+        case Sleeping
+
+        /** Executions holding at least one input-wait row, narrowed to the row for `name` when a name is given. */
+        case WaitingForInput(name: Maybe[String] = Maybe.empty)
+
+        /** Executions somebody has asked to cancel that have not finished unwinding yet. */
+        case Cancelling
+
+        /** Non-terminal executions whose structural hash is not among `servedHashes`.
+          *
+          * The predicate behind [[kyo.FlowEngine.parked]], pushed into the store so the pagination happens after the filter rather than
+          * before it. The served set is one engine's own, which is why this arm has no place in a wire vocabulary.
+          */
+        case Orphaned(servedHashes: Set[String])
+    end ExecutionFilter
 
     /** Paginated event history. */
     case class HistoryPage(events: Chunk[Flow.Event], hasMore: Boolean) derives CanEqual

--- a/kyo-flow/shared/src/main/scala/kyo/internal/FlowApi.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/FlowApi.scala
@@ -17,9 +17,48 @@ private[kyo] object FlowApi:
         offset: Option[Int] = None
     ) derives Schema
     case class SearchResponse(items: Seq[ExecutionInfoDto], total: Int) derives Schema
-    case class ExecutionInfoDto(executionId: String, flowId: String, status: String) derives Schema
+
+    /** One outstanding wait: which node, what kind, and the condition it is waiting on (a deadline, or an input's name). */
+    case class WaitDto(path: String, kind: String, detail: Option[String]) derives Schema
+
+    /** An execution as a listing shows it. `status` is the lifecycle; `waits` is what it is waiting for, because "running" alone would
+      * answer a caller asking why an execution is not progressing.
+      */
+    case class ExecutionInfoDto(executionId: String, flowId: String, status: String, waits: Seq[WaitDto]) derives Schema
+
+    /** One flow node's progress, as the execution-detail response carries it. */
+    case class NodeProgressDto(name: String, nodeType: String, status: String, location: String) derives Schema
+
+    /** The execution-detail response: the three scalars a search result carries, plus the two things a caller asks this endpoint for.
+      *
+      * `progress` is which node the execution is on and what happened to the ones before it, and `inputs` is which of its inputs have been
+      * delivered. Both are already part of [[FlowEngine.ExecutionDetail]], which is what the endpoint reads; answering with the scalars
+      * alone sends a caller to the store to find out where an execution is.
+      */
+    case class ExecutionDetailDto(
+        executionId: String,
+        flowId: String,
+        status: String,
+        waits: Seq[WaitDto],
+        cancelRequested: Boolean,
+        inputs: Seq[InputInfoDto],
+        progress: Seq[NodeProgressDto]
+    ) derives Schema
     case class CancelAllRequest(workflowId: Option[String] = None) derives Schema
-    case class CancelAllResponse(cancelled: Int) derives Schema
+
+    /** What a sweep asked for: the number of cancel REQUESTS this call put on, not the number of executions that have stopped.
+      *
+      * Named for the ask because that is what the call does. The executions counted here are running their compensations after this
+      * answer is written, and a field named for completed work would tell an operator the sweep is over when it has just begun.
+      */
+    case class CancelAllResponse(requested: Int) derives Schema
+
+    /** What a cancel request did, and what the execution ended as when there was nothing left to cancel.
+      *
+      * `outcome` is one of `accepted`, `already-requested` or `already-terminal`. `status` is present only for the last, where the
+      * caller's next move is to read the result rather than to wait.
+      */
+    case class CancelResponse(outcome: String, status: Option[String] = None) derives Schema
 
     def handlers(engine: FlowEngine)(using Frame): Chunk[HttpHandler[?, ?, ?]] =
         Chunk(
@@ -92,11 +131,23 @@ private[kyo] object FlowApi:
 
     private def getExecution(engine: FlowEngine)(using Frame): HttpHandler[?, ?, ?] =
         HttpRoute.getRaw("api" / "v1" / "executions" / Capture[String]("eid"))
-            .response(_.bodyJson[ExecutionInfoDto])
+            .response(_.bodyJson[ExecutionDetailDto])
             .handler { req =>
                 Abort.run[Throwable] {
-                    engine.executions.describe(Flow.Id.Execution(req.fields.eid)).map { state =>
-                        HttpResponse.ok(ExecutionInfoDto(state.executionId.value, state.flowId.value, state.status.show))
+                    engine.executions.describe(Flow.Id.Execution(req.fields.eid)).map { detail =>
+                        HttpResponse.ok(
+                            ExecutionDetailDto(
+                                detail.executionId.value,
+                                detail.flowId.value,
+                                detail.status.show,
+                                waitsOf(detail.state),
+                                detail.cancelRequested,
+                                detail.inputs.map(i => InputInfoDto(i.name, i.tag, i.delivered)),
+                                detail.progress.nodes.map(n =>
+                                    NodeProgressDto(n.name, n.nodeType.toString, n.status.show, n.location)
+                                )
+                            )
+                        )
                     }
                 }.map(mapError)
             }
@@ -112,6 +163,20 @@ private[kyo] object FlowApi:
                 }.map(mapError)
             }
 
+    /** A page offset a client cannot have meant, refused here rather than forwarded.
+      *
+      * **The asymmetry with `limit` is the point, not an oversight.** A negative limit has a reading the whole stack agrees on, that
+      * the caller wants everything, and [[FlowStore.getHistory]] states it as a contract every implementation keeps. A negative offset
+      * has no reading at all: it is not "start before the beginning", it is a number that should not have been sent. The SPI makes
+      * `offset` non-negative a caller obligation, and this handler is the caller, so the check belongs here.
+      *
+      * It is answered 400 because this is the one layer that can tell a client's bad query parameter from a store fault. Forwarded, it
+      * is tolerated by a store that drops from a chunk and rejected by one that writes `OFFSET -1` into SQL, where it would surface as
+      * a 500 and send an operator hunting a fault that is not there.
+      */
+    private def refuseNegativeOffset(offset: Int)(using Frame): Unit < Abort[HttpResponse.Halt] =
+        if offset < 0 then HttpResponse.halt(HttpResponse.badRequest) else ()
+
     private def getExecutionHistory(engine: FlowEngine)(using Frame): HttpHandler[?, ?, ?] =
         HttpRoute.getRaw("api" / "v1" / "executions" / Capture[String]("eid") / "history")
             .request(_.queryOpt[Int]("limit"))
@@ -120,11 +185,13 @@ private[kyo] object FlowApi:
             .handler { req =>
                 val limit  = req.fields.limit.getOrElse(50)
                 val offset = req.fields.offset.getOrElse(0)
-                engine.executions.history(Flow.Id.Execution(req.fields.eid), limit, offset).map { page =>
-                    HttpResponse.ok(HistoryResponse(
-                        page.events.toSeq.map(e => EventDto(e.kind.toString, e.detail, e.timestamp.show)),
-                        page.hasMore
-                    ))
+                refuseNegativeOffset(offset).andThen {
+                    engine.executions.history(Flow.Id.Execution(req.fields.eid), limit, offset).map { page =>
+                        HttpResponse.ok(HistoryResponse(
+                            page.events.toSeq.map(e => EventDto(e.kind.toString, e.detail, e.timestamp.show)),
+                            page.hasMore
+                        ))
+                    }
                 }
             }
 
@@ -153,15 +220,23 @@ private[kyo] object FlowApi:
                     engine.executions.describe(eid).map { detail =>
                         if detail.status.isTerminal then HttpResponse.halt(HttpResponse(HttpStatus.Conflict))
                         else
-                            engine.defs.use(_.get(detail.flowId)).map {
+                            engine.defs.use(_.of(detail.flowId, detail.state.hash)).map {
                                 case Present(defn) =>
                                     Maybe.fromOption(defn.inputs.find(_.name == name)) match
                                         case Present(info) =>
                                             info.schema.decodeString[Json](body) match
                                                 case Result.Success(value) =>
-                                                    engine.store.putFieldIfAbsent[Any](eid, name, value)(using info.tag, info.schema).map {
-                                                        case true  => HttpResponse.ok(OkResponse(true))
-                                                        case false => HttpResponse.halt(HttpResponse(HttpStatus.Conflict))
+                                                    // The delivery goes through the engine's own verb rather than around it. Writing
+                                                    // the field directly leaves an HTTP-delivered input durable and invisible:
+                                                    // nothing in the history says it arrived, so an operator reading the execution
+                                                    // sees a value with no story. One verb, one set of guards, one event.
+                                                    Abort.run[FlowSignalException | FlowExecutionStateException] {
+                                                        engine.executions.signal[Any](eid, name, value)(using info.tag, info.schema)
+                                                    }.map {
+                                                        case Result.Success(_) => HttpResponse.ok(OkResponse(true))
+                                                        // Already delivered, or the execution finished while this delivery was in
+                                                        // flight. The pre-checks above have already answered every other refusal.
+                                                        case _ => HttpResponse.halt(HttpResponse(HttpStatus.Conflict))
                                                     }
                                                 case _ => HttpResponse.halt(HttpResponse.badRequest)
                                         case Absent => HttpResponse.halt(HttpResponse.badRequest)
@@ -171,11 +246,29 @@ private[kyo] object FlowApi:
                 }.map(mapError)
             }
 
+    /** Answers which of the three things a cancel request did, rather than `ok: true` to all of them.
+      *
+      * A caller cancelling over HTTP has no other way to learn the outcome, since the execution does not stop while the request is in
+      * flight, and a boolean that is true whether the request was taken or fell on an execution that finished last week is the answer
+      * a caller can do least with.
+      *
+      * None of the three is a client error. An `already-terminal` caller asked to stop something that had already stopped, which is
+      * the outcome it wanted; what it gets back is the terminal status, so its next call is a read rather than a retry.
+      */
     private def cancelExecution(engine: FlowEngine)(using Frame): HttpHandler[?, ?, ?] =
         HttpRoute.postRaw("api" / "v1" / "executions" / Capture[String]("eid") / "cancel")
-            .response(_.bodyJson[OkResponse])
+            .response(_.bodyJson[CancelResponse])
             .handler { req =>
-                engine.executions.cancel(Flow.Id.Execution(req.fields.eid)).andThen(HttpResponse.ok(OkResponse(true)))
+                engine.executions.cancel(Flow.Id.Execution(req.fields.eid)).map {
+                    // The only answer that changed the row, and 202 is the code for a request taken whose work has not been done:
+                    // the compensations run after this response is written.
+                    case FlowStore.CancelOutcome.Accepted =>
+                        HttpResponse.accepted(CancelResponse("accepted"))
+                    case FlowStore.CancelOutcome.AlreadyRequested =>
+                        HttpResponse.ok(CancelResponse("already-requested"))
+                    case FlowStore.CancelOutcome.AlreadyTerminal(status) =>
+                        HttpResponse.ok(CancelResponse("already-terminal", Some(status.show)))
+                }
             }
 
     private def cancelAllExecutions(engine: FlowEngine)(using Frame): HttpHandler[?, ?, ?] =
@@ -186,7 +279,7 @@ private[kyo] object FlowApi:
                 val wfId = req.fields.body.workflowId match
                     case Some(id) => Maybe(Flow.Id.Workflow(id))
                     case _        => Maybe.empty
-                engine.executions.cancelAll(wfId).map(count => HttpResponse.ok(CancelAllResponse(count)))
+                engine.executions.cancelAll(wfId).map(count => HttpResponse.ok(CancelAllResponse(requested = count)))
             }
 
     private def searchExecutions(engine: FlowEngine)(using Frame): HttpHandler[?, ?, ?] =
@@ -198,25 +291,59 @@ private[kyo] object FlowApi:
                 val wfId = body.workflowId match
                     case Some(id) => Maybe(Flow.Id.Workflow(id))
                     case _        => Maybe.empty
-                val status = body.status match
-                    case Some(s) => parseStatus(s)
-                    case _       => Maybe.empty
                 val limit  = body.limit.getOrElse(25)
                 val offset = body.offset.getOrElse(0)
-                engine.executions.search(wfId, status, limit, offset).map { result =>
-                    val items = result.items.map(s => ExecutionInfoDto(s.executionId.value, s.flowId.value, s.status.show))
-                    HttpResponse.ok(SearchResponse(items, result.total))
+                // A filter string that parses to nothing is a client error, not "no filter": answering every execution to a caller who
+                // asked for a subset reports a typo as a result set.
+                val filter: Maybe[FlowStore.ExecutionFilter] < Abort[HttpResponse.Halt] = body.status match
+                    case Some(s) =>
+                        parseFilter(s) match
+                            case Present(f) => Maybe(f)
+                            case Absent     => HttpResponse.halt(HttpResponse.badRequest)
+                    case _ => Maybe.empty
+                refuseNegativeOffset(offset).andThen {
+                    filter.map { f =>
+                        engine.executions.search(wfId, f, limit, offset).map { result =>
+                            val items =
+                                result.items.map(s => ExecutionInfoDto(s.executionId.value, s.flowId.value, s.status.show, waitsOf(s)))
+                            HttpResponse.ok(SearchResponse(items, result.total))
+                        }
+                    }
                 }
             }
 
-    private def parseStatus(s: String): Maybe[Flow.Status] =
+    /** The filter vocabulary as a caller spells it on the wire.
+      *
+      * `Orphaned` is deliberately absent: its parameter is one engine's own served set, which no HTTP caller can supply, and the operator
+      * reaches that predicate through the engine's `parked` report instead.
+      *
+      * **A narrowing prefix with nothing after it does not parse.** Taking `failed:` and `waiting:` as a narrowing on the empty string
+      * matches nothing, since no kind or input name is empty (a kind is a class name), so both would answer an empty result set with a
+      * 200. That is the same typo class as an unrecognized filter, telling the opposite lie: nothing matched rather than everything did.
+      * A caller who meant the bare form gets a refusal it can act on instead.
+      */
+    private def parseFilter(s: String): Maybe[FlowStore.ExecutionFilter] =
         s match
-            case "running"                     => Maybe(Flow.Status.Running)
-            case "completed"                   => Maybe(Flow.Status.Completed)
-            case "cancelled"                   => Maybe(Flow.Status.Cancelled)
-            case "compensating"                => Maybe(Flow.Status.Compensating)
-            case s if s.startsWith("failed:")  => Maybe(Flow.Status.Failed(s.stripPrefix("failed:")))
-            case s if s.startsWith("waiting:") => Maybe(Flow.Status.WaitingForInput(s.stripPrefix("waiting:")))
-            case _                             => Maybe.empty
+            case "running"      => Maybe(FlowStore.ExecutionFilter.Running)
+            case "completed"    => Maybe(FlowStore.ExecutionFilter.Completed)
+            case "cancelled"    => Maybe(FlowStore.ExecutionFilter.Cancelled)
+            case "cancelling"   => Maybe(FlowStore.ExecutionFilter.Cancelling)
+            case "compensating" => Maybe(FlowStore.ExecutionFilter.Compensating)
+            case "failed"       => Maybe(FlowStore.ExecutionFilter.Failed(Maybe.empty))
+            case "sleeping"     => Maybe(FlowStore.ExecutionFilter.Sleeping)
+            case "waiting"      => Maybe(FlowStore.ExecutionFilter.WaitingForInput(Maybe.empty))
+            case s if s.startsWith("failed:") && s.stripPrefix("failed:").nonEmpty =>
+                Maybe(FlowStore.ExecutionFilter.Failed(Maybe(s.stripPrefix("failed:"))))
+            case s if s.startsWith("waiting:") && s.stripPrefix("waiting:").nonEmpty =>
+                Maybe(FlowStore.ExecutionFilter.WaitingForInput(Maybe(s.stripPrefix("waiting:"))))
+            case _ => Maybe.empty
+
+    /** An execution's wait rows on the wire: what each waiting node is waiting for, by the node's path. */
+    private def waitsOf(state: FlowStore.ExecutionState): Seq[WaitDto] =
+        state.waits.toChunk.sortBy(_._1).map { (path, wake) =>
+            wake match
+                case Flow.Wake.At(instant)   => WaitDto(path, "sleeping", Some(instant.show))
+                case Flow.Wake.OnField(name) => WaitDto(path, "waiting", Some(name))
+        }
 
 end FlowApi

--- a/kyo-flow/shared/src/main/scala/kyo/internal/FlowGraph.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/FlowGraph.scala
@@ -23,7 +23,7 @@ private[kyo] object FlowGraph:
 
     case class Edge(id: String, source: String, target: String, label: String = "", style: String = "")
 
-    // Internal result type for building the graph -- captures start/end for linking
+    // Internal result type for building the graph: captures start/end for linking
     private case class SubGraph(
         nodes: Seq[Node],
         edges: Seq[Edge],
@@ -32,7 +32,7 @@ private[kyo] object FlowGraph:
     )
 
     // State-threading builder: takes a counter, returns (SubGraph, nextCounter).
-    // This is the pure State monad pattern encoded as a function — no mutable state.
+    // This is the pure State monad pattern encoded as a function, holding no mutable state.
     private type Builder = Int => (SubGraph, Int)
 
     private def nextId(counter: Int): (String, Int) =
@@ -104,7 +104,7 @@ private[kyo] object FlowGraph:
                     )
             end onSleep
 
-            def onDispatch(name: String, branchInfos: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
+            def onDispatch[V](name: String, branchInfos: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
                 (counter: Int) =>
                     val (did, c1) = nextId(counter)
                     val (jid, c2) = nextId(c1)
@@ -131,7 +131,7 @@ private[kyo] object FlowGraph:
                     )
             end onDispatch
 
-            def onLoop(name: String, frame: Frame, meta: Flow.Meta) =
+            def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V], Tag[State], Schema[State]) =
                 (counter: Int) =>
                     val (lid, c1) = nextId(counter)
                     val (eid, c2) = nextId(c1)
@@ -146,7 +146,7 @@ private[kyo] object FlowGraph:
                     )
             end onLoop
 
-            def onForEach(name: String, concurrency: Int, frame: Frame, meta: Flow.Meta) =
+            def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
                 (counter: Int) =>
                     val (id, c) = nextId(counter)
                     (
@@ -189,7 +189,9 @@ private[kyo] object FlowGraph:
                     )
             end onRace
 
-            def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta) =
+            // A subflow is drawn as one node: the diagram is of the parent's shape, and a child's own nodes belong to the child's
+            // diagram, which is why the child's builder is not used here.
+            def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Builder, frame: Frame, meta: Flow.Meta) =
                 (counter: Int) =>
                     val (id, c) = nextId(counter)
                     (SubGraph(Seq(Node(id, name, "subflow", meta)), Seq.empty, id, id), c)
@@ -284,6 +286,7 @@ private[kyo] object FlowGraph:
             case FlowEngine.Progress.NodeStatus.Running         => "running"
             case FlowEngine.Progress.NodeStatus.Pending         => "pending"
             case FlowEngine.Progress.NodeStatus.WaitingForInput => "waiting"
+            case FlowEngine.Progress.NodeStatus.Compensated     => "compensated"
             case FlowEngine.Progress.NodeStatus.Sleeping(_)     => "sleeping"
             case FlowEngine.Progress.NodeStatus.Failed(_)       => "failed"
 

--- a/kyo-flow/shared/src/main/scala/kyo/internal/FlowInterpreter.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/FlowInterpreter.scala
@@ -14,6 +14,56 @@ abstract private[kyo] class FlowInterpreter[S]:
 
     def onStep(name: String, computation: Unit < Sync, frame: Frame, meta: Flow.Meta): Unit < S
 
+    /** Run one iteration of an unscheduled loop under the node's own policy, recording nothing.
+      *
+      * The bracket [[onStep]] gives a step, without the two events and the completion mark. An unscheduled loop's iteration count is
+      * unbounded, so a checkpoint per iteration is unbounded history, which is the cost [[kyo.Flow.loop]]'s scaladoc states and
+      * declines to pay. What an iteration still gets is everything the node declared: a `timeout` that bounds the single slow
+      * iteration rather than the sum of every fast one, a `retry` that re-asks one iteration, and the node boundary's own check, so an
+      * execution somebody asked to cancel stops rather than going on running a body nothing ever looked at.
+      */
+    def onIteration[V](name: String, computation: V < Sync, frame: Frame, meta: Flow.Meta): V < S
+
+    /** Record durably which branch of a dispatch is about to run, BEFORE it runs.
+      *
+      * A dispatch persists only the branch's value, so a crash between the branch's side effects and that write lets replay re-ask the
+      * conditions, and a condition that answers differently (time moved, another writer changed the data) runs a SECOND branch's side
+      * effects beside the first's, with nothing durable saying either ran. Recording the choice first makes the record the truth of what
+      * ran: replay re-enters the recorded branch without evaluating any condition, and the conditions' determinism stops being a
+      * correctness requirement.
+      *
+      * The record is a field under [[FlowInterpreter.chosenKey]] carrying the branch's NAME, which is durable and part of the flow's
+      * version identity, so it survives everything a stored value survives. Replay reads it back through [[getField]].
+      */
+    def onChoice(name: String, branch: String, frame: Frame, meta: Flow.Meta): Unit < S
+
+    /** Record durably the value a subflow's mapper supplied for one of the child's inputs, BEFORE the child's first node runs.
+      *
+      * The same rule [[onChoice]] follows, one level up. A subflow that rebuilt the child's input record from the mapper on every
+      * attempt and persisted none of it would let a mapper answering differently after a crash run the child's remaining nodes
+      * against values its recorded outputs were never computed from, with nothing durable saying so. Recording each input first makes
+      * the record the truth of what the child ran against: an attempt that finds every declared input recorded re-enters the child
+      * without running the mapper at all, so the mapper's determinism is not a correctness requirement.
+      *
+      * The record is an ordinary field under the input's own durable path (`review~amount`), carrying the value, so replay reads it
+      * back the way it reads any other field and the assembled record a reader receives carries the field its type promises. The
+      * answer says whether THIS attempt was the writer, which is what the shared-name race corner reads: two arms of a race
+      * embedding one subflow name both write, the first lands, and the second reads the recorded value back rather than running its
+      * child against a value nothing kept.
+      *
+      * @return
+      *   true when this attempt recorded the value, false when the path already held one
+      */
+    def onInputSupplied[V](name: String, value: V, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]): Boolean < S
+
+    /** Record that an input node found its value and went on, which is what discharges the wait it had recorded.
+      *
+      * The only node whose satisfied path writes anything. Every other node that can wait discharges through work it was going to record
+      * anyway, while a satisfied `Input` proceeds with the value already in its record; without a transition of its own, the row it wrote
+      * while parking would never be cleared and the execution would be handed back on every poll.
+      */
+    def onInputDischarged(name: String, frame: Frame, meta: Flow.Meta): Unit < S
+
     def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta): Unit < S
 
     def onZip(
@@ -32,13 +82,70 @@ abstract private[kyo] class FlowInterpreter[S]:
     /** Check if the execution has been cancelled. Used by loops to break between iterations. */
     def checkCancelled: Boolean < S = false
 
-    /** Called before compensation handlers run. */
-    def onCompensationStart: Unit < S = ()
+    /** Called before compensation handlers run, carrying the verdict that started the unwind. */
+    def onCompensationStart(cause: Flow.Cause): Unit < S = ()
 
     /** Called after all compensation handlers complete. */
     def onCompensationComplete: Unit < S = ()
 
     /** Called when a compensation handler throws. */
     def onCompensationFailed(error: Throwable): Unit < S = ()
+
+    /** Called when one node's compensation handler has run to completion, so a resumed unwind can skip it.
+      *
+      * An unwind that is interrupted part-way leaves handlers run and handlers not run, and the three compensation events are
+      * per-UNWIND, so nothing among them tells the two apart and a recovered execution could only run every handler again. Recording
+      * each one as it lands is what makes "re-run only the handlers with no recorded completion" a fact about the store rather than a
+      * hope about how far the last attempt got.
+      */
+    def onCompensated(name: String): Unit < S = ()
+
+    /** Re-raises what ended the flow, once its compensations have run.
+      *
+      * The interpreter owns this because the interpreter owns the effect row: whether a [[FlowException]] can go back out on a typed
+      * channel depends on whether `S` has one, which only the interpreter knows. Abstract rather than defaulted to a panic for that
+      * reason: `Abort.panic` is itself an effect, and one an arbitrary `S` does not have.
+      */
+    def onUnwind(error: Throwable): Nothing < S
+
+    /** Raise a declared failure of the flow, on the typed channel the interpreter's row has for one.
+      *
+      * The sibling of [[onUnwind]], and abstract for the same reason: whether a [[FlowException]] can go back out as a FAILURE
+      * rather than as a panic depends on whether `S` carries a channel for it, which only the interpreter knows.
+      *
+      * The difference is not cosmetic. A panic reaches the engine as an escaped throwable with no declared kind, so the status it
+      * writes keeps only a message and "how many executions ended this way" becomes a search over message text; a failure carries
+      * the exception's own kind into the status, where it can be grouped by. A verdict the engine itself reaches, a loop that ran
+      * its schedule out as much as a step that exceeded its timeout, is a declared failure of the flow and belongs here.
+      *
+      * It is raised INTO the flow rather than around it, so everything that already ran still unwinds before the failure reaches
+      * the engine.
+      *
+      * `path` is the durable name of the node the verdict is about, and it is a parameter because the exception does not carry one an
+      * implementation can trust: it holds whatever name reads well in a message, while the store is keyed by the composition path. An
+      * implementation records the failure under `path` before raising, so a reader can say WHICH node ended the execution rather than
+      * inferring it from where a walk happens to stop.
+      */
+    def onFailure(path: String, error: FlowException): Nothing < S
+
+end FlowInterpreter
+
+private[kyo] object FlowInterpreter:
+
+    /** The durable key a dispatch records its chosen branch under.
+      *
+      * It rides `#`, which the engine reserves for the keys it derives itself and which registration refuses in a user's node name, so
+      * the key can never collide with one a flow declared. It is written by [[FlowInterpreter.onChoice]] and read back by the dispatch
+      * arm through [[FlowInterpreter.getField]]; nothing else addresses it.
+      */
+    def chosenKey(dispatch: String): String = s"$dispatch#chosen"
+
+    /** The durable key a node's compensation handler records its completion under.
+      *
+      * It rides `#` for the same reason [[chosenKey]] does, and it has to be a key of its own rather than the node's: progress is
+      * write-once per path, and the node's forward completion already occupies the node's path, so a handler writing there would be
+      * answered already-recorded and record nothing.
+      */
+    def compensatedKey(node: String): String = s"$node#compensated"
 
 end FlowInterpreter

--- a/kyo-flow/shared/src/main/scala/kyo/internal/FlowLint.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/FlowLint.scala
@@ -13,55 +13,228 @@ private[kyo] object FlowLint:
     // Type alias for the common chunk-collecting visitor pattern
     abstract private class CollectVisitor[A] extends FlowVisitorCollect[Chunk[A]](Chunk.empty, _ ++ _)
 
+    /** The name collisions `Flow.lint` warns about, which are exactly the ones registration refuses.
+      *
+      * One classification with two consumers, because a warning broader than the refusal is worse than no warning at all. It
+      * flags the module's own canonical race, whose branches share their result name because the union result type is readable only
+      * through a field both carry, so every correct race would carry a warning teaching its author that right code is wrong; and it flags
+      * two branches waiting on one input, which is one wait and one field and which the design blesses in as many words. A lint a user
+      * learns to ignore protects nothing.
+      *
+      * The rendering keeps the count, because how many nodes claim the name is the first thing a reader wants and the locations carry it:
+      * one flow value embedded three times is one call site, so the count is of distinct sites rather than of joins.
+      */
     def duplicateNames(flow: Flow[?, ?, ?]): Seq[Warning] =
-        val visitor = new CollectVisitor[(String, String)]:
-            override def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
-                Chunk((name, frame.snippetShort))
-            override def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
-                Chunk((name, frame.snippetShort))
-            override def onStep(name: String, frame: Frame, meta: Flow.Meta) =
-                Chunk((name, frame.snippetShort))
-            override def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta) =
-                Chunk((name, frame.snippetShort))
-            override def onDispatch(name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
-                Chunk((name, frame.snippetShort))
-            override def onLoop(name: String, frame: Frame, meta: Flow.Meta) =
-                Chunk((name, frame.snippetShort))
-            override def onForEach(name: String, concurrency: Int, frame: Frame, meta: Flow.Meta) =
-                Chunk((name, frame.snippetShort))
-            override def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta) =
-                Chunk((name, frame.snippetShort))
-        val names   = FlowFold(flow)(visitor)
-        val grouped = names.toSeq.groupBy(_._1)
-        grouped.collect {
-            case (name, locations) if locations.size > 1 =>
-                Warning(
-                    s"Duplicate node name '$name' appears ${locations.size} times",
-                    locations.map(_._2).mkString(", ")
-                )
-        }.toSeq
+        nameConflicts(flow).map { conflict =>
+            Warning(
+                s"Duplicate node name '${conflict.name}' appears ${conflict.locations.size} times",
+                conflict.locations.mkString(", ")
+            )
+        }
     end duplicateNames
+
+    /** The characters the engine reserves in a node name, because it builds durable keys with them. See [[NodePath]]. */
+    val Reserved: Set[Char] = NodePath.Reserved
+
+    /** The flow's own name, taken from the `Init` node every public constructor roots.
+      *
+      * `Absent` for a flow with no `Init` at all, which no public constructor can build; the engine treats that and an empty name as the
+      * same refusal, so the one code path that answers this question is the one that decides it.
+      */
+    def flowName(flow: Flow[?, ?, ?]): Maybe[String] =
+        FlowFold(flow)(new FlowVisitorCollect[Maybe[String]](Maybe.empty, (a, b) => a.orElse(b)):
+            override def onInit(name: String, frame: Frame, meta: Flow.Meta) = Maybe(name))
+
+    /** Node names using a character the engine reserves for the keys it generates itself.
+      *
+      * Descends into subflows, because a child's names become durable keys under the parent's path, so a child node whose name carries
+      * the separator would forge a path the parent never declared. The names are checked as their author wrote them, unqualified: the
+      * question is about the characters a user chose, and checking the qualified form would refuse every node inside a subflow, since
+      * the separator is exactly what qualifying adds.
+      */
+    def reservedNames(flow: Flow[?, ?, ?]): Seq[String] =
+        val visitor = new CollectVisitor[String]:
+            override def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V])  = Chunk(name)
+            override def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) = Chunk(name)
+            override def onStep(name: String, frame: Frame, meta: Flow.Meta)                               = Chunk(name)
+            override def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta)          = Chunk(name)
+            override def onDispatch[V](name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using
+                Tag[V],
+                Schema[V]
+            ) =
+                Chunk(name)
+            override def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using
+                Tag[V],
+                Schema[V],
+                Tag[State],
+                Schema[State]
+            ) = Chunk(name)
+            override def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+                Chunk(name)
+            override def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Chunk[String], frame: Frame, meta: Flow.Meta) =
+                Chunk(name) ++ child
+        FlowFold(flow)(visitor).toSeq.filter(_.exists(Reserved.contains)).distinct
+    end reservedNames
+
+    /** What a flow's nodes claim of one name, folded per composition so a join can decide whether the claim is shared.
+      *
+      * Three categories rather than one, because the answer differs by what a node's name is FOR. `result` names land in the composed
+      * record, which is what makes them shareable by a race's branches and by nothing else. `internal` names are written but never appear
+      * in the result, so nothing forces them to be shared and a shared one corrupts. `read` names are waited on rather than written, and
+      * two waits on one name are one wait.
+      */
+    private case class Names(
+        result: Map[String, Chunk[String]],
+        internal: Map[String, Chunk[String]],
+        read: Map[String, Chunk[String]],
+        conflicts: Chunk[FlowNameConflict]
+    ):
+        def locationsOf(name: String): Chunk[String] =
+            result.getOrElse(name, Chunk.empty[String]) ++ internal.getOrElse(name, Chunk.empty[String]) ++
+                read.getOrElse(name, Chunk.empty[String])
+        def written: Set[String] = result.keySet ++ internal.keySet
+    end Names
+
+    private object Names:
+        val empty: Names                            = Names(Map.empty, Map.empty, Map.empty, Chunk.empty[FlowNameConflict])
+        def result(name: String, at: String): Names = empty.copy(result = Map(name -> Chunk(at)))
+        def internal(name: String, at: String)      = empty.copy(internal = Map(name -> Chunk(at)))
+        def read(name: String, at: String): Names   = empty.copy(read = Map(name -> Chunk(at)))
+    end Names
+
+    private def mergeLocations(a: Map[String, Chunk[String]], b: Map[String, Chunk[String]]): Map[String, Chunk[String]] =
+        b.foldLeft(a) { case (acc, (name, locations)) => acc.updated(name, acc.getOrElse(name, Chunk.empty[String]) ++ locations) }
+
+    /** What a subflow's child claims, seen from the parent: every name re-keyed under the instance's path.
+      *
+      * A conflict the child has with itself is still a conflict and travels up under the same path, which is how a child embedded but
+      * never registered on its own gets checked at all. A name the child shares with the PARENT stops being a conflict here, and that is
+      * the point of qualifying: the two nodes write different durable keys.
+      */
+    private def underPath(path: String, names: Names): Names =
+        Names(
+            NodePath.qualifyAll(path, names.result),
+            NodePath.qualifyAll(path, names.internal),
+            NodePath.qualifyAll(path, names.read),
+            names.conflicts.map(c => FlowNameConflict(NodePath.qualify(path, c.name), c.composition, c.locations))
+        )
+
+    /** Joins what two sides of a composition claim, and records every name they claim against each other.
+      *
+      * A name one side WRITES conflicts with the other side writing it, and equally with the other side READING it: the write lands on the
+      * field the read already occupies, so the reader forever sees a value the writer did not put there and the writer's node skips as
+      * already complete. Two READS of one name are not a conflict at all.
+      *
+      * `exemptShared` is the race, and only the race. Its branches return the winner's record rather than a merged one, and its result type
+      * is the union of the two, readable downstream only through a field both branches carry, so branches sharing a RESULT name is the
+      * shape the type forces rather than a collision. Everything else the two claim still conflicts, `internal` names included, because
+      * nothing forces those to be shared: one sleep row would hand the second branch the first's deadline, and one step's completion would
+      * mark the other branch's work done.
+      */
+    private def join(left: Names, right: Names, composition: String, exemptShared: Boolean): Names =
+        val shared = (left.written & (right.written ++ right.read.keySet)) ++ (right.written & left.read.keySet)
+        val exempt = if exemptShared then left.result.keySet & right.result.keySet else Set.empty[String]
+        val found = (shared -- exempt).toSeq.sorted.map { name =>
+            FlowNameConflict(name, composition, (left.locationsOf(name) ++ right.locationsOf(name)).toSeq)
+        }
+        Names(
+            mergeLocations(left.result, right.result),
+            mergeLocations(left.internal, right.internal),
+            mergeLocations(left.read, right.read),
+            left.conflicts ++ right.conflicts ++ Chunk.from(found)
+        )
+    end join
+
+    /** Every durable-name collision that makes a flow unregisterable, and how each pair of nodes reaches the other.
+      *
+      * Narrower than [[duplicateNames]], which is the advisory warning `Flow.lint` reports and which counts every repeated name in the AST.
+      * This is the enforced rule, so it refuses only what has no defensible reading: a name two nodes WRITE, or one node writes and another
+      * reads. A race's branches sharing a result name and two branches waiting on one input are both left alone, for the reasons [[join]]
+      * gives.
+      *
+      * The walk descends into a subflow and re-keys what it finds under the instance's path, so it answers about every durable key the
+      * definition will write. A collision between a parent and a child is not one, because the child's keys carry the path; a collision
+      * a child has with ITSELF is one, and descending is the only way to see it in a child that is embedded but never registered alone.
+      */
+    def nameConflicts(flow: Flow[?, ?, ?]): Seq[FlowNameConflict] =
+        val visitor = new FlowVisitor[Names]:
+            def onInit(name: String, frame: Frame, meta: Flow.Meta)                               = Names.empty
+            def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V])  = Names.read(name, frame.snippetShort)
+            def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) = Names.result(name, frame.snippetShort)
+            def onStep(name: String, frame: Frame, meta: Flow.Meta)                               = Names.internal(name, frame.snippetShort)
+            def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta)          = Names.internal(name, frame.snippetShort)
+            def onDispatch[V](name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+                Names.result(name, frame.snippetShort)
+            def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V], Tag[State], Schema[State]) =
+                Names.result(name, frame.snippetShort)
+            def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+                Names.result(name, frame.snippetShort)
+            def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Names, frame: Frame, meta: Flow.Meta) =
+                val own    = Names.result(name, frame.snippetShort)
+                val inside = underPath(name, child)
+                Names(
+                    mergeLocations(own.result, inside.result),
+                    inside.internal,
+                    inside.read,
+                    inside.conflicts
+                )
+            end onSubflow
+            def onRace(left: Names, right: Names, frame: Frame) =
+                join(left, right, "by two race branches", exemptShared = true)
+            def onAndThen(first: Names, second: Names, frame: Frame) =
+                join(first, second, "in sequence", exemptShared = false)
+            def onZip(left: Names, right: Names, frame: Frame) =
+                join(left, right, "by two zip branches", exemptShared = false)
+            def onGather(flows: Seq[Names], frame: Frame) =
+                flows.foldLeft(Names.empty)((acc, branch) => join(acc, branch, "by two gather branches", exemptShared = false))
+        // One entry per name rather than one per JOIN. A fold over three branches joins twice, so keying by join would report a
+        // name all three write twice and count two collisions where a reader sees one. Locations are deduplicated for the same
+        // reason a name is: a flow VALUE embedded three times is one call site, and repeating it says nothing.
+        FlowFold(flow)(visitor).conflicts.toSeq
+            .groupBy(conflict => (conflict.name, conflict.composition))
+            .toSeq
+            .sortBy(_._1)
+            .map { case ((name, composition), found) =>
+                FlowNameConflict(name, composition, found.flatMap(_.locations).distinct)
+            }
+    end nameConflicts
 
     def emptyBranches(flow: Flow[?, ?, ?]): Seq[Warning] =
         val visitor = new CollectVisitor[Warning]:
-            override def onDispatch(name: String, branchInfos: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
+            override def onDispatch[V](name: String, branchInfos: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using
+                Tag[V],
+                Schema[V]
+            ) =
                 if branchInfos.size <= 1 then
                     Chunk(Warning(s"Dispatch '$name' has no conditional branches", frame.snippetShort))
                 else Chunk.empty[Warning]
         FlowFold(flow)(visitor).toSeq
     end emptyBranches
 
+    /** The names of one definition's OWN nodes, which is what a question about a single flow's shape wants. A subflow contributes its
+      * own name and not its child's; see [[reservedNames]] for the walk that descends.
+      */
     def nodeNames(flow: Flow[?, ?, ?]): Seq[String] =
         val visitor = new CollectVisitor[String]:
             override def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V])  = Chunk(name)
             override def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) = Chunk(name)
             override def onStep(name: String, frame: Frame, meta: Flow.Meta)                               = Chunk(name)
             override def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta)          = Chunk(name)
-            override def onDispatch(name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
+            override def onDispatch[V](name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using
+                Tag[V],
+                Schema[V]
+            ) =
                 Chunk(name)
-            override def onLoop(name: String, frame: Frame, meta: Flow.Meta)                              = Chunk(name)
-            override def onForEach(name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)         = Chunk(name)
-            override def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta) = Chunk(name)
+            override def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using
+                Tag[V],
+                Schema[V],
+                Tag[State],
+                Schema[State]
+            ) = Chunk(name)
+            override def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+                Chunk(name)
+            override def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Chunk[String], frame: Frame, meta: Flow.Meta) =
+                Chunk(name)
         FlowFold(flow)(visitor).toSeq
     end nodeNames
 
@@ -81,11 +254,23 @@ private[kyo] object FlowLint:
     def outputNames(flow: Flow[?, ?, ?]): Seq[String] =
         val visitor = new CollectVisitor[String]:
             override def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) = Chunk(name)
-            override def onDispatch(name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
+            override def onDispatch[V](name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using
+                Tag[V],
+                Schema[V]
+            ) =
                 Chunk(name)
-            override def onLoop(name: String, frame: Frame, meta: Flow.Meta)                              = Chunk(name)
-            override def onForEach(name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)         = Chunk(name)
-            override def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta) = Chunk(name)
+            override def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using
+                Tag[V],
+                Schema[V],
+                Tag[State],
+                Schema[State]
+            ) = Chunk(name)
+            override def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+                Chunk(name)
+            // The subflow's own name and not its child's: these are the names the PARENT's record carries, and a child's
+            // outputs reach the parent through the subflow's field rather than beside it.
+            override def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Chunk[String], frame: Frame, meta: Flow.Meta) =
+                Chunk(name)
         FlowFold(flow)(visitor).toSeq
     end outputNames
 

--- a/kyo-flow/shared/src/main/scala/kyo/internal/FlowRender.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/FlowRender.scala
@@ -218,8 +218,8 @@ private[kyo] object FlowRender:
         toBpmn(FlowGraph.build(flow))
 
     private def toBpmn(g: FlowGraph): String =
-        // BPMN needs a different node mapping than the graph structure.
-        // We iterate FlowGraph nodes/edges and produce BPMN XML elements using pure functions.
+        // BPMN needs a different node mapping than the graph structure, so the graph's nodes and edges are walked here and turned
+        // into BPMN XML elements by pure functions.
 
         // Generate BPMN elements from nodes
         val elements = g.nodes.flatMap { n =>
@@ -315,13 +315,14 @@ private[kyo] object FlowRender:
 
     private def statusColorFromName(status: String): String =
         status match
-            case "completed" => "#90EE90"
-            case "running"   => "#FFD700"
-            case "pending"   => "#D3D3D3"
-            case "waiting"   => "#87CEEB"
-            case "sleeping"  => "#DDA0DD"
-            case "failed"    => "#FF6B6B"
-            case _           => "#D3D3D3"
+            case "completed"   => "#90EE90"
+            case "running"     => "#FFD700"
+            case "pending"     => "#D3D3D3"
+            case "waiting"     => "#87CEEB"
+            case "compensated" => "#F4A460"
+            case "sleeping"    => "#DDA0DD"
+            case "failed"      => "#FF6B6B"
+            case _             => "#D3D3D3"
 
     private def escapeJson(s: String): String =
         s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")

--- a/kyo-flow/shared/src/main/scala/kyo/internal/FlowSuspension.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/FlowSuspension.scala
@@ -4,13 +4,36 @@ import kyo.*
 
 /** Typed signal for flow suspension. NOT a Throwable, NOT a FlowException.
   *
-  * Used with Abort[FlowSuspension] for short-circuiting when a flow needs to park (sleep, input wait, claim lost). Because FlowSuspension
-  * is not Throwable, it passes through Abort.run[Throwable] in Flow.run's compensation handler untouched — suspension never fires
-  * compensations.
+  * Used with Abort[FlowSuspension] for short-circuiting when a flow parks (an input it is waiting for, a sleep it is serving out) or
+  * when the claim behind it is gone. Because FlowSuspension is not Throwable, it passes through Abort.run[Throwable] in Flow.run's
+  * compensation handler untouched, so a suspension never fires compensations.
+  *
+  * The parked token is PLURAL, and the plurality is the point. A composition can be waiting on more than one condition at once:
+  * `race(input("approval"), sleep("deadline"))` is waiting for the signal AND for the deadline, and a token naming only one of them
+  * makes the other unreachable. So a leaf parks with its own name, and the zip and race joins merge their branches' parked names,
+  * recursively through nested compositions, so what reaches the engine names every condition the attempt ended waiting on.
   */
 private[kyo] enum FlowSuspension derives CanEqual:
-    case Sleeping(name: String, until: Instant)
-    case WaitingForInput(name: String)
+
+    /** The attempt parked, and these are the conditions it is waiting on. */
+    case Parked(waitingOn: Set[String])
+
+    /** The row is somebody else's now, so there is nothing to wait on and nothing to record. */
     case ClaimLost
-    case StepAlreadyCompleted(name: String)
+
+end FlowSuspension
+
+private[kyo] object FlowSuspension:
+
+    /** The suspension a composition ends with when neither branch produced a value.
+      *
+      * `ClaimLost` outranks a park because an executor that no longer owns the row has nothing to park: whatever its branches were
+      * waiting for is the new owner's business. Otherwise the parks merge, which is what keeps every branch's condition reachable.
+      */
+    def merge(left: FlowSuspension, right: FlowSuspension): FlowSuspension =
+        (left, right) match
+            case (ClaimLost, _)         => ClaimLost
+            case (_, ClaimLost)         => ClaimLost
+            case (Parked(l), Parked(r)) => Parked(l ++ r)
+
 end FlowSuspension

--- a/kyo-flow/shared/src/main/scala/kyo/internal/FlowVisitor.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/FlowVisitor.scala
@@ -5,38 +5,68 @@ import kyo.Flow.BranchInfo
 import kyo.Flow.Meta
 import kyo.Flow.internal.*
 
+/** A total fold over a flow's AST, one arm per node kind and one per combinator.
+  *
+  * Every arm is abstract, so a node kind added to `Flow` forces every implementer to say what it contributes rather than letting it fold
+  * away unnoticed. That matters most for computations whose answer is only as complete as the arms they implement, the structural hash
+  * above all: a missing arm there is a flow whose change no engine can detect.
+  *
+  * **Every arm that persists a value receives that value's type.** A dispatch, a loop and a foreach each write a field replay decodes,
+  * exactly as an input and an output do, and an arm carrying only the name would force anything needing those types to walk the AST a
+  * second time. A loop receives two, because a scheduled one checkpoints the state its next iteration starts from as well as its value.
+  */
 private[kyo] trait FlowVisitor[R]:
     def onInput[V](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R
     def onOutput[V](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R
     def onStep(name: String, frame: Frame, meta: Meta): R
     def onSleep(name: String, duration: Duration, frame: Frame, meta: Meta): R
-    def onDispatch(name: String, branches: Seq[BranchInfo], frame: Frame, meta: Meta): R
-    def onLoop(name: String, frame: Frame, meta: Meta): R
-    def onForEach(name: String, concurrency: Int, frame: Frame, meta: Meta): R
+    def onDispatch[V](name: String, branches: Seq[BranchInfo], frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R
+    def onLoop[V, State](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V], Tag[State], Schema[State]): R
+    def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R
     def onInit(name: String, frame: Frame, meta: Meta): R
     def onRace(left: R, right: R, frame: Frame): R
-    def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Meta): R
+
+    /** A subflow, with both the child flow itself and this same visitor's answer for it.
+      *
+      * Both, because the two kinds of visitor need different halves. One answers about a single definition's own nodes and ignores
+      * `child` entirely; the other answers about everything the parent will durably write, and that includes the child's nodes under
+      * the parent's path, so it re-keys `child` rather than walking the AST a second time.
+      */
+    def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: R, frame: Frame, meta: Meta): R
     def onAndThen(first: R, second: R, frame: Frame): R
     def onZip(left: R, right: R, frame: Frame): R
     def onGather(flows: Seq[R], frame: Frame): R
 end FlowVisitor
 
+/** A visitor that collects a monoidal result and defaults every arm it is not given.
+  *
+  * Convenient for a query that cares about a few node kinds, such as gathering every name of one kind. It is the wrong base for anything
+  * that must be complete, because a node kind it does not override contributes `empty` and every combinator folds with the same `combine`,
+  * so both an unhandled node and two different compositions are indistinguishable in the result.
+  */
 abstract private[kyo] class FlowVisitorCollect[R](empty: R, combine: (R, R) => R) extends FlowVisitor[R]:
-    def onInit(name: String, frame: Frame, meta: Meta): R                                = empty
-    def onInput[V](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R   = empty
-    def onOutput[V](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R  = empty
-    def onStep(name: String, frame: Frame, meta: Meta): R                                = empty
-    def onSleep(name: String, duration: Duration, frame: Frame, meta: Meta): R           = empty
-    def onDispatch(name: String, branches: Seq[BranchInfo], frame: Frame, meta: Meta): R = empty
-    def onLoop(name: String, frame: Frame, meta: Meta): R                                = empty
-    def onForEach(name: String, concurrency: Int, frame: Frame, meta: Meta): R           = empty
-    def onRace(left: R, right: R, frame: Frame): R                                       = combine(left, right)
-    def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Meta): R   = empty
-    def onAndThen(first: R, second: R, frame: Frame): R                                  = combine(first, second)
-    def onZip(left: R, right: R, frame: Frame): R                                        = combine(left, right)
-    def onGather(flows: Seq[R], frame: Frame): R                                         = flows.foldLeft(empty)(combine)
+    def onInit(name: String, frame: Frame, meta: Meta): R                                                               = empty
+    def onInput[V](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R                                  = empty
+    def onOutput[V](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R                                 = empty
+    def onStep(name: String, frame: Frame, meta: Meta): R                                                               = empty
+    def onSleep(name: String, duration: Duration, frame: Frame, meta: Meta): R                                          = empty
+    def onDispatch[V](name: String, branches: Seq[BranchInfo], frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R    = empty
+    def onLoop[V, State](name: String, frame: Frame, meta: Meta)(using Tag[V], Schema[V], Tag[State], Schema[State]): R = empty
+    def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Meta)(using Tag[V], Schema[V]): R              = empty
+    def onRace(left: R, right: R, frame: Frame): R                                               = combine(left, right)
+    def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: R, frame: Frame, meta: Meta): R = empty
+    def onAndThen(first: R, second: R, frame: Frame): R                                          = combine(first, second)
+    def onZip(left: R, right: R, frame: Frame): R                                                = combine(left, right)
+    def onGather(flows: Seq[R], frame: Frame): R                                                 = flows.foldLeft(empty)(combine)
 end FlowVisitorCollect
 
+/** Runs a [[FlowVisitor]] over a flow, bottom up.
+  *
+  * The walk descends into a subflow: `onSubflow` receives the child flow AND the visitor's answer for it, so a visitor that answers about
+  * everything the parent durably writes re-keys the child's answer under the subflow's path, and one that answers about a single
+  * definition's own nodes ignores it. Descending here rather than leaving each visitor to fold the child itself is what keeps the
+  * duplicate-name check and the structural hash looking at the same tree.
+  */
 private[kyo] object FlowFold:
 
     def apply[R](flow: Flow[?, ?, ?])(visitor: FlowVisitor[R]): R =
@@ -51,12 +81,15 @@ private[kyo] object FlowFold:
                 case n: Dispatch[?, ?, ?, ?, ?] @unchecked =>
                     val infos = n.branches.toSeq.map(b => BranchInfo(b.name, b.frame, b.meta)) :+
                         BranchInfo(n.defaultName, n.defaultFrame, Meta())
-                    visitor.onDispatch(n.name, infos, n.frame, n.meta)
-                case n: LoopNode[?, ?, ?, ?, ?] @unchecked => visitor.onLoop(n.name, n.frame, n.meta)
-                case n: ForEach[?, ?, ?, ?, ?] @unchecked  => visitor.onForEach(n.name, n.concurrency, n.frame, n.meta)
+                    visitor.onDispatch(n.name, infos, n.frame, n.meta)(using n.tag, n.schema)
+                case n: LoopNode[?, ?, ?, ?, ?] @unchecked =>
+                    visitor.onLoop(n.name, n.frame, n.meta)(using n.tag, n.schema, n.stateTag, n.stateSchema)
+                case n: ForEach[?, ?, ?, ?, ?] @unchecked =>
+                    visitor.onForEach(n.name, n.concurrency, n.frame, n.meta)(using n.tag, n.schema)
                 case n: Race[?, ?, ?, ?, ?, ?] @unchecked =>
                     visitor.onRace(loop(n.left), loop(n.right), n.frame)
-                case n: Subflow[?, ?, ?, ?, ?, ?] @unchecked => visitor.onSubflow(n.name, n.childFlow, n.frame, n.meta)
+                case n: Subflow[?, ?, ?, ?, ?, ?] @unchecked =>
+                    visitor.onSubflow(n.name, n.childFlow, loop(n.childFlow), n.frame, n.meta)
                 case n: AndThen[?, ?, ?, ?, ?, ?] @unchecked =>
                     visitor.onAndThen(loop(n.first), loop(n.second), n.frame)
                 case n: Zip[?, ?, ?, ?, ?, ?] @unchecked =>

--- a/kyo-flow/shared/src/main/scala/kyo/internal/IterationName.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/IterationName.scala
@@ -2,8 +2,10 @@ package kyo.internal
 
 /** Naming convention for scheduled loop iterations and their durable sleeps.
   *
-  * Scheduled loops checkpoint each iteration as a separate step in the store. This object centralizes the naming scheme so the interpreter
-  * (Flow.run) and progress tracker (Progress.build) share a single source of truth.
+  * Scheduled loops checkpoint each iteration as a separate step in the store. This object is the one place the scheme is written down, and
+  * both sides of the interpreter's scheduled-loop arm derive their names from it: the side that WRITES a checkpoint and the side that
+  * reads one back on resume. A reader that only has to attribute a recorded path to the node that owns it walks up through the reserved
+  * characters instead, since a fan-out's item is the same shape as an iteration.
   *
   * Given a loop named "sum":
   *   - iteration 0 step: "sum#0"
@@ -18,9 +20,5 @@ private[kyo] object IterationName:
 
     /** Sleep name for iteration `n` of loop `base`. */
     def sleep(base: String, n: Int): String = s"$base##$n"
-
-    /** Whether `completed` is an iteration step of loop `base`. */
-    def isIteration(completed: String, base: String): Boolean =
-        completed.startsWith(s"$base#")
 
 end IterationName

--- a/kyo-flow/shared/src/main/scala/kyo/internal/MemoryFlowStore.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/MemoryFlowStore.scala
@@ -2,139 +2,370 @@ package kyo.internal
 
 import kyo.*
 
+/** The reference store's whole database.
+  *
+  * @param progress
+  *   the paths at which a valueless [[kyo.FlowStore.Claimed.recordProgress]] has landed, per execution. A field cannot carry that mark,
+  *   because a valueless write is exactly the one that writes no field, and write-once still has to refuse a second one.
+  * @param nextToken
+  *   the next claim generation to issue. One counter for the whole store, which satisfies "strictly greater than any token this row has
+  *   carried" for every row at once and survives a claim being made absent, where a token kept on the row alone would not.
+  */
 private[kyo] case class MemoryData(
-    executions: Map[Flow.Id.Execution, FlowStore.ExecutionState],
-    fields: Map[(Flow.Id.Execution, String), FlowStore.FieldData],
-    events: Map[Flow.Id.Execution, Chunk[Flow.Event]],
-    workflows: Map[Flow.Id.Workflow, FlowEngine.WorkflowInfo]
+    executions: Dict[Flow.Id.Execution, FlowStore.ExecutionState],
+    fields: Dict[(Flow.Id.Execution, String), FlowStore.FieldData],
+    events: Dict[Flow.Id.Execution, Chunk[Flow.Event]],
+    workflows: Dict[Flow.Id.Workflow, FlowEngine.WorkflowInfo],
+    progress: Dict[Flow.Id.Execution, Set[String]],
+    nextToken: Long
 )
 
 private[kyo] object MemoryData:
-    val empty = MemoryData(Map.empty, Map.empty, Map.empty, Map.empty)
+    val empty = MemoryData(Dict.empty, Dict.empty, Dict.empty, Dict.empty, Dict.empty, 1L)
 
 private[kyo] class MemoryFlowStore(
     ref: AtomicRef[MemoryData],
-    channel: Channel[Unit]
+    channel: Channel[Unit],
+    registrations: Channel[Unit]
 )(using Frame) extends FlowStore:
 
     private def notify(using Frame): Unit < Sync =
         Abort.run[Closed](channel.offer(())).unit
 
+    /** A registration is a different kind of change from a write about an execution, and a blocked poll answers it differently.
+      *
+      * A write may make an execution ready for the caller that is waiting, so that caller re-asks and keeps waiting. A registration
+      * cannot: what a caller serves is fixed for the life of one `claimReady` call, so the only useful answer is to hand control back
+      * and let the next poll ask with the wider set.
+      */
+    private def notifyRegistration(using Frame): Unit < Sync =
+        Abort.run[Closed](registrations.offer(())).unit
+
+    /** One atomic transition over the whole database, answering what it did.
+      *
+      * `f` is pure and total: it is handed the current snapshot and the store's own clock, and answers the next snapshot beside the
+      * value the caller sees. Returning the snapshot it was given means nothing changed, which skips the compare-and-set and the wake,
+      * so a refused write costs no notification and cannot be told from having never been issued.
+      */
+    private def transact[A](f: (MemoryData, Instant) => (MemoryData, A))(using Frame): A < Async =
+        Clock.nowWith { now =>
+            def attempt: A < Sync =
+                ref.use { data =>
+                    val (next, answer) = f(data, now)
+                    if next eq data then answer
+                    else
+                        ref.compareAndSet(data, next).map {
+                            case true  => notify.andThen(answer)
+                            case false => attempt
+                        }
+                    end if
+                }
+            attempt
+        }
+
+    /** Whether a write presented under `token` is applied, which is the whole of the acceptance rule.
+      *
+      * Both halves, never either. The token alone refuses a superseded writer and lets a lapsed one through; the expiry alone refuses a
+      * lapsed writer and lets a superseded one through while its lease still runs. The executor id is not consulted at all: two workers
+      * of one engine share one, so a claim bearing the writer's own name proves nothing about which generation wrote it.
+      */
+    private def accepted(ex: FlowStore.ExecutionState, token: Long, now: Instant): Boolean =
+        ex.claimToken == Maybe(token) && ex.claimExpiry.exists(e => now < e)
+
+    private def eventsOf(data: MemoryData, eid: Flow.Id.Execution): Chunk[Flow.Event] =
+        data.events.getOrElse(eid, Chunk.empty)
+
+    /** The capability over one claimed row, carrying the generation it was granted under.
+      *
+      * Every verb runs one [[transact]] that re-reads the row, so the acceptance rule is evaluated against the store's state at WRITE
+      * time rather than against the snapshot the claim was granted with. That is what makes a write issued before a release and
+      * delivered after it refusable: by then the claim is absent, and absence fails the rule whenever the write was issued.
+      */
+    private class ClaimedRow(
+        val state: FlowStore.ExecutionState,
+        val satisfied: Set[String],
+        token: Long
+    ) extends FlowStore.Claimed:
+
+        private val eid = state.executionId
+
+        def appendEvent(event: Flow.Event)(using Frame): FlowStore.WriteOutcome < Async =
+            transact { (data, now) =>
+                data.executions.get(eid) match
+                    case Present(ex) if accepted(ex, token, now) =>
+                        (
+                            data.copy(events = data.events.update(eid, eventsOf(data, eid) :+ event)),
+                            FlowStore.WriteOutcome.Applied
+                        )
+                    case _ => (data, FlowStore.WriteOutcome.ClaimLost)
+            }
+
+        def recordWait(path: String, wake: Flow.Wake, event: Flow.Event)(using Frame): FlowStore.WriteOutcome < Async =
+            transact { (data, now) =>
+                data.executions.get(eid) match
+                    case Present(ex) if accepted(ex, token, now) =>
+                        // The row is written only if absent, so a sleep re-recorded on a later attempt keeps the deadline it was
+                        // first given. The event is appended either way: a replay that re-records is something the history shows.
+                        val waits = if ex.waits.contains(path) then ex.waits else ex.waits.update(path, wake)
+                        (
+                            data.copy(
+                                executions = data.executions.update(eid, ex.copy(waits = waits, updated = now)),
+                                events = data.events.update(eid, eventsOf(data, eid) :+ event)
+                            ),
+                            FlowStore.WriteOutcome.Applied
+                        )
+                    case _ => (data, FlowStore.WriteOutcome.ClaimLost)
+            }
+
+        def renewClaim(lease: Duration)(using Frame): Boolean < Async =
+            transact { (data, now) =>
+                data.executions.get(eid) match
+                    case Present(ex) if accepted(ex, token, now) =>
+                        (
+                            data.copy(executions =
+                                data.executions.update(eid, ex.copy(claimExpiry = Maybe(now + lease), updated = now))
+                            ),
+                            true
+                        )
+                    case _ => (data, false)
+            }
+
+        def updateStatus(status: Flow.Status, event: Flow.Event)(using Frame): FlowStore.StatusOutcome < Async =
+            transact { (data, now) =>
+                data.executions.get(eid) match
+                    case Present(ex) if accepted(ex, token, now) =>
+                        if status.isTerminal then (data, FlowStore.StatusOutcome.WrongSideOfTerminal)
+                        else
+                            (
+                                data.copy(
+                                    executions = data.executions.update(eid, ex.copy(status = status, updated = now)),
+                                    events = data.events.update(eid, eventsOf(data, eid) :+ event)
+                                ),
+                                FlowStore.StatusOutcome.Applied
+                            )
+                    case _ => (data, FlowStore.StatusOutcome.ClaimLost)
+            }
+
+        def recordProgress[V](path: String, value: Maybe[V], event: Flow.Event)(using
+            Tag[V],
+            Schema[V],
+            Frame
+        ): FlowStore.ProgressOutcome < Async =
+            transact { (data, now) =>
+                data.executions.get(eid) match
+                    case Present(ex) if accepted(ex, token, now) =>
+                        val key      = (eid, path)
+                        val recorded = data.progress.getOrElse(eid, Set.empty)
+                        // A value-carrying write is refused by the field it would overwrite; a valueless one only by its own
+                        // recorded completion, because an input's discharge always lands on a path the signalled value occupies.
+                        val refused = value match
+                            case Present(_) => data.fields.contains(key)
+                            case _          => recorded.contains(path)
+                        if refused then (data, FlowStore.ProgressOutcome.AlreadyRecorded)
+                        else
+                            val withField = value match
+                                case Present(v) =>
+                                    data.fields.update(key, FlowStore.FieldData(summon[Schema[V]].encodeString[Json](v), Tag[V]))
+                                case _ => data.fields
+                            (
+                                data.copy(
+                                    executions = data.executions.update(eid, ex.copy(waits = ex.waits.remove(path), updated = now)),
+                                    events = data.events.update(eid, eventsOf(data, eid) :+ event),
+                                    fields = withField,
+                                    progress = data.progress.update(eid, recorded + path)
+                                ),
+                                FlowStore.ProgressOutcome.Recorded
+                            )
+                        end if
+                    case _ => (data, FlowStore.ProgressOutcome.ClaimLost)
+            }
+
+        def finish(outcome: FlowStore.Claimed.Outcome)(using Frame): FlowStore.StatusOutcome < Async =
+            transact { (data, now) =>
+                data.executions.get(eid) match
+                    case Present(ex) if accepted(ex, token, now) =>
+                        // The claim becomes absent in the same transition, and this is the only verb that makes it so: an absent
+                        // claim is what tells readiness the rows below are a finished attempt's statement rather than a guess.
+                        def released(next: FlowStore.ExecutionState) =
+                            next.copy(executor = Maybe.empty, claimExpiry = Maybe.empty, claimToken = Maybe.empty, updated = now)
+                        outcome match
+                            case FlowStore.Claimed.Outcome.Terminal(status, event) =>
+                                if !status.isTerminal then (data, FlowStore.StatusOutcome.WrongSideOfTerminal)
+                                else
+                                    (
+                                        data.copy(
+                                            executions =
+                                                data.executions.update(eid, released(ex.copy(status = status, waits = Dict.empty))),
+                                            events = data.events.update(eid, eventsOf(data, eid) :+ event)
+                                        ),
+                                        FlowStore.StatusOutcome.Applied
+                                    )
+                            case FlowStore.Claimed.Outcome.Suspended(waitingOn) =>
+                                (
+                                    data.copy(executions =
+                                        data.executions.update(
+                                            eid,
+                                            released(ex.copy(waits = ex.waits.filter((path, _) => waitingOn.contains(path))))
+                                        )
+                                    ),
+                                    FlowStore.StatusOutcome.Applied
+                                )
+                        end match
+                    case _ => (data, FlowStore.StatusOutcome.ClaimLost)
+            }
+    end ClaimedRow
+
     // --- Coordination ---
 
     def claimReady(
-        workflowIds: Set[Flow.Id.Workflow],
+        served: Set[(Flow.Id.Workflow, String)],
         executorId: Flow.Id.Executor,
         lease: Duration,
         limit: Int,
         timeout: Duration
-    )(using Frame): Seq[FlowStore.ExecutionState] < Async =
-        def tryOnce: Seq[FlowStore.ExecutionState] < Sync =
-            Clock.nowWith { now =>
-                ref.getAndUpdate { data =>
-                    val ready = data.executions.values.filter { ex =>
-                        workflowIds.contains(ex.flowId) &&
-                        !ex.status.isTerminal &&
-                        (ex.executor match
-                            case Absent                                               => true
-                            case Present(_) if ex.claimExpiry.exists(e => !(now < e)) => true
-                            case _                                                    => false) &&
-                        (ex.status match
-                            case Flow.Status.Running            => true
-                            case Flow.Status.Sleeping(_, until) => !(now < until)
-                            case Flow.Status.WaitingForInput(name) =>
-                                data.fields.contains((ex.executionId, name))
-                            case Flow.Status.Cancelled => true
-                            case _                     => false)
-                    }.take(limit).toSeq
+    )(using Frame): Seq[FlowStore.Claimed] < Async =
+        // A row nobody is working on RIGHT NOW, judged by whether the claim is live rather than by whose name is on it.
+        // Judging it by identity strands executions: an executor that skips a row without releasing it leaves its own
+        // name there, so every later poll by that executor re-claims the row, pushes its expiry forward by a full
+        // lease, and then filters it out of its own answer. Nobody receives it and no competitor can take it, because
+        // from outside the lease never lapses.
+        def unclaimed(ex: FlowStore.ExecutionState, now: Instant): Boolean =
+            ex.claimExpiry.forall(e => !(now < e))
 
-                    val claimed = ready.map(ex =>
-                        ex.executionId -> ex.copy(
-                            executor = Maybe(executorId),
-                            claimExpiry = Maybe(now + lease),
-                            updated = now
-                        )
-                    ).toMap
+        // The last attempt died without ending: it never released, so the claim is still active, and its deadline has passed.
+        // Its rows describe waits the execution may no longer be in, and nothing but a new attempt can heal them.
+        def diedMidFlight(ex: FlowStore.ExecutionState, now: Instant): Boolean =
+            ex.claimToken.isDefined && ex.claimExpiry.exists(e => !(now < e))
 
-                    data.copy(executions = data.executions ++ claimed)
-                }.map { oldData =>
-                    // Return only executions newly claimed by this call (were not already owned by us)
-                    ref.use { newData =>
-                        newData.executions.values.filter { ex =>
-                            ex.executor == Maybe(executorId) &&
-                            ex.claimExpiry.exists(e => now < e) &&
-                            // Was not already claimed by us before this call
-                            oldData.executions.get(ex.executionId).forall(old =>
-                                old.executor != Maybe(executorId)
-                            )
-                        }.toSeq.sortBy(_.created)(using Ordering[Instant]).take(limit)
-                    }
-                }
+        def satisfiedBy(data: MemoryData, ex: FlowStore.ExecutionState, wake: Flow.Wake, now: Instant): Boolean =
+            wake match
+                case Flow.Wake.At(instant)   => !(now < instant)
+                case Flow.Wake.OnField(name) => data.fields.contains((ex.executionId, name))
+
+        def satisfiedPaths(data: MemoryData, ex: FlowStore.ExecutionState, now: Instant): Set[String] =
+            ex.waits.foldLeft(Set.empty[String]) { (acc, path, wake) =>
+                if satisfiedBy(data, ex, wake, now) then acc + path else acc
             }
 
-        def loop: Seq[FlowStore.ExecutionState] < (Async & Abort[Closed]) =
-            tryOnce.map { results =>
-                if results.nonEmpty then results
-                else channel.take.andThen(loop)
-            }
+        def ready(data: MemoryData, ex: FlowStore.ExecutionState, now: Instant): Boolean =
+            // The version gate is a separate universal clause rather than one arm of the disjunction below: an execution
+            // with no rows, or with a cancel request, would otherwise be handed to an executor that can neither run it nor
+            // unwind it, because the definition it was started under is not one this caller serves.
+            served.contains((ex.flowId, ex.hash)) &&
+                !ex.status.isTerminal &&
+                unclaimed(ex, now) &&
+                (ex.cancelRequested ||
+                    ex.waits.isEmpty ||
+                    ex.waits.exists((_, wake) => satisfiedBy(data, ex, wake, now)) ||
+                    diedMidFlight(ex, now))
 
-        tryOnce.map { results =>
-            if results.nonEmpty then results
+        // The transition answers WHAT IT CLAIMED, and the handles it hands back are exactly the rows whose token it just
+        // took. Deriving that afterwards from a second read cannot be made correct: the answer to "which of these are
+        // mine" is the same whether this call claimed the row or a previous one did.
+        def claim(data: MemoryData, now: Instant): (MemoryData, Seq[FlowStore.Claimed]) =
+            val due = data.executions.toChunk.map(_._2).filter(ready(data, _, now))
+                .sortBy(_.created)(using Ordering[Instant]).take(limit)
+            if due.isEmpty then (data, Seq.empty)
             else
-                Abort.run[Closed] {
-                    Async.race(
-                        Async.delay(timeout)(Seq.empty[FlowStore.ExecutionState]),
-                        loop
+                val claimed = due.zipWithIndex.map { (ex, i) =>
+                    val token = data.nextToken + i
+                    val row = ex.copy(
+                        executor = Maybe(executorId),
+                        claimExpiry = Maybe(now + lease),
+                        claimToken = Maybe(token),
+                        updated = now
                     )
-                }.map(_.getOrElse(Seq.empty))
+                    (row, new ClaimedRow(row, satisfiedPaths(data, ex, now), token))
+                }
+                (
+                    data.copy(
+                        executions = claimed.foldLeft(data.executions)((acc, entry) => acc.update(entry._1.executionId, entry._1)),
+                        nextToken = data.nextToken + claimed.size
+                    ),
+                    claimed.map((_, handle) => handle)
+                )
+            end if
+        end claim
+
+        // A poll that claims nothing writes nothing, so it cannot extend a deadline it is not handing back. Writing the
+        // fresh expiry and then withholding the row makes an execution invisible to the whole system for a full lease
+        // while its row looks perfectly healthy.
+        def tryOnce: Seq[FlowStore.Claimed] < Sync =
+            Clock.nowWith { now =>
+                def attempt: Seq[FlowStore.Claimed] < Sync =
+                    ref.use { data =>
+                        val (next, claimed) = claim(data, now)
+                        if claimed.isEmpty then Seq.empty
+                        else
+                            ref.compareAndSet(data, next).map {
+                                case true  => claimed
+                                case false => attempt
+                            }
+                        end if
+                    }
+                attempt
+            }
+
+        // What ended a blocked wait. The claim is made OUTSIDE the race that produces this, which is what keeps the call's
+        // own racers from interrupting a claiming branch between its commit and its hand-over: a claim a caller does not
+        // receive is a row nobody can take for a whole lease, and the rule is that either the call hands the row over or it
+        // leaves the row as it found it.
+        enum Woke derives CanEqual:
+            case Write, Registration, TimedOut
+
+        def awaitChange(remaining: Duration): Woke < Async =
+            Abort.run[Closed] {
+                Async.race(
+                    Async.delay(remaining)(Woke.TimedOut),
+                    channel.take.andThen(Woke.Write),
+                    registrations.take.andThen(Woke.Registration)
+                )
+            }.map(_.getOrElse(Woke.TimedOut))
+
+        Clock.nowWith { start =>
+            val deadline = start + timeout
+            def poll: Seq[FlowStore.Claimed] < Async =
+                tryOnce.map { claimed =>
+                    if claimed.nonEmpty then claimed
+                    else
+                        Clock.nowWith { now =>
+                            if !(now < deadline) then Seq.empty
+                            else
+                                awaitChange(deadline - now).map {
+                                    // A write about an execution may have made one ready for this caller, so the poll
+                                    // re-asks and keeps waiting until its own deadline.
+                                    case Woke.Write => poll
+                                    // A registration cannot make anything ready for THIS call, whose served set was fixed
+                                    // when it was made, so the answer goes back to the caller: the next poll asks with the
+                                    // wider set. Without it an execution held for a version nobody served waits out a whole
+                                    // poll timeout after the definition it needs arrives.
+                                    case Woke.Registration => tryOnce
+                                    // The deadline ASKS ONE MORE TIME rather than answering empty on the strength of having
+                                    // run out of time. Two things become ready without a write to wake anyone: a sleep row
+                                    // whose instant simply passed, and a claim that simply expired, and a caller that
+                                    // answered empty while one of them sat ready would hide it for a whole poll cycle. The
+                                    // rule the call is held to says either it hands the row over or it leaves the row as it
+                                    // found it, and it admits no exception for the last instant of the wait.
+                                    case Woke.TimedOut => tryOnce
+                                }
+                        }
+                }
+            poll
         }
     end claimReady
 
-    def renewClaim(
-        executionId: Flow.Id.Execution,
-        executorId: Flow.Id.Executor,
-        lease: Duration
-    )(using Frame): Boolean < Async =
-        Clock.nowWith { now =>
-            ref.updateAndGet { data =>
-                data.executions.get(executionId) match
-                    case Some(ex) if ex.executor == Maybe(executorId) && ex.claimExpiry.exists(e => now < e) =>
-                        data.copy(executions =
-                            data.executions +
-                                (executionId -> ex.copy(claimExpiry = Maybe(now + lease), updated = now))
-                        )
-                    case _ => data
-            }.map { newData =>
-                newData.executions.get(executionId).exists(ex =>
-                    ex.executor == Maybe(executorId) && ex.claimExpiry.exists(e => now < e)
-                )
-            }
-        }
-
-    def releaseClaim(
-        executionId: Flow.Id.Execution,
-        executorId: Flow.Id.Executor
-    )(using Frame): Unit < Async =
-        ref.getAndUpdate { data =>
-            data.executions.get(executionId) match
-                case Some(ex) if ex.executor == Maybe(executorId) =>
-                    data.copy(executions =
-                        data.executions +
-                            (executionId -> ex.copy(executor = Maybe.empty, claimExpiry = Maybe.empty))
-                    )
-                case _ => data
-        }.unit.andThen(notify)
-
     // --- Execution state ---
 
-    def createExecution(
+    def createExecutionIfAbsent(
         executionId: Flow.Id.Execution,
         status: Flow.Status,
         event: Flow.Event,
-        hash: String
-    )(using Frame): Unit < Async =
-        Clock.nowWith { now =>
-            ref.getAndUpdate { data =>
+        hash: String,
+        fields: Dict[String, FlowStore.FieldData]
+    )(using Frame): Boolean < Async =
+        transact { (data, now) =>
+            if data.executions.contains(executionId) then (data, false)
+            else
                 val ex = FlowStore.ExecutionState(
                     executionId,
                     event.flowId,
@@ -143,85 +374,117 @@ private[kyo] class MemoryFlowStore(
                     created = now,
                     updated = now
                 )
-                val events = Chunk(event)
-                data.copy(
-                    executions = data.executions + (executionId -> ex),
-                    events = data.events + (executionId         -> events)
+                (
+                    data.copy(
+                        executions = data.executions.update(executionId, ex),
+                        events = data.events.update(executionId, Chunk(event)),
+                        fields = fields.foldLeft(data.fields)((acc, name, fd) => acc.update((executionId, name), fd))
+                    ),
+                    true
                 )
-            }.unit.andThen(notify)
+            end if
         }
 
-    def updateStatus(
+    def signal[V: Tag: Schema](
         executionId: Flow.Id.Execution,
-        status: Flow.Status,
+        name: String,
+        value: V,
         event: Flow.Event
-    )(using Frame): Unit < Async =
-        Clock.nowWith { now =>
-            ref.getAndUpdate { data =>
-                data.executions.get(executionId) match
-                    case Some(ex) if ex.status.isTerminal =>
-                        // Terminal status is irreversible — only append the event
-                        val events = data.events.getOrElse(executionId, Chunk.empty)
-                        data.copy(events = data.events + (executionId -> (events :+ event)))
-                    case Some(ex) =>
-                        val updated = ex.copy(status = status, updated = now)
-                        val events  = data.events.getOrElse(executionId, Chunk.empty)
+    )(using Frame): FlowStore.SignalOutcome < Async =
+        transact { (data, now) =>
+            val key = (executionId, name)
+            data.executions.get(executionId) match
+                // A row that is not there can never consume a value, and no retry will change that. `Cancelled` is the one
+                // terminal status that does not claim the execution produced a result or failed to.
+                case Absent                                   => (data, FlowStore.SignalOutcome.AlreadyTerminal(Flow.Status.Cancelled))
+                case Present(ex) if ex.status.isTerminal      => (data, FlowStore.SignalOutcome.AlreadyTerminal(ex.status))
+                case Present(ex) if data.fields.contains(key) => (data, FlowStore.SignalOutcome.AlreadyDelivered)
+                case Present(ex) =>
+                    (
                         data.copy(
-                            executions = data.executions + (executionId -> updated),
-                            events = data.events + (executionId         -> (events :+ event))
-                        )
-                    case None => data
-            }.unit.andThen(notify)
+                            fields =
+                                data.fields.update(key, FlowStore.FieldData(summon[Schema[V]].encodeString[Json](value), Tag[V])),
+                            events = data.events.update(executionId, eventsOf(data, executionId) :+ event),
+                            executions = data.executions.update(executionId, ex.copy(updated = now))
+                        ),
+                        FlowStore.SignalOutcome.Delivered
+                    )
+            end match
+        }
+
+    def requestCancel(executionId: Flow.Id.Execution)(using Frame): FlowStore.CancelOutcome < Async =
+        transact { (data, now) =>
+            data.executions.get(executionId) match
+                case Absent                              => (data, FlowStore.CancelOutcome.AlreadyTerminal(Flow.Status.Cancelled))
+                case Present(ex) if ex.status.isTerminal => (data, FlowStore.CancelOutcome.AlreadyTerminal(ex.status))
+                case Present(ex) if ex.cancelRequested   => (data, FlowStore.CancelOutcome.AlreadyRequested)
+                case Present(ex) =>
+                    (
+                        data.copy(executions =
+                            data.executions.update(executionId, ex.copy(cancelRequested = true, updated = now))
+                        ),
+                        FlowStore.CancelOutcome.Accepted
+                    )
+            end match
         }
 
     def getExecution(
         executionId: Flow.Id.Execution
     )(using Frame): Maybe[FlowStore.ExecutionState] < Async =
-        ref.use(_.executions.get(executionId) match
-            case Some(ex) => Maybe(ex)
-            case None     => Maybe.empty)
+        ref.use(_.executions.get(executionId))
+
+    /** Whether one execution answers one filter, judged from the row and the fields the store already holds. */
+    private def matches(filter: FlowStore.ExecutionFilter, ex: FlowStore.ExecutionState): Boolean =
+        filter match
+            case FlowStore.ExecutionFilter.Running   => ex.status == Flow.Status.Running
+            case FlowStore.ExecutionFilter.Completed => ex.status == Flow.Status.Completed
+            case FlowStore.ExecutionFilter.Cancelled => ex.status == Flow.Status.Cancelled
+            case FlowStore.ExecutionFilter.Compensating =>
+                ex.status match
+                    case _: Flow.Status.Compensating => true
+                    case _                           => false
+            case FlowStore.ExecutionFilter.Failed(kind) =>
+                ex.status match
+                    case Flow.Status.Failed(_, k) => kind.forall(want => k.contains(want))
+                    case _                        => false
+            case FlowStore.ExecutionFilter.Sleeping =>
+                ex.waits.exists((_, wake) =>
+                    wake match
+                        case _: Flow.Wake.At => true
+                        case _               => false
+                )
+            case FlowStore.ExecutionFilter.WaitingForInput(name) =>
+                ex.waits.exists((_, wake) =>
+                    wake match
+                        case Flow.Wake.OnField(field) => name.forall(_ == field)
+                        case _                        => false
+                )
+            case FlowStore.ExecutionFilter.Cancelling       => ex.cancelRequested && !ex.status.isTerminal
+            case FlowStore.ExecutionFilter.Orphaned(hashes) => !ex.status.isTerminal && !hashes.contains(ex.hash)
 
     def listExecutions(
         flowId: Flow.Id.Workflow,
-        status: Maybe[Flow.Status],
-        limit: Int,
+        filter: Maybe[FlowStore.ExecutionFilter],
+        limit: Maybe[Int],
         offset: Int
     )(using Frame): Chunk[FlowStore.ExecutionState] < Async =
         ref.use { data =>
-            val filtered = data.executions.values.filter(_.flowId == flowId)
-            val byStatus = status match
-                case Present(s) => filtered.filter(_.status == s)
-                case _          => filtered
-            Chunk.from(byStatus.toSeq.sortBy(_.created)(using Ordering[Instant]).reverse.drop(offset).take(limit))
+            val ofFlow = data.executions.toChunk.map(_._2).filter(_.flowId == flowId)
+            // Filtered BEFORE the page is cut, so a caller asking for the first 25 matches gets 25 matches rather than the
+            // matches among the first 25 rows.
+            val matched = filter match
+                case Present(f) => ofFlow.filter(matches(f, _))
+                case _          => ofFlow
+            val sorted = matched.sortBy(_.created)(using Ordering[Instant]).reverse.drop(offset)
+            // A negative count is not a meaningful limit, so it is answered the same as Absent: the alternative, an empty page,
+            // is indistinguishable from a workflow that genuinely has nothing matching.
+            val paged = limit match
+                case Present(n) if n >= 0 => sorted.take(n)
+                case _                    => sorted
+            Chunk.from(paged)
         }
 
     // --- Fields ---
-
-    def putField[V: Tag: Schema](
-        executionId: Flow.Id.Execution,
-        name: String,
-        value: V
-    )(using Frame): Unit < Async =
-        val data = FlowStore.FieldData(summon[Schema[V]].encodeString[Json](value), Tag[V].erased)
-        ref.getAndUpdate(d => d.copy(fields = d.fields + ((executionId, name) -> data))).unit
-            .andThen(notify)
-    end putField
-
-    def putFieldIfAbsent[V: Tag: Schema](
-        executionId: Flow.Id.Execution,
-        name: String,
-        value: V
-    )(using Frame): Boolean < Async =
-        val data = FlowStore.FieldData(summon[Schema[V]].encodeString[Json](value), Tag[V].erased)
-        val key  = (executionId, name)
-        ref.getAndUpdate { d =>
-            if d.fields.contains(key) then d
-            else d.copy(fields = d.fields + (key -> data))
-        }.map { oldData =>
-            val wasAbsent = !oldData.fields.contains(key)
-            if wasAbsent then notify.andThen(true) else false
-        }
-    end putFieldIfAbsent
 
     def getField[V: Tag: Schema](
         executionId: Flow.Id.Execution,
@@ -229,7 +492,7 @@ private[kyo] class MemoryFlowStore(
     )(using Frame): Maybe[V] < Async =
         ref.use { data =>
             data.fields.get((executionId, name)) match
-                case Some(fd) if fd.tag =:= Tag[V] =>
+                case Present(fd) if fd.tag =:= Tag[V] =>
                     summon[Schema[V]].decodeString[Json](fd.value).toMaybe
                 case _ => Maybe.empty
         }
@@ -238,44 +501,43 @@ private[kyo] class MemoryFlowStore(
         executionId: Flow.Id.Execution
     )(using Frame): Dict[String, FlowStore.FieldData] < Async =
         ref.use { data =>
-            data.fields.foldLeft(Dict.empty[String, FlowStore.FieldData]) { case (acc, ((eid, name), fd)) =>
-                if eid == executionId then acc.update(name, fd) else acc
+            data.fields.foldLeft(Dict.empty[String, FlowStore.FieldData]) { (acc, key, fd) =>
+                if key._1 == executionId then acc.update(key._2, fd) else acc
             }
         }
 
     // --- Events ---
 
-    def appendEvent(
-        executionId: Flow.Id.Execution,
-        event: Flow.Event
-    )(using Frame): Unit < Async =
-        ref.getAndUpdate { data =>
-            val events = data.events.getOrElse(executionId, Chunk.empty)
-            data.copy(events = data.events + (executionId -> (events :+ event)))
-        }.unit.andThen(notify)
-
     def getHistory(
         executionId: Flow.Id.Execution,
-        limit: Int,
+        limit: Maybe[Int],
         offset: Int
     )(using Frame): FlowStore.HistoryPage < Async =
         ref.use { data =>
-            val all   = data.events.getOrElse(executionId, Chunk.empty)
-            val paged = all.drop(offset).take(limit)
-            FlowStore.HistoryPage(paged, all.length > offset + limit)
+            val all     = data.events.getOrElse(executionId, Chunk.empty)
+            val dropped = all.drop(offset)
+            // A negative count is not a meaningful limit, so it is answered the same as Absent: an implementation that clamped it
+            // to zero instead would still have to answer `hasMore`, and doing so from a page it just emptied is exactly the
+            // "empty page that claims more" pair a paging caller loops on forever. Bounding `hasMore` by what is actually left,
+            // rather than adding to `limit`, is what keeps this free of the overflow an `Int.MaxValue` sentinel would force.
+            limit match
+                case Present(n) if n >= 0 => FlowStore.HistoryPage(dropped.take(n), dropped.length > n)
+                case _                    => FlowStore.HistoryPage(dropped, hasMore = false)
         }
 
     // --- Workflows ---
 
+    // Registering a definition is the one change that can widen what a poller serves, so it wakes them. An execution held
+    // because no engine served its version becomes claimable the moment one does, and without the notification it would sit
+    // until the blocked poll timed out on its own.
     def putWorkflow(meta: FlowEngine.WorkflowInfo)(using Frame): Unit < Async =
-        ref.getAndUpdate(d => d.copy(workflows = d.workflows + (Flow.Id.Workflow(meta.id) -> meta))).unit
+        ref.getAndUpdate(d => d.copy(workflows = d.workflows.update(Flow.Id.Workflow(meta.id), meta))).unit
+            .andThen(notifyRegistration)
 
     def getWorkflow(id: Flow.Id.Workflow)(using Frame): Maybe[FlowEngine.WorkflowInfo] < Async =
-        ref.use(_.workflows.get(id) match
-            case Some(m) => Maybe(m)
-            case None    => Maybe.empty)
+        ref.use(_.workflows.get(id))
 
     def listWorkflows(using Frame): Seq[FlowEngine.WorkflowInfo] < Async =
-        ref.use(_.workflows.values.toSeq)
+        ref.use(_.workflows.toChunk.map(_._2))
 
 end MemoryFlowStore

--- a/kyo-flow/shared/src/main/scala/kyo/internal/NodePath.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/NodePath.scala
@@ -1,0 +1,33 @@
+package kyo.internal
+
+/** How a node is named durably: by the path it occupies in a composition, not by its bare name.
+  *
+  * A node inside subflow instance `review` is durably `review~<name>`, in every place a node's name reaches the store: its field, its
+  * history events, its completion mark, its schema entry, and its wait row. The bare name is what the record is keyed by, because the
+  * record's type is the flow's own; the path is what the store is keyed by, because two instances of one subflow are two sets of nodes
+  * and the store has to tell them apart.
+  *
+  * Global uniqueness would be the cheaper rule and it is the wrong one: it forbids embedding the same subflow twice in one parent, which
+  * is what a subflow is for.
+  *
+  * Two characters are reserved in a user's node name and refused at registration. [[Separator]] joins a path, and `#` is what
+  * [[IterationName]] uses to distinguish a loop's iterations and what a dispatch's choice field rides. The two compose, because a loop
+  * can sit inside a subflow: iteration 0 of `sum` under `review` is `review~sum#0`.
+  */
+private[kyo] object NodePath:
+
+    /** The character that joins a subflow instance's name to a node inside it. */
+    val Separator: Char = '~'
+
+    /** The characters the engine reserves in a node name, because it builds durable keys with them. */
+    val Reserved: Set[Char] = Set(Separator, '#')
+
+    /** The durable name of `name` inside `path`, where an empty path is the flow's own top level. */
+    def qualify(path: String, name: String): String =
+        if path.isEmpty then name else s"$path$Separator$name"
+
+    /** Every entry of `names` re-keyed as if it sat inside subflow instance `path`. */
+    def qualifyAll[V](path: String, names: Map[String, V]): Map[String, V] =
+        names.map((name, value) => (qualify(path, name), value))
+
+end NodePath

--- a/kyo-flow/shared/src/main/scala/kyo/internal/StoreInterpreter.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/StoreInterpreter.scala
@@ -10,15 +10,21 @@ private[kyo] case class InputMeta(name: String, tag: Tag[Any], schema: Schema[An
   *
   * The identity-typed `erased` method slots into any effect context. At runtime the implementation handles effects pending inside the
   * computation via type erasure.
+  *
+  * **The `Scope` in the answer is not decoration.** A runner is built from
+  * `[V] => V < S => V < (Async & Scope & Abort[FlowException])`, so wrapping a computation PRODUCES a scope requirement, and a signature
+  * that answered the caller's own row would erase it: the step's resources would then be acquired against whatever scope happened to be
+  * open around the engine, and a file or a connection a step opened would stay open until the engine itself shut down. Saying it in the
+  * type is what makes the caller close the scope at the end of the attempt that opened it.
   */
 abstract private[kyo] class FlowRunner:
-    def erased[V, S](v: V < S)(using Frame): V < S
+    def erased[V, S](v: V < S)(using Frame): V < (S & Scope)
 
 private[kyo] object FlowRunner:
     def apply[S](f: [V] => V < S => V < (Async & Scope & Abort[FlowException])): FlowRunner =
         new FlowRunner:
-            def erased[V, S2](v: V < S2)(using Frame): V < S2 =
-                f(v.asInstanceOf[V < S]).asInstanceOf[V < S2]
+            def erased[V, S2](v: V < S2)(using Frame): V < (S2 & Scope) =
+                f(v.asInstanceOf[V < S]).asInstanceOf[V < (S2 & Scope)]
 end FlowRunner
 
 private[kyo] case class FlowDefinition(
@@ -30,163 +36,401 @@ private[kyo] case class FlowDefinition(
     schema: WorkflowSchema
 )
 
+/** Interprets one attempt at one claimed execution.
+  *
+  * **It holds two capabilities and they are not interchangeable.** Reads go to the `FlowStore`, which anybody may read; every write
+  * goes through the [[kyo.FlowStore.Claimed]] the poll was handed, and the store judges each one against the generation that claim
+  * carries. There is no client-side claim check left: an executor learns it has lost the row by having a write REFUSED, which is what
+  * makes the guarantee the store's rather than the interpreter's good manners.
+  *
+  * @param retried
+  *   how many times each node has already been retried, counted from the history this attempt read. A step's retry schedule resumes at
+  *   its recorded position: without it an executor that crashed at attempt 3 of 5 begins again at attempt 1, and a step that fails
+  *   deterministically burns its whole schedule once per resume without ever exhausting it.
+  * @param reentering
+  *   the verdict a previous attempt recorded when it entered its unwind, present exactly when this attempt is resuming one. The forward
+  *   pass then runs in skip-only mode: completed nodes re-register their handlers, and the first node that would actually RUN raises the
+  *   recorded verdict instead, because replaying forward into the step that failed is how an unwind silently turns into a completion.
+  */
 private[kyo] class StoreInterpreter(
     store: FlowStore,
-    eid: Flow.Id.Execution,
-    flowId: Flow.Id.Workflow,
+    claimed: FlowStore.Claimed,
     executorId: Flow.Id.Executor,
-    defn: FlowDefinition
-)(using Frame) extends FlowInterpreter[Async & Abort[FlowException] & Abort[FlowSuspension]]:
+    defn: FlowDefinition,
+    retried: Map[String, Int] = Map.empty,
+    reentering: Maybe[Flow.Cause] = Maybe.empty
+)(using Frame) extends FlowInterpreter[Async & Abort[FlowException | FlowSuspension | FlowStoreException]]:
 
-    type S = Async & Abort[FlowException] & Abort[FlowSuspension]
+    // The store's own error channel is part of the interpreter's row: a store failure raised while an execution is running is a failure
+    // of that execution, and the engine discharges it where it discharges the flow's own.
+    type S = Async & Abort[FlowException | FlowSuspension | FlowStoreException]
+
+    private val eid    = claimed.state.executionId
+    private val flowId = claimed.state.flowId
+
+    /** A write the store refused because the claim is gone stops this attempt, and that is the ONLY thing that stops it.
+      *
+      * The authority is the store's rather than this executor's, so a refusal is how an executor finds out the row is somebody else's.
+      * `ClaimLost` is its own ending: the new owner needs no help from the executor that stopped owning the row, so nothing at all is
+      * written, not a status, not an event, not a release.
+      */
+    private def fenced(outcome: FlowStore.WriteOutcome < S): Unit < S =
+        outcome.map {
+            case FlowStore.WriteOutcome.Applied   => ()
+            case FlowStore.WriteOutcome.ClaimLost => Abort.fail[FlowSuspension](FlowSuspension.ClaimLost)
+        }
+
+    /** The same, for a write that moves the lifecycle.
+      *
+      * A status on the wrong side of the partition is a defect in the CALL rather than a state of the execution, so it panics here
+      * instead of ending the attempt quietly: nothing in this interpreter hands `updateStatus` a terminal status, and if something ever
+      * does, the loud answer is the useful one.
+      */
+    private def fencedStatus(outcome: FlowStore.StatusOutcome < S): Unit < S =
+        outcome.map {
+            case FlowStore.StatusOutcome.Applied   => ()
+            case FlowStore.StatusOutcome.ClaimLost => Abort.fail[FlowSuspension](FlowSuspension.ClaimLost)
+            case FlowStore.StatusOutcome.WrongSideOfTerminal =>
+                Abort.panic(new IllegalStateException(
+                    s"a mid-attempt lifecycle write for ${eid.value} carried a terminal status, which only finish may write"
+                ))
+        }
+
+    /** The same, for progress, answering whether THIS attempt was the writer.
+      *
+      * An already-recorded answer is not a failure. It is the race exemption working: two live branches completing a shared output name
+      * resolve to the first writer at the store, which is the same answer replay derives from the field's presence.
+      */
+    private def fencedProgress(outcome: FlowStore.ProgressOutcome < S): Boolean < S =
+        outcome.map {
+            case FlowStore.ProgressOutcome.Recorded        => true
+            case FlowStore.ProgressOutcome.AlreadyRecorded => false
+            case FlowStore.ProgressOutcome.ClaimLost       => Abort.fail[FlowSuspension](FlowSuspension.ClaimLost)
+        }
+
+    private def appendEvent(event: Instant => Flow.Event): Unit < S =
+        Clock.nowWith(ts => fenced(claimed.appendEvent(event(ts))))
 
     private def withEvent[A](event: Instant => Flow.Event)(body: => A < S): A < S =
-        Clock.nowWith(ts => store.appendEvent(eid, event(ts))).andThen(body)
+        appendEvent(event).andThen(body)
 
-    private def checkClaim: Unit < S =
-        store.getExecution(eid).map {
-            case Present(s) if s.executor == Maybe(executorId) => ()
-            case _                                             => Abort.fail[FlowSuspension](FlowSuspension.ClaimLost)
-        }
+    /** What every node boundary asks before it does anything: is this attempt still supposed to be going forward.
+      *
+      * Two reasons it is not, and they are read here rather than anywhere else because a node boundary is the only place an execution
+      * can be stopped cleanly. A CANCEL REQUEST is read fresh from the row, never from the claim's snapshot, which was taken before the
+      * attempt began and cannot see a request that arrived mid-flight. A RESUMED UNWIND raises the verdict the interrupted attempt
+      * recorded, so the forward pass re-registers the handlers of everything already done and then stops rather than re-running the step
+      * that failed, whose second attempt might succeed and complete an execution whose compensations have already half run.
+      *
+      * The claim is deliberately not among them. It is not this executor's to check: every write below carries it and the store
+      * decides.
+      */
+    private def guard: Unit < S =
+        reentering match
+            case Present(cause) => Abort.fail[FlowException](FlowResumedUnwindException(cause))
+            case _ =>
+                store.getExecution(eid).map {
+                    case Present(s) if s.cancelRequested => Abort.fail[FlowException](FlowCancelledException(eid.value))
+                    case _                               => ()
+                }
 
-    private def checkInFlight(name: String, timeout: Duration): Unit < S =
-        store.getHistory(eid, Int.MaxValue, 0).map { page =>
-            val started = page.events.exists {
-                case Flow.Event.StepStarted(_, _, n, _, _) => n == name
-                case _                                     => false
-            }
-            val completed = page.events.exists {
-                case Flow.Event.StepCompleted(_, _, n, _) => n == name
-                case _                                    => false
-            }
-            if started && !completed then
-                def poll(remaining: Duration): Unit < S =
-                    if remaining <= Duration.Zero then ()
-                    else
-                        Async.sleep(1.second).map { _ =>
-                            store.getHistory(eid, Int.MaxValue, 0).map { fresh =>
-                                val done = fresh.events.exists {
-                                    case Flow.Event.StepCompleted(_, _, n, _) => n == name
-                                    case _                                    => false
-                                }
-                                if done then
-                                    Abort.fail[FlowSuspension](FlowSuspension.StepAlreadyCompleted(name))
-                                else poll(remaining - 1.second)
-                            }
-                        }
-                poll(timeout)
-            else ()
-            end if
-        }
-
-    /** Run a computation with timeout and retry according to the step's Meta. */
+    /** Runs a step's computation under the `timeout` and the `retry` schedule its [[Flow.Meta]] declared.
+      *
+      * The schedule wraps the COMPUTATION alone. Everything the interpreter writes about an attempt, the `StepTimedOut` and the
+      * `StepRetried` events, rides the store's own channel in the continuation of that catch, so a store failure can never be read as
+      * a failure of the step: it leaves on the channel the engine classifies as infrastructure instead of spending a budget the
+      * caller allotted to their own work and writing events that say the step failed when the store did. Those writes are claimed like
+      * every other, so an executor whose lease is taken as its step begins cannot write its whole retry schedule into an execution
+      * somebody else now owns, re-running the body once per entry.
+      *
+      * **The position is read back from history rather than restarted.** Every retry appends a `StepRetried` carrying its attempt
+      * number, so the position is durable; an entry point that always began at attempt 1 would leave it durable and never read, and a
+      * step failing deterministically then burns its whole schedule once per resume without ever exhausting it, which turns a bounded
+      * retry policy into an unbounded one exactly when the system is already unhealthy.
+      *
+      * What the schedule re-asks is an accident and nothing else. A [[FlowException]] is a verdict on the work and ends the step at
+      * its first appearance, failed or thrown, because re-asking a decision re-fires the step's side effects to reach the same
+      * answer. A [[FlowStoreException]] is a fact about the store rather than about the step. An interrupt is the one mechanism that
+      * stops an executor whose lease lapsed, and a schedule that consumed it would sleep its backoff and re-run the body under a
+      * claim the store may have handed to somebody else, with nothing left to fire a second time. The timeout is the exception that
+      * proves the rule: it is typed, but it measures slowness rather than deciding anything, and pairing `timeout` with `retry` is
+      * exactly what the two `Meta` fields are for.
+      */
     private def withTimeoutAndRetry[V](name: String, computation: V < Sync, meta: Flow.Meta): V < S =
-        val withTimeout: V < S =
+        val bounded: V < (Async & Abort[FlowStepTimeoutException]) =
             if meta.timeout == Duration.Infinity then computation
             else
-                Abort.recover[Timeout] { _ =>
-                    Clock.nowWith { ts =>
-                        store.appendEvent(eid, Flow.Event.StepTimedOut(flowId, eid, name, meta.timeout, ts))
-                    }.andThen(Abort.panic(new RuntimeException(s"Step '$name' timed out after ${meta.timeout.show}")))
-                }(Async.timeout(meta.timeout)(computation))
+                Abort.recover[Timeout](_ => Abort.fail(FlowStepTimeoutException(name, meta.timeout)))(
+                    Async.timeout(meta.timeout)(computation)
+                )
+
+        def errorOf(result: Result[Throwable, V]): Throwable =
+            result match
+                case Result.Failure(e) => e
+                case Result.Panic(e)   => e
+                case _                 => new IllegalStateException(s"Step '$name' ended with neither a value nor an error")
+
+        /** The node's failure, recorded under its own name before it is re-raised into the flow.
+          *
+          * This is the one place every unrecovered failure of this node passes through, whatever route it took: a node with no retry
+          * schedule, a declared failure the schedule is not allowed to re-ask, and a schedule that ran out. Recording here rather
+          * than at each of the three keeps the record and the raise from ever disagreeing.
+          *
+          * **Two errors are not the node's verdict and write nothing.** A [[FlowStoreException]] is a fact about the store, and the
+          * execution is left exactly as claimable as it was for the next poll to try again; an [[Interrupted]] means this attempt was
+          * told to stop, which is no statement about the work. Painting either as a failed node would report a failure to an operator
+          * where the engine itself records none.
+          */
+        def recordFailure(error: Throwable): Unit < S =
+            error match
+                case _: FlowStoreException => ()
+                case _: Interrupted        => ()
+                case e: FlowException =>
+                    appendEvent(ts => Flow.Event.StepFailed(flowId, eid, name, e.getMessage, Maybe(e.kind), ts))
+                case e =>
+                    appendEvent(ts => Flow.Event.StepFailed(flowId, eid, name, e.getMessage, Maybe.empty, ts))
+
+        def raise(result: Result[Throwable, V]): V < S =
+            result match
+                case Result.Success(v) => v
+                case _ =>
+                    val error = errorOf(result)
+                    recordFailure(error).andThen {
+                        error match
+                            case e: FlowException      => Abort.fail(e)
+                            case e: FlowStoreException => Abort.fail(e)
+                            case e                     => Abort.panic(e)
+                    }
+
+        def isAccident(error: Throwable): Boolean =
+            error match
+                case _: FlowStepTimeoutException => true
+                case _: FlowException            => false
+                case _: FlowStoreException       => false
+                case _: Interrupted              => false
+                case _                           => true
+
+        // One attempt, with the timeout's own event appended in the continuation of the catch rather than inside it.
+        val attemptOnce: Result[Throwable, V] < S =
+            Abort.run[Throwable](bounded).map { result =>
+                result match
+                    case Result.Failure(_: FlowStepTimeoutException) =>
+                        appendEvent(ts => Flow.Event.StepTimedOut(flowId, eid, name, meta.timeout, ts)).andThen(result)
+                    case _ => result
+            }
+
+        // Where this node's schedule already stood when the last attempt on it ended. Walking `next` that many times is the same
+        // derivation `deriveCompleted` makes from the same history, and a schedule that runs out on the way is one whose budget was
+        // already spent: the first failure then raises instead of sleeping a delay nobody has left.
+        def resume(schedule: Schedule, spent: Int): Maybe[Schedule] < S =
+            if spent <= 0 then Maybe(schedule)
+            else
+                Clock.nowWith { now =>
+                    @annotation.tailrec
+                    def walk(sched: Schedule, remaining: Int): Maybe[Schedule] =
+                        if remaining <= 0 then Maybe(sched)
+                        else
+                            sched.next(now) match
+                                case Present((_, next)) => walk(next, remaining - 1)
+                                case _                  => Maybe.empty
+                    walk(schedule, spent)
+                }
+
         meta.retry match
-            case Absent => withTimeout
+            case Absent => attemptOnce.map(raise)
             case Present(schedule) =>
-                def attempt(sched: Schedule, attemptNum: Int): V < S =
-                    Abort.run[Throwable](withTimeout).map {
+                def attempt(sched: Maybe[Schedule], attemptNum: Int): V < S =
+                    attemptOnce.map {
                         case Result.Success(v) => v
                         case result =>
-                            Clock.nowWith { now =>
-                                sched.next(now) match
-                                    case Present((delay, nextSched)) =>
-                                        val error = result match
-                                            case Result.Failure(e) => e.getMessage
-                                            case Result.Panic(e)   => e.getMessage
-                                            case _                 => "unknown"
-                                        store.appendEvent(eid, Flow.Event.StepRetried(flowId, eid, name, error, attemptNum, delay, now))
-                                            .andThen(Async.sleep(delay))
-                                            .andThen(attempt(nextSched, attemptNum + 1))
-                                    case _ =>
-                                        result match
-                                            case Result.Failure(e) => Abort.panic(e)
-                                            case Result.Panic(e)   => Abort.panic(e)
-                                            case _                 => Abort.panic(new RuntimeException("retry exhausted"))
-                            }
+                            val error = errorOf(result)
+                            if !isAccident(error) then raise(result)
+                            else
+                                Clock.nowWith { now =>
+                                    sched.flatMap(_.next(now)) match
+                                        case Present((delay, nextSched)) =>
+                                            appendEvent(_ =>
+                                                Flow.Event.StepRetried(flowId, eid, name, error.getMessage, attemptNum, delay, now)
+                                            )
+                                                .andThen(Async.sleep(delay))
+                                                .andThen(attempt(Maybe(nextSched), attemptNum + 1))
+                                        case _ => raise(result)
+                                }
+                            end if
                     }
-                attempt(schedule, 1)
+                val spent = retried.getOrElse(name, 0)
+                resume(schedule, spent).map(attempt(_, spent + 1))
         end match
     end withTimeoutAndRetry
+
+    /** A [[FlowException]] goes back out as a failure, which is what keeps a step's own [[FlowDomainException]] a typed failure the
+      * engine records with its kind, rather than a panic carrying only a message. Anything else was never a declared failure of this
+      * flow and stays a panic.
+      */
+    override def onUnwind(error: Throwable): Nothing < S =
+        error match
+            case flowError: FlowException => Abort.fail(flowError)
+            // The store's own failures go back out on the store's own channel, which this row carries. Panicking them
+            // instead would throw away the classification a store went to the trouble of making, the retryable marker
+            // included, at the one place that still has somewhere to put it.
+            case storeError: FlowStoreException => Abort.fail(storeError)
+            case other                          => Abort.panic(other)
 
     def getField[V](name: String)(using Tag[V], Schema[V]): Maybe[V] < S =
         store.getField[V](eid, name)
 
     def onOutput[V](name: String, computation: V < Sync, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]): V < S =
         for
-            _   <- checkClaim
-            _   <- checkInFlight(name, meta.timeout)
-            ts  <- Clock.now
-            _   <- store.appendEvent(eid, Flow.Event.StepStarted(flowId, eid, name, executorId, ts))
-            v   <- withTimeoutAndRetry(name, computation, meta)
-            _   <- store.putField[V](eid, name, v)
-            ts2 <- Clock.now
-            _   <- store.updateStatus(eid, Flow.Status.Running, Flow.Event.StepCompleted(flowId, eid, name, ts2))
+            _ <- guard
+            _ <- appendEvent(ts => Flow.Event.StepStarted(flowId, eid, name, executorId, ts))
+            v <- withTimeoutAndRetry(name, computation, meta)
+            // The value, its completion event and the clearing of the rows under its path are ONE transition. Split, a store
+            // that fails between them leaves the value durably present and the history saying the step never finished, and the
+            // two readers then disagree forever: replay decides from the field and never runs the step again, while every
+            // operator surface reads the history and reports it unfinished.
+            _ <- fencedProgress(
+                Clock.nowWith(ts =>
+                    claimed.recordProgress[V](name, Maybe(v), Flow.Event.StepCompleted(flowId, eid, name, ts))
+                )
+            )
         yield v
 
     def onStep(name: String, computation: Unit < Sync, frame: Frame, meta: Flow.Meta): Unit < S =
         for
-            _   <- checkClaim
-            _   <- checkInFlight(name, meta.timeout)
-            ts  <- Clock.now
-            _   <- store.appendEvent(eid, Flow.Event.StepStarted(flowId, eid, name, executorId, ts))
-            _   <- withTimeoutAndRetry(name, computation, meta)
-            ts2 <- Clock.now
-            _   <- store.updateStatus(eid, Flow.Status.Running, Flow.Event.StepCompleted(flowId, eid, name, ts2))
+            _ <- guard
+            _ <- appendEvent(ts => Flow.Event.StepStarted(flowId, eid, name, executorId, ts))
+            _ <- withTimeoutAndRetry(name, computation, meta)
+            _ <- fencedProgress(
+                Clock.nowWith(ts => claimed.recordProgress(name, Flow.Event.StepCompleted(flowId, eid, name, ts)))
+            )
         yield ()
+
+    /** The verdict is recorded under the node it is about, then raised.
+      *
+      * This row carries `Abort[FlowException]`, so a declared failure goes back out as a failure and reaches the engine with its kind
+      * intact. See [[FlowInterpreter.onFailure]].
+      *
+      * The two failures that arrive here, a loop that ran its schedule out and a fan-out whose collection changed size, are node-level
+      * verdicts with a kind. Reaching the store as a terminal status and nothing else would leave no event naming the node, so the
+      * progress view would have nothing to paint and every node would read pending while the execution was Failed. The record is
+      * written first, for the reason [[withTimeoutAndRetry]]'s own record is: once the failure is raised it travels through the unwind
+      * and the name is gone.
+      */
+    def onFailure(path: String, error: FlowException): Nothing < S =
+        appendEvent(ts => Flow.Event.StepFailed(flowId, eid, path, error.getMessage, Maybe(error.kind), ts))
+            .andThen(Abort.fail(error))
+
+    /** The node boundary's own check and the node's `timeout` and `retry`, with nothing written. See [[FlowInterpreter.onIteration]]
+      * for why an unscheduled loop's iteration gets the policy without the record.
+      */
+    def onIteration[V](name: String, computation: V < Sync, frame: Frame, meta: Flow.Meta): V < S =
+        guard.andThen(withTimeoutAndRetry(name, computation, meta))
+
+    /** Writes the branch's name under the dispatch's reserved key, with the event that says so, in one transition.
+      *
+      * The field is the record replay reads and the event is what an operator reads, and one write carries both: a crash between two
+      * writes would leave the field without its event, and the dispatch is exactly the node where the two readers must not diverge.
+      */
+    def onChoice(name: String, branch: String, frame: Frame, meta: Flow.Meta): Unit < S =
+        guard.andThen(
+            fencedProgress(
+                Clock.nowWith(ts =>
+                    claimed.recordProgress[String](
+                        FlowInterpreter.chosenKey(name),
+                        Maybe(branch),
+                        Flow.Event.BranchChosen(flowId, eid, name, branch, ts)
+                    )
+                )
+            ).unit
+        )
+
+    /** Writes the value the mapper supplied under the child input's own path, with the event that says so, in one transition.
+      *
+      * Built exactly like [[onChoice]] and for the same reason: the field is what replay reads and the event is what an operator
+      * reads, and a crash between two writes would leave one of them able to answer and the other not. The answer is the store's,
+      * not this interpreter's: an already-recorded path means somebody else's write landed first, which is the race exemption
+      * working rather than a failure, and the caller reads the recorded value back.
+      */
+    def onInputSupplied[V](name: String, value: V, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]): Boolean < S =
+        guard.andThen(
+            fencedProgress(
+                Clock.nowWith(ts =>
+                    claimed.recordProgress[V](name, Maybe(value), Flow.Event.InputSupplied(flowId, eid, name, ts))
+                )
+            )
+        )
 
     def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]): V < S =
         store.getField[V](eid, name).map {
             case Present(v) => v
             case _ =>
-                store.getExecution(eid).map {
-                    case Present(s) if s.status == Flow.Status.Cancelled =>
-                        Abort.fail(FlowCancelledException(eid.value))
-                    case _ =>
-                        Clock.nowWith { now =>
-                            store.updateStatus(
-                                eid,
-                                Flow.Status.WaitingForInput(name),
+                guard.andThen(
+                    Clock.nowWith { now =>
+                        fenced(
+                            claimed.recordWait(
+                                name,
+                                Flow.Wake.OnField(name),
                                 Flow.Event.InputWaiting(flowId, eid, name, now)
-                            ).map(_ =>
-                                Abort.fail[FlowSuspension](FlowSuspension.WaitingForInput(name))
                             )
-                        }
-                }
+                        ).andThen(Abort.fail[FlowSuspension](FlowSuspension.Parked(Set(name))))
+                    }
+                )
+        }
+
+    /** The wait row an input wrote, cleared by the node that consumed the value.
+      *
+      * A satisfied input takes its value from the record and writes nothing else, so without this the row it wrote while parking would
+      * stay outstanding forever and readiness would hand the execution back on every poll. The row's own absence is what makes this
+      * idempotent: a replay past an input that was never waiting on finds nothing to clear and writes nothing.
+      *
+      * The progress is VALUELESS, and that is the one write the write-once rule has to treat differently: the path already carries the
+      * signalled value, so refusing it on field presence would silently delete this event and this clearing.
+      */
+    override def onInputDischarged(name: String, frame: Frame, meta: Flow.Meta): Unit < S =
+        store.getExecution(eid).map {
+            case Present(s) if s.waits.contains(name) =>
+                fencedProgress(
+                    Clock.nowWith(ts => claimed.recordProgress(name, Flow.Event.InputDischarged(flowId, eid, name, ts)))
+                ).unit
+            case _ => ()
         }
 
     def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta): Unit < S =
         if duration <= Duration.Zero then ()
         else
             for
-                _   <- checkClaim
+                _   <- guard
                 now <- Clock.now
                 until = now + duration
-                _ <- store.updateStatus(
-                    eid,
-                    Flow.Status.Sleeping(name, until),
-                    Flow.Event.SleepStarted(flowId, eid, name, until, now)
+                _ <- fenced(
+                    claimed.recordWait(
+                        name,
+                        Flow.Wake.At(until),
+                        Flow.Event.SleepStarted(flowId, eid, name, until, now)
+                    )
                 )
-            yield Abort.fail[FlowSuspension](FlowSuspension.Sleeping(name, until))
+            yield Abort.fail[FlowSuspension](FlowSuspension.Parked(Set(name)))
 
+    /** Joins two branches, where a FAILURE decides the composition immediately.
+      *
+      * Letting suspension outrank failure here would discard the branch that failed and re-run it from the start on every resume, with
+      * its retry schedule and its side effects, until the other branch stopped waiting. A `zip` needs every branch, so once one has
+      * failed the result is already unreachable and nothing is lost by saying so at once; the branches that parked have their rows
+      * retired by the transition that ends the attempt, which is the same rule a decided race gets. Remembering WHICH branch failed
+      * would need durable state, and this needs none.
+      */
     def onZip(
         left: Record[Any] < S,
         right: Record[Any] < S,
         ctx: Record[Any],
         isolate: Isolate[Any, Abort[FlowException] & Async, Any]
     ): Record[Any] < S =
-        type R = Result[FlowSuspension, Result[FlowException, Record[Any]]]
+        type R = Result[FlowSuspension, Result[FlowException | FlowStoreException, Record[Any]]]
         isolate.capture { state =>
-            val isoLeft  = isolate.isolate(state, Abort.run[FlowSuspension](Abort.run[FlowException](left)))
-            val isoRight = isolate.isolate(state, Abort.run[FlowSuspension](Abort.run[FlowException](right)))
+            val isoLeft =
+                isolate.isolate(state, Abort.run[FlowSuspension](Abort.run[FlowException | FlowStoreException](left)))
+            val isoRight =
+                isolate.isolate(state, Abort.run[FlowSuspension](Abort.run[FlowException | FlowStoreException](right)))
             Fiber.internal.foreachIndexed(Chunk.Indexed(isoLeft, isoRight), 2)((_, v) => v).map { fiber =>
                 fiber.use { results =>
                     Kyo.foreach(results)(isolate.restore(_)).map { restored =>
@@ -195,14 +439,21 @@ private[kyo] class StoreInterpreter(
                         (lr, rr) match
                             case (Result.Success(Result.Success(l)), Result.Success(Result.Success(r))) =>
                                 new Record[Any](ctx.toDict ++ l.toDict ++ r.toDict)
-                            case (Result.Failure(s), _)                 => Abort.fail[FlowSuspension](s)
-                            case (_, Result.Failure(s))                 => Abort.fail[FlowSuspension](s)
+                            // A failure decides the zip, ahead of any sibling's suspension: the composition needs every branch,
+                            // so its result is already unreachable, and parking on the sibling instead re-runs the failed branch
+                            // from the start on every resume until that sibling happens to stop waiting.
                             case (Result.Success(Result.Failure(e)), _) => Abort.fail(e)
                             case (_, Result.Success(Result.Failure(e))) => Abort.fail(e)
                             case (Result.Panic(e), _)                   => Abort.panic(e)
                             case (_, Result.Panic(e))                   => Abort.panic(e)
                             case (Result.Success(Result.Panic(e)), _)   => Abort.panic(e)
                             case (_, Result.Success(Result.Panic(e)))   => Abort.panic(e)
+                            // Both branches parked, so the composition is waiting on BOTH sets of conditions and a token
+                            // naming one of them makes the other unreachable. Merging is what makes a nested composition's
+                            // every parked branch wake on its own condition.
+                            case (Result.Failure(l), Result.Failure(r)) => Abort.fail(FlowSuspension.merge(l, r))
+                            case (Result.Failure(s), _)                 => Abort.fail[FlowSuspension](s)
+                            case (_, Result.Failure(s))                 => Abort.fail[FlowSuspension](s)
                             case _                                      => Abort.panic(new RuntimeException("unreachable: zip result"))
                         end match
                     }
@@ -211,33 +462,106 @@ private[kyo] class StoreInterpreter(
         }
     end onZip
 
+    /** Races two branches, where only a VALUE decides the outcome.
+      *
+      * A branch that fails does not decide a race the other branch can still win. `race(notify-via-flaky-api, input("manual-ack"))`
+      * exists precisely so the acknowledgement can rescue a failed notification, and a failure-wins rule terminally fails the flow
+      * while the answer it is waiting for is still deliverable, which deletes the idiom. So a failed branch is treated like a
+      * decided-away one: the composition parks on the surviving branches' merged parks, the failure stays recorded in the failing
+      * step's own events, and nothing else remembers it. Only a race whose every branch failed fails, with the last failure as its
+      * verdict, because from that point no branch can win any longer.
+      *
+      * Each branch's outcome is recorded as it ends rather than read off the race's own result, and the reason is what the race
+      * completes with: the first VALUE, or, if no branch produced one, the LAST error. The first value is the winner and needs
+      * nothing else. The last error is one branch's ending standing in for every branch's, which is exactly the choice this rule
+      * takes away from the scheduler, so the join re-decides from all of them.
+      */
     def onRace(
         left: Record[Any] < S,
         right: Record[Any] < S,
         isolate: Isolate[Any, Abort[FlowException] & Async, Any]
     ): Record[Any] < S =
-        isolate.capture { state =>
-            Fiber.internal.race(Seq(
-                isolate.isolate(state, left),
-                isolate.isolate(state, right)
-            )).map(fiber => isolate.restore(fiber.get))
+        type R = Result[FlowSuspension, Result[FlowException | FlowStoreException, Record[Any]]]
+
+        def reraise(outcome: R): Record[Any] < S =
+            outcome match
+                case Result.Success(Result.Success(record)) => record
+                case Result.Failure(suspension)             => Abort.fail[FlowSuspension](suspension)
+                case Result.Success(Result.Failure(e))      => Abort.fail(e)
+                case Result.Success(Result.Panic(e))        => Abort.panic(e)
+                case Result.Panic(e)                        => Abort.panic(e)
+                case _ => Abort.panic(new IllegalStateException("a race branch ended with neither a value nor an error"))
+
+        def decide(all: Chunk[R]): Record[Any] < S =
+            val parked = all.foldLeft(Maybe.empty[FlowSuspension]) {
+                case (acc, Result.Failure(suspension)) => Maybe(acc.fold(suspension)(FlowSuspension.merge(_, suspension)))
+                case (acc, _)                          => acc
+            }
+            parked match
+                case Present(suspension) => Abort.fail[FlowSuspension](suspension)
+                case Absent =>
+                    if all.isEmpty then Abort.panic(new IllegalStateException("a race ended with no branch outcome"))
+                    else reraise(all(all.size - 1))
+            end match
+        end decide
+
+        // The branches run in their own fibers, so the outcome each one ends with has to reach the join somehow; an atomic
+        // cell scoped to this one composition is the smallest thing that carries it.
+        AtomicRef.init(Chunk.empty[R]).map { outcomes =>
+            isolate.capture { state =>
+                def branch(b: Record[Any] < S) =
+                    isolate.isolate(
+                        state,
+                        Abort.run[FlowSuspension](Abort.run[FlowException | FlowStoreException](b)).map { outcome =>
+                            outcomes.updateAndGet(_.append(outcome)).andThen(reraise(outcome))
+                        }
+                    )
+                Fiber.internal.race(Seq(branch(left), branch(right))).map { fiber =>
+                    Abort.run[FlowSuspension](Abort.run[FlowException | FlowStoreException](isolate.restore(fiber.get))).map {
+                        case Result.Success(Result.Success(record)) => record
+                        case _                                      => outcomes.use(decide)
+                    }
+                }
+            }
         }
+    end onRace
 
     override def checkCancelled: Boolean < S =
         store.getExecution(eid).map {
-            case Present(s) => s.status == Flow.Status.Cancelled
+            case Present(s) => s.cancelRequested
             case _          => false
         }
 
-    override def onCompensationStart: Unit < S =
+    override def onCompensationStart(cause: Flow.Cause): Unit < S =
         Clock.nowWith { ts =>
-            store.updateStatus(eid, Flow.Status.Compensating, Flow.Event.CompensationStarted(flowId, eid, ts))
+            fencedStatus(
+                claimed.updateStatus(Flow.Status.Compensating(cause), Flow.Event.CompensationStarted(flowId, eid, cause, ts))
+            )
         }
 
     override def onCompensationComplete: Unit < S =
-        withEvent(ts => Flow.Event.CompensationCompleted(flowId, eid, ts))(())
+        appendEvent(ts => Flow.Event.CompensationCompleted(flowId, eid, ts))
 
     override def onCompensationFailed(error: Throwable): Unit < S =
-        withEvent(ts => Flow.Event.CompensationFailed(flowId, eid, error.getMessage, ts))(())
+        appendEvent(ts => Flow.Event.CompensationFailed(flowId, eid, error.getMessage, ts))
+
+    /** One handler ran to completion, recorded durably so a resumed unwind does not run it a second time.
+      *
+      * The same shape a step's own completion has, one path down: a valueless progress under a key of the handler's own, refused by
+      * write-once if it is already there. It cannot ride the node's own path, because the node's completion already occupies it and the
+      * handler's write would be answered already-recorded before it ever meant anything.
+      *
+      * Only a handler that SUCCEEDED is recorded. One that threw has no completion, so a later attempt runs it again, which is what an
+      * unwind that could not finish should do.
+      */
+    override def onCompensated(name: String): Unit < S =
+        fencedProgress(
+            Clock.nowWith(ts =>
+                claimed.recordProgress(
+                    FlowInterpreter.compensatedKey(name),
+                    Flow.Event.NodeCompensated(flowId, eid, name, ts)
+                )
+            )
+        ).unit
 
 end StoreInterpreter

--- a/kyo-flow/shared/src/main/scala/kyo/internal/WorkflowSchema.scala
+++ b/kyo-flow/shared/src/main/scala/kyo/internal/WorkflowSchema.scala
@@ -4,34 +4,31 @@ import kyo.*
 
 /** A typed entry linking a runtime type to its serialization codec and tag.
   *
-  * TypeEntry[V] ensures schema, tag, and concreteTag are all for the same V. The type parameter is erased when stored in WorkflowSchema's
-  * map, but Tag-based lookup provides a safe downcast.
+  * TypeEntry[V] ensures schema and tag are both for the same V. The type parameter is erased when stored in WorkflowSchema's map, but
+  * Tag-based lookup provides a safe downcast.
   */
-private[kyo] case class TypeEntry[V](tag: Tag[V], schema: Schema[V], postDecode: Any => Any = identity):
+private[kyo] case class TypeEntry[V](tag: Tag[V], schema: Schema[V]):
     def encode(value: V)(using Frame): FlowStore.FieldData = FlowStore.FieldData(schema.encodeString[Json](value), tag.erased)
     def decode(data: FlowStore.FieldData)(using Frame): Maybe[V] =
         if !(data.tag =:= tag.erased) then Maybe.empty
-        else schema.decodeString[Json](data.value).toMaybe.map(v => postDecode(v).asInstanceOf[V])
+        else schema.decodeString[Json](data.value).toMaybe
 end TypeEntry
 
-/** The schema of a workflow — all type entries for its inputs and outputs.
+/** The schema of a workflow: all type entries for its inputs and outputs.
   *
   * Immutable, derived from the flow AST. Serves as the bridge between serialized store state and live runtime types.
   */
 private[kyo] case class WorkflowSchema(
-    byTag: Dict[Tag[Any], TypeEntry[Any]],
-    byName: Dict[String, TypeEntry[Any]]
+    byName: Dict[String, TypeEntry[Any]],
+    subflows: Chunk[WorkflowSchema.SubflowAssembly]
 ):
 
-    /** Runtime typed lookup — Tag is the proof for the safe cast. */
-    def apply[V](using tag: Tag[V]): Maybe[TypeEntry[V]] =
-        byTag.get(tag.erased).map(_.asInstanceOf[TypeEntry[V]])
-
-    /** Store recovery — match a stored tag.show string against registered tags. */
-    def fromStore(tagStr: String): Maybe[TypeEntry[Any]] =
-        byTag.find((tag, _) => tag.show == tagStr).map((_, entry) => entry)
-
-    /** Lookup by output/input name — for result reconstruction. */
+    /** Lookup by the name the store holds a field under, which is the node's composition path.
+      *
+      * The only index this carries, and the only one replay can use: a stored field is found by the path it was written under, and its
+      * declared type is then compared against the reader's. A tag-keyed index answers a question nobody asks, because two nodes of one
+      * flow routinely persist the same type and the tag alone cannot say which of them a field belongs to.
+      */
     def fromStoreName(name: String): Maybe[TypeEntry[Any]] =
         byName.get(name)
 
@@ -39,34 +36,137 @@ end WorkflowSchema
 
 private[kyo] object WorkflowSchema:
 
-    /** XXH32 hash of the flow's structure (names, types, node types). */
-    def structuralHash(flow: Flow[?, ?, ?]): String =
-        val structure = FlowFold(flow)(new FlowVisitorCollect[String]("", _ + "|" + _):
-            override def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) = s"O:$name:${Tag[V].show}"
-            override def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V])  = s"I:$name:${Tag[V].show}"
-            override def onStep(name: String, frame: Frame, meta: Flow.Meta)                               = s"S:$name"
-            override def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta)          = s"SL:$name:$duration"
-            override def onDispatch(name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
-                s"D:$name:${branches.map(_.name).mkString(",")}"
-            override def onLoop(name: String, frame: Frame, meta: Flow.Meta)                              = s"L:$name"
-            override def onForEach(name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)         = s"FE:$name:$concurrency"
-            override def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta) = s"INV:$name")
-        java.lang.Integer.toHexString(XXHash.hash32(structure))
-    end structuralHash
-
     import Flow.internal.*
 
-    private type Maps = (Dict[Tag[Any], TypeEntry[Any]], Dict[String, TypeEntry[Any]])
-    private val empty: Maps                   = (Dict.empty, Dict.empty)
-    private def merge(a: Maps, b: Maps): Maps = (a._1 ++ b._1, a._2 ++ b._2)
+    /** How a subflow's promised field is put back together from what the store holds.
+      *
+      * `.subflow("result", child)` types the parent's record with `"result" ~ Record[Out2]` and the node persists nothing under that
+      * name by design: the child's nodes write under `result~<name>`, which is what makes two instances of one subflow two sets of
+      * fields rather than one set written twice. A reader that hands back a typed record therefore owes the assembly, and this is the
+      * entry it asks for.
+      *
+      * It nests, because a subflow inside a subflow is a path inside a path: the entry for `outer` carries the entry for `inner`, and
+      * assembling the first assembles the second under it.
+      *
+      * What the assembled record carries is what the store holds under the path, which is everything the child ran on: its inputs,
+      * written at the instance's entry before the child's first node, and everything the child computed after them. That is what
+      * `Record[Out2]` promises, inputs included, so the assembled record answers every field the type says it has.
+      *
+      * @param name
+      *   the subflow instance's own name, which is where the assembled record sits in its parent
+      * @param path
+      *   the durable path the child's fields sit under, `outer~inner` for an instance two levels down
+      * @param children
+      *   the subflow instances the child itself declares
+      */
+    case class SubflowAssembly(name: String, path: String, children: Chunk[SubflowAssembly]):
 
-    private def entry(name: String, tag: Tag[Any], schema: Schema[Any]): Maps =
-        val e = TypeEntry(tag, schema)
-        (Dict(tag -> e), Dict(name -> e))
+        /** The record this instance's field holds, built from the fields a reader has already decoded.
+          *
+          * The child's own fields are the ones directly under the path. A node's name cannot carry the separator, since registration
+          * refuses one that does, so a name that still carries it once the path is stripped belongs to a subflow the child declares
+          * and is assembled by that instance's own entry rather than landing here flattened.
+          */
+        def assemble(decoded: Dict[String, Any]): Record[Any] =
+            val prefix = s"$path${NodePath.Separator}"
+            val own = decoded.foldLeft(Dict.empty[String, Any]) { (acc, name, value) =>
+                if !name.startsWith(prefix) then acc
+                else
+                    val bare = name.substring(prefix.length)
+                    if bare.indexOf(NodePath.Separator) >= 0 then acc else acc.update(bare, value)
+            }
+            new Record[Any](children.foldLeft(own)((acc, child) => acc.update(child.name, child.assemble(decoded))))
+        end assemble
 
-    /** Build a schema by walking all AST nodes and collecting type entries. */
+    end SubflowAssembly
+
+    /** XXH32 hash of the flow's version identity: the shape it composes its nodes in, and the type of every value it persists.
+      *
+      * Version identity is what tells an engine that the code changed under an execution it is about to resume, so it covers two
+      * things. The shape is walked with a total [[FlowVisitor]], so every combinator contributes its own bracket and sequencing,
+      * zipping and racing the same nodes are three different versions; a subflow contributes its body rather than its name, so a
+      * child rewritten under a parent is a new version of the parent. The types are listed separately, in walk order, because
+      * replay decodes every persisted field back through [[WorkflowSchema]]: a loop that stored an `Int` and one that stores a
+      * `String` are different versions even where their shapes match, and resuming the second against the first's state fails the
+      * decode, drops the field, and re-runs the node it belonged to with its side effects.
+      */
+    def structuralHash(flow: Flow[?, ?, ?]): String =
+        val walked   = FlowFold(flow)(IdentityVisitor)
+        val identity = walked.shape + "||" + walked.types.mkString("|")
+        java.lang.Integer.toHexString(XXHash.hash32(identity))
+    end structuralHash
+
+    /** A flow's version identity as one walk produces it: the composition shape, and the types listed in walk order.
+      *
+      * @param shape
+      *   each node's kind, name and shape-bearing arguments, with each combinator's own bracket
+      * @param types
+      *   the type of every value the flow persists, one entry per field replay decodes, depth first and left to right
+      */
+    private case class Identity(shape: String, types: Chunk[String])
+
+    /** Both halves of the identity, from one total walk.
+      *
+      * Total rather than defaulted, so a node kind added to the AST states what it contributes to the version instead of folding away
+      * silently. A flow's own name and metadata are labels rather than shape, so they are deliberately absent: renaming a flow or
+      * editing its description must not hold every execution running under it.
+      *
+      * Type entries are positional and never keyed or sorted, so two nodes sharing a name stay two entries, and the result depends on
+      * nothing but the AST's shape and its nodes' tags: no map or set iteration order, no frames, no closures, so the same flow yields
+      * the same string in every process on every platform. See [[structuralHash]] for why the types are part of the identity at all.
+      *
+      * A subflow contributes its CHILD's shape under its own bracket and its child's type entries at the position it occupies, so a
+      * change inside a child re-keys every parent that embeds it, in both halves.
+      */
+    private object IdentityVisitor extends FlowVisitor[Identity]:
+        def onInit(name: String, frame: Frame, meta: Flow.Meta) = Identity("INIT", Chunk.empty)
+        def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+            Identity(s"I:$name:${Tag[V].show}", Chunk(s"$name:${Tag[V].show}"))
+        def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+            Identity(s"O:$name:${Tag[V].show}", Chunk(s"$name:${Tag[V].show}"))
+        def onStep(name: String, frame: Frame, meta: Flow.Meta)                      = Identity(s"S:$name", Chunk.empty)
+        def onSleep(name: String, duration: Duration, frame: Frame, meta: Flow.Meta) = Identity(s"SL:$name:$duration", Chunk.empty)
+        def onDispatch[V](name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+            Identity(s"D:$name:${branches.map(_.name).mkString(",")}", Chunk(s"$name:${Tag[V].show}"))
+        def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V], Tag[State], Schema[State]) =
+            Identity(s"L:$name", Chunk(s"$name:${Tag[V].show}:${Tag[State].show}"))
+        def onForEach[V](name: String, concurrency: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
+            Identity(s"FE:$name:$concurrency", Chunk(s"$name:${Tag[V].show}"))
+        def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Identity, frame: Frame, meta: Flow.Meta) =
+            Identity(s"INV:$name(${child.shape})", child.types)
+        def onAndThen(first: Identity, second: Identity, frame: Frame) =
+            Identity(s"SEQ(${first.shape},${second.shape})", first.types ++ second.types)
+        def onZip(left: Identity, right: Identity, frame: Frame) =
+            Identity(s"ZIP(${left.shape},${right.shape})", left.types ++ right.types)
+        def onRace(left: Identity, right: Identity, frame: Frame) =
+            Identity(s"RACE(${left.shape},${right.shape})", left.types ++ right.types)
+        def onGather(flows: Seq[Identity], frame: Frame) =
+            Identity(
+                s"ALL(${flows.map(_.shape).mkString(",")})",
+                flows.foldLeft(Chunk.empty[String])((acc, f) => acc ++ f.types)
+            )
+    end IdentityVisitor
+
+    private type Entries = Dict[String, TypeEntry[Any]]
+    private val empty: Entries                         = Dict.empty
+    private def merge(a: Entries, b: Entries): Entries = a ++ b
+
+    private def entry(name: String, tag: Tag[Any], schema: Schema[Any]): Entries =
+        Dict(name -> TypeEntry(tag, schema))
+
+    /** Every entry of `entries`, re-keyed under a subflow instance's path, which is what the store holds a child's fields under. */
+    private def underPath(path: String, entries: Entries): Entries =
+        entries.foldLeft(Dict.empty[String, TypeEntry[Any]]) { (acc, name, e) =>
+            acc.update(NodePath.qualify(path, name), e)
+        }
+
+    /** Build a schema by walking all AST nodes and collecting type entries.
+      *
+      * A child's entries are keyed by their path, because that is what the store holds them under. Two instances of one subflow are two
+      * sets of entries, which is exactly what makes both instances decodable from one execution's fields.
+      */
     def of(flow: Flow[?, ?, ?]): WorkflowSchema =
-        def loop(f: Flow[?, ?, ?]): Maps =
+        def loop(f: Flow[?, ?, ?]): Entries =
             f match
                 case n: Output[?, ?, ?, ?, ?] @unchecked =>
                     entry(n.name, n.erased.tag, n.erased.schema)
@@ -77,11 +177,11 @@ private[kyo] object WorkflowSchema:
                 case n: LoopNode[?, ?, ?, ?, ?] @unchecked =>
                     entry(n.name, n.erased.tag, n.erased.schema)
                 case n: ForEach[?, ?, ?, ?, ?] @unchecked =>
-                    given Schema[Any] = n.erased.schema
-                    val seqSchema     = summon[Schema[Seq[Any]]].asInstanceOf[Schema[Any]]
-                    val e             = TypeEntry[Any](Tag[Any], seqSchema, v => Chunk.from(v.asInstanceOf[Seq[Any]]))
-                    (Dict(Tag[Any] -> e), Dict(n.name -> e))
-                case n: Subflow[?, ?, ?, ?, ?, ?] @unchecked => loop(n.childFlow)
+                    // The node carries the evidence for the whole `Chunk[V]` it persists, captured at the DSL site, so the entry
+                    // replay decodes through is built the same way every other node's is. Building it here from a `Tag[Any]` and a
+                    // `Seq` schema instead would produce an entry no typed read could ever match.
+                    entry(n.name, n.erased.tag.erased, n.erased.schema.asInstanceOf[Schema[Any]])
+                case n: Subflow[?, ?, ?, ?, ?, ?] @unchecked => underPath(n.name, loop(n.childFlow))
                 case _: Sleep                                => empty
                 case _: Step[?, ?]                           => empty
                 case n: AndThen[?, ?, ?, ?, ?, ?] @unchecked =>
@@ -93,8 +193,26 @@ private[kyo] object WorkflowSchema:
                 case n: Gather[?, ?, ?] @unchecked =>
                     n.flows.foldLeft(empty)((acc, f) => merge(acc, loop(f)))
                 case _: Init => empty
-        val (tagMap, nameMap) = loop(flow)
-        WorkflowSchema(tagMap, nameMap)
+        WorkflowSchema(loop(flow), subflowsOf(flow, ""))
     end of
+
+    /** Every subflow instance the flow declares, each under the durable path its child's fields sit under.
+      *
+      * Nested rather than flat, because assembling a parent's field means knowing which of the names under its path are the child's own
+      * and which belong to an instance the child itself declares. A combinator is not a path component, so a subflow inside a `zip` or
+      * a `race` branch sits at the same level as one written in sequence.
+      */
+    private def subflowsOf(flow: Flow[?, ?, ?], path: String): Chunk[SubflowAssembly] =
+        flow match
+            case n: Subflow[?, ?, ?, ?, ?, ?] @unchecked =>
+                val instance  = n.name: String
+                val childPath = NodePath.qualify(path, instance)
+                Chunk(SubflowAssembly(instance, childPath, subflowsOf(n.childFlow, childPath)))
+            case n: AndThen[?, ?, ?, ?, ?, ?] @unchecked => subflowsOf(n.first, path) ++ subflowsOf(n.second, path)
+            case n: Zip[?, ?, ?, ?, ?, ?] @unchecked     => subflowsOf(n.left, path) ++ subflowsOf(n.right, path)
+            case n: Race[?, ?, ?, ?, ?, ?] @unchecked    => subflowsOf(n.left, path) ++ subflowsOf(n.right, path)
+            case n: Gather[?, ?, ?] @unchecked =>
+                n.flows.foldLeft(Chunk.empty[SubflowAssembly])((acc, f) => acc ++ subflowsOf(f, path))
+            case _ => Chunk.empty
 
 end WorkflowSchema

--- a/kyo-flow/shared/src/test/scala/kyo/FlowEngineForeachTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/FlowEngineForeachTest.scala
@@ -1,0 +1,724 @@
+package kyo
+
+/** What a `foreach` makes durable, per item, and what a resumed attempt does with it.
+  *
+  * An aspect file of `FlowEngineTest`, sharing its helpers through [[FlowEngineSupport]]. The split is forced rather than stylistic: a
+  * test class carries the body of every leaf it registers in its constructor, the JVM caps how large a class may be, and the engine
+  * suite sits at that cap. The fan-out leaves are the natural aspect to lift out, because every one of them is about one question,
+  * whether an item's durable record survives an attempt ending.
+  */
+class FlowEngineForeachTest extends FlowEngineSupport:
+
+    // =========================================================================
+    // Foreach durability
+    // =========================================================================
+    "foreach durability" - {
+
+        /** An interrupted fan-out resumes at the item it stopped on, rather than charging every card a second time.
+          *
+          * This is what per-item durability is FOR. A fan-out over a runtime collection is the only construct here for N external
+          * effects, since `gather` is fixed at definition time. Each item's result is a durable field of its own and an attempt that
+          * resumes reads back the ones already recorded, so a fan-out that charges five cards and dies on the third charges the three
+          * it owes on recovery rather than all five again.
+          *
+          * The handoff is real, the same instrument the loop and retry leaves use: the first engine's scope is closed while the
+          * fan-out is running, the clock passes the lease, and a second engine on the same store claims the row the ordinary way.
+          * Nothing is seeded and no store verb is decorated.
+          *
+          * **Where the interrupt lands is chosen rather than raced.** The settle waits for the first item's durable FIELD, not for
+          * the counter, and the count is what makes that deterministic: the field is written after its item finished, the next item
+          * is a virtual second away from its own, and the settle stops advancing time the moment it sees the field. So the item in
+          * flight when the engine goes is asleep and has charged nothing, and the total is exact rather than "at most one more".
+          */
+        "a foreach interrupted part-way resumes without re-charging the items it already charged" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(0).map { charges =>
+                        val items = 5
+                        val wfId  = Flow.Id.Workflow("fanout-handoff")
+                        val flow = Flow.init("fanout-handoff")
+                            .foreach("charges", concurrency = 1)(_ => (1 to items).toSeq) { item =>
+                                // Counted once the card is really charged, so an item interrupted in flight counts for nothing
+                                // and the assertion below is about charges that actually happened.
+                                val body: Int < Async =
+                                    Async.sleep(1.second).andThen(charges.incrementAndGet).map(_ => item * 10)
+                                body
+                            }
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 2.seconds,
+                            renewEvery = 500.millis,
+                            pollTimeout = 100.millis
+                        )
+                        for
+                            eid <- Scope.run {
+                                FlowEngine.init(store, config, flow)([v] => (c: v < Async) => c).map { first =>
+                                    first.workflows.start(wfId).map { handle =>
+                                        settle(tc, step = 100.millis, maxRounds = 60)(
+                                            store.getField[Int](handle.executionId, "charges~0").map(_.isDefined)
+                                        ).andThen(handle.executionId)
+                                    }
+                                }
+                            }
+                            before <- charges.get
+                            _      <- tc.advance(10.seconds)
+                            _ <- Scope.run {
+                                FlowEngine.init(store, config, flow)([v] => (c: v < Async) => c).map { _ =>
+                                    settle(tc, step = 250.millis, maxRounds = 200)(
+                                        store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                    )
+                                }
+                            }
+                            after   <- charges.get
+                            state   <- store.getExecution(eid)
+                            results <- store.getField[Chunk[Int]](eid, "charges")
+                            fields  <- store.getAllFields(eid)
+                        yield
+                            assert(
+                                before >= 1 && before < items,
+                                s"the premise is that the first engine charged some of the $items cards and not all of them, " +
+                                    s"and it charged $before"
+                            )
+                            assert(
+                                (0 until items).forall(i => fields.contains(s"charges~$i")),
+                                s"an item is durably named by its position under the fan-out's own path, and " +
+                                    s"${(0 until items).count(i => fields.contains(s"charges~$i"))} of the $items are stored " +
+                                    s"under one, out of ${fields.size} fields in all"
+                            )
+                            assert(
+                                state.exists(_.status == Flow.Status.Completed),
+                                s"the premise is that the second engine finished the execution, got ${state.map(_.status)}"
+                            )
+                            assert(
+                                results.map(_.toSeq) == Present(Seq(10, 20, 30, 40, 50)),
+                                s"a resumed fan-out must still produce every result in collection order, got $results"
+                            )
+                            assert(
+                                after == items,
+                                s"an item already recorded must be read back rather than run again: $items cards were charged " +
+                                    s"$after times in total, $before of them before the handoff"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** The same handoff above one worker, where what an attempt recorded is no longer a prefix of the collection.
+          *
+          * The leaf above runs its items one at a time, so the fan-out it hands over always has a prefix shape: items 0 to k
+          * recorded, everything after k untouched. Above one worker that shape is gone. The workers pull the next index off a shared
+          * counter, so a fast item lands while a slower one EARLIER in the collection is still running, and what the store carries at
+          * the handoff has a hole in it: index 0 absent while 1 and 2 are recorded. A resume that read its own progress as "the first
+          * index with no result, and everything after it" would charge those two cards a second time and still pass the leaf above.
+          *
+          * **The hole is built rather than raced.** Index 0 runs for five virtual seconds, index 1 for one and index 2 for two, so
+          * the settle that stops on the second recorded item stops three virtual seconds before anything else could land. The premise
+          * asserts the shape it built, because a leaf whose handoff happened to be a prefix would be the leaf above with a larger
+          * `concurrency`.
+          *
+          * **What is deliberately NOT asserted here is the total number of charges, and that is a property of concurrency rather
+          * than a gap in the leaf.** An item is charged by its body and recorded once its body returns, so an attempt that ends
+          * between the two leaves a card charged with no result to read back, and the resumed attempt charges it again. With N
+          * workers there can be N-1 items inside that window at once, which bounds the total at `items + concurrency - 1` rather
+          * than fixing it. Index 3 is put inside the window on purpose, charging half a second after it starts and holding its
+          * result for four more, so it is charged before the handoff and recorded on neither side of it: the premise says so, and it
+          * is why counting charges here would be counting a scheduling outcome. The exact total is the leaf above's to assert, where
+          * one worker means the window holds one item and the settle closes it before the engine goes.
+          *
+          * What is exact above one worker is the property the durable record exists for, and it is asserted per item over exactly
+          * the items the store carried at the handoff: each of them is charged once, and the resume charges none of them again.
+          */
+        "a foreach interrupted above concurrency one does not re-charge the items it recorded out of order" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicRef.init(Chunk.empty[Int]).map { charges =>
+                        val items = 4
+                        val wfId  = Flow.Id.Workflow("fanout-concurrent-handoff")
+                        // How long an item runs before it charges, and how long it holds the charged result before returning it.
+                        // The hold is what puts an item inside the window between a side effect and the record of it.
+                        def timing(item: Int): (Duration, Duration) = item match
+                            case 0 => (5.seconds, Duration.Zero)
+                            case 1 => (1.second, Duration.Zero)
+                            case 2 => (2.seconds, Duration.Zero)
+                            case _ => (500.millis, 4.seconds)
+                        val flow = Flow.init("fanout-concurrent-handoff")
+                            .foreach("charges", concurrency = 3)(_ => (0 until items).toSeq) { item =>
+                                val (until, hold) = timing(item)
+                                val body: Int < Async =
+                                    Async.sleep(until)
+                                        .andThen(charges.updateAndGet(_.append(item)))
+                                        .andThen(Async.sleep(hold))
+                                        .map(_ => item * 10)
+                                body
+                            }
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 2.seconds,
+                            renewEvery = 500.millis,
+                            pollTimeout = 100.millis
+                        )
+                        // Which items the store carries a result for, by position, which is the set the read-back property is about.
+                        def recorded(eid: Flow.Id.Execution): Set[Int] < (Async & Abort[FlowStoreException]) =
+                            store.getAllFields(eid).map { fields =>
+                                (0 until items).filter(i => fields.contains(s"charges~$i")).toSet
+                            }
+                        for
+                            eid <- Scope.run {
+                                FlowEngine.init(store, config, flow)([v] => (c: v < Async) => c).map { first =>
+                                    first.workflows.start(wfId).map { handle =>
+                                        settle(tc, step = 100.millis, maxRounds = 120)(
+                                            recorded(handle.executionId).map(_.size >= 2)
+                                        ).andThen(handle.executionId)
+                                    }
+                                }
+                            }
+                            held   <- recorded(eid)
+                            before <- charges.get
+                            _      <- tc.advance(10.seconds)
+                            _ <- Scope.run {
+                                FlowEngine.init(store, config, flow)([v] => (c: v < Async) => c).map { _ =>
+                                    settle(tc, step = 250.millis, maxRounds = 200)(
+                                        store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                    )
+                                }
+                            }
+                            state   <- store.getExecution(eid)
+                            results <- store.getField[Chunk[Int]](eid, "charges")
+                            after   <- charges.get
+                        yield
+                            assert(
+                                held.size == 2 && !held.contains(0),
+                                s"the premise is a handoff with a hole in it, two items recorded and the first item not among " +
+                                    s"them, and the store carried $held"
+                            )
+                            assert(
+                                before.toSeq.contains(3) && !held.contains(3),
+                                s"the premise is that one item sat inside the window the bound is about, charged and not yet " +
+                                    s"recorded when the attempt ended, and the first engine charged $before with $held recorded"
+                            )
+                            assert(
+                                state.exists(_.status == Flow.Status.Completed),
+                                s"the premise is that the second engine finished the execution, got ${state.map(_.status)}"
+                            )
+                            assert(
+                                results.map(_.toSeq) == Present(Seq(0, 10, 20, 30)),
+                                s"a fan-out resumed from an out-of-order record must still produce every result in collection " +
+                                    s"order, got $results"
+                            )
+                            val charged = held.toSeq.sorted.map(i => (i, after.toSeq.count(_ == i)))
+                            assert(
+                                charged.forall(_._2 == 1),
+                                s"an item whose result the store already carries must never be charged again, and the charge " +
+                                    s"counts of the items recorded before the handoff, by item, are $charged; the whole log " +
+                                    s"is $after"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A fan-out that failed part-way unwinds over the items that ran, and over no others.
+          *
+          * The reason the handler belongs to the ITEM. A node-level handler receives the node's stored value, and a fan-out's value
+          * exists only once every item has landed, so a fan-out that failed on its third card would hand its handler nothing at the
+          * one moment unwinding matters. Per-item identity makes the pairing well defined: each item's handler is registered as that
+          * item completes, carrying the item and what the item produced.
+          *
+          * `concurrency = 1` so the set of items that ran is a fact rather than a scheduling outcome: the first two cards are charged
+          * and recorded, the third throws, and nothing else started. The refunds are asserted as a sorted set, because the unwind
+          * runs handlers in reverse order of registration and the order among a fan-out's items is not a property this pins.
+          */
+        "a partially completed foreach unwinds exactly the items that ran" in {
+            withEngine { (engine, store, tc) =>
+                AtomicRef.init(Chunk.empty[String]).map { refunded =>
+                    val flow = Flow.init("charge-cards")
+                        .foreachCompensated("charges", concurrency = 1)(_ => Seq("a", "b", "c")) { card =>
+                            if card == "c" then throw new RuntimeException("declined") else s"receipt-$card"
+                        } { (card, receipt) =>
+                            refunded.updateAndGet(_.append(s"$card:$receipt")).unit
+                        }
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        status <- pump(tc, store, eid, _.isTerminal, 400)
+                        back   <- refunded.get
+                    yield
+                        assert(
+                            status != Flow.Status.Completed,
+                            s"the premise is that the third card failed the fan-out, got $status"
+                        )
+                        assert(
+                            back.toSeq.sorted == Seq("a:receipt-a", "b:receipt-b"),
+                            s"a fan-out that failed part-way must undo the items that ran and no others, it undid $back"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** A fan-out whose results were replayed rather than computed is still undone item by item.
+          *
+          * The half that is easy to get wrong, and the same one the dispatch arm has a leaf for. An execution that suspends after the
+          * fan-out and fails after resuming never runs the item bodies a second time, because every item's field is already stored
+          * and the node's own field with them, so a handler pushed only where an item is COMPUTED would silently not exist on the
+          * attempt that actually unwinds. The cards are charged just as much either way.
+          *
+          * The premise that the bodies did not run again is asserted first, because a leaf that undid three cards after charging six
+          * of them would be reporting a different fact than the one it is named for.
+          */
+        "a foreach's per-item compensation runs after the execution resumed past the fan-out" in {
+            withEngine { (engine, store, tc) =>
+                AtomicRef.init(Chunk.empty[String]).map { refunded =>
+                    AtomicInt.init(0).map { charged =>
+                        val flow = Flow.init("charge-then-wait")
+                            .foreachCompensated("charges", concurrency = 1)(_ => Seq("a", "b", "c")) { card =>
+                                charged.incrementAndGet.map(_ => s"receipt-$card")
+                            } { (card, receipt) =>
+                                refunded.updateAndGet(_.append(card)).unit
+                            }
+                            .input[String]("gate")
+                            .step("ship")(_ => throw new RuntimeException("carrier refused"))
+                        for
+                            _      <- engine.register(wf1, flow)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            _      <- pumpState(tc, store, eid, waitingFor("gate"))
+                            _      <- engine.executions.signal[String](eid, "gate", "go")
+                            status <- pump(tc, store, eid, _.isTerminal, 400)
+                            runs   <- charged.get
+                            back   <- refunded.get
+                        yield
+                            assert(
+                                runs == 3,
+                                s"the premise is that the three cards were charged before the suspension and not again after it, " +
+                                    s"and the body ran $runs times"
+                            )
+                            assert(
+                                status != Flow.Status.Completed,
+                                s"the premise is that the step after the resume failed, got $status"
+                            )
+                            assert(
+                                back.toSeq.sorted == Seq("a", "b", "c"),
+                                s"a fan-out whose results were replayed rather than computed must still be undone item by item, " +
+                                    s"it undid $back"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** An attempt that finished a fan-out somebody else started undoes all of it, not just its own share.
+          *
+          * The leaf above replays a fan-out that was already whole. This one replays a fan-out that was not: the first engine records
+          * some of the cards and goes, the second reads those back and charges the rest, and a later step then fails. Every card that
+          * was charged has to be refunded, whichever attempt charged it, so the handler is registered where an item is READ
+          * BACK exactly as it is where an item is computed. Registering it in only one of the two places leaves a partially recovered
+          * fan-out half undone, and how big that half is depends on where the first engine happened to die.
+          *
+          * The refunds are asserted as the whole set of cards, which is the assertion that cannot pass by accident: it fails one way
+          * if a read-back item registers nothing, and the other way if an item is undone twice.
+          */
+        "a resumed fan-out undoes the items it read back as well as the ones it ran" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicRef.init(Chunk.empty[Int]).map { refunded =>
+                        val items = 5
+                        val wfId  = Flow.Id.Workflow("fanout-unwind")
+                        val flow = Flow.init("fanout-unwind")
+                            .foreachCompensated("charges", concurrency = 1)(_ => (1 to items).toSeq) { item =>
+                                val body: Int < Async = Async.sleep(1.second).andThen(item * 10)
+                                body
+                            } { (item, charged) =>
+                                refunded.updateAndGet(_.append(item)).unit
+                            }
+                            .step("ship")(_ => throw new RuntimeException("carrier refused"))
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 2.seconds,
+                            renewEvery = 500.millis,
+                            pollTimeout = 100.millis
+                        )
+                        for
+                            eid <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { first =>
+                                    first.workflows.start(wfId).map { handle =>
+                                        settle(tc, step = 100.millis, maxRounds = 60)(
+                                            store.getField[Int](handle.executionId, "charges~0").map(_.isDefined)
+                                        ).andThen(handle.executionId)
+                                    }
+                                }
+                            }
+                            partial <- refunded.get
+                            _       <- tc.advance(10.seconds)
+                            _ <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { _ =>
+                                    settle(tc, step = 250.millis, maxRounds = 200)(
+                                        store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                    )
+                                }
+                            }
+                            state <- store.getExecution(eid)
+                            back  <- refunded.get
+                        yield
+                            assert(
+                                partial.isEmpty,
+                                s"the premise is that an interrupted attempt unwinds nothing, and the first engine refunded $partial"
+                            )
+                            assert(
+                                state.exists(_.status != Flow.Status.Completed),
+                                s"the premise is that the step after the fan-out failed the execution, got ${state.map(_.status)}"
+                            )
+                            assert(
+                                back.toSeq.sorted == (1 to items).toSeq,
+                                s"every card charged has to be refunded, whichever attempt charged it, and the unwind undid $back"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A collection that answers a different size on replay fails the node instead of guessing.
+          *
+          * Per-item identity is positional, so it holds only while the collection is a deterministic function of the record. The
+          * count the fan-out started with is recorded beside its items for exactly this check, and a size that disagrees with it
+          * leaves every pairing unknowable: the results recorded under the old positions belong to items the new collection may not
+          * contain.
+          *
+          * **No per-item handler fires on this path, and that is deliberate rather than an omission.** Running the fan-out again
+          * instead is unimplementable under a write-once store, and pairing the recorded results with the recomputed items would hand
+          * each handler a value from a run it did not belong to, which is the stale pairing the design removes by construction. So
+          * the items that ran are reported by the failure and not undone by a guess.
+          *
+          * **What that costs is stated rather than implied: the items that already ran are STRANDED.** Their side effects happened
+          * and nothing here undoes them, because the only thing that could pair them with a handler is the collection the mismatch
+          * just proved untrustworthy. Remediating them is an operator's job, so the evidence they need has to survive the failure,
+          * and the last assertion is that it does: every item's recorded result is still readable under its own durable name after
+          * the execution has failed. A fail path that swept the per-item fields away would pass every other assertion here.
+          *
+          * The compensated step BEFORE the fan-out is what keeps the leaf honest: it proves the unwind really ran, so the absence of
+          * refunds is a decision rather than a flow that failed before compensating anything.
+          */
+        "a foreach whose recomputed collection changed size fails the node naming the mismatch" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(3).map { size =>
+                    AtomicRef.init(Chunk.empty[String]).map { undone =>
+                        val flow = Flow.init("nondeterministic-fanout")
+                            .stepCompensated("open")(_ => ())(_ => undone.updateAndGet(_.append("open")).unit)
+                            .foreachCompensated("charges", concurrency = 1)(_ => size.get.map(n => (1 to n).toSeq)) { item =>
+                                item * 10
+                            } { (item, charged) =>
+                                undone.updateAndGet(_.append(s"item-$item")).unit
+                            }
+                            .input[String]("gate")
+                            .output("done")(_ => "ok")
+                        for
+                            _      <- engine.register(wf1, flow)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            _        <- pumpState(tc, store, eid, waitingFor("gate"))
+                            _        <- size.set(2)
+                            _        <- engine.executions.signal[String](eid, "gate", "go")
+                            status   <- pump(tc, store, eid, _.isTerminal, 400)
+                            back     <- undone.get
+                            stranded <- Kyo.foreach(0 until 3)(i => store.getField[Int](eid, s"charges~$i"))
+                        yield
+                            val failure = status match
+                                case Flow.Status.Failed(error, kind) => Maybe((error, kind))
+                                case _                               => Maybe.empty
+                            assert(
+                                failure.isDefined,
+                                s"a fan-out whose collection changed size must fail the execution, got $status"
+                            )
+                            val (error, kind) = failure.get
+                            assert(
+                                kind == Present("FlowNondeterministicCollectionException"),
+                                s"the failure must carry a kind an operator can group by, got $kind"
+                            )
+                            assert(
+                                error.contains("'charges'") && error.contains("3 item(s)") && error.contains("to 2"),
+                                s"the failure must name the node, the count it recorded and the size it recomputed, got '$error'"
+                            )
+                            assert(
+                                back.toSeq == Seq("open"),
+                                s"the unwind must run, and no item handler may be fed a pairing the mismatch made unknowable, " +
+                                    s"it undid $back"
+                            )
+                            assert(
+                                stranded.toSeq == Seq(Present(10), Present(20), Present(30)),
+                                s"the items that ran are stranded rather than undone, so their recorded results have to survive " +
+                                    s"the failure for whoever remediates them, and the store answered $stranded"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** The fan-out whose collection changed size is reported as the failed node.
+          *
+          * The mismatch is a verdict the ENGINE reaches, like a loop running out of schedule, and it reaches the store through the
+          * interpreter's failure verb. That verb has to write the node's record: a failure verb that writes nothing leaves an
+          * execution failed for the one reason a fan-out fails on its own showing a progress view with every node pending, unable to
+          * name the node whose message the lifecycle is already carrying. The record lands under the fan-out's durable name before
+          * the failure is raised.
+          */
+        "a foreach whose collection changed size is the node reported failed" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(3).map { size =>
+                    // Compensated, because that is the shape this detection site lives in: a completed fan-out recomputes its
+                    // collection only to re-pair item handlers with their items, so a fan-out with no handler has nothing to
+                    // recompute for and returns without looking. The leaf is about which node the failure is reported on.
+                    val flow = Flow.init("mismatch-node")
+                        .foreachCompensated("charges", concurrency = 1)(_ => size.get.map(n => (1 to n).toSeq)) { item =>
+                            item * 10
+                        } { (item, charged) =>
+                            ()
+                        }
+                        .input[String]("gate")
+                        .output("done")(_ => "ok")
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _      <- pumpState(tc, store, eid, waitingFor("gate"))
+                        _      <- size.set(2)
+                        _      <- engine.executions.signal[String](eid, "gate", "go")
+                        status <- pump(tc, store, eid, _.isTerminal, 400)
+                        detail <- engine.executions.describe(eid)
+                    yield
+                        val error = status match
+                            case Flow.Status.Failed(message, _) => Maybe(message)
+                            case _                              => Maybe.empty
+                        assert(error.isDefined, s"the premise is that the changed collection failed the execution, got $status")
+                        assert(
+                            detail.progress.nodeByName("charges").map(_.status) ==
+                                Maybe(FlowEngine.Progress.NodeStatus.Failed(error.get)),
+                            s"the fan-out whose collection moved must be the node reported failed, carrying the execution's own " +
+                                s"message, got ${detail.progress.nodeByName("charges").map(_.status)}"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** A PARTIALLY completed fan-out resumed under a changed collection fails at the site the stale-pairing argument is about.
+          *
+          * A fan-out detects a size mismatch at two places, and the leaf above drives only one of them: its fan-out completes whole
+          * before the gate, so the replay finds the node's own field and checks the recomputed collection against the RESULTS. The
+          * other site is the one the argument is actually about: a fan-out that never finished, whose node field is absent and whose
+          * COUNT is the only record of how many items it started with. A regression confined to that branch, a count never written,
+          * a comparison inverted, a mismatch quietly ignored, passes every platform green without it.
+          *
+          * The handoff is the deterministic one the resume leaf above uses: the settle waits for the first item's durable field, so
+          * the engine goes away with the fan-out part-way rather than at a moment the scheduler picked. The collection then answers
+          * a different size before the second engine starts, and the four facts asserted are the ones the completed-fan-out leaf
+          * asserts, item for item.
+          */
+        "a partially completed foreach resumed under a changed collection fails the node naming the mismatch" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(5).map { size =>
+                        AtomicRef.init(Chunk.empty[String]).map { undone =>
+                            val wfId = Flow.Id.Workflow("fanout-resumed-mismatch")
+                            val flow = Flow.init("fanout-resumed-mismatch")
+                                .stepCompensated("open")(_ => ())(_ => undone.updateAndGet(_.append("open")).unit)
+                                .foreachCompensated("charges", concurrency = 1)(_ => size.get.map(n => (1 to n).toSeq)) { item =>
+                                    val body: Int < Async = Async.sleep(1.second).map(_ => item * 10)
+                                    body
+                                } { (item, charged) =>
+                                    undone.updateAndGet(_.append(s"item-$item")).unit
+                                }
+                                .output("done")(_ => "ok")
+                            val config = FlowEngine.Config(
+                                workerCount = 1,
+                                lease = 2.seconds,
+                                renewEvery = 500.millis,
+                                pollTimeout = 100.millis
+                            )
+                            for
+                                eid <- Scope.run {
+                                    FlowEngine.init(store, config, flow).map { first =>
+                                        first.workflows.start(wfId).map { handle =>
+                                            settle(tc, step = 100.millis, maxRounds = 60)(
+                                                store.getField[Int](handle.executionId, "charges~0").map(_.isDefined)
+                                            ).andThen(handle.executionId)
+                                        }
+                                    }
+                                }
+                                node <- store.getField[Chunk[Int]](eid, "charges")
+                                _ = assert(
+                                    node.isEmpty,
+                                    s"the premise is that the fan-out is part-way, so its own field is not there yet, got $node"
+                                )
+                                _ <- size.set(4)
+                                _ <- tc.advance(10.seconds)
+                                _ <- Scope.run {
+                                    FlowEngine.init(store, config, flow).map { _ =>
+                                        settle(tc, step = 250.millis, maxRounds = 200)(
+                                            store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                        )
+                                    }
+                                }
+                                state    <- store.getExecution(eid)
+                                back     <- undone.get
+                                stranded <- store.getField[Int](eid, "charges~0")
+                            yield
+                                val failure = state.map(_.status) match
+                                    case Present(Flow.Status.Failed(error, kind)) => Maybe((error, kind))
+                                    case _                                        => Maybe.empty
+                                assert(
+                                    failure.isDefined,
+                                    s"a fan-out whose collection changed size must fail the execution, got ${state.map(_.status)}"
+                                )
+                                val (error, kind) = failure.get
+                                assert(
+                                    kind == Present("FlowNondeterministicCollectionException"),
+                                    s"the failure must carry a kind an operator can group by, got $kind"
+                                )
+                                assert(
+                                    error.contains("'charges'") && error.contains("5 item(s)") && error.contains("to 4"),
+                                    s"the failure must name the node, the count it recorded and the size it recomputed, got '$error'"
+                                )
+                                assert(
+                                    back.toSeq == Seq("open"),
+                                    s"the unwind must run, and no item handler may be fed a pairing the mismatch made unknowable, " +
+                                        s"it undid $back"
+                                )
+                                assert(
+                                    stranded == Present(10),
+                                    s"the items that ran are stranded rather than undone, so their recorded results have to survive " +
+                                        s"the failure for whoever remediates them, and the store answered $stranded"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A fan-out whose ITEM failed reports the fan-out, not the item key nobody can see.
+          *
+          * An item records under the fan-out's name with its index appended, so item 1 of `charges` lands under `charges~1`, and no
+          * node on the progress view is called that: the items are the fan-out's own bookkeeping. The record is attributed to the
+          * parent for the same reason a loop's iteration is, and it is why the attribution resolves against the nodes the flow
+          * actually has rather than by stripping a suffix: `charges~1` and a subflow child `review~step` are the same shape, and only
+          * one of them is a node in its own right.
+          */
+        "a foreach whose item failed reports the fan-out as the failed node" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("item-fails")
+                    .foreach("charges", concurrency = 1)(_ => Seq(1, 2, 3)) { item =>
+                        if item == 2 then throw new RuntimeException("card two declined")
+                        item * 10
+                    }
+                    .output("done")(_ => "ok")
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status <- pump(tc, store, eid, _.isTerminal, 400)
+                    detail <- engine.executions.describe(eid)
+                yield
+                    val error = status match
+                        case Flow.Status.Failed(message, _) => Maybe(message)
+                        case _                              => Maybe.empty
+                    assert(error.isDefined, s"the premise is that the failing item ended the execution, got $status")
+                    assert(
+                        detail.progress.nodeByName("charges").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Failed(error.get)),
+                        s"an item's failure belongs to the fan-out, which is the node a reader has, got " +
+                            s"${detail.progress.nodeByName("charges").map(_.status)}"
+                    )
+                end for
+            }
+        }
+
+        /** The retry schedule re-asks the ITEM that failed, not the fan-out that contains it.
+          *
+          * `foreach` declares `timeout` and `retry` like the five constructs beside it, and the item is the unit both govern: a
+          * schedule that re-asked the whole fan-out would re-run the cards that already succeeded, which is the same shape ruled out
+          * on the unscheduled loop, and per-item retry is exactly what a flow charging N cards needs.
+          *
+          * The asserted value is the SEQUENCE of items the body ran for, which is what tells the two shapes apart. Under a per-item
+          * schedule it is 1, 2, 2, 3: the second card is asked twice and its neighbours once. Under a whole-fan-out schedule the
+          * first card appears twice as well.
+          */
+        "a foreach item that throws is retried by the foreach's schedule without re-running completed items" in {
+            withEngine { (engine, store, tc) =>
+                AtomicRef.init(Chunk.empty[Int]).map { ran =>
+                    AtomicInt.init(0).map { failures =>
+                        val flow = Flow.init("flaky-fanout")
+                            .foreach("charges", retry = Maybe(Schedule.fixed(10.millis).repeat(3)), concurrency = 1)(_ => Seq(1, 2, 3)) {
+                                item =>
+                                    val outcome: Int < Sync =
+                                        if item != 2 then item * 10
+                                        else
+                                            failures.incrementAndGet.map { n =>
+                                                if n == 1 then throw new RuntimeException("flaky card") else item * 10
+                                            }
+                                    ran.updateAndGet(_.append(item)).andThen(outcome)
+                            }
+                        for
+                            _      <- engine.register(wf1, flow)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            status  <- pump(tc, store, eid, _.isTerminal, 400)
+                            results <- store.getField[Chunk[Int]](eid, "charges")
+                            order   <- ran.get
+                        yield
+                            assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                            assert(
+                                results.map(_.toSeq) == Present(Seq(10, 20, 30)),
+                                s"a retried item must land its result beside the others, got $results"
+                            )
+                            assert(
+                                order.toSeq == Seq(1, 2, 2, 3),
+                                s"the schedule must re-ask the item that failed and leave the items already recorded alone, " +
+                                    s"the bodies ran for $order"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** The timeout bounds ONE item, not the sum of every item.
+          *
+          * The other half of putting the knobs on the item, and the same argument the unscheduled loop's timeout carries: a bound
+          * over the whole fan-out cannot be sized for the single slow item, which is the one thing a caller bounds. Four items of
+          * 400 virtual milliseconds each run for 1.6 seconds in total under a one second bound, so a fan-out-wide timeout fails the
+          * execution while no item is anywhere near slow.
+          */
+        "a foreach's timeout bounds one item, not the whole fan-out" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("bounded-items")
+                    .foreach("items", timeout = 1.second, concurrency = 1)(_ => Seq(1, 2, 3, 4)) { item =>
+                        val body: Int < Async = Async.sleep(400.millis).andThen(item * 10)
+                        body
+                    }
+                for
+                    _      <- engine.register(wf1, flow)([v] => (c: v < Async) => c)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status  <- pump(tc, store, eid, _.isTerminal, 2000)
+                    results <- store.getField[Chunk[Int]](eid, "items")
+                yield
+                    assert(
+                        status == Flow.Status.Completed,
+                        s"four items of 400ms each must each pass a one second bound, got $status"
+                    )
+                    assert(
+                        results.map(_.toSeq) == Present(Seq(10, 20, 30, 40)),
+                        s"every item must produce its result under a per-item bound, got $results"
+                    )
+                end for
+            }
+        }
+    }
+
+end FlowEngineForeachTest

--- a/kyo-flow/shared/src/test/scala/kyo/FlowEngineLifecycleTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/FlowEngineLifecycleTest.scala
@@ -1,0 +1,173 @@
+package kyo
+
+/** How an engine is built, what it holds while it runs, and what closing it does.
+  *
+  * An aspect file of `FlowEngineTest`, sharing its helpers through [[FlowEngineSupport]], split off for the reason
+  * [[FlowEngineForeachTest]] states: a test class carries the body of every leaf it registers in its constructor and the JVM caps how
+  * large a class may be, so the engine suite sits at that cap again. The lifecycle leaves are the natural aspect to lift out, because
+  * each is about the engine as an object rather than about an execution: what its tuning refuses, what it retains per attempt, and
+  * what it stops when its scope closes.
+  */
+class FlowEngineLifecycleTest extends FlowEngineSupport:
+
+    // =========================================================================
+    // Engine construction
+    // =========================================================================
+    "engine construction" - {
+
+        /** What an engine holds is the attempts it is running, never the attempts it has run.
+          *
+          * `Fiber.init` is `Scope.acquireRelease(...)(_.interrupt)` and a scope's finalizer store only ever grows: nothing removes an
+          * entry once the fiber it would interrupt has finished. An attempt whose fibers all register with the ENGINE's scope leaves
+          * three entries there, the supervision fiber plus the execution and renewal fibers under it, each retaining its closure and
+          * the finished fiber's result. For a process meant to run for its own lifetime that is unbounded growth in the number of
+          * attempts, and an execution that parks and resumes a thousand times costs three thousand of them.
+          *
+          * So the two inner fibers live in a scope belonging to the attempt, which closes when the attempt ends, and the supervision
+          * is spawned detached and tracked in a registry that an ending removes it from. The registry is what this reads, because it
+          * is the one thing the engine keeps per attempt and no surface exposes a scope's finalizer count: the number it holds is the
+          * number of attempts IN FLIGHT, which the second half pins by watching one appear.
+          */
+        "the engine holds no record of the attempts it has finished" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val quick  = Flow.init("bounded-engine").output("y")(_ => 1)
+                    val slow   = Flow.init("bounded-engine-slow").output("y")(_ => Async.sleep(1.hour).andThen(1))
+                    val config = FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis)
+                    FlowEngine.init(store, config, quick, slow).map { engine =>
+                        for
+                            _ <- Kyo.foreachDiscard(1 to 8) { _ =>
+                                engine.workflows.start(Flow.Id.Workflow("bounded-engine")).map { handle =>
+                                    pump(tc, store, handle.executionId, _.isTerminal, 400)
+                                }
+                            }
+                            drained <- settle(tc, step = 10.millis, maxRounds = 200)(
+                                engine.supervisions.get.map(_.exists(_.isEmpty))
+                            )
+                            afterEight <- engine.supervisions.get
+                            _          <- engine.workflows.start(Flow.Id.Workflow("bounded-engine-slow"))
+                            tracked <- settle(tc, step = 10.millis, maxRounds = 200)(
+                                engine.supervisions.get.map(_.exists(_.nonEmpty))
+                            )
+                            inFlight <- engine.supervisions.get
+                        yield
+                            assert(
+                                drained && afterEight.exists(_.isEmpty),
+                                s"eight finished attempts must leave nothing behind, got ${afterEight.map(_.size)}"
+                            )
+                            assert(
+                                tracked && inFlight.exists(_.size == 1),
+                                s"and the one attempt still running must be the only thing held, got ${inFlight.map(_.size)}"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** Closing an engine is the engine going away, and nothing about it is a fact about the store.
+          *
+          * The distinction has one observable place to go wrong, and it is `Health`: the worker's recovery arm and the supervision's
+          * both count what they catch against `pollFailures` and put its message on `lastPollFailure`, which is what an operator reads
+          * to decide whether the database is reachable. A shutdown that lands there reports a store outage that never happened.
+          *
+          * The one way a shutdown lands there is an attempt registering its fibers with the ENGINE's scope: a registration that races
+          * the close is refused with a `Closed` panic, and neither arm picks `Closed` out the way both pick `Interrupted` out. So an
+          * attempt's supervision is spawned detached and its own fibers live in a scope belonging to the attempt, leaving no
+          * registration for the close to race, and a closing engine interrupts rather than refuses. `Closed` stays uncaught on
+          * purpose, because a store is free to raise one of its own and that IS a store failure.
+          */
+        "closing an engine charges nothing to the store's health" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val slow   = Flow.init("closing-engine").output("y")(_ => Async.sleep(1.hour).andThen(1))
+                    val config = FlowEngine.Config(workerCount = 2, pollTimeout = 100.millis)
+                    for
+                        engine <- Scope.run {
+                            FlowEngine.init(store, config, slow).map { engine =>
+                                Kyo.foreachDiscard(1 to 4)(_ =>
+                                    engine.workflows.start(Flow.Id.Workflow("closing-engine"))
+                                ).andThen(
+                                    settle(tc, step = 10.millis, maxRounds = 200)(
+                                        engine.supervisions.get.map(_.exists(_.nonEmpty))
+                                    )
+                                ).andThen(engine)
+                            }
+                        }
+                        _      <- tc.advance(500.millis)
+                        health <- engine.health
+                        live   <- engine.supervisions.get
+                    yield
+                        assert(
+                            health.pollFailures == 0L && health.lastPollFailure.isEmpty,
+                            s"a shutdown must not be reported as a store failure, got ${health.pollFailures} failures and " +
+                                s"${health.lastPollFailure}"
+                        )
+                        assert(
+                            live.isEmpty,
+                            s"and the engine must stop tracking the attempts it interrupted, got ${live.map(_.size)}"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** Tuning and a runner are available together.
+          *
+          * Splitting the two across overloads, tuning on one and a runner on the other, strands every flow whose steps touch a resource
+          * (which is any flow with a non-trivial effect row, and therefore the reason a runner exists) on the default lease and worker
+          * count. `lease` is what decides how long crash recovery waits.
+          */
+        "a tuned engine runs a flow whose steps need a runner" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val flow   = Flow.init("tuned").output("greeting")(_ => Env.use[String](name => s"hello $name"))
+                    val config = FlowEngine.Config(workerCount = 1, lease = 5.seconds, renewEvery = 1.second, pollTimeout = 100.millis)
+                    FlowEngine.init(store, config, flow)([v] => (c: v < Env[String]) => Env.run("world")(c)).map { engine =>
+                        for
+                            handle <- engine.workflows.start(Flow.Id.Workflow("tuned"))
+                            eid = handle.executionId
+                            status   <- pump(tc, store, eid, _.isTerminal)
+                            greeting <- store.getField[String](eid, "greeting")
+                        yield
+                            assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                            assert(greeting == Present("hello world"), s"the runner must have supplied the effect, got $greeting")
+                        end for
+                    }
+                }
+            }
+        }
+
+        "the untuned overloads carry the default config" in {
+            assert(FlowEngine.Config.default == FlowEngine.Config())
+            assert(FlowEngine.Config.default.workerCount == 2)
+            assert(FlowEngine.Config.default.lease == 30.seconds)
+        }
+
+        /** Every `runHandlers` overload binds the same way in a for-comprehension.
+          *
+          * An overload answering a bare `Chunk` makes `handlers <- Flow.runHandlers(engine)` bind over `Chunk`'s own `flatMap`, so the
+          * rest of the comprehension runs once per handler with `handlers` being a single one. A type error catches that only when the
+          * body's types happen to disagree.
+          */
+        "runHandlers binds as one value in a kyo comprehension" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { store =>
+                    val flow = Flow.init("handlers").output("y")(_ => 1)
+                    FlowEngine.init(store, flow).map { engine =>
+                        for
+                            handlers <- Flow.runHandlers(engine)
+                            again    <- Flow.runHandlers(store, flow)
+                        yield
+                            assert(handlers.size > 1, s"the engine overload must answer every handler, got ${handlers.size}")
+                            assert(
+                                handlers.size == again.size,
+                                s"every overload answers the same handlers, ${handlers.size} vs ${again.size}"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+    }
+end FlowEngineLifecycleTest

--- a/kyo-flow/shared/src/test/scala/kyo/FlowEngineSubflowTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/FlowEngineSubflowTest.scala
@@ -1,0 +1,781 @@
+package kyo
+
+/** What a subflow makes durable: the child's inputs at its entry, and the child's own fields under its path.
+  *
+  * An aspect file of `FlowEngineTest`, sharing its helpers through [[FlowEngineSupport]], split off for the reason
+  * [[FlowEngineForeachTest]] states: a test class carries the body of every leaf it registers in its constructor and the JVM caps how
+  * large a class may be, so the engine suite sits at that cap again. The subflow leaves are the natural aspect to lift out, because
+  * every one of them is about composition under a path: which instance a durable key belongs to, what an entry records before the
+  * child runs, and what a re-entry does with what it finds.
+  */
+class FlowEngineSubflowTest extends FlowEngineSupport:
+
+    // =========================================================================
+    // Subflow execution
+    // =========================================================================
+    "subflow" - {
+
+        "child output accessible downstream via nested record" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("a").output("b")(ctx => ctx.a * 10)
+                val flow = Flow.input[Int]("x")
+                    .subflow("payment", child)(ctx => "a" ~ ctx.x)
+                    .output("result")(ctx => ctx.payment.b)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 5)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    v      <- store.getField[Int](eid, "result")
+                yield
+                    assert(status == Flow.Status.Completed)
+                    assert(v.get == 50, s"Expected 50 but got ${v}")
+                end for
+            }
+        }
+
+        "child fields do not leak into parent namespace" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("a").output("b")(ctx => ctx.a * 10)
+                val flow = Flow.input[Int]("x")
+                    .subflow("payment", child)(ctx => "a" ~ ctx.x)
+                    .output("result")(ctx => ctx.x + 1) // uses parent field, not child
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 5)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    v      <- store.getField[Int](eid, "result")
+                    // read for the contrast: the child's field is durable under `payment~b`, so the bare name is not a parent field
+                    bField <- store.getField[Int](eid, "b")
+                yield
+                    assert(status == Flow.Status.Completed)
+                    assert(v.get == 6)
+                    // the type system keeps the two apart ahead of the store: `ctx.b` does not compile, since `b` is not in the
+                    // parent's Out
+                    ()
+                end for
+            }
+        }
+
+        "subflow replays correctly after suspension" in {
+            withEngine { (engine, store, tc) =>
+                var childBodyCount = 0
+                val child = Flow.input[Int]("a").output("b") { ctx =>
+                    childBodyCount += 1
+                    ctx.a * 10
+                }
+                val flow = Flow.input[Int]("x")
+                    .subflow("payment", child)(ctx => "a" ~ ctx.x)
+                    .input[String]("approval") // suspends here
+                    .output("result")(ctx => s"${ctx.approval}: ${ctx.payment.b}")
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _ <- engine.executions.signal[Int](eid, "x", 5)
+                    _ <- pumpState(tc, store, eid, waitingFor("approval"))
+                    // Child executed once
+                    count1 = childBodyCount
+                    _      <- engine.executions.signal[String](eid, "approval", "yes")
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    v      <- store.getField[String](eid, "result")
+                yield
+                    assert(status == Flow.Status.Completed)
+                    assert(v.get == "yes: 50")
+                    // Child body should have run exactly once, because replay skips it
+                    assert(count1 == 1, s"Child body ran $count1 times before suspension")
+                end for
+            }
+        }
+
+        "multiple subflows don't interfere" in {
+            withEngine { (engine, store, tc) =>
+                val child1 = Flow.input[Int]("a").output("b")(ctx => ctx.a + 1)
+                val child2 = Flow.input[Int]("a").output("b")(ctx => ctx.a * 2)
+                val flow = Flow.input[Int]("x")
+                    .subflow("first", child1)(ctx => "a" ~ ctx.x)
+                    .subflow("second", child2)(ctx => "a" ~ ctx.x)
+                    .output("result")(ctx => ctx.first.b + ctx.second.b)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 5)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    v      <- store.getField[Int](eid, "result")
+                yield
+                    assert(status == Flow.Status.Completed)
+                    assert(v.get == 16, s"Expected 6+10=16 but got ${v}") // (5+1) + (5*2)
+                end for
+            }
+        }
+
+        "child failure propagates to parent" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("a").output("b")(ctx =>
+                    if ctx.a == 0 then throw new RuntimeException("zero") else ctx.a
+                )
+                val flow = Flow.input[Int]("x")
+                    .subflow("payment", child)(ctx => "a" ~ ctx.x)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 0)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                yield assert(status match
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
+                end for
+            }
+        }
+    }
+
+    // =========================================================================
+    // Subflow advanced
+    // =========================================================================
+    "subflow advanced" - {
+
+        "child with multiple outputs keeps its nested record accessible" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("a")
+                    .output("b")(ctx => ctx.a * 2)
+                    .output("c")(ctx => ctx.a + ctx.b)
+                val flow = Flow.input[Int]("x")
+                    .subflow("sub", child)(ctx => "a" ~ ctx.x)
+                    .output("result")(ctx => ctx.sub.b + ctx.sub.c)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 5)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    v      <- store.getField[Int](eid, "result")
+                yield
+                    assert(status == Flow.Status.Completed)
+                    // b=10, c=5+10=15, result=10+15=25
+                    assert(v.get == 25, s"Expected 25 but got ${v}")
+                end for
+            }
+        }
+
+        "nested subflow (subflow within subflow)" in {
+            withEngine { (engine, store, tc) =>
+                val inner = Flow.input[Int]("a").output("b")(ctx => ctx.a * 3)
+                val middle = Flow.input[Int]("a")
+                    .subflow("inner", inner)(ctx => "a" ~ ctx.a)
+                    .output("c")(ctx => ctx.inner.b + 1)
+                val flow = Flow.input[Int]("x")
+                    .subflow("mid", middle)(ctx => "a" ~ ctx.x)
+                    .output("result")(ctx => ctx.mid.c)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 4)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    v      <- store.getField[Int](eid, "result")
+                yield
+                    assert(status == Flow.Status.Completed)
+                    // inner.b = 4*3=12, middle.c = 12+1=13
+                    assert(v.get == 13, s"Expected 13 but got ${v}")
+                end for
+            }
+        }
+
+        "inputMapper throws, so the parent fails" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("a").output("b")(ctx => ctx.a)
+                val flow = Flow.input[Int]("x")
+                    .subflow("sub", child)(ctx =>
+                        throw new RuntimeException("mapper fail"); "a" ~ 0
+                    )
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 1)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                yield assert(status match
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
+                end for
+            }
+        }
+
+        /** A subflow's completed output is not re-executed when the parent resumes.
+          *
+          * The module's central promise, stated on [[FlowEngine]] itself: "completed steps are never re-executed, but an in-flight step
+          * (started but not completed) may re-execute on a new engine". A subflow's inner nodes run through the same interpreter and
+          * the same execution id, and the child's output records a field and a `StepCompleted` event exactly as a parent node does, so
+          * a completed one is durably completed by every measure the store has.
+          *
+          * What makes it hold is what the child STARTS FROM. An `Output` node skips itself when its name is already in the record it
+          * is handed, which is an in-memory lookup, so the child's starting record has to carry the child's own durable fields or
+          * every completed output inside a subflow re-runs on every resume, once per resume, for the life of the execution. It does
+          * carry them: `childRecord` reads everything the store holds under the instance's path and lets it win over anything the
+          * entry supplied, so a resumed child skips exactly what a resumed parent skips. The parent's own nodes are never at risk,
+          * because the parent's record is rebuilt from the store.
+          *
+          * The run count is the whole assertion: one before the suspension and one after, for a child output with a side effect.
+          */
+        "a subflow's completed output is not re-executed when the parent resumes" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { runs =>
+                    val child = Flow.input[Int]("amount")
+                        .output("fee")(ctx => runs.incrementAndGet.map(_ => ctx.amount * 2))
+                    val flow = Flow.input[Int]("x")
+                        .subflow("payment", child)(ctx => "amount" ~ ctx.x)
+                        .input[String]("gate")
+                        .output("done")(ctx => ctx.payment.fee)
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _      <- engine.executions.signal[Int](eid, "x", 5)
+                        _      <- pumpState(tc, store, eid, waitingFor("gate"))
+                        before <- runs.get
+                        _      <- engine.executions.signal[String](eid, "gate", "go")
+                        status <- pump(tc, store, eid, _.isTerminal)
+                        after  <- runs.get
+                        done   <- store.getField[Int](eid, "done")
+                    yield
+                        assert(status == Flow.Status.Completed)
+                        assert(done == Present(10), s"the child's output must survive the resume, got $done")
+                        assert(before == 1, s"the child's output runs once before the suspension, got $before")
+                        assert(
+                            after == 1,
+                            s"a completed subflow output must not re-execute when the parent resumes, ran $after times"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** Two instances of one subflow both run their steps, rather than one running for both.
+          *
+          * Durable node identity is the node's PATH, not its bare name: a field, a completion event, a wait row and a schema entry
+          * are all keyed by `instance~name` (`kyo.internal.NodePath`). That is what embedding one child twice depends on, and the
+          * bare name cannot carry it. A `Step` skips itself when its durable name is in the completed set, which is derived once per
+          * attempt from history, so under bare names the two instances would both run on the FIRST attempt and then, after any
+          * resume, the second would be skipped as work the first already did: a charge that must happen twice happening once, and
+          * only after a crash, which is the shape that survives testing.
+          *
+          * The resume is therefore the load-bearing half of the fixture rather than decoration. Both instances charging on one clean
+          * pass proves nothing; the assertion that matters is that the second still charges on the attempt AFTER the parent parked
+          * and resumed, which is where a flat identity would collapse the two into one.
+          */
+        "two instances of one subflow both run their steps" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { charges =>
+                    val child = Flow.input[Int]("amount")
+                        .step("charge")(_ => charges.incrementAndGet.unit)
+                    val flow = Flow.input[Int]("x")
+                        .subflow("first", child)(ctx => "amount" ~ ctx.x)
+                        .input[String]("gate")
+                        .subflow("second", child)(ctx => "amount" ~ ctx.x)
+                        .output("done")(_ => "ok")
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _      <- engine.executions.signal[Int](eid, "x", 5)
+                        _      <- pumpState(tc, store, eid, waitingFor("gate"))
+                        first  <- charges.get
+                        _      <- engine.executions.signal[String](eid, "gate", "go")
+                        status <- pump(tc, store, eid, _.isTerminal)
+                        total  <- charges.get
+                    yield
+                        assert(status == Flow.Status.Completed)
+                        assert(first == 1, s"the first instance charges before the suspension, got $first")
+                        assert(
+                            total == 2,
+                            s"each subflow instance must charge once, so two instances charge twice, got $total"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** Entering an instance writes each of the child's inputs under its own path, once, with its own event.
+          *
+          * The engine-side twin of the record the caller receives. The value is an ordinary field under `review~amount`, so replay
+          * reads it back the way it reads any other and the assembly finds it under the prefix; the event is `InputSupplied`, which
+          * is the third arrival shape and the only one a mapper produces.
+          *
+          * **No `InputDischarged` for the same path**, which is what keeps the arrival kinds apart. A discharge is a node's own
+          * consumption of a value it waited for and its writer is guarded on the wait row, so a mapper-fed input, which never parks,
+          * records none; writing one from the subflow's arm would put a consumption record before the node was even reached.
+          */
+        "a child input is recorded under its path at the subflow's entry" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("amount").output("fee")(ctx => ctx.amount * 2)
+                val flow = Flow.input[Int]("x")
+                    .subflow("review", child)(ctx => "amount" ~ ctx.x)
+                    .output("done")(ctx => ctx.review.fee)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _       <- engine.executions.signal[Int](eid, "x", 5)
+                    status  <- pump(tc, store, eid, _.isTerminal)
+                    amount  <- store.getField[Int](eid, "review~amount")
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    assert(status == Flow.Status.Completed, s"the premise is that the execution completed, got $status")
+                    assert(amount == Present(5), s"the mapper's value must be recorded under the child's path, got $amount")
+                    val supplied = history.events.filter(_.kind == Flow.EventKind.InputSupplied).map(_.detail)
+                    assert(
+                        supplied == Chunk("review~amount"),
+                        s"exactly one supply event, naming the child's path, got $supplied"
+                    )
+                    assert(
+                        !history.events.exists(e =>
+                            e.kind == Flow.EventKind.InputDischarged && e.detail == "review~amount"
+                        ),
+                        s"and no discharge for it, since the node never waited, got ${history.events.map(e => (e.kind, e.detail))}"
+                    )
+                end for
+            }
+        }
+
+        /** A re-entered subflow runs its child against the inputs it recorded, and does not ask the mapper again.
+          *
+          * The resume rule, and the reason the mapper's determinism is not a correctness requirement. The child parks on its sleep, so
+          * the parent's arm is entered a second time; the entry finds every declared input already recorded and re-enters the child
+          * without running the mapper at all, exactly as a dispatch re-enters its recorded branch without re-asking its conditions.
+          *
+          * The mapper's source is moved between the two entries, so a second run would be VISIBLE: the child's remaining node would
+          * compute its fee from 9 while the field says 5, which is the mixed record the recorded-input rule exists to prevent. One run
+          * of the mapper and a fee of 10 is the whole assertion.
+          */
+        "a re-entered subflow runs its child against the inputs it recorded and does not run the mapper again" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(5).map { source =>
+                    AtomicInt.init(0).map { mapperRuns =>
+                        val child = Flow.input[Int]("amount")
+                            .sleep("hold", 500.millis)
+                            .output("fee")(ctx => ctx.amount * 2)
+                        val flow = Flow.init("resumed-subflow")
+                            .subflow("review", child)(_ =>
+                                mapperRuns.incrementAndGet.andThen(source.get).map(v => "amount" ~ v)
+                            )
+                            .output("done")(_ => "ok")
+                        for
+                            _      <- engine.register(wf1, flow)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            _      <- pumpState(tc, store, eid, sleeping)
+                            _      <- source.set(9)
+                            status <- pump(tc, store, eid, _.isTerminal, 400)
+                            amount <- store.getField[Int](eid, "review~amount")
+                            fee    <- store.getField[Int](eid, "review~fee")
+                            ran    <- mapperRuns.get
+                        yield
+                            assert(status == Flow.Status.Completed, s"the premise is that the execution completed, got $status")
+                            assert(amount == Present(5), s"the recorded input stands across the resume, got $amount")
+                            assert(fee == Present(10), s"and the child computes from it rather than from the moved source, got $fee")
+                            assert(ran == 1, s"an entry that finds its inputs recorded does not run the mapper, ran $ran times")
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** An entry that recorded only some of its inputs records the rest on re-entry, and keeps what it recorded.
+          *
+          * The one partial state this design admits, and it is benign because the writes precede the child's first node: nothing of
+          * the child ran against the half-written seed, so no recorded child field was computed from a value the record does not
+          * hold. The store fails the write for `b` once, on its own channel and marked retryable, so the attempt ends as
+          * infrastructure with nothing else written and its claim left to lapse.
+          *
+          * The mapper answers from its own run count, so the two entries supply different values and which value each input kept is
+          * observable: `a` is the FIRST run's, because a recorded input is never rewritten and never compared, and `b` is the
+          * SECOND's, because it was still owed. The child then runs once, against that one record, and `sum` proves which pair it
+          * saw. A short lease is what gets the second entry to happen at all, for the reason the retryable-store leaves state: an
+          * attempt that could not reach the store leaves its claim to expire rather than releasing it.
+          */
+        "a subflow whose first entry recorded only some of its inputs records the rest on re-entry" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(1).map { blips =>
+                        AtomicInt.init(0).map { mapperRuns =>
+                            val flaky = new FailingInputSupplyStore(store, "review~b", blips)
+                            val child = Flow.input[Int]("a").input[Int]("b")
+                                .output("sum")(ctx => ctx.a + ctx.b)
+                            val flow = Flow.init("partial-seed")
+                                .subflow("review", child)(_ =>
+                                    mapperRuns.incrementAndGet.map(n => "a" ~ (n * 10) & "b" ~ (n * 100))
+                                )
+                                .output("done")(_ => "ok")
+                            val config =
+                                FlowEngine.Config(workerCount = 1, lease = 1.second, renewEvery = 500.millis, pollTimeout = 100.millis)
+                            FlowEngine.init(flaky, config, flow).map { engine =>
+                                for
+                                    handle <- engine.workflows.start(Flow.Id.Workflow("partial-seed"))
+                                    eid = handle.executionId
+                                    status  <- pump(tc, store, eid, _.isTerminal, 400)
+                                    a       <- store.getField[Int](eid, "review~a")
+                                    b       <- store.getField[Int](eid, "review~b")
+                                    sum     <- store.getField[Int](eid, "review~sum")
+                                    ran     <- mapperRuns.get
+                                    history <- store.getHistory(eid, Maybe.empty, 0)
+                                yield
+                                    assert(status == Flow.Status.Completed, s"a blip the next entry got past completes, got $status")
+                                    assert(a == Present(10), s"the input the first entry recorded stands, got $a")
+                                    assert(b == Present(200), s"and the one it owed is recorded by the second entry, got $b")
+                                    assert(sum == Present(210), s"so the child runs once against that one record, got $sum")
+                                    assert(ran == 2, s"the mapper runs once per entry that owed something, ran $ran times")
+                                    val supplied = history.events.filter(_.kind == Flow.EventKind.InputSupplied).map(_.detail)
+                                    assert(
+                                        supplied == Chunk("review~a", "review~b"),
+                                        s"one supply event per input, in the order the child declares them, got $supplied"
+                                    )
+                                end for
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A settled subflow's inputs are recorded once, not once per attempt that walks past them.
+          *
+          * Write-once at the arm, and the reason it costs nothing to check: the entry consults the record before it writes, so a
+          * re-entry whose inputs are all present writes nothing and the mapper never runs. Without that, a parent suspending after
+          * the subflow would append a supply event per resume, which is a settled execution's history growing while it waits.
+          */
+        "a re-entered subflow does not record its inputs twice" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("amount").output("fee")(ctx => ctx.amount * 2)
+                val flow = Flow.input[Int]("x")
+                    .subflow("payment", child)(ctx => "amount" ~ ctx.x)
+                    .input[String]("gate")
+                    .output("done")(ctx => ctx.payment.fee)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _       <- engine.executions.signal[Int](eid, "x", 5)
+                    _       <- pumpState(tc, store, eid, waitingFor("gate"))
+                    _       <- engine.executions.signal[String](eid, "gate", "go")
+                    status  <- pump(tc, store, eid, _.isTerminal)
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    assert(status == Flow.Status.Completed, s"the premise is that the execution completed, got $status")
+                    val supplied = history.events.filter(_.kind == Flow.EventKind.InputSupplied).map(_.detail)
+                    assert(
+                        supplied == Chunk("payment~amount"),
+                        s"the resume past a settled subflow records nothing new, got $supplied"
+                    )
+                end for
+            }
+        }
+
+        /** A nested instance's inputs are recorded under the qualified path, at every depth.
+          *
+          * The entry writes under `childPath`, which is the path the instance occupies rather than its bare name, so the inner
+          * instance's input lands at `outer~inner~ia` and the outer one's at `outer~oa`. That is the same key the schema carries for
+          * it and the same prefix the assembly strips, which is what makes both levels readable from one execution's fields.
+          */
+        "a nested subflow records the inner instance's inputs under both paths" in {
+            withEngine { (engine, store, tc) =>
+                val inner = Flow.input[Int]("ia").output("ib")(ctx => ctx.ia + 1)
+                val outer = Flow.input[Int]("oa")
+                    .subflow("inner", inner)(ctx => "ia" ~ ctx.oa)
+                    .output("ob")(ctx => ctx.inner.ib * 2)
+                val flow = Flow.input[Int]("x").subflow("outer", outer)(ctx => "oa" ~ ctx.x)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 5)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    oa     <- store.getField[Int](eid, "outer~oa")
+                    ia     <- store.getField[Int](eid, "outer~inner~ia")
+                yield
+                    assert(status == Flow.Status.Completed, s"the premise is that the execution completed, got $status")
+                    assert(oa == Present(5), s"the outer instance's input sits under its own path, got $oa")
+                    assert(ia == Present(5), s"and the inner instance's under the qualified one, got $ia")
+                end for
+            }
+        }
+
+        /** Two zipped instances record their children's inputs under their own paths, with their own values.
+          *
+          * One child flow embedded twice is two instances and therefore two sets of fields, which is what a subflow is for. The
+          * mappers answer differently on purpose: a write that used the child's bare name, or one instance's path for both, would
+          * leave one value where two belong, and asserting both values is what catches it.
+          */
+        "two zipped subflows record each child's inputs under its own path" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("a").output("b")(ctx => ctx.a * 10)
+                val left  = Flow.init("zipped").subflow("left", child)(_ => "a" ~ 1)
+                val right = Flow.init("zipped").subflow("right", child)(_ => "a" ~ 2)
+                val flow  = left.zip(right)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    left   <- store.getField[Int](eid, "left~a")
+                    right  <- store.getField[Int](eid, "right~a")
+                    leftB  <- store.getField[Int](eid, "left~b")
+                    rightB <- store.getField[Int](eid, "right~b")
+                yield
+                    assert(status == Flow.Status.Completed, s"the premise is that the execution completed, got $status")
+                    assert(left == Present(1), s"the left instance's input is its own, got $left")
+                    assert(right == Present(2), s"and so is the right one's, got $right")
+                    assert(leftB == Present(10), s"each child computes from the input recorded under its path, got $leftB")
+                    assert(rightB == Present(20), s"and the other from its own, got $rightB")
+                end for
+            }
+        }
+
+        /** A child that declares no inputs records nothing at entry, and its mapper never runs.
+          *
+          * The entry writes what the child declared and asks the mapper only for what it still owes, so a child owing nothing asks
+          * nothing. The mapper's contract is to produce the child's inputs; with none declared there is nothing for it to produce and
+          * its effects were never part of any record, which is why not running it is the rule rather than an omission.
+          */
+        "a subflow whose child declares no inputs never runs its mapper" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { mapperRuns =>
+                    val child = Flow.init("no-inputs").output("b")(_ => 7)
+                    val flow = Flow.init("empty-mapper")
+                        .subflow("review", child)(_ => mapperRuns.incrementAndGet.andThen(Record.empty))
+                        .output("done")(_ => "ok")
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        status  <- pump(tc, store, eid, _.isTerminal)
+                        b       <- store.getField[Int](eid, "review~b")
+                        ran     <- mapperRuns.get
+                        history <- store.getHistory(eid, Maybe.empty, 0)
+                    yield
+                        assert(status == Flow.Status.Completed, s"the premise is that the execution completed, got $status")
+                        assert(b == Present(7), s"the child's own work still lands, got $b")
+                        assert(ran == 0, s"a child owing no input never asks its mapper, ran $ran times")
+                        assert(
+                            !history.events.exists(_.kind == Flow.EventKind.InputSupplied),
+                            s"and nothing is recorded at its entry, got ${history.events.map(e => (e.kind, e.detail))}"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** Two race arms embedding one subflow name run their children against the first-recorded inputs.
+          *
+          * The corner the race exemption creates: two arms may share a written name, so both entries write `review~amount` and the
+          * store answers the second already-recorded. That answer is not a failure, it is the exemption's own rule (the first
+          * completion decides the field) reaching the moment of writing, so the arm that lost the write reads the recorded value back
+          * and runs its child against it.
+          *
+          * Which arm wins is not asserted, because nothing decides it durably; what is asserted is that the two facts AGREE. Without
+          * the read-back the loser's child would compute its fee from the value it mapped rather than the one recorded, and a fee of
+          * 4 beside an amount of 1 is exactly the record the read-back exists to prevent. The relation `fee == amount * 2` is therefore
+          * the discriminating assertion, and it holds whichever arm landed first.
+          */
+        "two race arms embedding one subflow name run their children against the first-recorded inputs" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("amount").output("fee")(ctx => ctx.amount * 2)
+                val left  = Flow.init("shared-name").subflow("review", child)(_ => "amount" ~ 1)
+                val right = Flow.init("shared-name").subflow("review", child)(_ => "amount" ~ 2)
+                val flow  = Flow.race(left, right)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status  <- pump(tc, store, eid, _.isTerminal, 400)
+                    amount  <- store.getField[Int](eid, "review~amount")
+                    fee     <- store.getField[Int](eid, "review~fee")
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    assert(status == Flow.Status.Completed, s"the premise is that the race completed, got $status")
+                    assert(
+                        amount == Present(1) || amount == Present(2),
+                        s"one of the two arms records the input, got $amount"
+                    )
+                    assert(
+                        fee == amount.map(_ * 2),
+                        s"and both children run against the value that landed rather than the one they mapped, got $fee for $amount"
+                    )
+                    val supplied = history.events.filter(_.kind == Flow.EventKind.InputSupplied).map(_.detail)
+                    assert(
+                        supplied == Chunk("review~amount"),
+                        s"the second write is refused rather than appended, so the path is recorded once, got $supplied"
+                    )
+                end for
+            }
+        }
+
+        /** A child input is not signallable, by its bare name or by its path, and a refused signal writes nothing.
+          *
+          * A child input has exactly one source, the mapper, which is why its record needs no atomic seed the way a top-level input's
+          * does: a top-level input can arrive from the start or from a later `signal`, so a missing field there is ambiguous, and a
+          * missing child field never is. That rests on `signal` resolving names against the definition's own declared inputs, which do
+          * not descend into a child, and this pins it by asking rather than by reading the resolver.
+          *
+          * Both spellings are refused with the same error, and the recorded value is untouched by either attempt: the bare name
+          * belongs to no input this definition declares, and the qualified one is a durable path rather than a name.
+          */
+        "a child input cannot be signalled by either name" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("amount").output("fee")(ctx => ctx.amount * 2)
+                val flow = Flow.input[Int]("x")
+                    .subflow("review", child)(ctx => "amount" ~ ctx.x)
+                    .input[String]("gate")
+                    .output("done")(_ => "ok")
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _         <- engine.executions.signal[Int](eid, "x", 5)
+                    _         <- pumpState(tc, store, eid, waitingFor("gate"))
+                    bare      <- Abort.run[FlowException](engine.executions.signal[Int](eid, "amount", 9))
+                    qualified <- Abort.run[FlowException](engine.executions.signal[Int](eid, "review~amount", 9))
+                    amount    <- store.getField[Int](eid, "review~amount")
+                    stray     <- store.getField[Int](eid, "amount")
+                yield
+                    bare match
+                        case Result.Failure(e: FlowSignalNotFoundException) =>
+                            assert(e.inputName == "amount", s"the refusal names what was asked for, got ${e.inputName}")
+                        case other => fail(s"the bare name must be refused as an unknown input, got $other")
+                    end match
+                    qualified match
+                        case Result.Failure(e: FlowSignalNotFoundException) =>
+                            assert(e.inputName == "review~amount", s"the refusal names what was asked for, got ${e.inputName}")
+                        case other => fail(s"the qualified name must be refused too, got $other")
+                    end match
+                    assert(amount == Present(5), s"and the recorded value is untouched by either attempt, got $amount")
+                    assert(stray == Absent, s"with nothing written under the bare name, got $stray")
+                end for
+            }
+        }
+
+        /** An attempt resuming an unwind records nothing at a subflow it never entered.
+          *
+          * The entry's writes are guarded like every other write, so an attempt that is re-entering an unwind reaches the arm and
+          * leaves without writing. That matters because the alternative is a durable input for work that will never run: the
+          * execution is on its way to the verdict a previous attempt recorded, and seeding a child it is abandoning would leave the
+          * store holding a value nothing ever ran against, on an execution that ends anyway.
+          *
+          * **Reaching the arm at all takes care, and every simpler shape fails to.** A resumed forward pass raises at the first
+          * node that would actually run, so a subflow AFTER a failing node is never reached (the failing node re-runs and its own
+          * verb's guard raises first), and a subflow BEFORE one was entered on the earlier attempt and owes nothing. A `zip` sibling
+          * holding an un-entered subflow does reach it, but the branches are concurrent and a failure decides the composition at
+          * once, so whether the sibling walks that far is a scheduling race rather than a fact.
+          *
+          * The shape here drops the failure entirely: the verdict is a CANCELLATION, seeded as the row's recorded lifecycle, and the
+          * subflow is the flow's only node. A subflow writes nothing under its own name, so the arm is entered on every attempt;
+          * nothing precedes it, so no other guard can fire first; and the instance was never entered, so it owes its child's one
+          * declared input.
+          *
+          * **The mapper's run count is the discriminating assertion.** Absent it, the leaf would pass just as well against an arm
+          * that never reached the hook at all, or one whose owed-check wrongly found nothing owed. One run says the arm went the
+          * whole way, built the child's record, and was stopped by the guard rather than by anything upstream of it.
+          */
+        "a resumed unwind that reaches an un-entered subflow writes no input" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { mapperRuns =>
+                    val child = Flow.input[Int]("amount").output("fee")(ctx => ctx.amount * 2)
+                    val flow = Flow.init("resumed-unwind")
+                        .subflow("review", child)(_ => mapperRuns.incrementAndGet.andThen("amount" ~ 1))
+                    for
+                        eid <- Sync.defer(Flow.Id.Execution("exec-resumed-unwind-subflow"))
+                        // Seeded before the workflow is registered, for the reason the other seeded leaves state: a row nothing
+                        // serves yet cannot be claimed out from under the fixture. The lifecycle IS the premise here, because
+                        // `Compensating(cause)` is what the attempt reads to know it is re-entering an unwind.
+                        hash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                        _       <- seedExecution(store, eid, wf1, Flow.Status.Compensating(Flow.Cause.Cancellation), hash)
+                        _       <- engine.register(wf1, flow)
+                        status  <- pump(tc, store, eid, _.isTerminal)
+                        amount  <- store.getField[Int](eid, "review~amount")
+                        ran     <- mapperRuns.get
+                        history <- store.getHistory(eid, Maybe.empty, 0)
+                    yield
+                        assert(
+                            status == Flow.Status.Cancelled,
+                            s"the execution ends as the verdict it was resuming says, got $status"
+                        )
+                        assert(ran == 1, s"the arm ran the mapper, so it reached the hook rather than stopping short, ran $ran times")
+                        assert(
+                            !history.events.exists(_.kind == Flow.EventKind.InputSupplied),
+                            s"and recorded no input for the instance it never entered, got " +
+                                s"${history.events.map(e => (e.kind, e.detail))}"
+                        )
+                        assert(amount == Absent, s"with no field under its path either, got $amount")
+                    end for
+                }
+            }
+        }
+
+        /** A name two race arms of one child read is recorded once, under one path.
+          *
+          * A child may declare one input twice, because two branches waiting on one name is the case registration allows outright:
+          * two READS of one name are not a conflict, it is one wait and one field. The entry therefore has to be total over a
+          * collector that sees the name twice, and this runs that child to completion through a subflow.
+          *
+          * **What it pins, stated precisely, because it is less than it looks.** It pins the PATH: one supply event and one field
+          * for `review~k`, whichever way the collector is built. It does NOT discriminate the collector's deduplication: with the
+          * dedup removed the leaf still passes, because the second write is answered already-recorded, the store appends no event on
+          * a refusal, and the read-back substitutes the value that landed, which is the same value. So the dedup is a store round-trip
+          * the entry avoids rather than a behaviour anything can observe, and this leaf is the coverage of the doubled-name path
+          * rather than a guard on the dedup.
+          */
+        "a child whose two race arms read one input name records it once" in {
+            withEngine { (engine, store, tc) =>
+                val leftArm  = Flow.init("left-arm").input[Int]("k").output("lv")(ctx => ctx.k * 2)
+                val rightArm = Flow.init("right-arm").input[Int]("k").output("rv")(ctx => ctx.k * 3)
+                val child    = Flow.race(leftArm, rightArm)
+                val flow     = Flow.init("shared-read").subflow("review", child)(_ => "k" ~ 5)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status  <- pump(tc, store, eid, _.isTerminal)
+                    k       <- store.getField[Int](eid, "review~k")
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    assert(status == Flow.Status.Completed, s"the premise is that the execution completed, got $status")
+                    assert(k == Present(5), s"the doubly-declared name carries the mapper's one value, got $k")
+                    val supplied = history.events.filter(_.kind == Flow.EventKind.InputSupplied).map(_.detail)
+                    assert(
+                        supplied == Chunk("review~k"),
+                        s"and is recorded once rather than once per arm that declares it, got $supplied"
+                    )
+                end for
+            }
+        }
+    }
+
+    /** A store that fails the write recording one child input's supplied value, the first `remaining` times.
+      *
+      * The sibling of [[FailingCompletionStore]] one node kind over, and what it stages is the one partial state a subflow's entry
+      * can be left in: a child declaring two inputs whose first write landed and whose second did not. Nothing of the child has run
+      * at that point, because the writes precede its first node, so the state is legitimate and the next entry has to complete it
+      * rather than start over.
+      */
+    private class FailingInputSupplyStore(underlying: FlowStore, path: String, remaining: AtomicInt) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def recordProgress[V](target: String, value: Maybe[V], event: Flow.Event)(using
+                    Tag[V],
+                    Schema[V],
+                    Frame
+                ): FlowStore.ProgressOutcome < (Async & Abort[FlowStoreException]) =
+                    event match
+                        case Flow.Event.InputSupplied(_, _, name, _) if name == path =>
+                            remaining.getAndDecrement.map { left =>
+                                if left > 0 then Abort.fail(FlowEngineTest.StoreUnavailable(s"blip supplying '$name'"))
+                                else super.recordProgress[V](target, value, event)
+                            }
+                        case _ => super.recordProgress[V](target, value, event)
+    end FailingInputSupplyStore
+
+end FlowEngineSubflowTest

--- a/kyo-flow/shared/src/test/scala/kyo/FlowEngineTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/FlowEngineTest.scala
@@ -1,6 +1,22 @@
 package kyo
 
-class FlowEngineTest extends kyo.test.Test[Any]:
+object FlowEngineTest:
+    /** A step's own domain failure: not an engine error, and the reason FlowException has an open branch. */
+    case class ChargeDeclined(orderId: String, cents: Long)(using Frame)
+        extends FlowDomainException(s"charge declined for $orderId: $cents cents over limit")
+
+    /** A store's own failure, the way a store over a database reports one: typed, and marked retryable when the backend says so. */
+    case class StoreUnavailable(detail: String)(using Frame)
+        extends FlowStoreException(s"the store could not be reached: $detail") with FlowStoreException.Retryable
+end FlowEngineTest
+
+/** What every engine suite needs to drive an execution: an engine, a controlled clock, and the pumps that move one forward.
+  *
+  * The engine's leaves are spread over more than one class out of necessity: a test class carries the body of every leaf it registers
+  * in its constructor, and the JVM caps how large a class may be. `FlowEngineForeachTest` is one such aspect file. The helpers live
+  * here rather than being copied, so a fixture that changes shape changes in one place.
+  */
+abstract private[kyo] class FlowEngineSupport extends kyo.test.Test[Any]:
 
     override def timeout = 30.seconds
 
@@ -8,7 +24,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
 
     val wf1 = Flow.Id.Workflow("test-flow")
 
-    private def withEngine[A](
+    protected def withEngine[A](
         f: (FlowEngine, FlowStore, Clock.TimeControl) => A < (Async & Scope & Abort[Any])
     )(using Frame): A < (Async & Scope & Abort[Any]) =
         Clock.withTimeControl { tc =>
@@ -19,17 +35,17 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-    private def pump(
+    protected def pump(
         tc: Clock.TimeControl,
         store: FlowStore,
         eid: Flow.Id.Execution,
         predicate: Flow.Status => Boolean,
         maxRounds: Int = 200
-    )(using Frame): Flow.Status < Async =
-        def go(remaining: Int): Flow.Status < Async =
+    )(using Frame): Flow.Status < (Async & Abort[FlowStoreException]) =
+        def go(remaining: Int): Flow.Status < (Async & Abort[FlowStoreException]) =
             if remaining <= 0 then
                 store.getExecution(eid).map { state =>
-                    Abort.panic(new AssertionError(s"pump timed out — last state: $state"))
+                    Abort.panic(new AssertionError(s"pump timed out, last state: $state"))
                 }
             else
                 tc.advance(10.millis).map { _ =>
@@ -40,6 +56,262 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 }
         go(maxRounds)
     end pump
+
+    /** [[pump]] over the whole execution row rather than its status, for the questions the status cannot answer.
+      *
+      * What an execution is waiting for is a row per waiting node, so a predicate about waiting reads `waits`; the status says `Running`
+      * for a working execution and a waiting one alike.
+      */
+    protected def pumpState(
+        tc: Clock.TimeControl,
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        predicate: FlowStore.ExecutionState => Boolean,
+        maxRounds: Int = 200
+    )(using Frame): FlowStore.ExecutionState < (Async & Abort[FlowStoreException]) =
+        def go(remaining: Int): FlowStore.ExecutionState < (Async & Abort[FlowStoreException]) =
+            if remaining <= 0 then
+                store.getExecution(eid).map { state =>
+                    Abort.panic(new AssertionError(s"pumpState timed out, last state: $state"))
+                }
+            else
+                tc.advance(10.millis).map { _ =>
+                    store.getExecution(eid).map {
+                        case Present(state) if predicate(state) => state
+                        case _                                  => go(remaining - 1)
+                    }
+                }
+        go(maxRounds)
+    end pumpState
+
+    /** The execution holds an outstanding wait for the input named `name`. */
+    protected def waitingFor(name: String)(state: FlowStore.ExecutionState): Boolean =
+        state.waits.get(name).exists {
+            case Flow.Wake.OnField(_) => true
+            case _                    => false
+        }
+
+    /** The execution holds at least one outstanding sleep. */
+    protected def sleeping(state: FlowStore.ExecutionState): Boolean =
+        state.waits.values.exists {
+            case Flow.Wake.At(_) => true
+            case _               => false
+        }
+
+    /** The deadline of the execution's wait row at `path`, for a leaf that asserts which deadline stands. */
+    protected def deadlineOf(state: FlowStore.ExecutionState, path: String): Maybe[Instant] =
+        state.waits.get(path) match
+            case Present(Flow.Wake.At(instant)) => Maybe(instant)
+            case _                              => Maybe.empty
+
+    /** Takes the claim on one execution the way a poll does, for a fixture that needs to write to it.
+      *
+      * Every run-time write is a method on the claim, so a fixture that writes to a row has to be handed one first. A poll
+      * claims a batch, and a fixture wants one row, so the others go back exactly as they were found: an ending that keeps precisely
+      * the rows they already held, which neither retires a row nor blesses one.
+      *
+      * **The claim is asked for exactly once, and a leaf that must seed makes sure nothing else can be asking.** A claim belongs to
+      * its holder until that holder's attempt ends, so a fixture that loses one has no way to win it back: it cannot wait for an
+      * attempt it did not start, and asking again in a loop is worse than useless, because a fixture re-asks as fast as the store
+      * answers and spends every attempt inside the moment the holder needed to make progress. What keeps the fixture and a worker
+      * from competing is ORDER, and the leaves here use it: they seed before the workflow is registered, so readiness serves no pair
+      * this row could be claimed under while the fixture writes.
+      */
+    protected def seedClaim(
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        flowId: Flow.Id.Workflow,
+        hash: String,
+        executor: Flow.Id.Executor = Flow.Id.Executor("seeder")
+    )(using Frame): FlowStore.Claimed < (Async & Abort[FlowStoreException]) =
+        store.claimReady(Set((flowId, hash)), executor, 30.seconds, 10, Duration.Zero).map { batch =>
+            Kyo.foreachDiscard(batch.filter(_.state.executionId != eid)) { other =>
+                other.finish(FlowStore.Claimed.Outcome.Suspended(other.state.waits.toChunk.map(_._1).toSet)).unit
+            }.andThen {
+                Maybe.fromOption(batch.find(_.state.executionId == eid)) match
+                    case Present(claimed) => claimed
+                    case Absent =>
+                        store.getExecution(eid).map { row =>
+                            Abort.panic(new IllegalStateException(
+                                s"the fixture could not claim ${eid.value}: it is held by ${row.flatMap(_.executor)}, and " +
+                                    s"readiness handed back ${batch.map(_.state.executionId.value)}. Seed before the workflow " +
+                                    s"is registered, or before the engine exists."
+                            ))
+                        }
+            }
+        }
+    end seedClaim
+
+    /** Seeds wait rows the way the system parks an execution: claim the row, record each branch, end the attempt parked on them.
+      *
+      * The rows a fixture wants are exactly the rows a suspending ending blesses, so seeding through the public recipe is what makes
+      * the seeded state one a real attempt could have produced. A row written under a claim that is still live is a different state,
+      * and readiness reads the difference.
+      *
+      * **Seed while nothing else can claim the row, which for these leaves means before the engine is built.** A freshly created
+      * execution with no rows yet is READY, so a worker already polling for its pair will take it, and a fixture that loses the claim
+      * cannot get it back: see [[seedClaim]] for why asking again in a loop is not a fix. Building the engine after the seeding
+      * closes it completely, because the row is parked on deadlines that have not arrived by the time any worker first looks at it.
+      */
+    protected def seedWaits(
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        flowId: Flow.Id.Workflow,
+        hash: String,
+        waits: (String, Flow.Wake)*
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        def record(claimed: FlowStore.Claimed): Unit < (Async & Abort[FlowStoreException]) =
+            Kyo.foreachDiscard(waits) { (path, wake) =>
+                Clock.nowWith { now =>
+                    val event = wake match
+                        case Flow.Wake.At(instant)   => Flow.Event.SleepStarted(flowId, eid, path, instant, now)
+                        case Flow.Wake.OnField(name) => Flow.Event.InputWaiting(flowId, eid, name, now)
+                    claimed.recordWait(path, wake, event)
+                }
+            }.andThen(claimed.finish(FlowStore.Claimed.Outcome.Suspended(waits.map(_._1).toSet))).unit
+
+        store.claimReady(Set((flowId, hash)), Flow.Id.Executor("seeder"), 30.seconds, 10, Duration.Zero).map { batch =>
+            Kyo.foreachDiscard(batch.filter(_.state.executionId != eid)) { other =>
+                other.finish(FlowStore.Claimed.Outcome.Suspended(other.state.waits.toChunk.map(_._1).toSet)).unit
+            }.andThen {
+                Maybe.fromOption(batch.find(_.state.executionId == eid)) match
+                    case Present(claimed) => record(claimed)
+                    case Absent =>
+                        store.getExecution(eid).map { row =>
+                            Abort.panic(new IllegalStateException(
+                                s"the fixture could not claim ${eid.value} to seed its waits: it is held by " +
+                                    s"${row.flatMap(_.executor)}, row is $row. Seed before the engine is built."
+                            ))
+                        }
+            }
+        }
+    end seedWaits
+
+    /** Creates an execution the way a start does, for a fixture that needs a row the engine did not make. */
+    protected def seedExecution(
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        flowId: Flow.Id.Workflow,
+        status: Flow.Status,
+        hash: String
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        Clock.nowWith { now =>
+            store.createExecutionIfAbsent(eid, status, Flow.Event.Created(flowId, eid, now), hash, Dict.empty).unit
+        }
+
+    /** Advances the controlled clock until `cond` holds, and answers whether it ever did.
+      *
+      * The engine makes progress when its fibers run, and its fibers run when virtual time moves, so a leaf that advances a fixed
+      * number of rounds and then asserts is really asserting that the work happened to be scheduled inside that window, which is a
+      * coin flip dressed as a test. Driving the advance from the condition removes the dependence, and a leaf that wants to assert
+      * something did NOT happen still gets a definite answer, because the condition is re-checked after every step rather than once
+      * at the end.
+      */
+    protected def settle(
+        tc: Clock.TimeControl,
+        step: Duration = 10.millis,
+        maxRounds: Int = 500
+    )(cond: => Boolean < (Async & Abort[FlowStoreException]))(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+        def go(remaining: Int): Boolean < (Async & Abort[FlowStoreException]) =
+            cond.map {
+                case true  => true
+                case false => if remaining <= 0 then false else tc.advance(step).andThen(go(remaining - 1))
+            }
+        go(maxRounds)
+    end settle
+
+    /** Forwards every method of one claimed row to `underlying`, so a double that changes one of them says only what it changes.
+      *
+      * The run-time write verbs live on the claim rather than on the store, so a decorator intercepts a write by wrapping the CLAIM
+      * the poll was handed. That is a second decorator layer, and it is the only place those verbs can be reached.
+      */
+    protected class DelegatingClaimed(underlying: FlowStore.Claimed) extends FlowStore.Claimed:
+        def state: FlowStore.ExecutionState = underlying.state
+        def satisfied: Set[String]          = underlying.satisfied
+        def appendEvent(event: Flow.Event)(using Frame): FlowStore.WriteOutcome < (Async & Abort[FlowStoreException]) =
+            underlying.appendEvent(event)
+        def recordWait(path: String, wake: Flow.Wake, event: Flow.Event)(using
+            Frame
+        ): FlowStore.WriteOutcome < (Async & Abort[FlowStoreException]) =
+            underlying.recordWait(path, wake, event)
+        def renewClaim(lease: Duration)(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+            underlying.renewClaim(lease)
+        def updateStatus(status: Flow.Status, event: Flow.Event)(using
+            Frame
+        ): FlowStore.StatusOutcome < (Async & Abort[FlowStoreException]) =
+            underlying.updateStatus(status, event)
+        def recordProgress[V](path: String, value: Maybe[V], event: Flow.Event)(using
+            Tag[V],
+            Schema[V],
+            Frame
+        ): FlowStore.ProgressOutcome < (Async & Abort[FlowStoreException]) =
+            underlying.recordProgress[V](path, value, event)
+        def finish(outcome: FlowStore.Claimed.Outcome)(using Frame): FlowStore.StatusOutcome < (Async & Abort[FlowStoreException]) =
+            underlying.finish(outcome)
+    end DelegatingClaimed
+
+    /** Forwards every SPI method to `underlying`, so a double that changes one of them says only what it changes. */
+    protected class DelegatingStore(underlying: FlowStore) extends FlowStore:
+
+        /** How a claim handed back by `claimReady` is decorated. Subclasses that intercept a run-time write override this. */
+        protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed)
+
+        def claimReady(
+            served: Set[(Flow.Id.Workflow, String)],
+            executorId: Flow.Id.Executor,
+            lease: Duration,
+            limit: Int,
+            timeout: Duration
+        )(using Frame): Seq[FlowStore.Claimed] < (Async & Abort[FlowStoreException]) =
+            underlying.claimReady(served, executorId, lease, limit, timeout).map(_.map(wrapClaimed))
+
+        def createExecutionIfAbsent(
+            executionId: Flow.Id.Execution,
+            status: Flow.Status,
+            event: Flow.Event,
+            hash: String,
+            fields: Dict[String, FlowStore.FieldData]
+        )(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+            underlying.createExecutionIfAbsent(executionId, status, event, hash, fields)
+        def signal[V: Tag: Schema](executionId: Flow.Id.Execution, name: String, value: V, event: Flow.Event)(using
+            Frame
+        ): FlowStore.SignalOutcome < (Async & Abort[FlowStoreException]) =
+            underlying.signal[V](executionId, name, value, event)
+        def requestCancel(executionId: Flow.Id.Execution)(using
+            Frame
+        ): FlowStore.CancelOutcome < (Async & Abort[FlowStoreException]) =
+            underlying.requestCancel(executionId)
+        def getExecution(executionId: Flow.Id.Execution)(using
+            Frame
+        ): Maybe[FlowStore.ExecutionState] < (Async & Abort[FlowStoreException]) =
+            underlying.getExecution(executionId)
+        def listExecutions(flowId: Flow.Id.Workflow, filter: Maybe[FlowStore.ExecutionFilter], limit: Maybe[Int], offset: Int)(using
+            Frame
+        ): Chunk[FlowStore.ExecutionState] < (Async & Abort[FlowStoreException]) =
+            underlying.listExecutions(flowId, filter, limit, offset)
+        def getField[V: Tag: Schema](executionId: Flow.Id.Execution, name: String)(using
+            Frame
+        ): Maybe[V] < (Async & Abort[FlowStoreException]) =
+            underlying.getField[V](executionId, name)
+        def getAllFields(executionId: Flow.Id.Execution)(using
+            Frame
+        ): Dict[String, FlowStore.FieldData] < (Async & Abort[FlowStoreException]) =
+            underlying.getAllFields(executionId)
+        def getHistory(executionId: Flow.Id.Execution, limit: Maybe[Int], offset: Int)(using
+            Frame
+        ): FlowStore.HistoryPage < (Async & Abort[FlowStoreException]) =
+            underlying.getHistory(executionId, limit, offset)
+        def putWorkflow(meta: FlowEngine.WorkflowInfo)(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+            underlying.putWorkflow(meta)
+        def getWorkflow(id: Flow.Id.Workflow)(using Frame): Maybe[FlowEngine.WorkflowInfo] < (Async & Abort[FlowStoreException]) =
+            underlying.getWorkflow(id)
+        def listWorkflows(using Frame): Seq[FlowEngine.WorkflowInfo] < (Async & Abort[FlowStoreException]) = underlying.listWorkflows
+    end DelegatingStore
+
+end FlowEngineSupport
+
+class FlowEngineTest extends FlowEngineSupport:
 
     // =========================================================================
     // Basic execution
@@ -119,8 +391,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 1)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield status match
-                    case Flow.Status.Failed(msg) => assert(msg.contains("boom"))
-                    case other                   => fail(s"Expected Failed, got $other")
+                    case Flow.Status.Failed(msg, _) => assert(msg.contains("boom"))
+                    case other                      => fail(s"Expected Failed, got $other")
                 end for
             }
         }
@@ -138,10 +410,59 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _      <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _      <- pumpState(tc, store, eid, waitingFor("name"))
                     _      <- engine.executions.signal[String](eid, "name", "World")
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status == Flow.Status.Completed)
+                end for
+            }
+        }
+
+        /** A start-seeded input and a signalled one leave histories a reader can tell apart.
+          *
+          * What distinguishes them is the ABSENCE of input events on the seeded side, not a discharge event on both. The discharge
+          * write is guarded on the wait row, and a seeded input never parks: its value is in the record before the first attempt
+          * reads it, the satisfied branch takes it, and nothing about waiting is recorded. An unguarded discharge would append one
+          * `InputDischarged` per attempt on every replay past that input, which is a settled execution's history growing while it
+          * waits, so making the two shapes identical is the one way to make them indistinguishable in practice.
+          *
+          * The signalled twin is asserted as an ordered triple rather than a set, because the order is the arrival story: the
+          * execution parked, the value landed, the node consumed it and gave the row back.
+          */
+        "a seeded input and a signalled input leave different histories" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x + 1)
+                def inputEvents(eid: Flow.Id.Execution) =
+                    store.getHistory(eid, Maybe.empty, 0).map(_.events.map(_.kind).filter { kind =>
+                        kind == Flow.EventKind.InputWaiting ||
+                        kind == Flow.EventKind.InputReceived ||
+                        kind == Flow.EventKind.InputDischarged
+                    })
+                for
+                    _      <- engine.register(wf1, flow)
+                    seeded <- engine.workflows.start(wf1, new Record[Any](Dict("x" -> 1)))
+                    seededId = seeded.executionId
+                    _         <- pump(tc, store, seededId, _.isTerminal)
+                    signalled <- engine.workflows.start(wf1)
+                    signalledId = signalled.executionId
+                    _             <- pumpState(tc, store, signalledId, waitingFor("x"))
+                    _             <- engine.executions.signal[Int](signalledId, "x", 1)
+                    _             <- pump(tc, store, signalledId, _.isTerminal)
+                    seededKinds   <- inputEvents(seededId)
+                    signalledKind <- inputEvents(signalledId)
+                yield
+                    assert(
+                        seededKinds.isEmpty,
+                        s"an input that never waited records nothing about waiting, got $seededKinds"
+                    )
+                    assert(
+                        signalledKind == Chunk(
+                            Flow.EventKind.InputWaiting,
+                            Flow.EventKind.InputReceived,
+                            Flow.EventKind.InputDischarged
+                        ),
+                        s"a signalled input records parking, arrival and discharge in that order, got $signalledKind"
+                    )
                 end for
             }
         }
@@ -153,11 +474,65 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _   <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _   <- pumpState(tc, store, eid, waitingFor("name"))
                     _   <- engine.executions.signal[String](eid, "name", "first")
                     res <- Abort.run[FlowException](engine.executions.signal[String](eid, "name", "second"))
                 yield assert(res.isFailure)
                 end for
+            }
+        }
+
+        /** A signal that RACES completion must not land on a terminal execution.
+          *
+          * The sequential case, "signal to terminal execution fails", pumps to terminal first and then signals, and it is the easy
+          * one: the check sees a terminal status and refuses. The racing case is the one a read-check-write engine cannot handle,
+          * because nothing makes the read, the check and the write atomic. `FlowStore.signal` is one store verb that checks and
+          * writes in a single transition and answers `AlreadyTerminal` for an execution that is over.
+          *
+          * **The interleaving is forced, not sampled.** The store completes the execution at the moment the delivery's write
+          * arrives, which is exactly the window between the check and the write. Every answer the store gives is truthful: the
+          * status really is terminal by the time the field lands, which is the state a concurrent completion produces.
+          *
+          * What must not happen is a field, and an `InputReceived` after `Completed`, landing on an execution that is over. Either
+          * the delivery is refused or it leaves nothing behind, and one verb makes it both at once.
+          */
+        "a signal racing completion does not land on a terminal execution" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    AtomicInt.init(0).map { completions =>
+                        val store = new CompleteOnDeliveryStore(plain, "x", completions, tc)
+                        FlowEngine.init(store, workerCount = 1, lease = 30.seconds, pollTimeout = 100.millis).map { engine =>
+                            val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+                            for
+                                _      <- engine.register(wf1, flow)
+                                handle <- engine.workflows.start(wf1)
+                                eid = handle.executionId
+                                _     <- pumpState(tc, plain, eid, waitingFor("x"))
+                                res   <- Abort.run[FlowException](engine.executions.signal[Int](eid, "x", 7))
+                                raced <- completions.get
+                                state <- plain.getExecution(eid)
+                                field <- plain.getField[Int](eid, "x")
+                                page  <- plain.getHistory(eid, Maybe.empty, 0)
+                                after = page.events.dropWhile(_.kind != Flow.EventKind.Completed).map(_.kind)
+                            yield
+                                assert(raced == 1, s"the premise is that the store completed the execution under the delivery, $raced")
+                                assert(
+                                    state.exists(_.status.isTerminal),
+                                    s"the premise is that the execution is terminal when the delivery lands, got ${state.map(_.status)}"
+                                )
+                                assert(
+                                    res.isFailure || field.isEmpty,
+                                    s"a delivery that loses the race to completion must be refused or leave nothing behind, " +
+                                        s"got result $res with the field at $field"
+                                )
+                                assert(
+                                    after.count(_ == Flow.EventKind.InputReceived) == 0,
+                                    s"no delivery may be recorded after the execution completed, got $after"
+                                )
+                            end for
+                        }
+                    }
+                }
             }
         }
 
@@ -168,7 +543,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _   <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _   <- pumpState(tc, store, eid, waitingFor("x"))
                     res <- Abort.run[FlowException](engine.executions.signal[Int](eid, "unknown", 1))
                 yield assert(res.isFailure)
                 end for
@@ -216,8 +591,11 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _     <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
-                    _     <- engine.executions.cancel(eid)
+                    _ <- pumpState(tc, store, eid, waitingFor("x"))
+                    _ <- engine.executions.cancel(eid)
+                    // The request comes back before the execution stops, because cancelling runs its compensations: the terminal
+                    // write happens at the end of the unwind rather than in the caller's own call.
+                    _     <- pump(tc, store, eid, _.isTerminal)
                     state <- store.getExecution(eid)
                 yield assert(state.get.status == Flow.Status.Cancelled)
                 end for
@@ -240,6 +618,84 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
+        /** A cancel the store took says so, through the handle the caller already holds.
+          *
+          * Cancelling is a request, so nothing about it is observable on return except the answer: the execution keeps running until
+          * an executor reaches a node boundary, unwinds it and writes the terminal status. The answer is therefore the only thing
+          * separating a request that was taken from one that fell on an execution already over, and `Unit` would separate nothing.
+          */
+        "a cancel taken on a live execution answers accepted" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+                for
+                    _       <- engine.register(wf1, flow)
+                    handle  <- engine.workflows.start(wf1)
+                    _       <- pumpState(tc, store, handle.executionId, waitingFor("x"))
+                    outcome <- handle.cancel
+                    state   <- store.getExecution(handle.executionId)
+                yield
+                    assert(
+                        outcome == FlowStore.CancelOutcome.Accepted,
+                        s"a request the store took must answer accepted, got $outcome"
+                    )
+                    assert(
+                        state.exists(_.cancelRequested),
+                        s"and the answer must be about a request that is now outstanding, got ${state.map(_.cancelRequested)}"
+                    )
+                end for
+            }
+        }
+
+        /** A second ask says somebody asked first, which is a different instruction to the caller than the first answer.
+          *
+          * Staged on an execution this engine does not serve, so nothing can claim it and terminalise it between the two asks:
+          * the leaf is about which answer a repeat gets, and racing an unwind would make it about scheduling instead.
+          */
+        "a repeated cancel answers already-requested" in {
+            withEngine { (engine, store, tc) =>
+                val unserved = Flow.Id.Execution("cancel-twice")
+                for
+                    _      <- seedExecution(store, unserved, Flow.Id.Workflow("unserved-flow"), Flow.Status.Running, "")
+                    first  <- engine.executions.cancel(unserved)
+                    second <- engine.executions.cancel(unserved)
+                yield
+                    assert(
+                        first == FlowStore.CancelOutcome.Accepted,
+                        s"the premise is that the first ask was taken, got $first"
+                    )
+                    assert(
+                        second == FlowStore.CancelOutcome.AlreadyRequested,
+                        s"a repeat must say the request already stands, got $second"
+                    )
+                end for
+            }
+        }
+
+        /** Cancelling an execution that is over is an answer carrying what it ended as, not a failure.
+          *
+          * The caller got the outcome it asked for, so there is nothing to refuse; what it does not have is the result, and the
+          * status is what tells it to go and read one rather than wait for an unwind that will never run.
+          */
+        "a cancel on a finished execution answers already-terminal with its status" in {
+            withEngine { (engine, store, tc) =>
+                val finished = Flow.Id.Execution("cancel-finished")
+                for
+                    _       <- seedExecution(store, finished, Flow.Id.Workflow("unserved-flow"), Flow.Status.Completed, "")
+                    outcome <- engine.executions.cancel(finished)
+                    state   <- store.getExecution(finished)
+                yield
+                    assert(
+                        outcome == FlowStore.CancelOutcome.AlreadyTerminal(Flow.Status.Completed),
+                        s"the answer must carry what the execution ended as, got $outcome"
+                    )
+                    assert(
+                        !state.exists(_.cancelRequested),
+                        s"and nothing may be written on a terminal row, got ${state.map(_.cancelRequested)}"
+                    )
+                end for
+            }
+        }
+
         "cancelAll cancels multiple executions" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x)
@@ -249,10 +705,55 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     eid1 = h1.executionId
                     h2 <- engine.workflows.start(wf1)
                     eid2 = h2.executionId
-                    _     <- pump(tc, store, eid1, _ == Flow.Status.WaitingForInput("x"))
-                    _     <- pump(tc, store, eid2, _ == Flow.Status.WaitingForInput("x"))
+                    _     <- pumpState(tc, store, eid1, waitingFor("x"))
+                    _     <- pumpState(tc, store, eid2, waitingFor("x"))
                     count <- engine.executions.cancelAll(Maybe(wf1))
                 yield assert(count == 2)
+                end for
+            }
+        }
+
+        /** "Cancel everything" reaches an execution whose workflow this engine does not have registered.
+          *
+          * Enumerating `defs.keys`, the workflows registered in THIS engine, and asking only the executions belonging to them is the
+          * tempting implementation of an unfiltered `cancelAll` and the wrong one. The store is shared and the engine is one of
+          * several, so an execution written by another engine, or one left behind by a workflow that has since been unregistered, is
+          * invisible to that sweep.
+          *
+          * That is the wrong population to be blind to. An execution whose definition this engine cannot resolve is exactly the one
+          * an operator is trying to stop: nothing claims it, because `claimReady` is also called with the registered ids only, so it
+          * cannot make progress and could not be cancelled either. The count is the damaging part: an operator reads "cancelled 3"
+          * as "nothing is running", and the one execution that actually needed stopping is the one left out of the count.
+          *
+          * **What the sweep can promise is the request, which is why this asserts the request and the count.** Cancelling is a
+          * request that an executor observes and unwinds, and the terminal write needs a claim-holding executor; the execution this
+          * leaf is about is unclaimable here BY CONSTRUCTION, since readiness gates on the served set, so no engine in this test can
+          * ever write `Cancelled` on it. Asserting a terminal status would be asserting something no correct engine could produce,
+          * and would hide the two facts that are the leaf's actual subject.
+          */
+        "cancelAll requests cancellation of an execution whose workflow is not registered here" in {
+            withEngine { (engine, store, tc) =>
+                val flow    = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+                val orphan  = Flow.Id.Workflow("unregistered-flow")
+                val orphanE = Flow.Id.Execution("orphan-cancel")
+                for
+                    _ <- engine.register(wf1, flow)
+                    // The other engine's registration, which is what makes the workflow a fact about the STORE while this engine
+                    // serves nothing under it. Its execution is written the same way that engine would have written it.
+                    _     <- store.putWorkflow(FlowEngine.WorkflowInfo.of(orphan.value, flow))
+                    now   <- Clock.now
+                    _     <- seedExecution(store, orphanE, orphan, Flow.Status.Running, "")
+                    count <- engine.executions.cancelAll()
+                    state <- store.getExecution(orphanE)
+                yield
+                    assert(
+                        state.exists(_.cancelRequested),
+                        s"the request must reach an execution this engine cannot resolve, got ${state.map(_.cancelRequested)}"
+                    )
+                    assert(
+                        count == 1,
+                        s"and it must be counted, since a count that leaves it out reads as nothing being left running, got $count"
+                    )
                 end for
             }
         }
@@ -308,6 +809,1547 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 end for
             }
         }
+
+        /** A node whose executor died mid-step is re-run by the executor that reclaims the lease.
+          *
+          * The durable state below is exactly what a crash leaves behind: a `StepStarted` for a node with no `StepCompleted` after it, on
+          * an execution nobody holds. It is built through the store rather than by killing a process, so the test states the condition it
+          * is about instead of racing to produce it.
+          *
+          * Reading that event as "another executor is working on this node" and waiting for a completion is bounded only by the node's own
+          * `timeout`, which defaults to `Duration.Infinity`, so the wait never ends: the claim lapses, another executor claims, resumes,
+          * waits again, and the execution sits at `Running` forever with nothing reporting a problem.
+          */
+        "a step in flight when its executor died is re-run on resume" in {
+            withEngine { (engine, store, tc) =>
+                val flow      = Flow.init("fulfillment").step("charge")(_ => ()).output("receipt")(_ => "paid")
+                val deadOne   = Flow.Id.Executor("executor-that-died")
+                val leaseSpan = 2.seconds
+                for
+                    eid <- Sync.defer(Flow.Id.Execution("exec-crashed-mid-step"))
+                    now <- Clock.now
+                    // The hash comes from the flow itself rather than from a registration, so the execution exists
+                    // BEFORE this engine polls for its workflow: that is what lets the dying executor take the lease
+                    // first, deterministically, instead of racing the engine's own worker for it.
+                    hash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                    _ <- seedExecution(store, eid, wf1, Flow.Status.Running, hash)
+                    // The executor that is about to die holds the lease, which is the state a crash interrupts, and its
+                    // half-finished step is written UNDER that claim because every run-time write is. Its claim then
+                    // has to LAPSE before anyone else may touch the execution, so the test waits it out rather than
+                    // starting from an execution that is conveniently unheld.
+                    claimed <- store.claimReady(Set((wf1, hash)), deadOne, leaseSpan, 10, Duration.Zero)
+                    _       <- Kyo.foreachDiscard(claimed)(_.appendEvent(Flow.Event.StepStarted(wf1, eid, "charge", deadOne, now)))
+                    held    <- store.getExecution(eid)
+                    _       <- engine.register(wf1, flow)
+                    _       <- tc.advance(leaseSpan + 1.second)
+                    status  <- pump(tc, store, eid, _.isTerminal)
+                    receipt <- store.getField[String](eid, "receipt")
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    assert(claimed.map(_.state.executionId) == Seq(eid), s"the dying executor must have held it, claimed ${claimed.size}")
+                    assert(held.exists(_.executor == Present(deadOne)), s"the lease must have been held, state was $held")
+                    assert(status == Flow.Status.Completed, s"expected the reclaimed execution to complete, got $status")
+                    assert(receipt == Present("paid"), s"expected the flow to have produced its output, got $receipt")
+                    val chargeStarts = history.events.count {
+                        case Flow.Event.StepStarted(_, _, "charge", _, _) => true
+                        case _                                            => false
+                    }
+                    val chargeCompletions = history.events.count {
+                        case Flow.Event.StepCompleted(_, _, "charge", _) => true
+                        case _                                           => false
+                    }
+                    assert(chargeStarts == 2, s"expected the dead executor's start plus the re-run, got $chargeStarts")
+                    assert(chargeCompletions == 1, s"expected the re-run to record one completion, got $chargeCompletions")
+                end for
+            }
+        }
+
+        "a step already recorded as completed is not re-run when its start is also present" in {
+            withEngine { (engine, store, tc) =>
+                var charges = 0
+                val flow = Flow.init("fulfillment").step("charge") { _ =>
+                    charges += 1
+                }.output("receipt")(_ => "paid")
+                for
+                    eid <- Sync.defer(Flow.Id.Execution("exec-charge-already-done"))
+                    now <- Clock.now
+                    // The whole history is durable BEFORE the workflow is registered, for the same reason as the leaf
+                    // above: the engine's worker polls for registered workflows only, so writing the start and the
+                    // completion first is what keeps it from claiming the execution between the two appends and
+                    // re-running a step whose completion had not been written yet.
+                    hash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                    _       <- seedExecution(store, eid, wf1, Flow.Status.Running, hash)
+                    claimed <- seedClaim(store, eid, wf1, hash, Flow.Id.Executor("executor-that-died"))
+                    _ <- claimed.appendEvent(
+                        Flow.Event.StepStarted(wf1, eid, "charge", Flow.Id.Executor("executor-that-died"), now)
+                    )
+                    _      <- claimed.appendEvent(Flow.Event.StepCompleted(wf1, eid, "charge", now))
+                    _      <- claimed.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                    _      <- engine.register(wf1, flow)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                yield
+                    assert(status == Flow.Status.Completed, s"expected the execution to complete, got $status")
+                    assert(charges == 0, s"a completed step must stay skipped on replay, ran $charges times")
+                end for
+            }
+        }
+    }
+
+    // =========================================================================
+    // A step's own failures and its compensation's own effects
+    // =========================================================================
+    "domain failures" - {
+
+        /** A step declines for a domain reason, and the execution records what kind of failure that was.
+          *
+          * `FlowDomainException` is the open branch of `FlowException` for exactly this. With nowhere typed to put a domain failure it
+          * becomes a panic, and the persisted status keeps a message and nothing else, which makes "how many failed for payment
+          * reasons" a LIKE over free text.
+          */
+        "a domain failure is a failure, and the status names its kind" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("charging").step("charge") { _ =>
+                    Abort.fail(FlowEngineTest.ChargeDeclined("ord-200", 54000L))
+                }
+                for
+                    _      <- engine.register(Flow.Id.Workflow("charging"), flow)
+                    handle <- engine.workflows.start(Flow.Id.Workflow("charging"))
+                    eid = handle.executionId
+                    status <- pump(tc, store, eid, _.isTerminal)
+                yield status match
+                    case Flow.Status.Failed(error, kind) =>
+                        assert(error.contains("54000"), s"the message must survive, got $error")
+                        assert(kind == Present("ChargeDeclined"), s"the failure's kind must be recorded, got $kind")
+                    case other => assert(false, s"expected Failed, got $other")
+                end for
+            }
+        }
+
+        "a panic carries no kind, since nothing declared one" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("panicking").step("fall-over")(_ => throw new RuntimeException("the process fell over"))
+                for
+                    _      <- engine.register(Flow.Id.Workflow("panicking"), flow)
+                    handle <- engine.workflows.start(Flow.Id.Workflow("panicking"))
+                    eid = handle.executionId
+                    status <- pump(tc, store, eid, _.isTerminal)
+                yield status match
+                    case Flow.Status.Failed(error, kind) =>
+                        assert(error.contains("fell over"), s"the message must survive, got $error")
+                        assert(kind == Absent, s"an escaped throwable declares no kind, got $kind")
+                    case other => assert(false, s"expected Failed, got $other")
+                end for
+            }
+        }
+
+        /** A compensation uses the effects its forward step used, discharged by the same runner.
+          *
+          * Pinning the handler's row to `Async & Abort[FlowException]` would stop a compensation that has to undo a write from asking the
+          * engine for the resource the write used, and push the flow into carrying a second dependency-injection mechanism.
+          */
+        "a compensation uses the forward step's own effects" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicRef.init(Chunk.empty[String]).map { audit =>
+                        val flow = Flow.init("saga")
+                            .outputCompensated("reserve")(_ => Env.use[String](w => s"reserved in $w"))(ctx =>
+                                Env.use[String](w => audit.getAndUpdate(_ :+ s"released in $w").unit)
+                            )
+                            .step("charge")(_ => Abort.fail(FlowEngineTest.ChargeDeclined("ord-1", 1L)))
+                        val config = FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis)
+                        FlowEngine.init(store, config, flow)([v] =>
+                            (c: v < (Env[String] & Abort[FlowEngineTest.ChargeDeclined])) =>
+                                Abort.recover[FlowEngineTest.ChargeDeclined](e => Abort.fail(e: FlowException))(
+                                    Env.run("warehouse")(c)
+                            )).map { engine =>
+                            for
+                                handle <- engine.workflows.start(Flow.Id.Workflow("saga"))
+                                eid = handle.executionId
+                                status  <- pump(tc, store, eid, _.isTerminal)
+                                entries <- audit.get
+                            yield
+                                assert(status.isInstanceOf[Flow.Status.Failed], s"expected the saga to fail, got $status")
+                                assert(
+                                    entries == Chunk("released in warehouse"),
+                                    s"the compensation must have run with the runner's effect, got $entries"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // A store that fails under the worker
+    // =========================================================================
+    "store failures" - {
+
+        /** A store that fails the claim keeps the engine alive, records the failure, and processes what follows.
+          *
+          * A failure raised while EXECUTING has an execution to record it against: the engine catches it, writes it on the row, and
+          * releases the claim. A failure raised while CLAIMING has no such row, and letting it escape kills every worker fiber with
+          * nothing logged and no status changed, leaving a process that answers its health check while no execution ever progresses.
+          */
+        "a claim that fails does not kill the worker" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(3).map { failuresLeft =>
+                        val flaky = new FailingClaimStore(store, failuresLeft)
+                        val flow  = Flow.init("resilient").output("y")(_ => 42)
+                        FlowEngine.init(flaky, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(Flow.Id.Workflow("resilient"))
+                                eid = handle.executionId
+                                status <- pump(tc, store, eid, _.isTerminal, maxRounds = 2000)
+                                y      <- store.getField[Int](eid, "y")
+                                health <- engine.health
+                            yield
+                                assert(status == Flow.Status.Completed, s"the engine must recover and run it, got $status")
+                                assert(y == Present(42), s"the flow must have produced its output, got $y")
+                                assert(health.workersAlive == 1, s"the worker must still be polling, got ${health.workersAlive}")
+                                assert(health.isHealthy, s"every configured worker must be alive, got $health")
+                                assert(health.pollFailures >= 3L, s"the failures must be counted, got ${health.pollFailures}")
+                                assert(
+                                    health.lastPollFailure.exists(_.contains("claimReady")),
+                                    s"the last failure must be reported, got ${health.lastPollFailure}"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A store that FAILS the claim, rather than panicking, is handled the same way and keeps its message.
+          *
+          * This is what the SPI's error channel buys: a store over a database has typed, classified failures, and reporting one by
+          * panicking throws the classification away at the boundary.
+          */
+        "a typed store failure on the claim path is retried and reported" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(3).map { failuresLeft =>
+                        val flaky = new FailingClaimStore(store, failuresLeft, ClaimFailure.Typed)
+                        val flow  = Flow.init("typed-store-failure").output("y")(_ => 42)
+                        FlowEngine.init(flaky, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(Flow.Id.Workflow("typed-store-failure"))
+                                eid = handle.executionId
+                                status <- pump(tc, store, eid, _.isTerminal, maxRounds = 2000)
+                                health <- engine.health
+                            yield
+                                assert(status == Flow.Status.Completed, s"the engine must recover and run it, got $status")
+                                assert(health.workersAlive == 1, s"the worker must still be polling, got ${health.workersAlive}")
+                                assert(health.pollFailures >= 3L, s"the failures must be counted, got ${health.pollFailures}")
+                                assert(
+                                    health.lastPollFailure.exists(_.contains("could not be reached")),
+                                    s"the store's own message must survive, got ${health.lastPollFailure}"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        "a healthy engine reports every worker alive" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { store =>
+                    val flow = Flow.init("healthy").output("y")(_ => 1)
+                    FlowEngine.init(store, FlowEngine.Config(workerCount = 2, pollTimeout = 100.millis), flow).map { engine =>
+                        engine.health.map { health =>
+                            assert(health.workersConfigured == 2, s"got ${health.workersConfigured}")
+                            assert(health.workersAlive == 2, s"got ${health.workersAlive}")
+                            assert(health.pollFailures == 0L, s"got ${health.pollFailures}")
+                            assert(health.lastPollFailure == Absent, s"got ${health.lastPollFailure}")
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A store failure raised while an execution is running is charged to the store's health, never to the execution.
+          *
+          * A terminal `Failed` carrying the store's kind is the wrong answer, and irreversibly so: terminal status cannot be
+          * reverted, so a transient outage recorded as the workflow having failed is a permanent verdict on work that never failed.
+          * Under the attempt classification a store failure is `Infra`: it writes nothing about the execution, the row stays exactly
+          * as claimable as it was (the retryable-store leaf pins the recovery when the store heals), and the failure surfaces where
+          * infrastructure failures belong, on `Health`, with the store's own message intact so an operator still sees what the store
+          * said.
+          */
+        "a store failure while running an execution is charged to health, not to the execution" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val failing = new FailingFieldStore(store, "receipt")
+                    val flow    = Flow.init("unwritable").output("receipt")(_ => "paid")
+                    FlowEngine.init(failing, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map { engine =>
+                        for
+                            handle <- engine.workflows.start(Flow.Id.Workflow("unwritable"))
+                            eid = handle.executionId
+                            _       <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(10.millis))
+                            state   <- store.getExecution(eid)
+                            history <- store.getHistory(eid, Maybe.empty, 0)
+                            health  <- engine.health
+                        yield
+                            assert(
+                                state.exists(!_.status.isTerminal),
+                                s"a store failure must not terminalise the execution, got ${state.map(_.status)}"
+                            )
+                            assert(
+                                !history.events.exists(_.kind == Flow.EventKind.Failed),
+                                s"a store failure must leave no Failed event in the execution's history, got " +
+                                    s"${history.events.map(_.kind)}"
+                            )
+                            assert(
+                                health.lastPollFailure.exists(_.contains("deadlock writing 'receipt'")),
+                                s"the store's own message must survive on the health surface, got ${health.lastPollFailure}"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** The same fact on a flow that has compensation handlers, where the unwind gives a store failure somewhere wrong to go.
+          *
+          * `Flow.run` discharges the whole walk with one `Abort.run[Throwable]`, so handing every failure to the unwind would send a
+          * store that could not be reached down it: `Compensating(Failure(<the store's own message>))` written through the claim,
+          * every handler the walk registered run, the unwind's events appended, and only then a re-raise on the store's channel. The
+          * attempt then ends `Infra` and writes nothing more, which is correct and far too late, because the row already says
+          * `Compensating`, so the next attempt reads it as a resumed unwind and terminalises the saga `Failed` carrying the store's
+          * message, with its refunds issued. One transient blip, one reversed saga.
+          *
+          * A store failure says nothing about the work, so it is not a verdict and the unwind is not entered at all: no status write,
+          * no handler, no event, and the execution stays exactly as claimable as it was for the next poll to try again.
+          */
+        "a store failure on a flow with handlers starts no unwind and runs no handler" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(0).map { compensations =>
+                        val failing = new FailingFieldStore(store, "receipt")
+                        val flow =
+                            Flow.init("compensated-outage")
+                                .outputCompensated("reserve")(_ => "held")(_ => compensations.incrementAndGet.unit)
+                                .output("receipt")(_ => "paid")
+                        FlowEngine.init(failing, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(Flow.Id.Workflow("compensated-outage"))
+                                eid = handle.executionId
+                                _       <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(10.millis))
+                                state   <- store.getExecution(eid)
+                                history <- store.getHistory(eid, Maybe.empty, 0)
+                                ran     <- compensations.get
+                                health  <- engine.health
+                            yield
+                                assert(
+                                    state.exists(!_.status.isTerminal),
+                                    s"a store failure must not terminalise a compensated execution, got ${state.map(_.status)}"
+                                )
+                                assert(
+                                    !state.exists(_.status match
+                                        case Flow.Status.Compensating(_) => true
+                                        case _                           => false),
+                                    s"nor put it into an unwind nothing asked for, got ${state.map(_.status)}"
+                                )
+                                assert(
+                                    !history.events.exists(e =>
+                                        e.kind == Flow.EventKind.CompensationStarted || e.kind == Flow.EventKind.Failed
+                                    ),
+                                    s"and must record no unwind in its history, got ${history.events.map(_.kind)}"
+                                )
+                                assert(ran == 0, s"no handler may have run, got $ran")
+                                assert(
+                                    health.lastPollFailure.exists(_.contains("deadlock writing 'receipt'")),
+                                    s"the store's own message must survive on the health surface, got ${health.lastPollFailure}"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** And when the store heals, the execution finishes the work rather than undoing it.
+          *
+          * The other half of the leaf above, on the store failure that lasts one attempt. What the next attempt finds decides whether
+          * the first one was a verdict: with the unwind never entered, the row is still `Running`, the completed step is read back
+          * from its field, the blipped step runs again and the saga COMPLETES. Had the blip written `Compensating` and run the
+          * refund, the same execution could only end `Failed`.
+          */
+        "an execution whose store blip healed completes, with its handler never run" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(1).map { blips =>
+                        AtomicInt.init(0).map { compensations =>
+                            val flaky = new FailingCompletionStore(store, "receipt", blips)
+                            val flow =
+                                Flow.init("compensated-blip")
+                                    .outputCompensated("reserve")(_ => "held")(_ => compensations.incrementAndGet.unit)
+                                    .output("receipt")(_ => "paid")
+                            // A short lease, for the reason the retryable-store leaf states: an attempt that could not reach the
+                            // store leaves its claim to expire rather than releasing it, so nothing re-runs until the lease lapses.
+                            val config =
+                                FlowEngine.Config(workerCount = 1, lease = 1.second, renewEvery = 500.millis, pollTimeout = 100.millis)
+                            FlowEngine.init(flaky, config, flow).map { engine =>
+                                for
+                                    handle <- engine.workflows.start(Flow.Id.Workflow("compensated-blip"))
+                                    eid = handle.executionId
+                                    status  <- pump(tc, store, eid, _.isTerminal, 400)
+                                    ran     <- compensations.get
+                                    history <- store.getHistory(eid, Maybe.empty, 0)
+                                yield
+                                    assert(
+                                        status == Flow.Status.Completed,
+                                        s"a blip the next attempt got past must leave the execution Completed, got $status"
+                                    )
+                                    assert(ran == 0, s"and its compensation must never have run, got $ran")
+                                    assert(
+                                        !history.events.exists(_.kind == Flow.EventKind.CompensationStarted),
+                                        s"nor may an unwind appear in its history, got ${history.events.map(_.kind)}"
+                                    )
+                                end for
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An interrupt raised inside the poll stops the worker rather than being retried as a store failure.
+          *
+          * The retry arm catches panics as well as failures, which is what keeps a store's defect from stopping the engine for good. An
+          * interrupt is not that: `Interrupted` is an ordinary exception, so it arrives on the same arm and would be logged, counted
+          * against the store's health, slept off, and tried again, for as long as the store kept raising it. Nothing about the engine
+          * would say why. The interrupt reaches this arm as a value rather than at the worker's own safepoint when the store raised it
+          * internally, from a race or a timeout of its own.
+          */
+        "an interrupt raised inside the poll stops the worker" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(Int.MaxValue).map { always =>
+                        val interrupting = new FailingClaimStore(store, always, ClaimFailure.Interrupt)
+                        val flow         = Flow.init("interrupted-poll").output("y")(_ => 42)
+                        FlowEngine.init(interrupting, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map { engine =>
+                            for
+                                _      <- Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                                health <- engine.health
+                            yield
+                                assert(
+                                    health.workersAlive == 0,
+                                    s"the interrupted worker must have stopped, ${health.workersAlive} still polling"
+                                )
+                                assert(
+                                    health.pollFailures == 0L,
+                                    s"an interrupt is not a store failure and must not be counted as one, got ${health.pollFailures}"
+                                )
+                                assert(
+                                    health.lastPollFailure.isEmpty,
+                                    s"an interrupt must not be reported as a store failure, got ${health.lastPollFailure}"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An executor whose lease has expired must not go on writing to the execution.
+          *
+          * A monotonic generation alone does not close this. A generation refuses a SUPERSEDED writer, one whose row somebody else
+          * claimed; it says nothing about an executor whose lease ran out while nobody else claimed the row, which still holds the
+          * highest generation the row has carried. This is exactly that shape, a single worker with no competitor anywhere, so it is
+          * the half of the acceptance rule the token cannot supply: a write is applied only if the claim is active, the token matches,
+          * AND the claim has not expired.
+          *
+          * **The lapse is real rather than reported.** Faking it by making the row's own read answer an expiry in the past proves
+          * nothing, because the store judges expiry against its own recorded claim at write time, and there the claim is perfectly
+          * valid. So the leaf produces the state instead: the step blocks, the renewals stop arriving, and the clock passes the lease,
+          * which is what a starved or partitioned executor looks like from the store's side. The renewal PARKS rather than being
+          * refused, because a refusal would interrupt the attempt and the writes would then stop because the work stopped rather than
+          * because the store refused them.
+          */
+        "an executor whose lease has expired does not keep writing" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicBoolean.init(false).map { armed =>
+                        AtomicInt.init(0).map { refusals =>
+                            Channel.init[Unit](1).map { parked =>
+                                val leaseSpan = 5.seconds
+                                val expired = new LapsingClaimStore(store, tc, leaseSpan, armed, refusals, parked)({
+                                    case _: Flow.Event.StepStarted => true
+                                    case _                         => false
+                                })
+                                val flow = Flow.init("expired-lease").step("reserve")(_ => ()).output("receipt")(_ => "paid")
+                                val config = FlowEngine.Config(
+                                    workerCount = 1,
+                                    lease = leaseSpan,
+                                    renewEvery = 1.second,
+                                    pollTimeout = 100.millis
+                                )
+                                for
+                                    eid <- Scope.run {
+                                        FlowEngine.init(expired, config, flow).map { engine =>
+                                            for
+                                                handle <- engine.workflows.start(Flow.Id.Workflow("expired-lease"))
+                                                eid = handle.executionId
+                                                // The refusal is what this leaf is about, so it waits for one to have fired
+                                                // rather than for a number of rounds. The engine's scope then closes: an
+                                                // executor whose lease lapsed with nothing renewing it is an executor that is
+                                                // gone, and one still polling would simply take the row again under a fresh
+                                                // generation, which is recovery working rather than the window under test.
+                                                refused <- settle(tc)(refusals.get.map(_ > 0))
+                                                _ = assert(
+                                                    refused,
+                                                    "the premise is that the lapsed executor presented a write and was refused"
+                                                )
+                                            yield eid
+                                        }
+                                    }
+                                    state   <- store.getExecution(eid)
+                                    receipt <- store.getField[String](eid, "receipt")
+                                yield
+                                    assert(
+                                        !state.exists(_.status.isTerminal),
+                                        s"an executor past its deadline must not carry the execution to a terminal status, got ${state.map(_.status)}"
+                                    )
+                                    assert(
+                                        receipt.isEmpty,
+                                        s"an executor past its deadline must not write a step's result, got $receipt"
+                                    )
+                                end for
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An executor that lost its claim writes nothing further about the execution.
+          *
+          * The leaf below asserts the step STOPPED, which is the presence of a stop rather than the absence of writes, and that holds
+          * even while the release path appends into the history of an execution somebody else now owns: a release is a no-op for a
+          * non-owner, but the event accompanying it can still go through an unfenced append. Both halves ride the claim, so a test
+          * for this area has to assert that the loser wrote nothing rather than that it noticed.
+          */
+        "an executor that has lost its claim writes nothing more" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicBoolean.init(false).map { started =>
+                        AtomicInt.init(1).map { grants =>
+                            val losing = new LosingRenewalStore(store, grants)
+                            val flow = Flow.init("losing-writes").step[Async]("work") { _ =>
+                                started.set(true).andThen(Async.never)
+                            }.output("done")(_ => Async.delay(Duration.Zero)("ok"))
+                            val config = FlowEngine.Config(
+                                workerCount = 1,
+                                lease = 5.seconds,
+                                renewEvery = 100.millis,
+                                pollTimeout = 100.millis
+                            )
+                            FlowEngine.init(losing, config, flow)([v] => (c: v < Async) => c).map { engine =>
+                                for
+                                    handle <- engine.workflows.start(Flow.Id.Workflow("losing-writes"))
+                                    eid = handle.executionId
+                                    _        <- Kyo.foreachDiscard(1 to 200)(_ => tc.advance(10.millis))
+                                    didStart <- started.get
+                                    history  <- store.getHistory(eid, Maybe.empty, 0)
+                                yield
+                                    assert(didStart, "the step must have begun, or this leaf proves nothing")
+                                    assert(
+                                        !history.events.exists(_.kind == Flow.EventKind.ExecutionReleased),
+                                        s"an executor that lost the claim must not write a release into the history of an " +
+                                            s"execution it no longer owns, got ${history.events.map(_.kind)}"
+                                    )
+                                end for
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An attempt that ended without a verdict leaves the waits it recorded exactly where they are.
+          *
+          * The release transition retires every wait the ending does not name, which is right for an attempt that finished: what it
+          * ended parked on is a trustworthy statement of what the execution waits for, and everything else is a race loser or an
+          * abandoned branch. An interrupted attempt states nothing, so retiring against it deletes rows the execution is still in,
+          * and the next attempt inherits a ledger that says the execution waits for less than it does. The damage is not a lost
+          * claim, it is a half-written ledger blessed as a finished one.
+          *
+          * **The retired rows are what makes a wrong release visible at all.** The claim itself is not: the moment a row is freed
+          * this engine's own poll re-claims it, so a release and no release look the same in the row a test can read afterwards. The
+          * rows do not come back, because the re-claim's confirmation renewal is refused too and no replay ever runs. The race is
+          * what puts a recorded wait and a live attempt in the execution at the same time, which is the only shape in which an
+          * ending can be interrupted while the ledger is non-empty.
+          */
+        "an ending with no verdict keeps the waits the attempt recorded" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(1).map { grants =>
+                        val losing  = new LosingRenewalStore(store, grants)
+                        val wfId    = Flow.Id.Workflow("unfinished-ledger")
+                        val parking = Flow.init("unfinished-ledger").input[String]("approval").output("answer")(ctx => ctx.approval)
+                        val working = Flow.init("unfinished-ledger").step[Async]("work")(_ => Async.never)
+                            .output("answer")(_ => "worked")
+                        val flow = Flow.race(parking, working)
+                        val config =
+                            FlowEngine.Config(workerCount = 1, lease = 5.seconds, renewEvery = 100.millis, pollTimeout = 100.millis)
+                        FlowEngine.init(losing, config, flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(wfId)
+                                eid = handle.executionId
+                                parked  <- settle(tc)(store.getExecution(eid).map(_.exists(_.waits.contains("approval"))))
+                                refused <- settle(tc)(grants.get.map(_ <= 0))
+                                _       <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(10.millis))
+                                state   <- store.getExecution(eid)
+                            yield
+                                assert(
+                                    parked,
+                                    "the premise is that one branch recorded its wait while the other was still running"
+                                )
+                                assert(refused, "the premise is that the executor then lost its claim mid-attempt")
+                                assert(
+                                    state.exists(_.waits.contains("approval")),
+                                    s"an attempt that reached no verdict has nothing to bless, so the waits it recorded must " +
+                                        s"survive it, got ${state.map(_.waits)}"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An executor that has lost its claim stops the work it is doing, rather than running on outside its lease.
+          *
+          * The lease is what authorises an executor to work on an execution, and the renewal loop is what keeps it. When a renewal is
+          * refused the claim is already someone else's, so everything this executor does from that moment is work on an execution it
+          * does not hold. A renewal loop that merely exits and leaves the step running has noticed without acting.
+          *
+          * **Refusing the writes is not enough on its own, which is why the engine has to stop the work.** The store judges what an
+          * attempt presents to it, and a step whose `timeout` defaults to `Duration.Infinity` presents nothing ever again: it holds a
+          * worker and the memory behind it for as long as the process lives, and no refusal is reached to end it.
+          *
+          * The step here blocks forever and records its own interruption, so the assertion is that the engine stopped it, not that the
+          * engine noticed.
+          */
+        "an executor that has lost its claim stops the step it is running" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicBoolean.init(false).map { started =>
+                        AtomicBoolean.init(false).map { stopped =>
+                            AtomicInt.init(1).map { grants =>
+                                val losing = new LosingRenewalStore(store, grants)
+                                val flow = Flow.init("long-step").step[Async]("work") { _ =>
+                                    Sync.ensure(stopped.set(true))(started.set(true).andThen(Async.never))
+                                }.output("done")(_ => Async.delay(Duration.Zero)("ok"))
+                                val config =
+                                    FlowEngine.Config(workerCount = 1, lease = 5.seconds, renewEvery = 100.millis, pollTimeout = 100.millis)
+                                FlowEngine.init(losing, config, flow)([v] => (c: v < Async) => c).map { engine =>
+                                    for
+                                        _        <- engine.workflows.start(Flow.Id.Workflow("long-step"))
+                                        _        <- Kyo.foreachDiscard(1 to 200)(_ => tc.advance(10.millis))
+                                        didStart <- started.get
+                                        didStop  <- stopped.get
+                                    yield
+                                        assert(didStart, "the step must have begun, or this leaf proves nothing")
+                                        assert(didStop, "an executor whose renewal was refused must stop the step it is running")
+                                    end for
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An interrupt the store raises while an attempt's outcome is being written is not a store failure.
+          *
+          * The recovery around that write is `Abort.run[Throwable]`, wide on purpose: a store is third-party code and is free to
+          * panic even though the SPI gives it somewhere typed to put a failure. An `Interrupted` is an ordinary throwable, so it
+          * arrives on that same arm, and the three other broad recoveries in the engine (the worker loop, the renewal loop, the
+          * supervise wrapper) each pick it out and re-raise it rather than counting it. Without the same arm here, an interrupt
+          * raised inside a store call, by a race or a timeout the store ran internally, is charged to the store's health and logged
+          * as a store that could not be reached: the engine blames the store for having been stopped.
+          *
+          * The health charge is the observable that separates the two, so it is what this leaf reads. What follows the classification
+          * is the same either way in the moment: the write did not land, so the execution stays non-terminal and its claim lapses.
+          */
+        "an interrupt raised inside the outcome write is not charged to the store" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(1).map { interrupts =>
+                        val interrupting = new InterruptingOutcomeStore(store, interrupts)
+                        val wfId         = Flow.Id.Workflow("interrupt-vs-outcome")
+                        val flow         = Flow.init("interrupt-vs-outcome").output("receipt")(_ => "paid")
+                        // The lease outlasts the whole run, so nothing reclaims the row while the health signal is being
+                        // watched and the only thing that can move the counter is the classification under test.
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 30.seconds,
+                            renewEvery = 5.seconds,
+                            pollTimeout = 100.millis
+                        )
+                        FlowEngine.init(interrupting, config, flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(wfId)
+                                eid = handle.executionId
+                                raised <- settle(tc, step = 100.millis, maxRounds = 40)(interrupts.get.map(_ <= 0))
+                                // Bounded room for a charged interrupt to show itself: under the defect the counter turns
+                                // over the moment the write is recovered, and with the arm it never moves at all.
+                                charged <- settle(tc, step = 100.millis, maxRounds = 20)(engine.health.map(_.pollFailures > 0))
+                                health  <- engine.health
+                                state   <- store.getExecution(eid)
+                                history <- store.getHistory(eid, Maybe.empty, 0)
+                            yield
+                                assert(raised, "the premise is that the store raised an interrupt from the outcome write")
+                                assert(
+                                    !charged && health.pollFailures == 0L,
+                                    s"an interrupt is not a store failure and must not be counted as one, got " +
+                                        s"${health.pollFailures} recorded failures"
+                                )
+                                assert(
+                                    health.lastPollFailure.isEmpty,
+                                    s"an interrupt must not be reported as a store failure, got ${health.lastPollFailure}"
+                                )
+                                assert(
+                                    !history.events.exists(_.kind == Flow.EventKind.Failed),
+                                    s"an interrupt is not a verdict on the work, got ${history.events.map(_.kind)}"
+                                )
+                                assert(
+                                    !state.exists(_.status.isTerminal),
+                                    s"an interrupt stops this attempt and writes nothing, so the execution is left for its " +
+                                        s"claim to lapse rather than carried to a terminal status, got ${state.map(_.status)}"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Scheduled loop exhaustion
+    // =========================================================================
+    "scheduled loop exhaustion" - {
+
+        /** A scheduled loop whose schedule runs out fails the execution, naming the loop.
+          *
+          * A flow declaring `N ~ V` promises a `V`, and a `loopOn` whose schedule is spent has none: the last state it carried is
+          * the loop's state type and the loop's name is typed for its value, so the two coincide only by accident. Nothing is
+          * written under the loop's name and the execution reaches a terminal `Failed` that says which loop ran out.
+          *
+          * Writing anything under the loop's name on the exhaustion path is worse than useless. A `()` written under the loop
+          * VALUE's own schema raises a cast error inside the field write, and where that error goes splits the platforms in two: the
+          * JVM and Native catch it and record a failed execution with `BoxedUnit cannot be cast to Integer`, while JS and Wasm let it
+          * escape and the host exits with code 1, taking `FlowEngineTest` and `MemoryFlowStoreTest` down with it so both report
+          * nothing at all.
+          *
+          * The KIND is the load-bearing assertion, and it is spelled exactly as the sibling timeout leaf spells it. Running a
+          * schedule out is a verdict the engine reaches about the flow, so it is raised as a declared failure and arrives carrying
+          * its own class name, which is what makes "how many executions ran their loop out" a query over a field rather than a
+          * search over message text. Raised as a panic instead, it would arrive with the kind stripped and this leaf would fail,
+          * which is the point of asserting the kind rather than only the status.
+          */
+        "a scheduled loop that exhausts its schedule records a defined outcome" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("exhausted")
+                    .loopOn("count", Schedule.fixed(100.millis).repeat(2)) { ctx =>
+                        Loop.continue[Int]
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    done  <- settle(tc, maxRounds = 200)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                    count <- store.getField[Int](eid, "count")
+                    state <- store.getExecution(eid)
+                yield
+                    assert(done, s"an exhausted loop must reach a terminal status, got ${state.map(_.status)}")
+                    val failure = state.map(_.status).collect { case f: Flow.Status.Failed => f }
+                    assert(
+                        failure.exists(f => f.error.contains("count") && f.error.contains("schedule")),
+                        s"an exhausted schedule must fail the execution and name the loop that ran out, got ${state.map(_.status)}"
+                    )
+                    val kindOf = state.map(_.status) match
+                        case Present(Flow.Status.Failed(_, kind)) => kind
+                        case other                                => Maybe(s"not-failed: $other")
+                    assert(
+                        kindOf == Maybe("FlowLoopExhaustedException"),
+                        s"exhaustion is a declared failure of the flow, not an escaped one, so it must terminalise as Failed " +
+                            s"carrying its own kind, got status ${state.map(_.status)}"
+                    )
+                    assert(
+                        count.isEmpty,
+                        s"nothing is written under the loop's name when it produces no value, got $count"
+                    )
+                end for
+            }
+        }
+
+        /** A loop that ran its schedule out is reported as the failed node, by name.
+          *
+          * Exhaustion is a verdict the ENGINE reaches rather than one a step threw, and it reaches the store through the interpreter's
+          * failure verb. That verb has to record the node: with nothing recorded, the execution terminalises `Failed` carrying the
+          * message and the kind while every node on the progress view reads pending, so the surface cannot say which node ended the
+          * run. The record is written under the loop's own durable name before the failure is raised.
+          *
+          * The node's message is asserted to be the execution's own, rather than a string spelled twice: one failure, one wording,
+          * whichever surface a reader is looking at.
+          */
+        "a loop that exhausted its schedule is the node reported failed" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("exhausted-node")
+                    .loopOn("count", Schedule.fixed(100.millis).repeat(2)) { ctx =>
+                        Loop.continue[Int]
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    done   <- settle(tc, maxRounds = 200)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                    state  <- store.getExecution(eid)
+                    detail <- engine.executions.describe(eid)
+                yield
+                    assert(done, s"the premise is that the loop ran out and the execution is over, got ${state.map(_.status)}")
+                    val error = state.map(_.status) match
+                        case Present(Flow.Status.Failed(message, _)) => Maybe(message)
+                        case _                                       => Maybe.empty
+                    assert(error.isDefined, s"the premise is a failed execution, got ${state.map(_.status)}")
+                    assert(
+                        detail.progress.nodeByName("count").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Failed(error.get)),
+                        s"the loop that ran out must be the node reported failed, carrying the execution's own message, got " +
+                            s"${detail.progress.nodeByName("count").map(_.status)}"
+                    )
+                end for
+            }
+        }
+
+        /** A scheduled loop whose BODY failed reports the loop, not the iteration nobody can see.
+          *
+          * An iteration records under the loop's name with its number appended, so the failure of iteration 0 of `tally` lands under
+          * `tally#0`, and no node on the progress view is called that: the iterations are the loop's internal bookkeeping. Attributing
+          * the record to the parent is the completion side's asymmetry the other way up. One iteration completing does not complete
+          * the loop, and one iteration failing does fail it, so the parent is the honest owner of the failure and the only node a
+          * reader can act on.
+          */
+        "a scheduled loop whose body failed reports the loop as the failed node" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("loop-body-fails")
+                    .loopOn("tally", Schedule.fixed(100.millis).repeat(5), 0) { (state: Int, ctx) =>
+                        throw new RuntimeException("tally broke"); Loop.done(state)
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    done   <- settle(tc, maxRounds = 200)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                    state  <- store.getExecution(eid)
+                    detail <- engine.executions.describe(eid)
+                yield
+                    assert(done, s"the premise is that the failing body ended the execution, got ${state.map(_.status)}")
+                    val error = state.map(_.status) match
+                        case Present(Flow.Status.Failed(message, _)) => Maybe(message)
+                        case _                                       => Maybe.empty
+                    assert(error.isDefined, s"the premise is a failed execution, got ${state.map(_.status)}")
+                    assert(
+                        detail.progress.nodeByName("tally").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Failed(error.get)),
+                        s"an iteration's failure belongs to the loop, which is the node a reader has, got " +
+                            s"${detail.progress.nodeByName("tally").map(_.status)}"
+                    )
+                end for
+            }
+        }
+    }
+
+    /** How a [[FailingClaimStore]] reports its failure.
+      *
+      * `Typed` is the SPI's own error channel, which is what a store over a database uses. `Panic` is what a store with nothing typed
+      * to report reaches for, and what a decode failure does. `Interrupt` is neither: it is the caller being told to stop.
+      */
+    private enum ClaimFailure derives CanEqual:
+        case Panic, Typed, Interrupt
+
+    /** A store whose `claimReady` fails the first `remaining` times it is called, in the manner `mode` names. */
+    private class FailingClaimStore(underlying: FlowStore, remaining: AtomicInt, mode: ClaimFailure = ClaimFailure.Panic)
+        extends DelegatingStore(underlying):
+        override def claimReady(
+            served: Set[(Flow.Id.Workflow, String)],
+            executorId: Flow.Id.Executor,
+            lease: Duration,
+            limit: Int,
+            timeout: Duration
+        )(using Frame): Seq[FlowStore.Claimed] < (Async & Abort[FlowStoreException]) =
+            remaining.getAndDecrement.map { left =>
+                if left <= 0 then super.claimReady(served, executorId, lease, limit, timeout)
+                else
+                    mode match
+                        case ClaimFailure.Typed     => Abort.fail(FlowEngineTest.StoreUnavailable("connection reset by peer"))
+                        case ClaimFailure.Interrupt => Abort.panic(Interrupted(summon[Frame]))
+                        case ClaimFailure.Panic     => Abort.panic(new RuntimeException("claimReady: the store could not decode a row"))
+            }
+    end FailingClaimStore
+
+    /** A store that raises an interrupt from the write recording a completed attempt's outcome, once, and takes every other call.
+      *
+      * The shape a store has when something it runs internally, a race or a timeout of its own, is interrupted while it is serving a
+      * call. `Interrupted` is an ordinary throwable, so it reaches the caller's broad recovery on the same arm as any other panic and
+      * only an explicit classification tells the two apart.
+      */
+    private class InterruptingOutcomeStore(underlying: FlowStore, remaining: AtomicInt) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def finish(outcome: FlowStore.Claimed.Outcome)(using
+                    Frame
+                ): FlowStore.StatusOutcome < (Async & Abort[FlowStoreException]) =
+                    outcome match
+                        case FlowStore.Claimed.Outcome.Terminal(_, _: Flow.Event.Completed) =>
+                            remaining.getAndDecrement.map { left =>
+                                if left > 0 then Abort.panic(Interrupted(summon[Frame]))
+                                else super.finish(outcome)
+                            }
+                        case _ => super.finish(outcome)
+    end InterruptingOutcomeStore
+
+    /** A store that fails every write recording the named node's progress, on the SPI's own channel and marked retryable. */
+    private class FailingFieldStore(underlying: FlowStore, field: String) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def recordProgress[V](path: String, value: Maybe[V], event: Flow.Event)(using
+                    Tag[V],
+                    Schema[V],
+                    Frame
+                ): FlowStore.ProgressOutcome < (Async & Abort[FlowStoreException]) =
+                    if path == field then Abort.fail(FlowEngineTest.StoreUnavailable(s"deadlock writing '$path'"))
+                    else super.recordProgress[V](path, value, event)
+    end FailingFieldStore
+
+    /** A store that fails the transition recording the named node's completion, the first `remaining` times.
+      *
+      * One transition writes the field, the event and the clearing, so there is no window between them for a decorator to sit in. What
+      * this stages is that transition failing whole, and the leaf below asserts that the two halves agree either way.
+      */
+    private class FailingCompletionStore(underlying: FlowStore, node: String, remaining: AtomicInt) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def recordProgress[V](path: String, value: Maybe[V], event: Flow.Event)(using
+                    Tag[V],
+                    Schema[V],
+                    Frame
+                ): FlowStore.ProgressOutcome < (Async & Abort[FlowStoreException]) =
+                    event match
+                        case Flow.Event.StepCompleted(_, _, name, _) if name == node =>
+                            remaining.getAndDecrement.map { left =>
+                                if left > 0 then Abort.fail(FlowEngineTest.StoreUnavailable(s"blip completing '$name'"))
+                                else super.recordProgress[V](path, value, event)
+                            }
+                        case _ => super.recordProgress[V](path, value, event)
+    end FailingCompletionStore
+
+    /** A store that refuses every append of a `StepTimedOut` event, on the SPI's own channel and marked retryable.
+      *
+      * The append sits inside the retry helper's catch, so refusing it is how the leaf below observes whether a store failure is
+      * routed to the engine as infra or consumed by the step's own schedule.
+      */
+    private class FailingTimeoutEventStore(underlying: FlowStore, refusals: AtomicInt) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def appendEvent(event: Flow.Event)(using
+                    Frame
+                ): FlowStore.WriteOutcome < (Async & Abort[FlowStoreException]) =
+                    event match
+                        case _: Flow.Event.StepTimedOut =>
+                            refusals.incrementAndGet.andThen(
+                                Abort.fail(FlowEngineTest.StoreUnavailable("blip recording the timeout"))
+                            )
+                        case _ => super.appendEvent(event)
+    end FailingTimeoutEventStore
+
+    /** A store that holds the first two readers of one execution id until both have arrived, so both see the same snapshot.
+      *
+      * A check-then-act race cannot be measured by running it and hoping: the two callers serialise more often than not, and a green
+      * run says nothing about the interleaving that matters. This forces the interleaving instead of sampling it. Only the first two
+      * reads of the target id rendezvous; every other read, including the engine's own, passes straight through.
+      */
+    private class RendezvousStore(
+        underlying: FlowStore,
+        target: Flow.Id.Execution,
+        barrier: Latch,
+        remaining: AtomicInt,
+        arrived: AtomicInt,
+        absent: AtomicInt
+    ) extends DelegatingStore(underlying):
+        override def createExecutionIfAbsent(
+            executionId: Flow.Id.Execution,
+            status: Flow.Status,
+            event: Flow.Event,
+            hash: String,
+            fields: Dict[String, FlowStore.FieldData]
+        )(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+            if executionId != target then super.createExecutionIfAbsent(executionId, status, event, hash, fields)
+            else
+                remaining.getAndDecrement.map { left =>
+                    if left > 0 then
+                        // Both callers are held on the doorstep of the deciding write, after each has looked and found nothing.
+                        // The probe is the decorator's own, not the engine's: the engine does not look before it creates, which is
+                        // the whole point, so the interleaving has to be forced at the verb that decides rather than at a read
+                        // nobody makes.
+                        super.getExecution(executionId).map { seen =>
+                            Kyo.when(seen.isEmpty)(absent.incrementAndGet)
+                                .andThen(barrier.release)
+                                .andThen(barrier.await)
+                                .andThen(arrived.incrementAndGet)
+                                .andThen(super.createExecutionIfAbsent(executionId, status, event, hash, fields))
+                        }
+                    else super.createExecutionIfAbsent(executionId, status, event, hash, fields)
+                }
+    end RendezvousStore
+
+    /** A store whose claim genuinely lapses the moment a chosen event is written, and whose renewals stop arriving from then on.
+      *
+      * **There is no read to lie to.** Authority is the generation a write presents and the deadline the store recorded, not anything
+      * a caller reads back, so a decorator cannot stage a lost claim by reporting somebody else as the owner. The only way to stage one
+      * is to lose one: at the trigger the clock is advanced past the lease, and every write the executor issues after that is refused
+      * by the store's own rule rather than by anything this decorator decides.
+      *
+      * The renewal PARKS rather than failing, which is the one shape that leaves a stale executor still running: a refusal would
+      * interrupt the attempt at its next safepoint, and the writes under test would then stop because the work stopped rather than
+      * because the store refused them.
+      *
+      * `refusals` counts the writes the underlying store turned away, so a leaf can wait for the refusal to have actually fired
+      * instead of waiting a number of rounds and hoping.
+      */
+    private class LapsingClaimStore(
+        underlying: FlowStore,
+        tc: Clock.TimeControl,
+        lease: Duration,
+        armed: AtomicBoolean,
+        refusals: AtomicInt,
+        parked: Channel[Unit]
+    )(trigger: Flow.Event => Boolean) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                private def counted(outcome: FlowStore.WriteOutcome): FlowStore.WriteOutcome < Sync =
+                    outcome match
+                        case FlowStore.WriteOutcome.ClaimLost => refusals.incrementAndGet.andThen(outcome)
+                        case _                                => outcome
+
+                override def appendEvent(event: Flow.Event)(using
+                    Frame
+                ): FlowStore.WriteOutcome < (Async & Abort[FlowStoreException]) =
+                    super.appendEvent(event).map(counted).map { outcome =>
+                        // The trigger event itself lands, and the lease lapses behind it, so what the leaf observes is every
+                        // write the executor makes AFTER the moment its claim died.
+                        if trigger(event) then armed.set(true).andThen(tc.advance(lease + 1.second)).andThen(outcome)
+                        else outcome
+                    }
+
+                override def recordWait(path: String, wake: Flow.Wake, event: Flow.Event)(using
+                    Frame
+                ): FlowStore.WriteOutcome < (Async & Abort[FlowStoreException]) =
+                    super.recordWait(path, wake, event).map(counted)
+
+                override def recordProgress[V](path: String, value: Maybe[V], event: Flow.Event)(using
+                    Tag[V],
+                    Schema[V],
+                    Frame
+                ): FlowStore.ProgressOutcome < (Async & Abort[FlowStoreException]) =
+                    super.recordProgress[V](path, value, event).map { outcome =>
+                        outcome match
+                            case FlowStore.ProgressOutcome.ClaimLost => refusals.incrementAndGet.andThen(outcome)
+                            case _                                   => outcome
+                    }
+
+                override def renewClaim(renewLease: Duration)(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+                    armed.get.map { a =>
+                        if a then Abort.run[Closed](parked.take).andThen(super.renewClaim(renewLease))
+                        else super.renewClaim(renewLease)
+                    }
+    end LapsingClaimStore
+
+    /** A store whose field read fails the first `remaining` times, on the SPI's channel and marked retryable.
+      *
+      * The marker exists so a store can tell the engine "this one is worth trying again", which is the distinction between a database
+      * that was briefly unreachable and a row that will never decode.
+      */
+    private class TransientFieldReadStore(underlying: FlowStore, remaining: AtomicInt) extends DelegatingStore(underlying):
+        override def getAllFields(executionId: Flow.Id.Execution)(using
+            Frame
+        ): Dict[String, FlowStore.FieldData] < (Async & Abort[FlowStoreException]) =
+            remaining.getAndDecrement.map { left =>
+                if left > 0 then Abort.fail(FlowEngineTest.StoreUnavailable("deadlock reading fields"))
+                else super.getAllFields(executionId)
+            }
+    end TransientFieldReadStore
+
+    /** A store that stores a field but cannot read it back, the way one holding a value that no longer decodes behaves.
+      *
+      * The store's readiness test for a waiting execution is field PRESENCE; the interpreter's read is a typed decode that answers
+      * `Absent` for a tag mismatch or a decode failure just as it does for a missing field. The two disagree exactly here.
+      */
+    private class UndecodableFieldStore(underlying: FlowStore, field: String) extends DelegatingStore(underlying):
+        override def getField[V: Tag: Schema](executionId: Flow.Id.Execution, name: String)(using
+            Frame
+        ): Maybe[V] < (Async & Abort[FlowStoreException]) =
+            if name == field then Maybe.empty
+            else super.getField[V](executionId, name)
+    end UndecodableFieldStore
+
+    /** A store whose second `renewClaim` fails on the SPI's own channel, and which takes every other call.
+      *
+      * The engine renews once before it starts executing, so failing the second call is failing the renewal loop's first attempt,
+      * which is the one that guards a live execution.
+      */
+    private class FlakyRenewalStore(underlying: FlowStore, calls: AtomicInt) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def renewClaim(lease: Duration)(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+                    calls.incrementAndGet.map { n =>
+                        if n == 2 then Abort.fail(FlowEngineTest.StoreUnavailable("connection reset while renewing"))
+                        else super.renewClaim(lease)
+                    }
+    end FlakyRenewalStore
+
+    /** A store whose `renewClaim`, once armed, parks without answering.
+      *
+      * The one instrument that produces a stale RUNNING executor. A renewal FAILURE does not: the renewal loop survives blips,
+      * retries, gets a refusal once the row is taken, and the refusal interrupts the lapsed executor at its next safepoint, so an
+      * executor built that way never comes back. A PARKED renewal is different in kind: the fiber is suspended
+      * awaiting the store's answer, so it neither renews nor refuses, no interrupt is ever issued, the lease lapses store-side,
+      * and the executor keeps running under a claim it no longer holds.
+      */
+    private class ParkedRenewalStore(underlying: FlowStore, armed: AtomicBoolean, parked: Channel[Unit])
+        extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def renewClaim(lease: Duration)(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+                    armed.get.map { a =>
+                        if a then Abort.run[Closed](parked.take).andThen(super.renewClaim(lease))
+                        else super.renewClaim(lease)
+                    }
+    end ParkedRenewalStore
+
+    /** A store that panics when the resume event is written, and takes every other call.
+      *
+      * The site matters. A panic raised inside the handler that records an execution's failure is caught and recorded; this one is
+      * raised on the way IN to that handler, which is the window the engine has nothing watching.
+      */
+    private class PanickingResumeStore(underlying: FlowStore) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def appendEvent(event: Flow.Event)(using
+                    Frame
+                ): FlowStore.WriteOutcome < (Async & Abort[FlowStoreException]) =
+                    event match
+                        case _: Flow.Event.ExecutionResumed =>
+                            Abort.panic(new RuntimeException("appendEvent: the store could not encode the event"))
+                        case _ => super.appendEvent(event)
+    end PanickingResumeStore
+
+    /** A store that refuses the write recording a wait the first `remaining` times, and takes every other write.
+      *
+      * The shape a database blip has: one statement fails, the next identical one succeeds.
+      */
+    private class FailingWaitStore(underlying: FlowStore, remaining: AtomicInt) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def recordWait(path: String, wake: Flow.Wake, event: Flow.Event)(using
+                    Frame
+                ): FlowStore.WriteOutcome < (Async & Abort[FlowStoreException]) =
+                    remaining.getAndDecrement.map { left =>
+                        if left <= 0 then super.recordWait(path, wake, event)
+                        else Abort.fail(FlowEngineTest.StoreUnavailable("deadlock recording the wait"))
+                    }
+    end FailingWaitStore
+
+    /** A store whose SECOND `recordWait` parks without answering, and which takes every other call.
+      *
+      * The instrument for an engine that goes away BETWEEN two parking branches. A failure at the second call cannot stage it: the
+      * attempt then ends with a verdict of its own, and the window under test is the one where no verdict is ever reached. Parking is
+      * different in kind, exactly as it is for `ParkedRenewalStore`: the branch is suspended inside the store with its row unwritten,
+      * so the attempt is still live when the engine's scope closes and the close is what ends it, which is the shutdown this stages.
+      *
+      * Only the second call parks, so the recovery that follows records both branches normally: an instrument that kept parking would
+      * stage the shutdown and then prevent the replay it exists to observe.
+      */
+    private class ParkedWaitStore(underlying: FlowStore, calls: AtomicInt, parked: Channel[Unit]) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def recordWait(path: String, wake: Flow.Wake, event: Flow.Event)(using
+                    Frame
+                ): FlowStore.WriteOutcome < (Async & Abort[FlowStoreException]) =
+                    calls.incrementAndGet.map { n =>
+                        if n == 2 then Abort.run[Closed](parked.take).andThen(super.recordWait(path, wake, event))
+                        else super.recordWait(path, wake, event)
+                    }
+    end ParkedWaitStore
+
+    /** A store that lets one claimed batch outlive its own lease before the caller can renew it.
+      *
+      * The engine renews the moment `claimReady` returns, so a conforming store cannot refuse that renewal as superseded and cannot
+      * refuse it as expired either, unless time really has passed in between. This decorator makes it pass, once, by advancing the
+      * virtual clock past the lease on the first non-empty batch. Every answer the store gives is still computed from the real row
+      * against the real clock, which is what separates this from `LosingRenewalStore`.
+      */
+    private class LateFirstRenewalStore(
+        underlying: FlowStore,
+        tc: Clock.TimeControl,
+        lease: Duration,
+        skews: AtomicInt,
+        refusals: AtomicInt,
+        polls: AtomicInt,
+        firstClaimAt: AtomicRef[Maybe[Instant]]
+    ) extends DelegatingStore(underlying):
+        override def claimReady(
+            served: Set[(Flow.Id.Workflow, String)],
+            executorId: Flow.Id.Executor,
+            claimLease: Duration,
+            limit: Int,
+            timeout: Duration
+        )(using Frame): Seq[FlowStore.Claimed] < (Async & Abort[FlowStoreException]) =
+            polls.incrementAndGet.andThen {
+                super.claimReady(served, executorId, claimLease, limit, timeout).map { batch =>
+                    Kyo.when(batch.nonEmpty) {
+                        skews.getAndIncrement.map { n =>
+                            Kyo.when(n == 0) {
+                                Clock.nowWith(now => firstClaimAt.set(Present(now))).andThen(tc.advance(lease + 1.second))
+                            }
+                        }
+                    }.andThen(batch)
+                }
+            }
+
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def renewClaim(renewLease: Duration)(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+                    super.renewClaim(renewLease).map { ok =>
+                        if ok then true else refusals.incrementAndGet.andThen(false)
+                    }
+    end LateFirstRenewalStore
+
+    /** A store that lets the execution finish under the caller's delivery, before that delivery reaches the store.
+      *
+      * Forces the window a delivery leaves open between checking the status and writing the field: the caller's check has already run
+      * and seen a live execution, and by the time its write lands the execution is over.
+      *
+      * **Every answer this store gives is truthful, which is what separates it from a decorator that lies about a row.** It stages
+      * the completion by letting it HAPPEN: the value goes in, the parked execution wakes, consumes it and finishes, and only then does
+      * the caller's own call reach the store. A terminal status cannot be conjured from outside, because writing one needs a claim, and
+      * that is the rule this leaf exists beside rather than around.
+      */
+    private class CompleteOnDeliveryStore(underlying: FlowStore, field: String, completions: AtomicInt, tc: Clock.TimeControl)
+        extends DelegatingStore(underlying):
+        override def signal[V: Tag: Schema](executionId: Flow.Id.Execution, name: String, value: V, event: Flow.Event)(using
+            Frame
+        ): FlowStore.SignalOutcome < (Async & Abort[FlowStoreException]) =
+            def untilTerminal(remaining: Int): Unit < (Async & Abort[FlowStoreException]) =
+                underlying.getExecution(executionId).map {
+                    case Present(state) if state.status.isTerminal => ()
+                    case _ => if remaining <= 0 then () else tc.advance(10.millis).andThen(untilTerminal(remaining - 1))
+                }
+            completions.get.map { seen =>
+                Kyo.when(name == field && seen == 0) {
+                    completions.incrementAndGet
+                        .andThen(super.signal[V](executionId, name, value, event))
+                        .andThen(untilTerminal(500))
+                }.andThen(super.signal[V](executionId, name, value, event))
+            }
+        end signal
+    end CompleteOnDeliveryStore
+
+    /** A store that grants the claim once and refuses every renewal after it, which is what an executor whose lease was taken sees.
+      *
+      * The first `renewClaim` has to succeed because the engine calls it once before it starts executing; refusing that one would mean
+      * the execution never begins and the test would prove nothing.
+      *
+      * **Valid only for what the ENGINE does with a refusal, never for what the STORE then holds.** The answer comes from a counter,
+      * not from the claim row, so the underlying row stays claimed by a live, unexpired lease no matter what this store returns: a
+      * conforming store does not refuse a renewal it has just granted. Assertions about the engine's reaction (it stops the step, it
+      * writes nothing more, it does not terminalise the execution) are sound, because the refusal the engine sees is real. Assertions
+      * about recovery are NOT: nothing can pick the row up under this store, so an execution that never re-enters here says nothing
+      * about the module. Recovery needs a real expiry, which `LateFirstRenewalStore` above is built to produce.
+      */
+    private class LosingRenewalStore(underlying: FlowStore, grants: AtomicInt) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def renewClaim(lease: Duration)(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+                    grants.getAndDecrement.map(remaining => remaining > 0)
+    end LosingRenewalStore
+
+    /** A store whose renewals stop arriving once an execution's unwind has begun.
+      *
+      * A lease bounds how long one executor may work on a row unwatched, and the renewal loop exists precisely so that live work can
+      * outlive a single lease. An engine that keeps renewing across a ten minute compensation handler is therefore doing the correct
+      * thing, and under a conforming store the claim never lapses while the handler runs, so the state this leaf is about cannot be
+      * staged by letting the engine run. What produces it is the renewal not arriving at all, which is what a starved or partitioned
+      * executor looks like from the store's side.
+      *
+      * The refusal reads the execution's status and nothing else, and it touches no row: no expiry is moved, no owner is cleared, no
+      * event is written. The claim therefore lapses at the deadline the last honoured renewal set, which is what separates this from
+      * `LosingRenewalStore` above and makes recovery assertions sound here.
+      */
+    private class UnrenewedCompensationStore(underlying: FlowStore, refusals: AtomicInt) extends DelegatingStore(underlying):
+        override protected def wrapClaimed(claimed: FlowStore.Claimed)(using Frame): FlowStore.Claimed =
+            new DelegatingClaimed(claimed):
+                override def renewClaim(lease: Duration)(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+                    underlying.getExecution(claimed.state.executionId).map { state =>
+                        val unwinding = state.exists {
+                            _.status match
+                                case _: Flow.Status.Compensating => true
+                                case _                           => false
+                        }
+                        if unwinding then refusals.incrementAndGet.andThen(false)
+                        else super.renewClaim(lease)
+                    }
+    end UnrenewedCompensationStore
+
+    // =========================================================================
+    // Definition changes under a live execution
+    // =========================================================================
+    "definition changes" - {
+
+        /** A structural change to a deployed flow holds its in-flight executions instead of killing them.
+          *
+          * Failing them is terminal and unrecoverable, and it skips every compensation on the way out, so a version bump would silently
+          * leak exactly the resources a saga exists to protect. Compensating on the way out is not available either: the handlers live
+          * in the definition the execution can no longer be matched to, so there is nothing to run. Holding is what keeps both options
+          * open, and re-registering the definition the execution was started under is the rollback that recovers it.
+          *
+          * Being held is a report rather than a status: nothing is written about it in either direction, so the assertions are that the
+          * execution is untouched and that `parked` names it with the hash it was started under.
+          */
+        "a structural change parks an in-flight execution instead of failing it" in {
+            withEngine { (engine, store, tc) =>
+                val v1 = Flow.init("fulfillment").step("reserve")(_ => ()).output("receipt")(_ => "paid")
+                val v2 = Flow.init("fulfillment").step("reserve")(_ => ()).step("audit")(_ => ()).output("receipt")(_ => "paid")
+                // Only v2 is registered here, so v1 is a version this engine cannot interpret. An engine that had registered v1 too
+                // would keep serving it, which is what makes a rolling deployment work and is not the case under test.
+                val v1Hash = kyo.internal.WorkflowSchema.structuralHash(v1)
+                for
+                    _ <- engine.register(wf1, v2)
+                    eid = Flow.Id.Execution("exec-version-bumped")
+                    _       <- seedExecution(store, eid, wf1, Flow.Status.Running, v1Hash)
+                    _       <- Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                    state   <- store.getExecution(eid)
+                    held    <- engine.parked(wf1)
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    assert(
+                        state.exists(_.status == Flow.Status.Running),
+                        s"nothing is written about being held, so the lifecycle is untouched, got ${state.map(_.status)}"
+                    )
+                    assert(
+                        state.exists(_.executor.isEmpty),
+                        s"an execution no engine serves must not be claimed, got ${state.map(_.executor)}"
+                    )
+                    assert(
+                        held.exists(e => e.executionId == eid && e.hash == v1Hash),
+                        s"`parked` must list the execution with the hash it was started under, got ${held.map(e => (e.executionId, e.hash))}"
+                    )
+                    assert(
+                        !history.events.exists(_.kind == Flow.EventKind.Failed),
+                        "a version mismatch must not fail the execution"
+                    )
+                    assert(
+                        !history.events.exists(_.kind == Flow.EventKind.StepStarted),
+                        "an execution no engine serves must not run a step"
+                    )
+                end for
+            }
+        }
+
+        /** A start after re-registration runs the definition registered last.
+          *
+          * Registration is the retention policy: a NEW start always resolves the definition registered last, never an older version
+          * that happens to share the workflow id. With definitions keyed by `(workflowId, hash)` a wrong resolution (oldest, or an
+          * arbitrary key-order pick) passes every other leaf, because in-flight executions pin their own hash and only a fresh start
+          * exercises the choice. The two versions differ in behaviour (x * 10 against x + 1) precisely so the assertion cannot pass
+          * by accident of shape.
+          */
+        "a start after re-registration runs the definition registered last" in {
+            withEngine { (engine, store, tc) =>
+                val v1 = Flow.input[Int]("x").output("answer")(ctx => ctx.x + 1)
+                val v2 = Flow.input[Int]("x").step("audit")(_ => ()).output("answer")(ctx => ctx.x * 10)
+                for
+                    _      <- engine.register(wf1, v1)
+                    _      <- engine.register(wf1, v2)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 4)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    answer <- store.getField[Int](eid, "answer")
+                yield
+                    assert(status == Flow.Status.Completed, s"the started execution must complete, got $status")
+                    assert(
+                        answer == Maybe(40),
+                        s"a start after re-registration must run the latest definition (4 * 10), got $answer"
+                    )
+                end for
+            }
+        }
+
+        /** A store that blips while recording a wait must not destroy the execution.
+          *
+          * Recording a durable wait is the write on the suspension path, and it sits inside the handler that fails an execution when
+          * running it raises. So a transient store failure there is recorded as terminal `Failed`, which is exactly the outcome
+          * suspending exists to survive, and terminal status cannot be reverted. A blip has to leave the execution where the next
+          * poll finds it, the way every other transient store failure on this path is retried rather than made permanent.
+          */
+        "a store failure while parking does not fail the execution" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(1).map { blips =>
+                        val failing = new FailingWaitStore(store, blips)
+                        val flow    = Flow.init("fulfillment").step("reserve")(_ => ()).input[String]("approval")
+                        // A short lease, because the blipped attempt could not reach the store and so leaves its claim to expire
+                        // rather than releasing it; the recovery is the next poll after the lapse.
+                        val config = FlowEngine.Config(workerCount = 1, lease = 1.second, renewEvery = 500.millis, pollTimeout = 100.millis)
+                        FlowEngine.init(failing, config).map { engine =>
+                            for
+                                _      <- engine.register(wf1, flow)
+                                handle <- engine.workflows.start(wf1)
+                                eid = handle.executionId
+                                state   <- pumpState(tc, store, eid, s => waitingFor("approval")(s) || s.status.isTerminal, 2000)
+                                history <- store.getHistory(eid, Maybe.empty, 0)
+                            yield
+                                assert(
+                                    waitingFor("approval")(state),
+                                    s"a store blip while recording a wait must leave the execution recoverable, got $state"
+                                )
+                                assert(
+                                    !history.events.exists(_.kind == Flow.EventKind.Failed),
+                                    "a store blip while recording a wait must not record the execution as failed"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** Registering a definition wakes a poller that is already blocked, rather than leaving it to time out.
+          *
+          * Which versions an engine serves is decided when it asks the store, so a poll already inside `claimReady` is asking a
+          * question that a registration has just made out of date. Nothing else can recover an execution held for a version nobody
+          * served: it is not ready for any caller, so no write about the EXECUTION will ever wake a poller for it, and the only event
+          * that changes the answer is the registration itself. Without a wake, the execution waits out a whole poll timeout, which is
+          * thirty seconds by default and unbounded by anything a caller controls.
+          *
+          * The engine is given a long poll timeout precisely so that timing out cannot be what recovers the execution: the assertion is
+          * that it finishes after strictly less virtual time than one poll.
+          */
+        "an execution parked after its definition was registered is still recovered" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId    = Flow.Id.Workflow("rolling")
+                    val v1      = Flow.init("rolling").step("reserve")(_ => ())
+                    val v2      = Flow.init("rolling").step("reserve")(_ => ()).output("receipt")(_ => "paid")
+                    val hashV2  = kyo.internal.WorkflowSchema.structuralHash(v2)
+                    val pollFor = 60.seconds
+                    // v1 is given at init rather than registered afterwards, so the worker's very first poll already has something to
+                    // serve and blocks inside `claimReady`. Registering it after init races the worker's first read of the map: lose
+                    // that race and the worker sleeps out a whole poll timeout with nothing registered, which is a different scenario.
+                    FlowEngine.init(store, FlowEngine.Config(workerCount = 1, pollTimeout = pollFor), v1).map { engine =>
+                        val eid = Flow.Id.Execution("rolling-1")
+                        for
+                            _ <- seedExecution(store, eid, wfId, Flow.Status.Running, hashV2)
+                            // Long enough for the poller to reach its blocking wait, and far short of one poll timeout.
+                            _    <- Kyo.foreachDiscard(1 to 20)(_ => tc.advance(10.millis))
+                            held <- store.getExecution(eid)
+                            _ = assert(
+                                held.exists(_.status == Flow.Status.Running),
+                                s"the premise is an execution no engine serves yet, got ${held.map(_.status)}"
+                            )
+                            _ <- engine.register(wfId, v2)
+                            reached <- settle(tc, 10.millis, 500) {
+                                store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                            }
+                            elapsed <- Clock.now
+                        yield
+                            assert(
+                                reached,
+                                "registering the definition must recover the execution it was held for"
+                            )
+                            assert(
+                                elapsed - Instant.Epoch < pollFor,
+                                s"the recovery must come from the registration rather than from the poll timing out, took ${elapsed - Instant.Epoch}"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A parked execution costs nothing while it waits.
+          *
+          * Parking is open-ended: an execution can sit in it for as long as it takes someone to notice the version bump and roll the
+          * definition back, which is hours, not seconds. So the cost of waiting has to be zero, and it is only zero if the store stops
+          * offering the execution to the poll loop. An engine that kept claiming it would spin at full speed, since a claim that can
+          * change nothing releases at once and the execution is ready again immediately, and it would write two history events per turn
+          * on top of that: the wait would grow the history without bound and burn a worker for the whole of it.
+          *
+          * The test measures over two equal stretches rather than against the moment of parking, so an event still in flight when the
+          * status flips cannot be read as a spin.
+          */
+        "a parked execution is left alone while it waits" in {
+            withEngine { (engine, store, tc) =>
+                val v1     = Flow.init("fulfillment").step("reserve")(_ => ()).output("receipt")(_ => "paid")
+                val v2     = Flow.init("fulfillment").step("reserve")(_ => ()).step("audit")(_ => ()).output("receipt")(_ => "paid")
+                val v1Hash = kyo.internal.WorkflowSchema.structuralHash(v1)
+                def idle(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+                    Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                for
+                    _ <- engine.register(wf1, v2)
+                    eid = Flow.Id.Execution("exec-parked-idles")
+                    _      <- seedExecution(store, eid, wf1, Flow.Status.Running, v1Hash)
+                    _      <- settle(tc)(engine.parked(wf1).map(_.exists(_.executionId == eid)))
+                    _      <- idle
+                    first  <- store.getHistory(eid, Maybe.empty, 0)
+                    _      <- idle
+                    second <- store.getHistory(eid, Maybe.empty, 0)
+                    state  <- store.getExecution(eid)
+                yield
+                    assert(
+                        second.events.size == first.events.size,
+                        s"a parked execution must not be re-claimed: history grew from ${first.events.size} to ${second.events.size}"
+                    )
+                    assert(
+                        state.exists(_.status == Flow.Status.Running),
+                        s"the execution must still be held and untouched, got ${state.map(_.status)}"
+                    )
+                    assert(
+                        state.exists(_.executor.isEmpty),
+                        s"nothing must be holding a claim on it, got ${state.map(_.executor)}"
+                    )
+                end for
+            }
+        }
+
+        "re-registering the definition an execution was started under recovers it" in {
+            withEngine { (engine, store, tc) =>
+                val v1     = Flow.init("fulfillment").step("reserve")(_ => ()).output("receipt")(_ => "paid")
+                val v2     = Flow.init("fulfillment").step("reserve")(_ => ()).step("audit")(_ => ()).output("receipt")(_ => "paid")
+                val v1Hash = kyo.internal.WorkflowSchema.structuralHash(v1)
+                for
+                    _ <- engine.register(wf1, v2)
+                    eid = Flow.Id.Execution("exec-rolled-back")
+                    _ <- seedExecution(store, eid, wf1, Flow.Status.Running, v1Hash)
+                    _ <- settle(tc)(engine.parked(wf1).map(_.exists(_.executionId == eid)))
+                    // The rollback: the definition the execution was started under is registered again.
+                    _       <- engine.register(wf1, v1)
+                    status  <- pump(tc, store, eid, _.isTerminal)
+                    receipt <- store.getField[String](eid, "receipt")
+                yield
+                    assert(status == Flow.Status.Completed, s"expected the recovered execution to complete, got $status")
+                    assert(receipt == Present("paid"), s"expected the recovered execution to produce its output, got $receipt")
+                end for
+            }
+        }
     }
 
     // =========================================================================
@@ -329,11 +2371,22 @@ class FlowEngineTest extends kyo.test.Test[Any]:
 
         "describe workflow" in {
             withEngine { (engine, store, tc) =>
-                val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+                val flow = Flow.input[Int]("x")
+                    .output("y")(ctx => ctx.x)
+                    .loop("acc")(_ => Loop.done("done"))
                 for
                     _    <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     meta <- engine.workflows.describe(wf1)
-                yield assert(meta.id == wf1.value)
+                yield
+                    assert(meta.id == wf1.value)
+                    // A loop persists a value like any other node, and the description says which type. Without evidence carried on
+                    // the walk the description is built from, a dispatch, a loop and a foreach all read `Any`.
+                    val loopNode = meta.nodes.find(_.name == "acc")
+                    assert(loopNode.nonEmpty, s"the loop must be described, got ${meta.nodes.map(_.name)}")
+                    assert(
+                        loopNode.get.tag.show == Tag[String].show,
+                        s"a loop's described type must be the type it stores, got ${loopNode.get.tag.show}"
+                    )
                 end for
             }
         }
@@ -369,7 +2422,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _      <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _      <- pumpState(tc, store, eid, waitingFor("x"))
                     _      <- handle.signal[Int]("x", 42)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status == Flow.Status.Completed)
@@ -385,9 +2438,9 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _   = ()
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _ <- pumpState(tc, store, eid, waitingFor("x"))
                     s <- handle.status
-                yield assert(s == Flow.Status.WaitingForInput("x"))
+                yield assert(s == Flow.Status.Running)
                 end for
             }
         }
@@ -400,8 +2453,10 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _   = ()
-                    _     <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
-                    _     <- handle.cancel
+                    _ <- pumpState(tc, store, eid, waitingFor("x"))
+                    _ <- handle.cancel
+                    // A cancel is a request, so the terminal write lands once the unwind has run rather than in this call.
+                    _     <- pump(tc, store, eid, _.isTerminal)
                     state <- store.getExecution(eid)
                 yield assert(state.get.status == Flow.Status.Cancelled)
                 end for
@@ -421,9 +2476,9 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _      <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _      <- pumpState(tc, store, eid, waitingFor("x"))
                     _      <- engine.executions.signal[Int](eid, "x", 42)
-                    _      <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _      <- pumpState(tc, store, eid, waitingFor("name"))
                     inputs <- engine.executions.inputs(eid)
                 yield
                     assert(inputs.find(_.name == "x").exists(_.delivered))
@@ -477,10 +2532,10 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _  <- pump(tc, store, eid1, _.isTerminal)
                     h2 <- engine.workflows.start(wf1)
                     eid2 = h2.executionId
-                    _ <- pump(tc, store, eid2, _ == Flow.Status.WaitingForInput("x"))
+                    _ <- pumpState(tc, store, eid2, waitingFor("x"))
                     running <- engine.executions.search(
                         wfId = Maybe(wf1),
-                        status = Maybe(Flow.Status.WaitingForInput("x"))
+                        filter = Maybe(FlowStore.ExecutionFilter.WaitingForInput(Maybe("x")))
                     )
                 yield assert(running.total == 1)
                 end for
@@ -572,9 +2627,9 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _      <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _      <- pumpState(tc, store, eid, waitingFor("x"))
                     _      <- engine.executions.signal[Int](eid, "x", 42)
-                    _      <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _      <- pumpState(tc, store, eid, waitingFor("name"))
                     _      <- engine.executions.signal[String](eid, "name", "Hello")
                     status <- pump(tc, store, eid, _.isTerminal)
                     v      <- store.getField[String](eid, "greeting")
@@ -618,7 +2673,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 1)
                     _ <- pump(tc, store, eid, _.isTerminal)
-                    h <- store.getHistory(eid, 100, 0)
+                    h <- store.getHistory(eid, Maybe(100), 0)
                 yield
                     val evs   = h.events.toSeq
                     val kinds = evs.map(_.kind)
@@ -660,6 +2715,113 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 assert(result.isFailure)
             }
         }
+
+        /** A subflow's own field is promised by the return type and never assembled.
+          *
+          * `.subflow("result", child)(...)` types the parent's `Out` with `"result" ~ Record[Out2]`, and `runLocal` returns
+          * `Record[In & Out]`. The decode loop builds that record from `getAllFields` through `WorkflowSchema.fromStoreName`
+          * (`Flow.scala:434-447`), and `WorkflowSchema.of` recurses into a subflow's child and creates no entry for the
+          * subflow's own name (`internal/WorkflowSchema.scala:84`), while the subflow node persists nothing of its own. Decoding
+          * the child's outputs under their own names and stopping there leaves `result` absent from a record whose type says it
+          * is there, so reading it fails at run time on a field the compiler was told is total. The rebuild rule ("a subflow's
+          * result is rebuilt from its children's durable fields under its path") covers the replay path, so assembling the
+          * result for the record a caller receives is a separate obligation.
+          */
+        "a subflow's result field is present on the record runLocal returns" in {
+            val child = Flow.input[Int]("a").output("b")(ctx => ctx.a * 10)
+            val flow  = Flow.input[Int]("x").subflow("result", child)(ctx => "a" ~ ctx.x)
+            Flow.runLocal(flow, "x" ~ 5).map { record =>
+                val sub = record.result
+                assert(sub.b == 50, s"the subflow's field must carry the child's outputs, got $sub")
+            }
+        }
+
+        /** A child's INPUT is a field of the record the parent's type promises, so it is on the record a caller receives.
+          *
+          * `.input[V]("a")` refines the child's `Out2` with `"a" ~ V` exactly as `.output` does, so `Record[Out2]` promises `a` and
+          * the parent's `"result" ~ Record[Out2]` carries it through to what `runLocal` hands back. `Record.selectDynamic` is a
+          * `Dict.apply`, which throws `NoSuchElementException` on a key it does not hold, so a promised field that is not there is
+          * not a compile error and not an absent value: it is a throw from a read the compiler was told is total.
+          *
+          * The value asserted is the one the mapper supplied, beside the child's own output, because an assembly that carried the
+          * key with the wrong value would satisfy presence alone.
+          */
+        "a child input field the type promises is present on the record runLocal returns" in {
+            val child = Flow.input[Int]("a").output("b")(ctx => ctx.a * 10)
+            val flow  = Flow.input[Int]("x").subflow("result", child)(ctx => "a" ~ ctx.x)
+            Flow.runLocal(flow, "x" ~ 5).map { record =>
+                val sub = record.result
+                assert(sub.a == 5, s"the child's input must be on the record its type promises it on, got $sub")
+                assert(sub.b == 50, s"beside the child's own output, got $sub")
+            }
+        }
+
+        /** The assembly recurses, because a subflow inside a subflow is a path inside a path.
+          *
+          * The leaf above is satisfied by an assembly that walks one level: it groups everything under `result~` into one record and
+          * stops. That answer is wrong for a child that embeds a child, because the inner instance's fields arrive under
+          * `outer~inner~ib` and a one-level walk either flattens them into the outer record under the name `inner~ib`, which no
+          * accessor can read, or drops them. Both leave `record.outer.inner` missing on a record whose type says it is there, which
+          * is the same defect one level down.
+          *
+          * Field VALUES are asserted at both levels rather than presence, so an assembly that produces an empty record at either
+          * level fails here instead of passing on a field that exists and is blank.
+          */
+        "a subflow inside a subflow assembles both levels of the record runLocal returns" in {
+            val inner = Flow.input[Int]("ia").output("ib")(ctx => ctx.ia + 1)
+            val outer = Flow.input[Int]("oa")
+                .subflow("inner", inner)(ctx => "ia" ~ ctx.oa)
+                .output("ob")(ctx => ctx.inner.ib * 2)
+            val flow = Flow.input[Int]("x").subflow("outer", outer)(ctx => "oa" ~ ctx.x)
+            Flow.runLocal(flow, "x" ~ 5).map { record =>
+                val out = record.outer
+                assert(out.ob == 12, s"the outer instance's own output must be on its assembled record, got $out")
+                assert(
+                    out.inner.ib == 6,
+                    s"the inner instance's record must be assembled under the outer one rather than flattened into it, got ${out.inner}"
+                )
+            }
+        }
+
+        /** A nested instance's inputs reach the caller's record at the level they belong to.
+          *
+          * The inputs compose the way the outputs do, because they are stored the same way: `outer~oa` is the outer child's own field
+          * and `outer~inner~ia` belongs to the instance the child declares, so the assembly puts one on `record.outer` and the other
+          * on `record.outer.inner` rather than flattening either. Both values are asserted, so an assembly that produced the key at
+          * the wrong level, or produced it empty, fails here.
+          */
+        "a nested subflow's inputs are on the record runLocal returns at both levels" in {
+            val inner = Flow.input[Int]("ia").output("ib")(ctx => ctx.ia + 1)
+            val outer = Flow.input[Int]("oa")
+                .subflow("inner", inner)(ctx => "ia" ~ ctx.oa)
+                .output("ob")(ctx => ctx.inner.ib * 2)
+            val flow = Flow.input[Int]("x").subflow("outer", outer)(ctx => "oa" ~ ctx.x)
+            Flow.runLocal(flow, "x" ~ 5).map { record =>
+                val out = record.outer
+                assert(out.oa == 5, s"the outer child's input must be on its own assembled record, got $out")
+                assert(out.inner.ia == 5, s"and the inner instance's under it rather than flattened, got ${out.inner}")
+            }
+        }
+
+        /** A fan-out inside a subflow reaches the caller's record through the instance's field.
+          *
+          * The other nesting the assembly has to get right, and the one where a fan-out's own durable keys look exactly like a
+          * subflow's. The items of `doubled` inside instance `batch` are stored as `batch~doubled~0` and so on, one separator deeper
+          * than the node's own `batch~doubled`, so an assembly that treats every deeper name as a nested instance would build a
+          * record with an `doubled` field holding item keys rather than the fan-out's `Chunk`.
+          *
+          * The asserted value is the whole chunk, in collection order, read through the subflow's field rather than out of the store.
+          */
+        "a foreach inside a subflow reaches the record runLocal returns through the subflow's field" in {
+            val child = Flow.input[Int]("n").foreach("doubled")(ctx => (1 to ctx.n).toSeq)(item => item * 2)
+            val flow  = Flow.input[Int]("x").subflow("batch", child)(ctx => "n" ~ ctx.x)
+            Flow.runLocal(flow, "x" ~ 3).map { record =>
+                assert(
+                    record.batch.doubled == Chunk(2, 4, 6),
+                    s"the fan-out's own results must reach the caller through the subflow's field, got ${record.batch}"
+                )
+            }
+        }
     }
 
     // =========================================================================
@@ -674,7 +2836,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _   <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _   <- pumpState(tc, store, eid, waitingFor("x"))
                     res <- Abort.run[FlowException](engine.executions.signal[String](eid, "x", "wrong"))
                 yield assert(res.isFailure)
                 end for
@@ -696,6 +2858,130 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 end for
             }
         }
+
+        /** A start that is refused does not leave an execution behind.
+          *
+          * Writing the execution row and its `Created` event FIRST, then walking the declared inputs validating each against its
+          * schema and aborting on the first that does not encode, leaves the row exactly where it was written: live, at a
+          * non-terminal status, with a history.
+          *
+          * The leaf above asserts only that the caller is told, which is the half that works. The caller is told the start failed
+          * and is given no handle, so it has no execution id and no reason to look for one, while the engine claims the row and
+          * parks it on an input that by construction can never arrive: the value the caller tried to supply is the one just
+          * rejected as undeliverable. Every such call leaks one permanently waiting execution, and the surface that would find it
+          * is a search the caller has no id to search for.
+          *
+          * Either order is defensible on its own. Validating before creating works, and so does creating first and cleaning up on
+          * refusal. Reporting failure while leaving the execution running does not.
+          */
+        "a refused start does not leave an execution behind" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x + 1)
+                for
+                    _ <- engine.register(wf1, flow)
+                    inputs = new Record[Any](Dict("x" -> "not-an-int"))
+                    res  <- Abort.run[FlowException](engine.workflows.start(wf1, inputs))
+                    _    <- Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                    live <- store.listExecutions(wf1, Maybe.empty, Maybe.empty, 0)
+                yield
+                    assert(res.isFailure, "the start must be refused")
+                    assert(
+                        live.isEmpty,
+                        s"a refused start must not leave an execution behind, got ${live.map(e => (e.executionId, e.status))}"
+                    )
+                end for
+            }
+        }
+
+        /** Seeding reports every failure of the encode as a type mismatch, because it cannot tell them apart.
+          *
+          * The leaf above is the case where that answer is right: the value really is the wrong type. This one is the case where it is
+          * wrong, and it holds the behaviour still rather than blessing it. The value supplied is of exactly the declared type, so no
+          * encoder could call it a mismatch; what fails is the schema's own write, and the caller is told its value had a type it did
+          * not have, while what actually happened is discarded.
+          *
+          * **The width of that catch is forced by kyo-schema.** `Schema.encodeString` answers a `String` or throws, with no total
+          * form, so the only way to learn a value does not match its schema is to attempt the write. What the attempt raises is
+          * platform-dependent: `ClassCastException` on the JVM, and on JS and Wasm a linker `UndefinedBehaviorError`. Catching only
+          * the JVM's exception kills the JS and Wasm hosts outright, and `Abort.catching` over `Throwable` misses it for a second
+          * reason: `UndefinedBehaviorError` extends `VirtualMachineError`, `NonFatal` rejects it, and `Abort.catching` filters on
+          * `NonFatal`. Only a plain `try`/`catch`, which is what `Result.catching` compiles to, reaches it on every platform.
+          *
+          * **It closes upstream, not here.** Give encoding a total form in kyo-schema and the failure becomes a value on every
+          * platform; seeding then reports the encoder's verdict and only that, and the leaf to hold that is one asserting that a
+          * throwable the encoding did not raise reaches the caller as itself.
+          */
+        "seeding cannot tell the encoder's verdict from anything else that passes through it" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.input[SeedProbe]("x").output("y")(ctx => ctx.x.value + 1)
+                for
+                    _ <- engine.register(wf1, flow)
+                    inputs = new Record[Any](Dict("x" -> SeedProbe(1)))
+                    res  <- Abort.run[FlowException](engine.workflows.start(wf1, inputs))
+                    live <- store.listExecutions(wf1, Maybe.empty, Maybe.empty, 0)
+                yield
+                    assert(
+                        res.failure.exists(_.isInstanceOf[FlowSignalTypeMismatchException]),
+                        s"until encoding is total, a failed write is reported as a mismatch whatever it was, got $res"
+                    )
+                    assert(
+                        res.failure.exists(_.getMessage.contains("x")),
+                        s"and the refusal names the input it was seeding, got ${res.failure.map(_.getMessage)}"
+                    )
+                    assert(
+                        live.isEmpty,
+                        s"and the start still leaves no execution behind, got ${live.map(e => (e.executionId, e.status))}"
+                    )
+                end for
+            }
+        }
+
+        /** A create the store refuses does not hand back a handle to somebody else's execution.
+          *
+          * `createExecutionIfAbsent` answers whether THIS call created the row, and a start that discards that answer is broken. A
+          * false there says the id was already taken, so the `Handle` returned would address an execution this caller never started:
+          * every later `signal`, `cancel` and `describe` through it would reach a stranger's execution, while the one the caller
+          * asked for does not exist and never will.
+          *
+          * The staging is a store that refuses the create, because a random id cannot be made to collide on purpose and the engine
+          * has no injection point for one. What the leaf is about is what the engine does with the answer, which is the same whether
+          * the id collided or the store refused for a reason of its own.
+          */
+        "a start whose create is refused does not return a handle" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x + 1)
+                for
+                    _ <- engine.register(wf1, flow)
+                    refusing = new DelegatingStore(store):
+                        override def createExecutionIfAbsent(
+                            executionId: Flow.Id.Execution,
+                            status: Flow.Status,
+                            event: Flow.Event,
+                            hash: String,
+                            fields: Dict[String, FlowStore.FieldData]
+                        )(using Frame): Boolean < (Async & Abort[FlowStoreException]) = false
+                    res <- Abort.run[Throwable] {
+                        Scope.run {
+                            FlowEngine.init(refusing, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis)).map { blocked =>
+                                // Registered here rather than through `init`, which derives the id from the flow's own name: the
+                                // leaf is about what `start` does with a refused create, and a start refused for being
+                                // unregistered would pass the same assertion having reached none of it.
+                                blocked.register(wf1, flow).andThen(blocked.workflows.start(wf1))
+                            }
+                        }
+                    }
+                yield
+                    val raised = res match
+                        case Result.Panic(_) => true
+                        case _               => false
+                    assert(
+                        raised,
+                        s"a create the store refused must be raised, not answered with a handle to an execution this call did " +
+                            s"not create, got $res"
+                    )
+                end for
+            }
+        }
     }
 
     // =========================================================================
@@ -714,7 +3000,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _      <- engine.executions.signal[Int](eid, "x", 1)
-                    _      <- pump(tc, store, eid, _.isSleeping)
+                    _      <- pumpState(tc, store, eid, sleeping)
                     status <- pump(tc, store, eid, _.isTerminal)
                     z      <- store.getField[Int](eid, "z")
                 yield
@@ -734,9 +3020,9 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 1)
-                    _ <- pump(tc, store, eid, _.isSleeping)
+                    _ <- pumpState(tc, store, eid, sleeping)
                     _ <- pump(tc, store, eid, _.isTerminal, 500)
-                    h <- store.getHistory(eid, 100, 0)
+                    h <- store.getHistory(eid, Maybe(100), 0)
                 yield assert(h.events.exists(_.kind == Flow.EventKind.SleepStarted))
                 end for
             }
@@ -763,9 +3049,152 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 1)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield status match
-                    case Flow.Status.Failed(_) => assert(compensated)
-                    case other                 => fail(s"Expected Failed, got $other")
+                    case Flow.Status.Failed(_, _) => assert(compensated)
+                    case other                    => fail(s"Expected Failed, got $other")
                 end for
+            }
+        }
+
+        /** A node whose compensation handler has run reads as compensated, not as merely completed.
+          *
+          * The per-handler completion records exist for the unwind's own sake, so a resumed unwind does not run a handler twice, and
+          * they answer the question an operator watching an unwind actually has: which compensations have landed, and therefore how
+          * far the unwind has got. Without an arm of its own a node that has been undone renders exactly like one whose work still
+          * stands, which is the progress view reporting the opposite of what happened.
+          *
+          * Rendering the active node of an unwinding execution as `Failed("compensating")` is the alternative to avoid: it fabricates
+          * a failure for a node that did not fail. The unwind is a fact about the flow, which the lifecycle carries, and the
+          * node-level fact worth having is the one recorded per handler.
+          */
+        "a node whose compensation ran reads as compensated on the progress surface" in {
+            withEngine { (engine, store, tc) =>
+                var compensated = false
+                val flow = Flow.input[Int]("x")
+                    .outputCompensated("y")(ctx => ctx.x + 1)(ctx => compensated = true)
+                    .output("z")(ctx =>
+                        throw new RuntimeException("fail"); ""
+                    )
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 1)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    detail <- engine.executions.describe(eid)
+                yield
+                    assert(compensated, s"the premise is that the handler ran, and the execution ended $status")
+                    assert(
+                        detail.progress.nodeByName("y").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Compensated),
+                        s"an undone node must read as compensated, got ${detail.progress.nodeByName("y").map(_.status)}"
+                    )
+                    assert(
+                        detail.progress.nodeByName("x").map(_.status) == Maybe(FlowEngine.Progress.NodeStatus.Completed),
+                        s"and a node nothing undid must still read as completed, got ${detail.progress.nodeByName("x").map(_.status)}"
+                    )
+                end for
+            }
+        }
+
+        /** The node that failed reads as failed while the execution is still unwinding, not only once it is over.
+          *
+          * An unwind is when an operator is watching hardest, and painting the failure on terminalisation blinds exactly that window,
+          * because the whole compensation runs before then. The record is written when the step fails, so the answer is available
+          * from that instant and does not change when the status does.
+          *
+          * The handler is held open on a gate so the assertion happens with the row genuinely `Compensating` rather than in a race
+          * with the unwind finishing, and the premise is asserted rather than assumed.
+          */
+        "a node that failed reads as failed while the execution is still unwinding" in {
+            withEngine { (engine, store, tc) =>
+                Channel.init[Unit](1).map { release =>
+                    val flow = Flow.init("unwind-view")
+                        .outputCompensated("reserve")(_ => "held")(_ => Abort.run[Closed](release.take).unit)
+                        .output("charge")(_ =>
+                            throw new RuntimeException("charge declined"); ""
+                        )
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        unwinding <- settle(tc)(store.getExecution(eid).map(_.exists(_.status match
+                            case _: Flow.Status.Compensating => true
+                            case _                           => false)))
+                        detail <- engine.executions.describe(eid)
+                        _      <- release.put(())
+                    yield
+                        assert(unwinding, "the premise is that the row is Compensating with the handler still running")
+                        assert(
+                            detail.progress.nodeByName("charge").map(_.status) ==
+                                Maybe(FlowEngine.Progress.NodeStatus.Failed("charge declined")),
+                            s"the failing node must say so mid-unwind, got ${detail.progress.nodeByName("charge").map(_.status)}"
+                        )
+                        assert(
+                            detail.progress.nodeByName("reserve").map(_.status) ==
+                                Maybe(FlowEngine.Progress.NodeStatus.Completed),
+                            s"and the node whose handler has not landed yet still reads completed, got " +
+                                s"${detail.progress.nodeByName("reserve").map(_.status)}"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** A race loser's completed work is still compensated when the saga later fails.
+          *
+          * A branch that loses a race is not a branch that did nothing. It can have completed a step, written its field, and registered
+          * the handler that undoes it, and only then lost, because a race is decided by the first branch to SUCCEED and a branch that
+          * parks resolves nothing (`Fiber.internal.race` is `Race.success`). Whatever it reserved is reserved for real.
+          *
+          * When the race resolves, `filterComps` (`Flow.scala:877-885`) keeps a compensation only if the keys of the context it was
+          * pushed with are a SUBSET of the winner's keys. A loser's handler is pushed with the loser's own output in scope, since
+          * `outputCompensated` hands the handler `Record[Out & (N ~ V)]`, so its key set is never a subset of the winner's and it is
+          * dropped. The reservation stays, and nothing will ever undo it.
+          *
+          * The filter is wrong in the other direction too, which this leaf does not exercise: a loser's handler pushed BEFORE that
+          * branch wrote anything of its own has the shared prefix as its key set, passes the subset test, and survives to compensate
+          * work whose branch lost. The mechanism that would have scoped this by branch identity, `restoreCompsForBranch`
+          * (`Flow.scala:872-875`), has no call site, and the `snapshot` the race binds for it (`:1134`) is unused.
+          *
+          * **The premise is forced rather than sampled.** Left to itself, which branch reserves before the race is decided is a
+          * scheduling fact: the winner has one step and the loser has a step plus an input, so the winner can finish first and the
+          * loser be interrupted with nothing written, and the leaf then measures a race that never had a loser. The winner is held
+          * until the loser's reservation is durably in the store, which is the state the leaf is about, and only then released to win.
+          */
+        "a race loser's completed work is still compensated when the saga fails" in {
+            withEngine { (engine, store, tc) =>
+                Channel.init[Unit](1).map { release =>
+                    var reserveUndone = false
+                    var answerUndone  = false
+                    val reserving = Flow.init("race-comp")
+                        .outputCompensated("reserve")(_ => "held")(_ => reserveUndone = true)
+                        .input[String]("never")
+                        .output("answer")(ctx => ctx.never)
+                    val answering = Flow.init("race-comp")
+                        .outputCompensated("answer") { _ =>
+                            val body: String < Async = Abort.run[Closed](release.take).andThen("quick")
+                            body
+                        }(_ => answerUndone = true)
+                    val flow = Flow.race(reserving, answering)
+                        .output("boom")(_ =>
+                            throw new RuntimeException("fail"); ""
+                        )
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        reserved <- settle(tc)(store.getField[String](eid, "reserve").map(_.isDefined))
+                        _ = assert(reserved, "the premise is that the losing branch reserved before the race was decided")
+                        _      <- Abort.run[Closed](release.put(()))
+                        status <- pump(tc, store, eid, _.isTerminal)
+                        held   <- store.getField[String](eid, "reserve")
+                    yield
+                        assert(status.isTerminal, s"the saga must terminate, got $status")
+                        assert(held == Present("held"), s"the losing branch really did reserve, got $held")
+                        assert(answerUndone, "the winner's own compensation must run")
+                        assert(reserveUndone, "the loser completed a step and must be compensated, but its handler was filtered out")
+                    end for
+                }
             }
         }
 
@@ -800,7 +3229,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 1)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _ <- pumpState(tc, store, eid, waitingFor("name"))
                 yield assert(!compensated)
                 end for
             }
@@ -835,16 +3264,97 @@ class FlowEngineTest extends kyo.test.Test[Any]:
 
     "search pagination" - {
 
-        "respects limit and offset" in {
+        /** `total` answers how many executions matched, not how many fit on this page.
+          *
+          * Asserting `total == 2` for a limit of two over three executions would pin the implementation
+          * (`SearchResult(r.toSeq, r.length)`) rather than any property a caller could want, and it is wrong rather than merely
+          * weak: a field named `total`, declared beside `items`, and returned from a method taking `limit` and `offset` means the
+          * size of the result set being paged through. Answering `items.length` makes it a second name for
+          * something the caller already has, and every paging client that divides `total` by its page size to size a control, or
+          * compares it against what it has collected to decide whether to ask for more, reads it as the match count and gets one
+          * page forever.
+          */
+        "reports the match count, not the length of the page" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x)
                 for
-                    _       <- engine.register(Flow.Id.Workflow("test-flow"), flow)
-                    _       <- engine.workflows.start(wf1).map(_.executionId)
-                    _       <- engine.workflows.start(wf1).map(_.executionId)
-                    _       <- engine.workflows.start(wf1).map(_.executionId)
+                    _       <- engine.register(wf1, flow)
+                    _       <- engine.workflows.start(wf1)
+                    _       <- engine.workflows.start(wf1)
+                    _       <- engine.workflows.start(wf1)
                     results <- engine.executions.search(wfId = Maybe(wf1), limit = 2, offset = 0)
-                yield assert(results.total == 2)
+                yield
+                    assert(results.items.length == 2, s"a limit of two must answer two items, got ${results.items.length}")
+                    assert(
+                        results.total == 3,
+                        s"total must count the executions that matched, not the ones on this page, got ${results.total}"
+                    )
+                end for
+            }
+        }
+
+        /** Searching across workflows applies its offset once.
+          *
+          * With no workflow filter, asking every registered workflow for `(limit, offset)` and then applying
+          * `.drop(offset).take(limit)` to the merged result applies the offset twice. Six executions across two workflows, paged at
+          * two with an offset of two, then answer nothing at all: each workflow contributes the one row past its own offset, and the
+          * second drop discards both.
+          *
+          * The per-workflow truncation is the deeper half. Taking `limit` rows from each workflow BEFORE the merge discards rows
+          * that belong in the global page whenever one workflow's executions are newer than another's, so even the first page can
+          * be wrong. A correct implementation fetches `offset + limit` from each, merges, sorts, and pages once.
+          */
+        "applies its offset once when searching across workflows" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+                val wf2  = Flow.Id.Workflow("second-flow")
+                for
+                    _    <- engine.register(wf1, flow)
+                    _    <- engine.register(wf2, flow)
+                    _    <- Kyo.foreachDiscard(1 to 3)(_ => engine.workflows.start(wf1).andThen(tc.advance(1.second)))
+                    _    <- Kyo.foreachDiscard(1 to 3)(_ => engine.workflows.start(wf2).andThen(tc.advance(1.second)))
+                    page <- engine.executions.search(limit = 2, offset = 2)
+                yield
+                    assert(
+                        page.items.length == 2,
+                        s"six executions paged at two with an offset of two must answer two, got ${page.items.length}"
+                    )
+                    assert(
+                        page.items.map(_.executionId).distinct.length == 2,
+                        s"a page must not repeat an execution, got ${page.items.map(_.executionId)}"
+                    )
+                end for
+            }
+        }
+
+        /** Searching every workflow finds an execution whose workflow this engine does not have registered.
+          *
+          * Enumerating `defs.keys` and asking each registered workflow for its executions leaves an execution belonging to a
+          * workflow this engine has not registered out of every result. The same blindness as `cancelAll`, in the surface an
+          * operator reaches for first.
+          *
+          * It is worst exactly where it matters most. An execution parked on a definition nobody has registered is unclaimable,
+          * because `claimReady` is called with the registered ids too, so it makes no progress and emits no events. Search is how
+          * an operator would find it, and search is looking through the registry that does not contain it. The execution is not
+          * merely hard to find: by every surface the engine offers, it does not exist.
+          */
+        "search across workflows finds an execution whose workflow is not registered here" in {
+            withEngine { (engine, store, tc) =>
+                val flow    = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+                val orphan  = Flow.Id.Workflow("unregistered-flow")
+                val orphanE = Flow.Id.Execution("orphan-search")
+                for
+                    _ <- engine.register(wf1, flow)
+                    // The other engine's registration, which is what makes the workflow a fact about the STORE while this engine
+                    // serves nothing under it. Its execution is written the same way that engine would have written it.
+                    _    <- store.putWorkflow(FlowEngine.WorkflowInfo.of(orphan.value, flow))
+                    now  <- Clock.now
+                    _    <- seedExecution(store, orphanE, orphan, Flow.Status.Running, "")
+                    page <- engine.executions.search()
+                yield assert(
+                    page.items.exists(_.executionId == orphanE),
+                    s"an execution this engine cannot resolve must still be findable, got ${page.items.map(_.executionId)}"
+                )
                 end for
             }
         }
@@ -894,7 +3404,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
 
         // --- Error recovery via Abort (safe, no onRecover) ---
         // Users handle errors inside their computations using Kyo's Abort effect.
-        // The output always produces a value — sound by construction.
+        // The output always produces a value, sound by construction.
 
         "output: Abort.recover catches specific error and provides fallback" in {
             withEngine { (engine, store, tc) =>
@@ -956,8 +3466,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 0)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
                 end for
             }
         }
@@ -1069,7 +3579,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 val flow = Flow.input[Int]("x")
                     .output("y") { ctx =>
                         Abort.recover[ExpectedError](_ => -1)(
-                            throw new UnexpectedError // not caught — propagates
+                            throw new UnexpectedError // not caught, propagates
                         )
                     }
                 for
@@ -1079,8 +3589,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 1)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
                 end for
             }
         }
@@ -1137,6 +3647,41 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "loop" - {
 
+        /** A loop's `timeout` bounds one iteration, not the sum of all of them.
+          *
+          * The unscheduled loop is interpreted as ONE computation under the node's `Meta`, so `timeout = 1.second` is a bound
+          * on the whole convergence: a loop whose every iteration is comfortably inside the bound still dies when enough of
+          * them add up, which makes the knob unusable for the thing a user bounds, the single slow iteration. A
+          * whole-computation bound cannot be sized at all for a loop that legitimately converges over many iterations.
+          */
+        "a loop's timeout bounds the iteration, not the whole loop" in {
+            withEngine { (engine, store, tc) =>
+                var iterations = 0
+                val flow = Flow.input[Int]("x")
+                    .loop("work", timeout = 1.second) { ctx =>
+                        iterations += 1
+                        Async.sleep(400.millis).andThen {
+                            if iterations >= 3 then Loop.done(iterations) else Loop.continue[Int]
+                        }
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 1)
+                    status <- pump(tc, store, eid, _.isTerminal, 400)
+                    v      <- store.getField[Int](eid, "work")
+                yield
+                    assert(iterations >= 3, s"the premise is that every single iteration fit the bound, got $iterations")
+                    assert(
+                        status == Flow.Status.Completed,
+                        s"iterations of 400 millis each must fit a 1 second per-iteration bound, got $status"
+                    )
+                    assert(v == Maybe(3), s"the loop's value must be stored, got $v")
+                end for
+            }
+        }
+
         "loop done immediately" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("count")
@@ -1173,7 +3718,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "loop with 1 state — accumulator" in {
+        "loop with 1 state, an accumulator" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                     .loop("result", 0) { (state: Int, ctx) =>
@@ -1256,7 +3801,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 10)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _ <- pumpState(tc, store, eid, waitingFor("name"))
                     c1 = callCount
                     _ <- engine.executions.signal[String](eid, "name", "hello")
                     _ <- pump(tc, store, eid, _.isTerminal)
@@ -1280,7 +3825,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 10)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _ <- pumpState(tc, store, eid, waitingFor("name"))
                     c1 = stepCount
                     _ <- engine.executions.signal[String](eid, "name", "hello")
                     _ <- pump(tc, store, eid, _.isTerminal)
@@ -1313,7 +3858,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 1)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _ <- pumpState(tc, store, eid, waitingFor("name"))
                     _ <- engine.executions.signal[String](eid, "name", "hello")
                     _ <- pump(tc, store, eid, _.isTerminal)
                 yield
@@ -1348,8 +3893,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(log.contains("revert-a"), s"revert-a should fire, log=$log")
                     assert(log.contains("revert-b"), s"revert-b should fire, log=$log")
                     assert(log.indexOf("revert-b") < log.indexOf("revert-a"), s"reverse order, log=$log")
@@ -1394,8 +3939,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(log.contains("revert-a"), "revert-a should still fire despite b's throw")
                     assert(log.contains("revert-c"), "revert-c should still fire")
                 end for
@@ -1414,7 +3959,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 1)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _ <- pumpState(tc, store, eid, waitingFor("name"))
                 yield assert(!fired, "compensation must not fire on suspension")
                 end for
             }
@@ -1434,14 +3979,14 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 1)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _ <- pumpState(tc, store, eid, waitingFor("name"))
                     _ = assert(!fired, "not fired during suspension")
                     _      <- engine.executions.signal[String](eid, "name", "hello")
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(fired, "compensation fires on replay after skip+failure")
                 end for
             }
@@ -1463,8 +4008,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(fired)
                 end for
             }
@@ -1505,8 +4050,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 1)
-                    _ <- pump(tc, store, eid, _.isSleeping)
-                    h <- store.getHistory(eid, 100, 0)
+                    _ <- pumpState(tc, store, eid, sleeping)
+                    h <- store.getHistory(eid, Maybe(100), 0)
                 yield assert(h.events.exists(_.kind == Flow.EventKind.SleepStarted))
                 end for
             }
@@ -1525,11 +4070,68 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _     <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
-                    _     <- engine.executions.cancel(eid)
+                    _ <- pumpState(tc, store, eid, waitingFor("x"))
+                    _ <- engine.executions.cancel(eid)
+                    // The terminal write lands at the end of the unwind, which is what lets a cancel run compensations at all.
+                    _     <- pump(tc, store, eid, _.isTerminal)
                     state <- store.getExecution(eid)
                 yield assert(state.get.status == Flow.Status.Cancelled)
                 end for
+            }
+        }
+
+        /** An execution reads as cancelling from the moment somebody asks until it has finished unwinding.
+          *
+          * The window is the whole point of making a cancel a REQUEST: the terminal status is written after the handlers have run, so
+          * between the ask and the ending there is a state an operator can see and a caller can act on. A surface that does not report
+          * that state leaves the flag free to be written and then dropped on the way out, with nobody able to observe either.
+          */
+        "an execution reads as cancelling until it is cancelled" in {
+            withEngine { (engine, store, tc) =>
+                Channel.init[Unit](1).map { gate =>
+                    // The compensated step runs BEFORE the park, so the replay that observes the cancel has a handler
+                    // registered to unwind: a cancel raised with nothing to undo terminalises at once and leaves no window.
+                    val flow = Flow.init("cancelling-view")
+                        .outputCompensated("y")(_ => "held")(_ => Abort.run[Closed](gate.take).unit)
+                        .input[Int]("x")
+                        .output("z")(ctx => ctx.x)
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        // Parked on an input nobody will deliver, so nothing but the cancel can move it.
+                        _ <- pumpState(tc, store, eid, waitingFor("x"))
+                        _ <- engine.executions.cancel(eid)
+                        // Held mid-unwind behind the gate, which is where the request is outstanding and the status is not
+                        // terminal yet. That is the state the promise is about.
+                        unwinding <- pumpState(
+                            tc,
+                            store,
+                            eid,
+                            s =>
+                                s.status match
+                                    case _: Flow.Status.Compensating => true
+                                    case _                           => false
+                        )
+                        detail <- engine.executions.describe(eid)
+                        _      <- Abort.run[Closed](gate.put(()))
+                        status <- pump(tc, store, eid, _.isTerminal)
+                    yield
+                        assert(
+                            unwinding.cancelRequested,
+                            s"an execution that has been asked to stop must read as cancelling, got $unwinding"
+                        )
+                        assert(
+                            detail.state.cancelRequested,
+                            s"and the request must reach the surface a caller reads, got ${detail.state}"
+                        )
+                        assert(
+                            !detail.status.isTerminal,
+                            s"the premise is that it had not terminalised yet, got ${detail.status}"
+                        )
+                        assert(status == Flow.Status.Cancelled, s"and it must end cancelled once the unwind is done, got $status")
+                    end for
+                }
             }
         }
 
@@ -1540,9 +4142,10 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _ <- pumpState(tc, store, eid, waitingFor("x"))
                     _ <- engine.executions.cancel(eid)
-                    h <- store.getHistory(eid, 100, 0)
+                    _ <- pump(tc, store, eid, _.isTerminal)
+                    h <- store.getHistory(eid, Maybe(100), 0)
                 yield assert(h.events.exists(_.kind == Flow.EventKind.Cancelled))
                 end for
             }
@@ -1559,130 +4162,6 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 .output("x")(ctx => ctx.x + 1)
             val warnings = kyo.internal.FlowLint.duplicateNames(flow)
             assert(warnings.exists(_.message.contains("Duplicate node name 'x'")))
-        }
-    }
-
-    // =========================================================================
-    // Subflow execution
-    // =========================================================================
-    "subflow" - {
-
-        "child output accessible downstream via nested record" in {
-            withEngine { (engine, store, tc) =>
-                val child = Flow.input[Int]("a").output("b")(ctx => ctx.a * 10)
-                val flow = Flow.input[Int]("x")
-                    .subflow("payment", child)(ctx => "a" ~ ctx.x)
-                    .output("result")(ctx => ctx.payment.b)
-                for
-                    _      <- engine.register(wf1, flow)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _      <- engine.executions.signal[Int](eid, "x", 5)
-                    status <- pump(tc, store, eid, _.isTerminal)
-                    v      <- store.getField[Int](eid, "result")
-                yield
-                    assert(status == Flow.Status.Completed)
-                    assert(v.get == 50, s"Expected 50 but got ${v}")
-                end for
-            }
-        }
-
-        "child fields do not leak into parent namespace" in {
-            withEngine { (engine, store, tc) =>
-                val child = Flow.input[Int]("a").output("b")(ctx => ctx.a * 10)
-                val flow = Flow.input[Int]("x")
-                    .subflow("payment", child)(ctx => "a" ~ ctx.x)
-                    .output("result")(ctx => ctx.x + 1) // uses parent field, not child
-                for
-                    _      <- engine.register(wf1, flow)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _      <- engine.executions.signal[Int](eid, "x", 5)
-                    status <- pump(tc, store, eid, _.isTerminal)
-                    v      <- store.getField[Int](eid, "result")
-                    // "b" should NOT be a top-level field — only nested under "payment"
-                    bField <- store.getField[Int](eid, "b")
-                yield
-                    assert(status == Flow.Status.Completed)
-                    assert(v.get == 6)
-                    // "b" IS in the store (child persisted it), but it shouldn't be confused with parent fields
-                    // The type system prevents ctx.b at compile time (b is not in Out)
-                    ()
-                end for
-            }
-        }
-
-        "subflow replays correctly after suspension" in {
-            withEngine { (engine, store, tc) =>
-                var childBodyCount = 0
-                val child = Flow.input[Int]("a").output("b") { ctx =>
-                    childBodyCount += 1
-                    ctx.a * 10
-                }
-                val flow = Flow.input[Int]("x")
-                    .subflow("payment", child)(ctx => "a" ~ ctx.x)
-                    .input[String]("approval") // suspends here
-                    .output("result")(ctx => s"${ctx.approval}: ${ctx.payment.b}")
-                for
-                    _      <- engine.register(wf1, flow)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _ <- engine.executions.signal[Int](eid, "x", 5)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("approval"))
-                    // Child executed once
-                    count1 = childBodyCount
-                    _      <- engine.executions.signal[String](eid, "approval", "yes")
-                    status <- pump(tc, store, eid, _.isTerminal)
-                    v      <- store.getField[String](eid, "result")
-                yield
-                    assert(status == Flow.Status.Completed)
-                    assert(v.get == "yes: 50")
-                    // Child body should have run exactly once — replay skips it
-                    assert(count1 == 1, s"Child body ran $count1 times before suspension")
-                end for
-            }
-        }
-
-        "multiple subflows don't interfere" in {
-            withEngine { (engine, store, tc) =>
-                val child1 = Flow.input[Int]("a").output("b")(ctx => ctx.a + 1)
-                val child2 = Flow.input[Int]("a").output("b")(ctx => ctx.a * 2)
-                val flow = Flow.input[Int]("x")
-                    .subflow("first", child1)(ctx => "a" ~ ctx.x)
-                    .subflow("second", child2)(ctx => "a" ~ ctx.x)
-                    .output("result")(ctx => ctx.first.b + ctx.second.b)
-                for
-                    _      <- engine.register(wf1, flow)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _      <- engine.executions.signal[Int](eid, "x", 5)
-                    status <- pump(tc, store, eid, _.isTerminal)
-                    v      <- store.getField[Int](eid, "result")
-                yield
-                    assert(status == Flow.Status.Completed)
-                    assert(v.get == 16, s"Expected 6+10=16 but got ${v}") // (5+1) + (5*2)
-                end for
-            }
-        }
-
-        "child failure propagates to parent" in {
-            withEngine { (engine, store, tc) =>
-                val child = Flow.input[Int]("a").output("b")(ctx =>
-                    if ctx.a == 0 then throw new RuntimeException("zero") else ctx.a
-                )
-                val flow = Flow.input[Int]("x")
-                    .subflow("payment", child)(ctx => "a" ~ ctx.x)
-                for
-                    _      <- engine.register(wf1, flow)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _      <- engine.executions.signal[Int](eid, "x", 0)
-                    status <- pump(tc, store, eid, _.isTerminal)
-                yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
-                end for
-            }
         }
     }
 
@@ -1825,8 +4304,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(log == Seq("e", "d", "c", "b", "a"), s"reverse order, got: $log")
                 end for
             }
@@ -1917,8 +4396,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(fired)
                 end for
             }
@@ -2007,7 +4486,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _      <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _      <- pumpState(tc, store, eid, waitingFor("x"))
                     detail <- engine.executions.describe(eid)
                 yield
                     assert(detail.progress.totalCount == 2)
@@ -2015,6 +4494,209 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     assert(xNode.isDefined)
                     assert(xNode.get.status == FlowEngine.Progress.NodeStatus.WaitingForInput)
                 end for
+            }
+        }
+
+        /** A twice-embedded subflow's child nodes are distinguishable in the progress list.
+          *
+          * `NodeProgress.name` carries the composition path (`instance~node`, the separator the design uses), rather than the
+          * child's bare name or nothing at all: a subflow can be embedded twice, and a progress list that either omits the children
+          * or lists two entries under one bare name gives a renderer no way to say which instance did what. The progress visitor
+          * descends into a child flow (`FlowEngine.scala`'s `onSubflow`) and qualifies every node the child contributes with the
+          * name of the instance that embedded it, which is also the name the store knows those nodes by.
+          */
+        "a twice-embedded subflow's progress names its nodes by path" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("amount").step("charge")(_ => ())
+                val flow = Flow.input[Int]("x")
+                    .subflow("first", child)(ctx => "amount" ~ ctx.x)
+                    .subflow("second", child)(ctx => "amount" ~ ctx.x)
+                    .output("done")(_ => "ok")
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 5)
+                    _      <- pump(tc, store, eid, _.isTerminal)
+                    detail <- engine.executions.describe(eid)
+                yield
+                    val names = detail.progress.nodes.map(_.name)
+                    assert(
+                        names.contains("first~charge") && names.contains("second~charge"),
+                        s"each embedded instance's child node must appear in progress under its own path, got $names"
+                    )
+                end for
+            }
+        }
+
+        /** A subflow and its child's inputs finish when the work under them has, and until then neither is the node that is running.
+          *
+          * The subflow's own name records nothing, by design: its children write under their qualified paths and the subflow arm
+          * calls no verb for the instance itself. Reading its completion from the recorded set therefore never completes it, and the
+          * surface pays for that twice: the instance takes the active marker whenever it comes first, so an operator watching a
+          * running execution sees the subflow `running` and the node actually executing `pending`, and once the execution finishes
+          * the instance reads `pending` forever, so `completedCount` never reaches `totalCount` on any workflow with a subflow in it
+          * and every renderer that colours by status draws it that way. Completion is derived from the recorded facts around it
+          * instead: the instance is done when the nodes under it are.
+          *
+          * The child's INPUT is not derived. Entering the instance records each declared input under its own path
+          * (`review~amount`) before the child's first node runs, so the input is read from its record like every other node, and the
+          * subflow's derivation rests on a recorded fact rather than on the walk having moved past it.
+          *
+          * **There is no failed arm, and its absence is the design rather than an omission.** A child that failed leaves its
+          * subflow `Pending` on a terminal execution, because painting the subflow `Failed` too would put the same message on two
+          * nodes and a reader asking which node failed would get two answers. That is exactly what the exact-match-first resolution
+          * rule exists to prevent: a recorded path is attributed to the node that owns it and to nothing above it, which the leaf
+          * "a failure keyed by an iteration paints its loop, and one keyed by a subflow's child paints the child" pins directly.
+          * Adding the arm would invert that leaf, so it is not an improvement waiting to be made.
+          */
+        "a subflow and its child's input read completed once the work under them has" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("amount").step("charge")(_ => ())
+                val flow = Flow.input[Int]("x")
+                    .subflow("review", child)(ctx => "amount" ~ ctx.x)
+                    .input[String]("approval")
+                    .output("done")(_ => "ok")
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _        <- engine.executions.signal[Int](eid, "x", 5)
+                    _        <- pumpState(tc, store, eid, waitingFor("approval"))
+                    parked   <- engine.executions.describe(eid)
+                    _        <- engine.executions.signal[String](eid, "approval", "yes")
+                    _        <- pump(tc, store, eid, _.isTerminal)
+                    finished <- engine.executions.describe(eid)
+                yield
+                    assert(
+                        parked.progress.nodeByName("review").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Completed),
+                        s"the subflow's nodes are done, so the subflow is done, got " +
+                            s"${parked.progress.nodes.map(n => (n.name, n.status.show))}"
+                    )
+                    assert(
+                        parked.progress.nodeByName("review~amount").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Completed),
+                        s"and the input the mapper filled in is done with it, got " +
+                            s"${parked.progress.nodeByName("review~amount").map(_.status)}"
+                    )
+                    assert(
+                        parked.progress.nodeByName("approval").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.WaitingForInput),
+                        s"and the node the execution is actually at wears its own status, got " +
+                            s"${parked.progress.nodeByName("approval").map(_.status)}"
+                    )
+                    assert(
+                        finished.progress.completedCount == finished.progress.totalCount,
+                        s"a completed execution has no node left unfinished, got " +
+                            s"${finished.progress.completedCount} of ${finished.progress.totalCount} in " +
+                            s"${finished.progress.nodes.map(n => (n.name, n.status.show))}"
+                    )
+                end for
+            }
+        }
+
+        /** A child that computes nothing still finishes, on the record its own entry wrote.
+          *
+          * The subflow's derivation rests on recorded facts one level out, its own child nodes, so a child whose nodes are ALL inputs
+          * is the case where that has to work with nothing but inputs. Leave a mapper-supplied input unpersisted and such a child
+          * records nothing at any level: no node under the instance can leave `Pending`, both read `Pending` forever on a `Completed`
+          * execution, and `completedCount` never reaches `totalCount`. Falling back to the LIFECYCLE, counting an execution that
+          * completed as having entered every instance it declares, is a stand-in for evidence rather than evidence.
+          *
+          * Entering the instance records `review~amount` under its own path, so an inputs-only child produces exactly the record any
+          * other child does and the instance is derived from it. The lifecycle is not consulted at all, which is what makes the same
+          * question answerable for an execution that did NOT complete: the leaf below pins the losing arm of a race, where the
+          * instance was never entered and reads `Pending` for that reason.
+          */
+        "a subflow whose child only declares inputs still completes" in {
+            withEngine { (engine, store, tc) =>
+                val child = Flow.input[Int]("amount")
+                val flow = Flow.input[Int]("x")
+                    .subflow("review", child)(ctx => "amount" ~ ctx.x)
+                    .output("done")(_ => "ok")
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 5)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    detail <- engine.executions.describe(eid)
+                yield
+                    assert(status == Flow.Status.Completed, s"the premise is that the execution completed, got $status")
+                    assert(
+                        detail.progress.nodeByName("review~amount").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Completed),
+                        s"a child input the mapper filled in is done once the execution is, got " +
+                            s"${detail.progress.nodeByName("review~amount").map(_.status)}"
+                    )
+                    assert(
+                        detail.progress.nodeByName("review").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Completed),
+                        s"and so is the instance it belongs to, got ${detail.progress.nodeByName("review").map(_.status)}"
+                    )
+                    assert(
+                        detail.progress.completedCount == detail.progress.totalCount,
+                        s"a completed execution has no node left unfinished, got ${detail.progress.completedCount} of " +
+                            s"${detail.progress.totalCount} in ${detail.progress.nodes.map(n => (n.name, n.status.show))}"
+                    )
+                end for
+            }
+        }
+
+        /** An inputs-only child in a race's LOSING arm reads Pending, on the evidence rather than by a rule.
+          *
+          * Deriving an instance from the LIFECYCLE, so that a `Completed` execution counts as having entered every instance it
+          * declares, is exact for `zip` and `gather`, which wait for every arm, and wrong for a `race`, whose losing arm is
+          * interrupted the moment the winner finishes. Here the loser is interrupted before it reaches the subflow at all, so that
+          * derivation paints an instance it never entered `Completed` with nothing recorded to say so.
+          *
+          * Entering an instance records the child's declared inputs under their own paths before the child's first node runs. The
+          * loser never entered, so `review~amount` has no field, no event and no row; it reads `Pending` by evidence, and `review`
+          * derives `Pending` from the one node under it. A node the loser DID complete is recorded exactly as a winner's is, so what
+          * the record buys is telling the un-entered case from the entered one rather than guessing at it.
+          *
+          * The loser is decided by a latch nobody releases, not by a duration, so which arm wins is not a scheduling race: the
+          * winning arm has no suspension point and the losing arm cannot pass its first one.
+          */
+        "an inputs-only subflow in a race's losing arm reads pending, because nothing under it was recorded" in {
+            withEngine { (engine, store, tc) =>
+                Latch.init(1).map { held =>
+                    val child = Flow.input[Int]("amount")
+                    val losing = Flow.init("race-derivation")
+                        .step("blocked")(_ => held.await)
+                        .subflow("review", child)(_ => "amount" ~ 1)
+                    val winning = Flow.init("race-derivation").output("winner")(_ => "quick")
+                    val flow    = Flow.race(winning, losing)
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        status <- pump(tc, store, eid, _.isTerminal, 400)
+                        detail <- engine.executions.describe(eid)
+                        winner <- store.getField[String](eid, "winner")
+                    yield
+                        assert(status == Flow.Status.Completed, s"the premise is that the race completed, got $status")
+                        assert(winner == Present("quick"), s"and that the arm with no suspension won it, got $winner")
+                        assert(
+                            detail.progress.nodeByName("review~amount").map(_.status) ==
+                                Maybe(FlowEngine.Progress.NodeStatus.Pending),
+                            s"the losing arm's child input reads pending, because the entry that would record it never ran, got " +
+                                s"${detail.progress.nodeByName("review~amount").map(_.status)}"
+                        )
+                        assert(
+                            detail.progress.nodeByName("review").map(_.status) ==
+                                Maybe(FlowEngine.Progress.NodeStatus.Pending),
+                            s"and so does the instance it belongs to, got ${detail.progress.nodeByName("review").map(_.status)}"
+                        )
+                        assert(
+                            detail.progress.nodeByName("blocked").map(_.status) ==
+                                Maybe(FlowEngine.Progress.NodeStatus.Pending),
+                            s"while the node the loser was actually interrupted on records nothing and reads pending, got " +
+                                s"${detail.progress.nodeByName("blocked").map(_.status)}"
+                        )
+                    end for
+                }
             }
         }
     }
@@ -2031,13 +4713,14 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.register(Flow.Id.Workflow("test-flow"), flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _     <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
-                    _     <- engine.executions.cancel(eid)
-                    state <- store.getExecution(eid)
-                    _ = assert(state.get.status == Flow.Status.Cancelled)
-                    // Attempt to overwrite with Failed via updateStatus
-                    now    <- Clock.now
-                    _      <- store.updateStatus(eid, Flow.Status.Failed("late"), Flow.Event.Failed(wf1, eid, "late", now))
+                    _      <- pumpState(tc, store, eid, waitingFor("x"))
+                    _      <- engine.executions.cancel(eid)
+                    status <- pump(tc, store, eid, _.isTerminal)
+                    _ = assert(status == Flow.Status.Cancelled)
+                    // The value the execution was parked on arrives after it was cancelled, which is the one thing left that
+                    // could still drive it forward. A status write of its own is not expressible: every one carries a claim,
+                    // and a finished execution has none to carry.
+                    _      <- Abort.run[FlowException](engine.executions.signal[Int](eid, "x", 1))
                     final_ <- store.getExecution(eid)
                 yield assert(final_.get.status == Flow.Status.Cancelled, "terminal status should not revert")
                 end for
@@ -2086,7 +4769,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "concurrent starts with same ID — at most one succeeds" in {
+        "concurrent starts with same ID, at most one succeeds" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x)
                 val eid  = Flow.Id.Execution("same-id")
@@ -2110,7 +4793,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
 
         "FlowGraph.build with progress annotates status" in {
             val flow     = Flow.input[Int]("x").output("y")(ctx => ctx.x + 1)
-            val progress = FlowEngine.Progress.build(flow, Set("x", "y"), Flow.Status.Completed)
+            val progress = FlowEngine.Progress.build(flow, Set("x", "y"), Flow.Status.Completed, Dict.empty)
             val graph    = kyo.internal.FlowGraph.build(flow, progress)
             assert(graph.nodes.exists(_.status == "completed"))
         }
@@ -2132,8 +4815,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 5)
-                    _ <- pump(tc, store, eid, _.isSleeping)
-                    _ <- pump(tc, store, eid, s => !s.isSleeping && s != Flow.Status.Running, 300)
+                    _ <- pumpState(tc, store, eid, sleeping)
+                    _ <- pumpState(tc, store, eid, s => !sleeping(s), 300)
                     _ <- pump(tc, store, eid, _.isTerminal, 300)
                     v <- store.getField[Int](eid, "y")
                 yield assert(v.get == 10)
@@ -2158,8 +4841,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal, 300)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(fired, "compensation should fire after sleep+failure")
                 end for
             }
@@ -2190,7 +4873,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 100)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("name"))
+                    _ <- pumpState(tc, store, eid, waitingFor("name"))
                     c1 = dispatchCalled
                     _  = dispatchCalled = false
                     _ <- engine.executions.signal[String](eid, "name", "done")
@@ -2221,7 +4904,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     h <- engine.workflows.start(wf1)
                     eid = h.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 1)
-                    _ <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("trigger"))
+                    _ <- pumpState(tc, store, eid, waitingFor("trigger"))
                     c1 = afterCount
                     _  = afterCount = 0
                     _ <- engine.executions.signal[String](eid, "trigger", "go")
@@ -2250,8 +4933,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     assert(compFired, "compensation should fire")
                     assert(
                         status match
-                            case Flow.Status.Failed(msg) => msg == "boom";
-                            case _                       => false
+                            case Flow.Status.Failed(msg, _) => msg == "boom";
+                            case _                          => false
                         ,
                         s"Should fail with 'boom' but got $status"
                     )
@@ -2278,8 +4961,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     // Handler should see "x" and "a" (fields at registration), not "b" (added after)
                     assert(capturedKeys.contains("x"), s"Should see 'x', got $capturedKeys")
                     assert(capturedKeys.contains("a"), s"Should see 'a', got $capturedKeys")
@@ -2302,7 +4985,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     eid = handle.executionId
                     _       <- engine.executions.signal[Int](eid, "x", 1)
                     status  <- pump(tc, store, eid, _.isTerminal)
-                    history <- store.getHistory(eid, Int.MaxValue, 0)
+                    history <- store.getHistory(eid, Maybe.empty, 0)
                 yield
                     assert(compFired, "compensation should fire")
                     val kinds = history.events.map(_.kind).toSeq
@@ -2323,7 +5006,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
         }
 
         "Compensating status is not terminal" in {
-            assert(!Flow.Status.Compensating.isTerminal)
+            assert(!Flow.Status.Compensating(Flow.Cause.Failure("boom")).isTerminal)
         }
     }
 
@@ -2332,7 +5015,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "scheduled loop" - {
 
-        "fixed schedule — stops when body returns done" in {
+        "fixed schedule stops when body returns done" in {
             withEngine { (engine, store, tc) =>
                 var iterations = 0
                 val flow = Flow.input[Int]("x")
@@ -2404,7 +5087,209 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "scheduled loop body throws — execution fails" in {
+        /** A scheduled loop's delay is honoured across the resume between iterations.
+          *
+          * Each iteration ends in a durable sleep, so every iteration boundary is a suspend and a replay. If the schedule's position
+          * were lost across that boundary the loop would either fire immediately on each resume, turning a paced loop into a spin, or
+          * restart the interval from scratch. Measured in virtual time, three iterations at a hundred milliseconds have to take at
+          * least the two intervals that separate them.
+          */
+        "a scheduled loop's delays survive the resume between iterations" in {
+            withEngine { (engine, store, tc) =>
+                var iterations = 0
+                val flow = Flow.init("paced")
+                    .loopOn("count", Schedule.fixed(100.millis).repeat(10)) { ctx =>
+                        iterations += 1
+                        if iterations < 3 then Loop.continue[Int]
+                        else Loop.done(iterations)
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    before <- Clock.now
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status <- pump(tc, store, eid, _.isTerminal, 400)
+                    after  <- Clock.now
+                yield
+                    assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                    assert(
+                        (after - before) >= 200.millis,
+                        s"three iterations separated by 100ms cannot finish in ${after - before}"
+                    )
+                end for
+            }
+        }
+
+        /** A loop with no schedule does not lose the iterations it already ran.
+          *
+          * The unscheduled `loop` never suspends, so it has no iteration checkpoints at all: the whole loop is one node, recorded
+          * complete only at the end. That is defensible, and it means the body must be idempotent across a crash, but the property
+          * that has to hold either way is that a completed loop is not re-run on a later resume. Everything after it depends on its
+          * recorded value, not on running it again.
+          */
+        "a completed unscheduled loop is not re-run on a later resume" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { bodyRuns =>
+                    val flow = Flow.init("unscheduled-loop")
+                        .loop("total", 0) { (state: Int, ctx) =>
+                            val outcome: Loop.Outcome[Int, Int] =
+                                if state < 3 then Loop.continue(state + 1)
+                                else Loop.done[Int, Int](state)
+                            bodyRuns.incrementAndGet.andThen(outcome)
+                        }
+                        .input[String]("gate")
+                        .output("done")(ctx => ctx.gate)
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _            <- pumpState(tc, store, eid, waitingFor("gate"))
+                        beforeSignal <- bodyRuns.get
+                        _            <- engine.executions.signal[String](eid, "gate", "go")
+                        status       <- pump(tc, store, eid, _.isTerminal, 400)
+                        after        <- bodyRuns.get
+                        total        <- store.getField[Int](eid, "total")
+                    yield
+                        assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                        assert(total == Present(3), s"the loop's recorded value should survive, got $total")
+                        assert(
+                            after == beforeSignal,
+                            s"a completed loop must not re-run on resume: the body ran $beforeSignal times before the " +
+                                s"input arrived and $after times after"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** An unscheduled loop interrupted part-way re-runs every iteration it already ran, and the cost is measured here.
+          *
+          * The leaf above pins the COMPLETED case. This is the other half, and it is an accepted limitation rather than a defect: an
+          * unscheduled `loop` is one node with no iteration checkpoints, so an execution that dies at iteration 40 of 50 starts again
+          * at 1. What is wrong with an accepted limitation is its invisibility, which is the argument for measuring it rather than
+          * describing it.
+          *
+          * The handoff is real: the first engine's scope is closed while the loop is running, the clock passes the lease, and a
+          * second engine on the same store claims the row the ordinary way. Nothing is seeded.
+          *
+          * Two things are asserted. The one that must hold whatever the limitation is: a loop that restarted still records the value
+          * it would have recorded without the interruption, which is what makes the restart survivable rather than merely documented.
+          * And the limitation itself, loosely enough that it cannot be flaky: the body runs MORE times than the loop has iterations,
+          * which can only happen if iterations were repeated. How many more depends on where the interrupt landed, which is a
+          * scheduling fact and is reported rather than asserted.
+          *
+          * **A failure of the second assertion is not a regression.** It means iteration checkpointing has arrived, and the design's
+          * statement of the limitation has to change with this leaf. That coupling is the point of pinning an accepted limitation: it
+          * cannot be quietly outgrown.
+          *
+          * The premises come first: the first engine really had begun looping, and the second really did finish the execution.
+          */
+        "an unscheduled loop interrupted part-way re-runs the iterations it already ran" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(0).map { bodyRuns =>
+                        val iterations = 6
+                        val wfId       = Flow.Id.Workflow("loop-handoff")
+                        val flow = Flow.init("loop-handoff")
+                            .loop("total", 0) { (state: Int, ctx) =>
+                                val outcome: Loop.Outcome[Int, Int] =
+                                    if state < iterations then Loop.continue(state + 1)
+                                    else Loop.done[Int, Int](state)
+                                bodyRuns.incrementAndGet.andThen(outcome)
+                            }
+                            .output("done")(ctx => ctx.total)
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 2.seconds,
+                            renewEvery = 500.millis,
+                            pollTimeout = 100.millis
+                        )
+                        for
+                            eid <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { first =>
+                                    first.workflows.start(wfId).map { handle =>
+                                        settle(tc, step = 10.millis, maxRounds = 40)(
+                                            bodyRuns.get.map(_ >= 1)
+                                        ).andThen(handle.executionId)
+                                    }
+                                }
+                            }
+                            before <- bodyRuns.get
+                            _      <- tc.advance(10.seconds)
+                            _ <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { second =>
+                                    settle(tc, step = 250.millis, maxRounds = 80)(
+                                        store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                    )
+                                }
+                            }
+                            after <- bodyRuns.get
+                            state <- store.getExecution(eid)
+                            total <- store.getField[Int](eid, "total")
+                        yield
+                            assert(
+                                before >= 1,
+                                s"the premise is that the first engine had begun looping when it stopped, and it ran $before times"
+                            )
+                            assert(
+                                state.exists(_.status == Flow.Status.Completed),
+                                s"the premise is that the second engine finished the execution, got ${state.map(_.status)}"
+                            )
+                            assert(
+                                total == Present(iterations),
+                                s"a loop that restarted must still record the value it would have recorded without the " +
+                                    s"interruption, got $total after $after body runs"
+                            )
+                            assert(
+                                after > iterations,
+                                s"D12 says an interrupted unscheduled loop restarts from the beginning: the body ran $after " +
+                                    s"times for a $iterations iteration loop ($before of them before the handoff), so nothing " +
+                                    s"was repeated. If that is now false, the non-goal has been FIXED and D12 plus section 6 " +
+                                    s"of the design have to change with it"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A scheduled loop that carries state gives each iteration the previous one's value.
+          *
+          * `loopOn(name, schedule, init)` takes a state and requires `Tag` and `Schema` for it, which is only meaningful if the state
+          * is persisted across the durable sleep between iterations. Checkpointing a continue iteration with a step that stores no
+          * value, and advancing the schedule on replay while passing the ORIGINAL `init` forward, loses it. Every scheduled iteration
+          * suspends through that sleep, so this is not a crash-recovery case: it is what a stateful scheduled loop does in normal
+          * operation, and the stateless overload with a local `var` that the other leaves in this group use never exercises it.
+          */
+        "a stateful scheduled loop carries its state across iterations" in {
+            withEngine { (engine, store, tc) =>
+                // The schedule is deliberately longer than this leaf watches. A short one lets the never-advancing state run the
+                // loop to exhaustion, and the exhaustion path encodes `()` under the loop value's own schema, which raises a cast
+                // error while writing the field. On the JVM that is caught and recorded; on a JS runtime it escapes and takes the
+                // process down, so a short schedule here makes the whole suite unrunnable on that platform. The exhaustion path has
+                // its own leaf; this one is about the state.
+                val flow = Flow.init("acc-loop")
+                    .loopOn("acc", Schedule.fixed(100.millis).repeat(1000), 0) { (state: Int, ctx) =>
+                        if state >= 2 then Loop.done(state)
+                        else Loop.continue(state + 1)
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    done <- settle(tc, maxRounds = 200)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                    acc  <- store.getField[Int](eid, "acc")
+                yield
+                    assert(
+                        acc == Present(2),
+                        s"each iteration must see the previous iteration's state, got $acc"
+                    )
+                    assert(done, "the loop should reach its done condition and the execution should finish")
+                end for
+            }
+        }
+
+        "scheduled loop body throws, so the execution fails" in {
             withEngine { (engine, store, tc) =>
                 var iterations = 0
                 val flow = Flow.input[Int]("x")
@@ -2420,8 +5305,46 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 1)
                     status <- pump(tc, store, eid, _.isTerminal, 200)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
+                end for
+            }
+        }
+
+        /** The loop's declared `retry` schedule never sees the body, because the body runs outside the bracket.
+          *
+          * `loopOn` declares `retry` in its signature and `executeIteration` computes the body FIRST, then brackets `Kyo.unit`
+          * with the node's `Meta` (`Flow.scala:1073-1077`): the schedule the user configured wraps a computation that cannot
+          * fail, and the body it was configured for runs outside it, outside the timeout, and outside the claim check. So a
+          * transient failure in an iteration terminalises the execution on the spot, with the retry budget untouched. The
+          * iteration is the unit the knobs govern, and a schedule that can never fire is a feature the signature promises and the
+          * interpreter does not have.
+          */
+        "a scheduled loop iteration that throws is retried by the loop's schedule" in {
+            withEngine { (engine, store, tc) =>
+                var calls = 0
+                val flow = Flow.input[Int]("x")
+                    .loopOn("poll", Schedule.fixed(100.millis).repeat(5), retry = Maybe(Schedule.fixed(100.millis).repeat(3))) {
+                        ctx =>
+                            calls += 1
+                            if calls == 1 then throw new RuntimeException("transient")
+                            Loop.done(42)
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- engine.executions.signal[Int](eid, "x", 1)
+                    status <- pump(tc, store, eid, _.isTerminal, 400)
+                    v      <- store.getField[Int](eid, "poll")
+                yield
+                    assert(calls >= 1, s"the premise is that the body ran and its first call threw, got $calls calls")
+                    assert(
+                        status == Flow.Status.Completed,
+                        s"a transient iteration failure with a retry schedule must be re-asked, not terminal, got $status " +
+                            s"after $calls call(s) of a body whose schedule allowed three more"
+                    )
+                    assert(v == Maybe(42), s"the retried iteration's result must be stored, got $v")
                 end for
             }
         }
@@ -2432,7 +5355,64 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "race execution" - {
 
-        "one branch fails, other succeeds — winner completes" in {
+        /** A race branch's failure does not decide a race that can still be won.
+          *
+          * The fallback idiom is the argument: `race(notify-via-flaky-api, input("manual-ack"))` exists precisely so the
+          * acknowledgement can rescue a failed notification. Completing the race on the FIRST success but on the LAST error makes
+          * the outcome scheduling-dependent, because a suspension travels as an error: with the input branch parked first and the
+          * flaky branch failing after it, the failure lands last, the race completes with it, and the flow terminally fails while
+          * the acknowledgement it exists to wait for is still deliverable. The join reads every branch's outcome and a park
+          * outranks a failure among them (`internal/StoreInterpreter.scala`'s `onRace`, whose `decide` answers the merged suspension
+          * whenever any branch parked), so only an all-failed race fails. Failure-wins is the right ranking for `zip`, whose result
+          * is unreachable once any branch fails; a race's result is still reachable through the parked branch, which is why the two
+          * compositions rank the same two outcomes in opposite orders.
+          */
+        "a race branch that fails beside a parked sibling does not decide the race" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId    = Flow.Id.Workflow("fallback-race")
+                    val waiting = Flow.init("fallback-race").input[String]("ack").output("answer")(ctx => ctx.ack)
+                    val flaky = Flow.init("fallback-race").step("notify") { _ =>
+                        Async.sleep(500.millis).andThen {
+                            throw new RuntimeException("notify endpoint down"); ()
+                        }
+                    }.output("answer")(_ => "notified")
+                    val flow   = Flow.race(waiting, flaky)
+                    val config = FlowEngine.Config(workerCount = 1, lease = 30.seconds, pollTimeout = 100.millis)
+                    FlowEngine.init(store, config, flow).map { engine =>
+                        for
+                            handle <- engine.workflows.start(wfId)
+                            eid = handle.executionId
+                            // Let the input branch park, then the flaky branch fail 500ms later: the failure lands last.
+                            settled <- settle(tc, step = 100.millis, maxRounds = 30)(
+                                store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                            )
+                            afterFailure <- store.getExecution(eid)
+                            _            <- Abort.run[FlowException](engine.executions.signal[String](eid, "ack", "rescued"))
+                            _ <- settle(tc, step = 100.millis, maxRounds = 40)(
+                                store.getExecution(eid).map(_.exists(_.status == Flow.Status.Completed))
+                            )
+                            finalState <- store.getExecution(eid)
+                            answer     <- store.getField[String](eid, "answer")
+                        yield
+                            assert(
+                                !afterFailure.exists(_.status.isTerminal),
+                                s"a race with a live sibling must not be decided by a branch failure, but the flow " +
+                                    s"terminalised as ${afterFailure.map(_.status)} while the acknowledgement was still " +
+                                    s"deliverable"
+                            )
+                            assert(
+                                finalState.exists(_.status == Flow.Status.Completed) && answer == Maybe("rescued"),
+                                s"the acknowledgement must rescue the race, got status ${finalState.map(_.status)} and " +
+                                    s"answer $answer"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        "one branch fails, other succeeds, so the winner completes" in {
             withEngine { (engine, store, tc) =>
                 val left = Flow.input[Int]("x").output("a")(ctx =>
                     throw new RuntimeException("left fails"); 0
@@ -2453,7 +5433,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "both branches fail — execution fails" in {
+        "both branches fail, so the execution fails" in {
             withEngine { (engine, store, tc) =>
                 val left = Flow.input[Int]("x").output("a")(ctx =>
                     throw new RuntimeException("left"); 0
@@ -2469,8 +5449,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 5)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
                 end for
             }
         }
@@ -2481,7 +5461,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "gather advanced" - {
 
-        "one branch fails — entire gather fails" in {
+        "one branch fails, so the entire gather fails" in {
             withEngine { (engine, store, tc) =>
                 val f1 = Flow.input[Int]("x").output("a")(ctx => ctx.x + 1)
                 val f2 = Flow.input[Int]("x").output("b")(ctx =>
@@ -2495,8 +5475,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 5)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
                 end for
             }
         }
@@ -2528,7 +5508,371 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "retry" - {
 
-        "output with retry — fails twice then succeeds" in {
+        /** A step's retry schedule resumes where it stopped, instead of restarting on every resume.
+          *
+          * Entering `withTimeoutAndRetry` at the first attempt no matter what came before, while every
+          * retry appends its own attempt number, writes the position durably and never reads it. A step
+          * that fails deterministically then spends its whole schedule once per resume without ever
+          * exhausting it, which turns a bounded retry policy into an unbounded one exactly when the
+          * system is already unhealthy. The position is read
+          * (`internal/StoreInterpreter.scala`'s `resume`, which walks the schedule's `next` once per
+          * retry the history counted), so a resumed attempt continues the schedule it inherited.
+          *
+          * **The assertion is the shape of the sequence, not a budget.** Reading `attempt` numbers out
+          * of history and requiring them to increase says exactly "the second executor continued the
+          * schedule" without this leaf having to know how many retries `repeat(n)` allows or which of
+          * them the handoff interrupted. A regression that restarted the schedule shows up as numbers
+          * that begin again at 1 after the handoff.
+          *
+          * **The instrument is a real handoff.** The first engine's scope is closed while the step is
+          * mid-retry, so it stops polling and stops renewing; the clock then passes the lease, and a
+          * second engine on the same store claims the row the ordinary way. Nothing here forges durable
+          * state and nothing refuses a renewal that a conforming store would grant: a fixture doing
+          * either proves nothing, because no conforming store behaves that way.
+          *
+          * Both premises are asserted before the outcome: the first engine must really have retried at
+          * least once before it went, and the second must really have retried after taking over. A run
+          * where the execution is never picked up again fails on the second premise and says so, rather
+          * than passing because no contradicting event was ever written.
+          */
+        "a step's retry schedule resumes at its recorded position across a handoff" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId = Flow.Id.Workflow("retry-budget")
+                    val flow = Flow.init("retry-budget")
+                        .output("charge", retry = Maybe(Schedule.fixed(1.second).repeat(6)))(_ =>
+                            throw new RuntimeException("keeps failing"); ""
+                        )
+                    val config = FlowEngine.Config(
+                        workerCount = 1,
+                        lease = 2.seconds,
+                        renewEvery = 500.millis,
+                        pollTimeout = 100.millis
+                    )
+                    def retriesOf(eid: Flow.Id.Execution) =
+                        store.getHistory(eid, Maybe.empty, 0).map(_.events.collect {
+                            case Flow.Event.StepRetried(_, _, _, _, n, _, _) => n
+                        })
+                    for
+                        eid <- Scope.run {
+                            FlowEngine.init(store, config, flow).map { first =>
+                                first.workflows.start(wfId).map { handle =>
+                                    settle(tc, step = 250.millis, maxRounds = 40)(
+                                        retriesOf(handle.executionId).map(_.size >= 2)
+                                    ).andThen(handle.executionId)
+                                }
+                            }
+                        }
+                        before <- retriesOf(eid)
+                        _      <- tc.advance(10.seconds)
+                        _ <- Scope.run {
+                            FlowEngine.init(store, config, flow).map { second =>
+                                settle(tc, step = 250.millis, maxRounds = 80)(
+                                    retriesOf(eid).map(_.size > before.size)
+                                )
+                            }
+                        }
+                        after <- retriesOf(eid)
+                    yield
+                        assert(
+                            before.size >= 2,
+                            s"the premise is that the first engine was mid-retry when it stopped, got $before"
+                        )
+                        assert(
+                            after.size > before.size,
+                            s"the premise is that the second engine took the execution over and retried, got $after " +
+                                s"against $before: the execution was never picked up again"
+                        )
+                        assert(
+                            after == after.sorted && after.distinct == after,
+                            s"a retry position that resumes must produce strictly increasing attempt numbers, got $after " +
+                                s"(the first engine wrote $before before it stopped)"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** A GUARD: losing a lease mid-step leaves the execution recoverable, rather than failing it.
+          *
+          * The code reads as though the opposite were true. `Abort.recover[Throwable] { ... updateStatus(eid,
+          * Flow.Status.Failed(...), ...) }(executeOne(eid))` (`FlowEngine.scala:456-464`) beside the renewal fiber's
+          * `execFiber.interrupt` (`:471`) suggests an executor which discovers it no longer owns the row uses that discovery to
+          * write the most final thing it can. It does not: after the lease is lost mid-retry the execution is NOT terminal. The
+          * guard keeps it that way, because the write is one refactor away from happening and losing a lease is not a verdict on
+          * the work.
+          *
+          * The premise is asserted first: the step must really have been mid-retry when the lease went, or the run says nothing
+          * about the case the leaf is named for.
+          *
+          * **What this leaf does NOT establish.** The run also shows the execution never being RE-ENTERED, one `StepStarted` across
+          * 30 virtual seconds against a 2 second lease, and that observation is worthless: `LosingRenewalStore` refuses renewals
+          * from a counter without consulting the claim row, so the UNDERLYING row stays claimed by a live, unexpired lease and no
+          * competitor could have taken it whatever the engine did. The refusal the engine sees is real, which is why the assertion
+          * above stands; the absence of a resume is the decorator's doing. Re-entry is a question only a real expiry and a second
+          * engine can answer, which is the shape the handoff leaves use.
+          */
+        "an execution whose lease is lost mid-step is recoverable, not failed" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    AtomicInt.init(1).map { grants =>
+                        val store = new LosingRenewalStore(plain, grants)
+                        val wfId  = Flow.Id.Workflow("lease-lost")
+                        val flow = Flow.init("lease-lost")
+                            .output("y", retry = Maybe(Schedule.fixed(1.second).repeat(5)))(_ =>
+                                throw new RuntimeException("keeps failing"); ""
+                            )
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 2.seconds,
+                            renewEvery = 500.millis,
+                            pollTimeout = 100.millis
+                        )
+                        FlowEngine.init(store, config, flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(wfId)
+                                eid = handle.executionId
+                                _ <- settle(tc, step = 250.millis, maxRounds = 40)(
+                                    plain.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                )
+                                state <- plain.getExecution(eid)
+                                page  <- plain.getHistory(eid, Maybe.empty, 0)
+                                retried = page.events.count(_.kind == Flow.EventKind.StepRetried)
+                            yield
+                                assert(
+                                    retried > 0,
+                                    s"the premise is that the step was mid-retry when the lease was lost, got $retried retries"
+                                )
+                                assert(
+                                    !state.exists(_.status.isTerminal),
+                                    s"losing a lease is not a verdict on the work: the execution must stay recoverable, got " +
+                                        s"${state.map(_.status)}"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A lapsed executor's interrupt must not be consumed by a step's retry schedule.
+          *
+          * The renewal fiber's `execFiber.interrupt` is the ONE mechanism that stops a lapsed executor's work, and the retry
+          * loop's catch is `Abort.run[Throwable]`, the kind that CATCHES panics where `Abort.recover` re-raises them. An
+          * `Interrupted` is an ordinary throwable ("`Result.Panic` carries every throwable `NonFatal` admits", the worker
+          * loop's own comment), so a schedule that classifies it an accident swallows the stop, sleeps the backoff, and
+          * re-runs the side-effecting body under a claim the store may have given to somebody else; the renewal fiber fired
+          * once and is done, so nothing ever interrupts again. This leaf measures which of the two happens: the body's call
+          * count must stop growing after the refusal that triggers the interrupt.
+          */
+        "a lapsed executor's interrupt is not consumed by a step's retry schedule" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    AtomicInt.init(1).map { grants =>
+                        val store = new LosingRenewalStore(plain, grants)
+                        val wfId  = Flow.Id.Workflow("interrupt-vs-retry")
+                        var calls = 0
+                        val flow = Flow.init("interrupt-vs-retry")
+                            .output("slow", retry = Maybe(Schedule.fixed(1.second).repeat(5))) { _ =>
+                                calls += 1
+                                Async.sleep(10.seconds).andThen("done")
+                            }
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 2.seconds,
+                            renewEvery = 500.millis,
+                            pollTimeout = 100.millis
+                        )
+                        FlowEngine.init(store, config, flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(wfId)
+                                eid = handle.executionId
+                                started <- settle(tc, step = 250.millis, maxRounds = 40)(Sync.defer(calls >= 1))
+                                refused <- settle(tc, step = 250.millis, maxRounds = 40)(grants.get.map(_ <= 0))
+                                countAtRefusal = calls
+                                // Bounded room for a swallowed interrupt to show itself: under the defect the schedule
+                                // catches the interrupt, sleeps its backoff, and re-runs the body, so the count grows;
+                                // under the correct classification it never grows again.
+                                _ <- settle(tc, step = 250.millis, maxRounds = 40)(Sync.defer(calls > countAtRefusal))
+                            yield
+                                assert(
+                                    started && refused,
+                                    s"the premise is that the body ran and the renewal was then refused, got calls=$calls, " +
+                                        s"grants=${grants}"
+                                )
+                                assert(
+                                    calls == countAtRefusal,
+                                    s"the interrupt is the mechanism that stops a lapsed executor: the schedule must not " +
+                                        s"consume it and re-run the body, but the body ran ${calls - countAtRefusal} more " +
+                                        s"time(s) after the refusal"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A GUARD: an engine closed mid-step writes nothing terminal, because a shutdown is not a verdict on the work.
+          *
+          * It holds by a rule rather than by an accident of shape: every attempt ends through one transition function, and
+          * `Interrupted` is one of its endings, the one that writes NOTHING, no status, no event, no release. The rule is not
+          * decoration. An interrupt is a `Throwable` that is not a `FlowException`, so an ending function
+          * without an explicit arm for it classifies a shutdown as a panic and terminalises every execution the engine was carrying,
+          * each under a claim that is still perfectly VALID: the scope closes while the lease stands, so no store-side fence can
+          * refuse a write the engine decides to make. The fence protects an execution from an executor that lost it, never from its
+          * own.
+          *
+          * **What actually reaches the store on this path is nothing at all, and the reason is worth keeping.** Closing the scope
+          * interrupts the supervisor along with the attempt, so no ending transition of any kind runs at shutdown; the
+          * `Interrupted` arm's reachable producer is a refused renewal instead. This guard therefore pins the outcome, an execution
+          * left claimable and unjudged, rather than the mechanism that delivers it.
+          */
+        "engine shutdown mid-step does not fail the execution" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId = Flow.Id.Workflow("shutdown-mid-step")
+                    val flow = Flow.init("shutdown-mid-step")
+                        .output("slow")(_ => Async.sleep(1.hour).andThen("done"))
+                    val config = FlowEngine.Config(
+                        workerCount = 1,
+                        lease = 2.seconds,
+                        renewEvery = 500.millis,
+                        pollTimeout = 100.millis
+                    )
+                    def startedCount(eid: Flow.Id.Execution) =
+                        store.getHistory(eid, Maybe.empty, 0).map(_.events.count(_.kind == Flow.EventKind.StepStarted))
+                    for
+                        eid <- Scope.run {
+                            FlowEngine.init(store, config, flow).map { engine =>
+                                engine.workflows.start(wfId).map { handle =>
+                                    settle(tc, step = 250.millis, maxRounds = 40)(
+                                        startedCount(handle.executionId).map(_ >= 1)
+                                    ).andThen(handle.executionId)
+                                }
+                            }
+                        }
+                        stateAfterClose <- store.getExecution(eid)
+                        before          <- startedCount(eid)
+                        _               <- tc.advance(10.seconds)
+                        _ <- Scope.run {
+                            FlowEngine.init(store, config, flow).map { _ =>
+                                settle(tc, step = 250.millis, maxRounds = 40)(startedCount(eid).map(_ > before))
+                            }
+                        }
+                        after <- startedCount(eid)
+                    yield
+                        assert(
+                            before >= 1,
+                            s"the premise is that a step was mid-flight when the engine closed, got $before StepStarted"
+                        )
+                        assert(
+                            !stateAfterClose.exists(_.status.isTerminal),
+                            s"a shutdown is not a verdict on the work: the execution must not be terminal after the engine " +
+                                s"closes, got ${stateAfterClose.map(_.status)}"
+                        )
+                        // The row half of the same rule. A closing scope interrupts the supervising fiber along with the work, so
+                        // no ending transition runs at all: nothing is written and nothing is handed back, and what frees the row
+                        // is the lease running out, which is what the recovery below waits for. The classification gate's own
+                        // Interrupted arm is pinned where it is reachable, on "an executor that has lost its claim writes nothing
+                        // more", because there the supervisor outlives the work it stopped.
+                        assert(
+                            stateAfterClose.exists(s => s.executor.isDefined && s.claimExpiry.isDefined),
+                            s"an interrupted ending releases nothing: the claim must still be held after the engine closes, got " +
+                                s"executor=${stateAfterClose.map(_.executor)} expiry=${stateAfterClose.map(_.claimExpiry)}"
+                        )
+                        assert(
+                            after > before,
+                            s"the execution must be claimable by the next engine once the lease lapses, got $after StepStarted " +
+                                s"against $before before the close"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** An execution whose immediate renewal is refused is still recovered.
+          *
+          * The poll loop renews the moment it claims, and skipping the execution on a refusal with `case false => ()`
+          * (`FlowEngine.scala:445-447`) writes no release, so the execution is never recovered at all: the polls keep discarding it
+          * while the status stays `Running` and the claim expiry walks forward ahead of them.
+          *
+          * **The mechanism is in the store, which is where the fix goes.** `claimReady` returns only rows "not already owned by
+          * us", and decides that from the previous snapshot's `executor` without asking whether that claim was still live
+          * (`internal/MemoryFlowStore.scala:66-75`). So each poll re-claims the row, renews its lease by a full period, and then
+          * filters it out of its own answer. The executor never receives it and no competitor can take it, because from outside the
+          * lease never lapses. `FlowStoreTest` pins both halves deterministically ("Running whose own claim expired → returned to
+          * the same executor", "a poll that returns nothing leaves the execution claimable by another executor"); this leaf shows
+          * what the pair costs a user, which is one execution that never runs again.
+          *
+          * **The instrument is the point.** Refusing renewals from a counter cannot answer this, because such a store refuses a
+          * renewal of a claim it has just granted and the underlying row then stays claimed by a live lease no matter what the engine
+          * does (see `LosingRenewalStore`'s note). Here the store answers from the real row against the real clock at all times: the
+          * decorator only advances virtual time past the lease once, between the claim and the immediate renewal, which is what a
+          * batch slow enough to outlive its own lease does. `MemoryFlowStore.renewClaim` then refuses because `now < e` is false
+          * (`internal/MemoryFlowStore.scala:106`), exactly as it would in production.
+          *
+          * **Skipping is not free, which is where the obvious argument goes wrong.** "An expired claim is claimable, so the skip
+          * costs nothing" holds for every executor except the one whose name is on the claim, and that is the one that skipped. A
+          * refused renewal has to release the claim it is refusing.
+          *
+          * The premise is asserted first: the renewal must really have been refused, or the run says nothing about the case.
+          */
+        "an execution whose immediate renewal is refused is still recovered" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    AtomicInt.init(0).map { skews =>
+                        AtomicInt.init(0).map { refusals =>
+                            AtomicInt.init(0).map { polls =>
+                                AtomicRef.init(Maybe.empty[Instant]).map { firstClaimAt =>
+                                    val lease = 2.seconds
+                                    val store = new LateFirstRenewalStore(plain, tc, lease, skews, refusals, polls, firstClaimAt)
+                                    val wfId  = Flow.Id.Workflow("refused-renewal")
+                                    val flow  = Flow.init("refused-renewal").output("done")(_ => "ok")
+                                    val config = FlowEngine.Config(
+                                        workerCount = 1,
+                                        lease = lease,
+                                        renewEvery = 500.millis,
+                                        pollTimeout = 100.millis
+                                    )
+                                    FlowEngine.init(store, config, flow).map { engine =>
+                                        for
+                                            handle <- engine.workflows.start(wfId)
+                                            eid = handle.executionId
+                                            done <- settle(tc, step = 250.millis, maxRounds = 80)(
+                                                plain.getExecution(eid).map(_.exists(_.status == Flow.Status.Completed))
+                                            )
+                                            refused <- refusals.get
+                                            state   <- plain.getExecution(eid)
+                                            page    <- plain.getHistory(eid, Maybe.empty, 0)
+                                            claims = page.events.count(_.kind == Flow.EventKind.ExecutionClaimed)
+                                            batches   <- skews.get
+                                            pollCount <- polls.get
+                                            claimedAt <- firstClaimAt.get
+                                        yield
+                                            assert(
+                                                refused > 0,
+                                                "the premise is that the immediate renewal was refused at least once; it never was"
+                                            )
+                                            assert(
+                                                done,
+                                                s"an execution skipped by the renewal gate must be claimable again and must run, got " +
+                                                    s"${state.map(_.status)} after $refused refusals, $claims claim events, " +
+                                                    s"$batches non-empty batches out of $pollCount polls, first claim at " +
+                                                    s"$claimedAt, executor=${state.flatMap(_.executor)}, " +
+                                                    s"expiry=${state.flatMap(_.claimExpiry)}, events=${page.events.map(_.kind)}"
+                                            )
+                                        end for
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "output with retry fails twice then succeeds" in {
             withEngine { (engine, store, tc) =>
                 var attempts = 0
                 val flow = Flow.input[Int]("x")
@@ -2552,7 +5896,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "output with retry — exhausts schedule then fails" in {
+        "output with retry exhausts its schedule then fails" in {
             withEngine { (engine, store, tc) =>
                 var attempts = 0
                 val flow = Flow.input[Int]("x")
@@ -2569,14 +5913,14 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal, 200)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(attempts >= 2, s"Expected at least 2 attempts but got $attempts")
                 end for
             }
         }
 
-        "step with retry — retries side-effect step" in {
+        "step with retry retries a side-effecting step" in {
             withEngine { (engine, store, tc) =>
                 var attempts = 0
                 val flow = Flow.input[Int]("x")
@@ -2597,6 +5941,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 end for
             }
         }
+
     }
 
     // =========================================================================
@@ -2604,7 +5949,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "timeout" - {
 
-        "output completes within timeout — succeeds" in {
+        "output completes within its timeout and succeeds" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                     .output("y", timeout = 5.seconds)(ctx => ctx.x * 2)
@@ -2621,6 +5966,96 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 end for
             }
         }
+
+        /** A configured timeout is a policy the user declared in the step's own `Meta`, and the failure it produces must carry a
+          * kind a caller can group by.
+          *
+          * Catching the typed `Timeout`, appending `StepTimedOut` and then panicking an anonymous `RuntimeException` leaves the
+          * terminal status `Failed(message, Absent)`: the one failure the engine itself classifies arrives with its classification
+          * stripped, and "how many executions timed out" becomes a LIKE over message text. The recovery raises
+          * `FlowStepTimeoutException` instead (`internal/StoreInterpreter.scala`'s `withTimeoutAndRetry`), a declared `FlowException`
+          * that travels the typed channel and reaches the status carrying its own class name. The hierarchy's own rationale
+          * (`FlowException.scala`, on `FlowDomainException`: "turning them into panics threw away the type on the way to a status
+          * that keeps a string") is the argument this leaf holds the timeout path to.
+          */
+        "a step that times out is recorded as a timeout, not an anonymous panic" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.input[Int]("x")
+                    .output("slow", timeout = 1.second)(ctx => Async.sleep(1.hour).andThen(ctx.x * 2))
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _       <- engine.executions.signal[Int](eid, "x", 5)
+                    status  <- pump(tc, store, eid, _.isTerminal, 600)
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    val timedOut = history.events.collect { case e: Flow.Event.StepTimedOut => e }
+                    assert(timedOut.nonEmpty, "the premise is that the step timed out, and no StepTimedOut event was recorded")
+                    val kindOf = status match
+                        case Flow.Status.Failed(_, kind) => kind
+                        case other                       => Maybe(s"not-failed: $other")
+                    assert(
+                        kindOf == Maybe("FlowStepTimeoutException"),
+                        s"a configured timeout must terminalise as Failed with its own kind, got status $status"
+                    )
+                end for
+            }
+        }
+
+        /** A store failure while the interpreter records `StepTimedOut` must ride the store's own channel to the engine, not be
+          * consumed by the step's retry schedule.
+          *
+          * The schedule's catch is `Abort.run[Throwable]` (`internal/StoreInterpreter.scala:79`), which swallows the
+          * `FlowStoreException` raised by that append: the step's bounded budget is spent on the store's failure, and the
+          * `StepRetried` events it writes into history say the step failed when the store did. The engine separates the two at the
+          * attempt level (a store failure is infra: health, claimable, no terminal write); the schedule erases the separation one
+          * level down.
+          */
+        "a store failure while recording a timeout does not charge the step's retry budget" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { mem =>
+                    AtomicInt.init(0).map { refusals =>
+                        val store = FailingTimeoutEventStore(mem, refusals)
+                        val wfId  = Flow.Id.Workflow("timeout-vs-infra")
+                        val flow = Flow.init("timeout-vs-infra")
+                            .output("slow", timeout = 1.second, retry = Maybe(Schedule.fixed(1.second).repeat(3)))(_ =>
+                                Async.sleep(1.hour).andThen("done")
+                            )
+                        def retriedOf(eid: Flow.Id.Execution) =
+                            mem.getHistory(eid, Maybe.empty, 0).map(_.events.collect {
+                                case Flow.Event.StepRetried(_, _, name, error, _, _, _) => (name, error)
+                            })
+                        val config = FlowEngine.Config(workerCount = 1, lease = 30.seconds, pollTimeout = 100.millis)
+                        for
+                            outcome <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { engine =>
+                                    engine.workflows.start(wfId).map { handle =>
+                                        settle(tc, step = 250.millis, maxRounds = 40)(refusals.get.map(_ >= 1)).map { refused =>
+                                            // Bounded room for the schedule to act on the refusal: under the defect the
+                                            // condition turns true at the first StepRetried; under the fix it burns the
+                                            // rounds and answers false, which is the definite no the assertion needs.
+                                            settle(tc, step = 250.millis, maxRounds = 20)(retriedOf(handle.executionId).map(_.nonEmpty))
+                                                .andThen((handle.executionId, refused))
+                                        }
+                                    }
+                                }
+                            }
+                            (eid, refused) = outcome
+                            retried <- retriedOf(eid)
+                            n       <- refusals.get
+                        yield
+                            assert(refused && n >= 1, s"the premise is that the StepTimedOut append was refused, refusals=$n")
+                            assert(
+                                retried.isEmpty,
+                                s"a store failure is infra, not a step failure: the schedule must not be charged for it, but " +
+                                    s"StepRetried was written ${retried.size} time(s): $retried"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
     }
 
     // =========================================================================
@@ -2628,7 +6063,78 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "dispatch advanced" - {
 
-        "all conditions false — default branch taken" in {
+        /** A dispatch persists only the branch's VALUE, so a crash between the branch's side effects and its field write lets
+          * replay re-ask the conditions, and a condition that answers differently runs a DIFFERENT branch's side effects beside
+          * the first's, with no durable trace that either ran. `foreach` guards this class of obligation with its persisted count
+          * and `subflow` guards it with the mapper's purity requirement. The rule for `dispatch`: entering a branch records the
+          * choice first, and a replay that finds the record re-enters that branch without evaluating any condition, because the
+          * record is the truth of what ran and running a second branch beside it is the one outcome worse than either branch
+          * alone.
+          */
+        "a dispatch replayed after a crash re-enters the branch that ran" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    var aCount = 0
+                    var bCount = 0
+                    var flag   = true
+                    val wfId   = Flow.Id.Workflow("dispatch-replay")
+                    val flow = Flow.init("dispatch-replay")
+                        .dispatch[String]("route")
+                        .when(_ => flag, name = "a") { ctx =>
+                            aCount += 1
+                            if aCount == 1 then Async.sleep(1.hour).andThen("A") else "A"
+                        }
+                        .otherwise(
+                            ctx =>
+                                bCount += 1
+                                "B"
+                            ,
+                            name = "b"
+                        )
+                    val config = FlowEngine.Config(
+                        workerCount = 1,
+                        lease = 2.seconds,
+                        renewEvery = 500.millis,
+                        pollTimeout = 100.millis
+                    )
+                    for
+                        eid <- Scope.run {
+                            FlowEngine.init(store, config, flow).map { engine =>
+                                engine.workflows.start(wfId).map { handle =>
+                                    settle(tc, step = 250.millis, maxRounds = 40)(Sync.defer(aCount >= 1))
+                                        .andThen(handle.executionId)
+                                }
+                            }
+                        }
+                        routeAtClose <- store.getField[String](eid, "route")
+                        _ = flag = false
+                        _ <- tc.advance(10.seconds)
+                        _ <- Scope.run {
+                            FlowEngine.init(store, config, flow).map { _ =>
+                                settle(tc, step = 250.millis, maxRounds = 60)(
+                                    store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                )
+                            }
+                        }
+                        route <- store.getField[String](eid, "route")
+                    yield
+                        assert(aCount >= 1, s"the premise is that branch a's side effects ran before the crash, got $aCount")
+                        assert(
+                            routeAtClose.isEmpty,
+                            s"the premise is that the crash landed before the branch's field write, got $routeAtClose"
+                        )
+                        assert(
+                            bCount == 0,
+                            s"replay must re-enter the branch that ran, not the branch the condition now picks: branch b's " +
+                                s"side effects ran $bCount time(s) beside branch a's"
+                        )
+                        assert(route == Maybe("A"), s"the recorded choice's value must be the one stored, got $route")
+                    end for
+                }
+            }
+        }
+
+        "all conditions false, so the default branch is taken" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                     .dispatch[String]("result")
@@ -2649,7 +6155,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "condition throws — execution fails" in {
+        "condition throws, so the execution fails" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                     .dispatch[String]("result")
@@ -2667,13 +6173,13 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 1)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
                 end for
             }
         }
 
-        "branch body throws — execution fails" in {
+        "branch body throws, so the execution fails" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                     .dispatch[String]("result")
@@ -2688,8 +6194,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 1)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
                 end for
             }
         }
@@ -2700,7 +6206,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "foreach advanced" - {
 
-        "empty collection — Chunk.empty stored" in {
+        "empty collection stores Chunk.empty" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                     .foreach("results")(ctx => Seq.empty[Int])(n => n * 10)
@@ -2715,7 +6221,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "body throws on one element — execution fails" in {
+        "body throws on one element, so the execution fails" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                     .foreach("results")(ctx => (1 to ctx.x).toSeq) { n =>
@@ -2729,13 +6235,13 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 5)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
                 end for
             }
         }
 
-        "collection computation throws — execution fails" in {
+        "collection computation throws, so the execution fails" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                     .foreach("results")(ctx =>
@@ -2748,81 +6254,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 1)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
-                end for
-            }
-        }
-    }
-
-    // =========================================================================
-    // Subflow advanced
-    // =========================================================================
-    "subflow advanced" - {
-
-        "child with multiple outputs — nested record accessible" in {
-            withEngine { (engine, store, tc) =>
-                val child = Flow.input[Int]("a")
-                    .output("b")(ctx => ctx.a * 2)
-                    .output("c")(ctx => ctx.a + ctx.b)
-                val flow = Flow.input[Int]("x")
-                    .subflow("sub", child)(ctx => "a" ~ ctx.x)
-                    .output("result")(ctx => ctx.sub.b + ctx.sub.c)
-                for
-                    _      <- engine.register(wf1, flow)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _      <- engine.executions.signal[Int](eid, "x", 5)
-                    status <- pump(tc, store, eid, _.isTerminal)
-                    v      <- store.getField[Int](eid, "result")
-                yield
-                    assert(status == Flow.Status.Completed)
-                    // b=10, c=5+10=15, result=10+15=25
-                    assert(v.get == 25, s"Expected 25 but got ${v}")
-                end for
-            }
-        }
-
-        "nested subflow (subflow within subflow)" in {
-            withEngine { (engine, store, tc) =>
-                val inner = Flow.input[Int]("a").output("b")(ctx => ctx.a * 3)
-                val middle = Flow.input[Int]("a")
-                    .subflow("inner", inner)(ctx => "a" ~ ctx.a)
-                    .output("c")(ctx => ctx.inner.b + 1)
-                val flow = Flow.input[Int]("x")
-                    .subflow("mid", middle)(ctx => "a" ~ ctx.x)
-                    .output("result")(ctx => ctx.mid.c)
-                for
-                    _      <- engine.register(wf1, flow)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _      <- engine.executions.signal[Int](eid, "x", 4)
-                    status <- pump(tc, store, eid, _.isTerminal)
-                    v      <- store.getField[Int](eid, "result")
-                yield
-                    assert(status == Flow.Status.Completed)
-                    // inner.b = 4*3=12, middle.c = 12+1=13
-                    assert(v.get == 13, s"Expected 13 but got ${v}")
-                end for
-            }
-        }
-
-        "inputMapper throws — parent fails" in {
-            withEngine { (engine, store, tc) =>
-                val child = Flow.input[Int]("a").output("b")(ctx => ctx.a)
-                val flow = Flow.input[Int]("x")
-                    .subflow("sub", child)(ctx =>
-                        throw new RuntimeException("mapper fail"); "a" ~ 0
-                    )
-                for
-                    _      <- engine.register(wf1, flow)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _      <- engine.executions.signal[Int](eid, "x", 1)
-                    status <- pump(tc, store, eid, _.isTerminal)
-                yield assert(status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
                 end for
             }
         }
@@ -2833,7 +6266,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "compensation deep nesting" - {
 
-        "5 compensated outputs — all fire in reverse on failure" in {
+        "5 compensated outputs all fire in reverse on failure" in {
             withEngine { (engine, store, tc) =>
                 var log = Seq.empty[String]
                 val flow = Flow.input[Int]("x")
@@ -2853,8 +6286,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield
                     assert(status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false)
+                        case Flow.Status.Failed(_, _) => true;
+                        case _                        => false)
                     assert(
                         log == Seq("comp-e", "comp-d", "comp-c", "comp-b", "comp-a"),
                         s"Expected reverse order but got $log"
@@ -2869,7 +6302,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     // =========================================================================
     "degenerate flows" - {
 
-        "flow with only init — completes immediately" in {
+        "flow with only init completes immediately" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.init("test")
                 for
@@ -2882,14 +6315,14 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "flow with only input — suspends then completes" in {
+        "flow with only input suspends then completes" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.input[Int]("x")
                 for
                     _      <- engine.register(wf1, flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _      <- pump(tc, store, eid, _ == Flow.Status.WaitingForInput("x"))
+                    _      <- pumpState(tc, store, eid, waitingFor("x"))
                     _      <- engine.executions.signal[Int](eid, "x", 42)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield assert(status == Flow.Status.Completed)
@@ -2897,14 +6330,14 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             }
         }
 
-        "flow with only sleep — suspends then completes" in {
+        "flow with only sleep suspends then completes" in {
             withEngine { (engine, store, tc) =>
                 val flow = Flow.init("test").sleep("wait", 1.second)
                 for
                     _      <- engine.register(wf1, flow)
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
-                    _      <- pump(tc, store, eid, _.isSleeping)
+                    _      <- pumpState(tc, store, eid, sleeping)
                     status <- pump(tc, store, eid, _.isTerminal, 200)
                 yield assert(status == Flow.Status.Completed)
                 end for
@@ -2924,8 +6357,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _    <- engine.register(wf1, flow)
                     defs <- engine.defs.get
                 yield
-                    assert(defs.size == 1, s"Expected 1 def, got ${defs.size}")
-                    assert(defs.get(wf1).nonEmpty, s"Expected wf1 in defs")
+                    assert(defs.byVersion.size == 1, s"Expected 1 def, got ${defs.byVersion.size}")
+                    assert(defs.latest.get(wf1).nonEmpty, s"Expected wf1 in defs")
                 end for
             }
         }
@@ -2940,13 +6373,15 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _     <- engine.register(wf1, flow2)
                     defs2 <- engine.defs.get
                 yield
-                    assert(defs1.size == 1)
-                    assert(defs2.size == 1)
-                    assert(defs1.get(wf1).nonEmpty)
-                    assert(defs2.get(wf1).nonEmpty)
+                    // What a fresh start runs is what a re-registration replaces. Every version registered stays servable, which is
+                    // what keeps an in-flight execution running while a new one is rolled out.
+                    assert(defs1.latest.size == 1)
+                    assert(defs2.latest.size == 1)
+                    assert(defs1.latest.get(wf1).nonEmpty)
+                    assert(defs2.latest.get(wf1).nonEmpty)
                     // Hash should change
-                    val h1 = defs1.get(wf1).get.meta.structuralHash
-                    val h2 = defs2.get(wf1).get.meta.structuralHash
+                    val h1 = defs1.latest.get(wf1).get.meta.structuralHash
+                    val h2 = defs2.latest.get(wf1).get.meta.structuralHash
                     assert(h1 != h2, s"Hashes should differ: $h1 vs $h2")
                 end for
             }
@@ -2958,7 +6393,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 for
                     _    <- engine.register(wf1, flow)
                     defs <- engine.defs.get
-                    wfIds = defs.foldLeft(Set.empty[Flow.Id.Workflow])((acc, k, _) => acc + k)
+                    wfIds = defs.workflowIds.toSet
                 yield
                     assert(wfIds.size == 1, s"Expected 1 wfId, got ${wfIds.size}")
                     assert(wfIds.contains(wf1), s"Expected wf1 in wfIds, got $wfIds")
@@ -2974,7 +6409,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _ <- engine.register(wf1, flow1)
                     // Check defs before start
                     d <- engine.defs.get
-                    _ = assert(d.get(wf1).nonEmpty, "flow1 should be registered")
+                    _ = assert(d.latest.get(wf1).nonEmpty, "flow1 should be registered")
                     handle <- engine.workflows.start(wf1)
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 42)
@@ -2987,7 +6422,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     defs   <- engine.defs.get
                 yield
                     assert(state1.get.status == Flow.Status.Completed)
-                    assert(defs.get(wf1).nonEmpty)
+                    assert(defs.latest.get(wf1).nonEmpty)
                 end for
             }
         }
@@ -3005,7 +6440,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     "Progress.build with empty completed steps" - {
 
         "first node is Running, rest are Pending" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running, Dict.empty)
             assert(progress.nodes.size == 4)
             assert(progress.nodes(0).status == FlowEngine.Progress.NodeStatus.Running)
             (1 until progress.nodes.size).foreach { i =>
@@ -3015,12 +6450,12 @@ class FlowEngineTest extends kyo.test.Test[Any]:
         }
 
         "completedCount is 0" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running, Dict.empty)
             assert(progress.completedCount == 0)
         }
 
         "totalCount matches node count" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running, Dict.empty)
             assert(progress.totalCount == 4)
         }
     }
@@ -3028,7 +6463,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     "Progress.build with some completed steps" - {
 
         "marks completed steps correctly" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set("x", "y"), Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set("x", "y"), Flow.Status.Running, Dict.empty)
             assert(progress.nodeByName("x").get.status == FlowEngine.Progress.NodeStatus.Completed)
             assert(progress.nodeByName("y").get.status == FlowEngine.Progress.NodeStatus.Completed)
             assert(progress.nodeByName("log").get.status == FlowEngine.Progress.NodeStatus.Running)
@@ -3036,12 +6471,12 @@ class FlowEngineTest extends kyo.test.Test[Any]:
         }
 
         "completedCount reflects completed steps" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set("x", "y"), Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set("x", "y"), Flow.Status.Running, Dict.empty)
             assert(progress.completedCount == 2)
         }
 
         "all completed gives full count" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set("x", "y", "log", "wait"), Flow.Status.Completed)
+            val progress = FlowEngine.Progress.build(linearFlow, Set("x", "y", "log", "wait"), Flow.Status.Completed, Dict.empty)
             assert(progress.completedCount == 4)
             assert(progress.completedCount == progress.totalCount)
         }
@@ -3050,7 +6485,8 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     "Progress.build with WaitingForInput status" - {
 
         "marks the waiting input as WaitingForInput" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.WaitingForInput("x"))
+            val progress =
+                FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running, Dict("x" -> Flow.Wake.OnField("x")))
             assert(progress.nodeByName("x").get.status == FlowEngine.Progress.NodeStatus.WaitingForInput)
         }
 
@@ -3058,7 +6494,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             val flow = Flow.input[Int]("a")
                 .input[String]("b")
                 .output("c")(ctx => ctx.a)
-            val progress = FlowEngine.Progress.build(flow, Set("a"), Flow.Status.WaitingForInput("b"))
+            val progress = FlowEngine.Progress.build(flow, Set("a"), Flow.Status.Running, Dict("b" -> Flow.Wake.OnField("b")))
             assert(progress.nodeByName("a").get.status == FlowEngine.Progress.NodeStatus.Completed)
             assert(progress.nodeByName("b").get.status == FlowEngine.Progress.NodeStatus.WaitingForInput)
         }
@@ -3067,8 +6503,9 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     "Progress.build with Sleeping status" - {
 
         "marks the sleeping node as Sleeping" in {
-            val until    = Instant.Epoch + 1.hour
-            val progress = FlowEngine.Progress.build(linearFlow, Set("x", "y", "log"), Flow.Status.Sleeping("wait", until))
+            val until = Instant.Epoch + 1.hour
+            val progress =
+                FlowEngine.Progress.build(linearFlow, Set("x", "y", "log"), Flow.Status.Running, Dict("wait" -> Flow.Wake.At(until)))
             assert(progress.nodeByName("wait").get.status == FlowEngine.Progress.NodeStatus.Sleeping(until))
         }
 
@@ -3076,8 +6513,9 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             val flow = Flow.input[Int]("x")
                 .sleep("s1", 1.minute)
                 .sleep("s2", 2.minutes)
-            val until    = Instant.Epoch + 2.minutes
-            val progress = FlowEngine.Progress.build(flow, Set("x", "s1"), Flow.Status.Sleeping("s2", until))
+            val until = Instant.Epoch + 2.minutes
+            val progress =
+                FlowEngine.Progress.build(flow, Set("x", "s1"), Flow.Status.Running, Dict("s2" -> Flow.Wake.At(until)))
             assert(progress.nodeByName("s1").get.status == FlowEngine.Progress.NodeStatus.Completed)
             assert(progress.nodeByName("s2").get.status == FlowEngine.Progress.NodeStatus.Sleeping(until))
         }
@@ -3086,7 +6524,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
     "Progress.nodeByName" - {
 
         "finds existing node" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running, Dict.empty)
             val node     = progress.nodeByName("x")
             assert(node.isDefined)
             assert(node.get.name == "x")
@@ -3094,7 +6532,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
         }
 
         "returns empty for missing name" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running, Dict.empty)
             assert(progress.nodeByName("nonexistent").isEmpty)
         }
 
@@ -3104,7 +6542,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                 .when(ctx => ctx.x > 0, name = "yes")(ctx => "yes")
                 .otherwise(ctx => "no", name = "default")
                 .loop("r") { ctx => Loop.done(ctx.x - 1) }
-            val progress = FlowEngine.Progress.build(flow, Set.empty, Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(flow, Set.empty, Flow.Status.Running, Dict.empty)
             assert(progress.nodeByName("x").get.nodeType == FlowEngine.Progress.NodeType.Input)
             assert(progress.nodeByName("d").get.nodeType == FlowEngine.Progress.NodeType.Dispatch)
             assert(progress.nodeByName("r").get.nodeType == FlowEngine.Progress.NodeType.Loop)
@@ -3123,44 +6561,3003 @@ class FlowEngineTest extends kyo.test.Test[Any]:
             val left     = Flow.input[Int]("a").output("b")(ctx => ctx.a)
             val right    = Flow.input[Int]("c").output("d")(ctx => ctx.c)
             val flow     = left.zip(right)
-            val progress = FlowEngine.Progress.build(flow, Set("a", "b"), Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(flow, Set("a", "b"), Flow.Status.Running, Dict.empty)
             assert(progress.completedCount == 2)
             assert(progress.totalCount == 4)
         }
     }
 
-    "Progress loop iteration detection" - {
+    "Progress loop completion" - {
 
-        "loop node shows Completed when only iteration-indexed steps are in completedSteps" in {
+        /** A loop is done when the loop's own completion was recorded, and never because an iteration was.
+          *
+          * Treating three recorded iterations with no completion of the loop's own as `Completed` draws a loop on iteration 1 of 50
+          * as finished and pushes `Running` onto the node after it, one that has not started.
+          *
+          * Both directions are pinned here rather than only the negative, since an implementation that never completes a loop node
+          * at all would satisfy the negative half alone. The end-to-end half is a leaf of its own, driving a real scheduled loop
+          * through `describe`; this one pins `Progress.build` itself.
+          */
+        "a loop's iterations do not complete the loop node" in {
             val flow = Flow.input[Int]("x")
                 .loop("result") { ctx => Loop.done(ctx.x - 1) }
-            val completedSteps = Set("x", "result#0", "result#1", "result#2")
-            val progress       = FlowEngine.Progress.build(flow, completedSteps, Flow.Status.Completed)
-            val resultNode     = progress.nodeByName("result")
-            assert(resultNode.isDefined)
-            assert(resultNode.get.status == FlowEngine.Progress.NodeStatus.Completed)
+            val iterationsOnly = FlowEngine.Progress.build(
+                flow,
+                Set("x", "result#0", "result#1", "result#2"),
+                Flow.Status.Completed,
+                Dict.empty
+            ).nodeByName("result")
+            val ownCompletion = FlowEngine.Progress.build(
+                flow,
+                Set("x", "result"),
+                Flow.Status.Completed,
+                Dict.empty
+            ).nodeByName("result")
+            assert(iterationsOnly.isDefined)
+            assert(
+                iterationsOnly.map(_.status) != Maybe(FlowEngine.Progress.NodeStatus.Completed),
+                s"iterations of a loop must not complete the loop, got ${iterationsOnly.map(_.status)}"
+            )
+            assert(
+                ownCompletion.map(_.status) == Maybe(FlowEngine.Progress.NodeStatus.Completed),
+                s"and the loop's own completion must, got ${ownCompletion.map(_.status)}"
+            )
         }
     }
 
     "Progress running and failed status" - {
 
         "first non-completed node shows Running when flow status is Running" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running, Dict.empty)
             assert(progress.nodeByName("x").get.status == FlowEngine.Progress.NodeStatus.Running)
         }
 
-        "last non-completed step shows Failed when flow status is Failed" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set("x"), Flow.Status.Failed("boom"))
-            assert(progress.nodeByName("y").get.status == FlowEngine.Progress.NodeStatus.Failed("boom"))
+        /** The node painted Failed is the node the record names, and no node is painted without one.
+          *
+          * Painting the FIRST node that is neither completed nor waiting with the execution's error is right for a straight line and
+          * wrong the moment a flow is not one: a guess about which node failed reads exactly like a fact. The scenario here is the
+          * one where the guess and the record agree, so what it discriminates is which of the two is being asked.
+          *
+          * The second half covers an execution whose history carries no failure record at all. It is painted NOWHERE: an absent
+          * record is not evidence about some other node, and pending is the honest answer for a fact nobody wrote down.
+          */
+        "the node a failure record names shows Failed, and no node does without one" in {
+            val recorded = FlowEngine.Progress.build(
+                linearFlow,
+                Set("x"),
+                Flow.Status.Failed("boom"),
+                Dict.empty,
+                failed = Map("y" -> "boom")
+            )
+            val unrecorded = FlowEngine.Progress.build(linearFlow, Set("x"), Flow.Status.Failed("boom"), Dict.empty)
+            assert(
+                recorded.nodeByName("y").map(_.status) == Maybe(FlowEngine.Progress.NodeStatus.Failed("boom")),
+                s"the recorded node must carry its failure, got ${recorded.nodeByName("y").map(_.status)}"
+            )
+            assert(
+                !unrecorded.nodes.exists(_.status.isInstanceOf[FlowEngine.Progress.NodeStatus.Failed]),
+                s"and with nothing recorded no node may claim the failure, got ${unrecorded.nodes.map(n => (n.name, n.status))}"
+            )
+        }
+
+        /** A record keyed under a path no node carries walks up to the node that owns it, and one keyed under a node stops there.
+          *
+          * `Progress.build` resolves a failure's path against the nodes the flow actually has: exact match first, then up through
+          * the last `#` or `~` until a node is reached, and nowhere if none is. Two rules meet in that sentence and this leaf pins
+          * both, because `acc#3` and `review~step` are indistinguishable by shape and the walk alone would treat them alike.
+          *
+          * **No writer produces an iteration-keyed failure today.** A loop's body runs through `onIteration` under the loop's own
+          * name, so a body that throws is already recorded as `acc`, and the `#` branch of the walk has no live producer. It is kept
+          * and covered here rather than deleted as unreachable: the moment a writer records an iteration under its own path, which
+          * is what a checkpointed iteration would do, the reader already paints the loop instead of painting nothing at all.
+          *
+          * The second half is the exact-match rule standing beside the walk. A subflow's child is qualified under its parent's path,
+          * so `review~step` IS a node, and it wears its own failure while `review` does not wear its child's. Strip the suffix
+          * without asking the node set first and the parent takes the paint, which is the failure a reader cannot see past: a
+          * subflow of twenty nodes reports only that something inside it broke.
+          */
+        "a failure keyed by an iteration paints its loop, and one keyed by a subflow's child paints the child" in {
+            val child = Flow.input[Int]("a").output("step")(ctx => ctx.a * 2)
+            val flow = Flow.input[Int]("x")
+                .loopOn("acc", Schedule.fixed(1.hour), 0) { (state: Int, ctx) => Loop.done(state) }
+                .subflow("review", child)(ctx => "a" ~ ctx.x)
+            val iterationKeyed = FlowEngine.Progress.build(
+                flow,
+                Set("x"),
+                Flow.Status.Failed("boom"),
+                Dict.empty,
+                failed = Map("acc#3" -> "boom")
+            )
+            val subflowChild = FlowEngine.Progress.build(
+                flow,
+                Set("x"),
+                Flow.Status.Failed("child broke"),
+                Dict.empty,
+                failed = Map("review~step" -> "child broke")
+            )
+            assert(
+                iterationKeyed.nodeByName("acc").map(_.status) == Maybe(FlowEngine.Progress.NodeStatus.Failed("boom")),
+                s"an iteration's failure belongs to its loop, got ${iterationKeyed.nodeByName("acc").map(_.status)}"
+            )
+            assert(
+                !iterationKeyed.nodes.exists(n =>
+                    n.name != "acc" && n.status.isInstanceOf[FlowEngine.Progress.NodeStatus.Failed]
+                ),
+                s"and to no other node, got ${iterationKeyed.nodes.map(n => (n.name, n.status))}"
+            )
+            assert(
+                subflowChild.nodeByName("review~step").map(_.status) ==
+                    Maybe(FlowEngine.Progress.NodeStatus.Failed("child broke")),
+                s"a child's failure belongs to the child, got ${subflowChild.nodeByName("review~step").map(_.status)}"
+            )
+            assert(
+                !subflowChild.nodeByName("review").exists(_.status.isInstanceOf[FlowEngine.Progress.NodeStatus.Failed]),
+                s"and not to the subflow that contains it, got ${subflowChild.nodeByName("review").map(_.status)}"
+            )
         }
     }
 
     "Progress node location" - {
 
         "location is populated" in {
-            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(linearFlow, Set.empty, Flow.Status.Running, Dict.empty)
             progress.nodes.foreach(node => assert(node.location.nonEmpty))
             ()
+        }
+    }
+
+    /** An execution has one status cell, and concurrent branches each write it.
+      *
+      * `zip`, `gather` and `race` run their branches concurrently, and every suspending branch records itself in the execution's
+      * single `Flow.Status`: a sleep writes `Sleeping(name, until)`, an input wait writes `WaitingForInput(name)`. Two suspending
+      * branches therefore race, the store keeps whichever landed last, and readiness is computed from that one cell. What the other
+      * branch was waiting for is no longer recorded anywhere the engine consults.
+      *
+      * Every leaf here is driven from durable state the test writes directly, rather than from whichever branch happens to win the
+      * race. That is deliberate: the write order is genuinely nondeterministic, so seeding the state that order produces is the only
+      * way to assert on the consequence without a flaky test.
+      */
+    "concurrent suspensions" - {
+
+        /** A race records which branch won, in the history.
+          *
+          * Replay reconstructs an execution from its events, and a race is the one construct whose outcome is not a function of the
+          * inputs: which branch won is a scheduling fact, and if it is not written down it cannot be recovered. `Flow.Event` has no
+          * case for it. The winner's own output event is the closest thing, so this leaf accepts that as the record, and fails only
+          * if nothing in the history distinguishes the branches at all.
+          */
+        "a race records which branch won" in {
+            withEngine { (engine, store, tc) =>
+                val quick = Flow.init("racer").output("winner")(_ => "quick")
+                val slow  = Flow.init("racer").sleep("wait", 1.hour).output("winner")(_ => "slow")
+                val flow  = Flow.race(quick, slow)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _       <- pump(tc, store, eid, _.isTerminal, 400)
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                    winner  <- store.getField[String](eid, "winner")
+                yield
+                    assert(winner == Present("quick"), s"the branch that does not sleep should win, got $winner")
+                    val names = history.events.collect {
+                        case Flow.Event.StepCompleted(_, _, name, _)   => name
+                        case Flow.Event.SleepStarted(_, _, name, _, _) => name
+                    }
+                    assert(
+                        names.nonEmpty,
+                        s"the history must record something that distinguishes the branches, got ${history.events.map(_.kind)}"
+                    )
+                end for
+            }
+        }
+
+        /** A race really replayed, by a different engine, keeps the winner the first engine picked.
+          *
+          * The sibling leaf "a race resumed from durable state keeps its original winner" pumps to TERMINAL, reads the field,
+          * advances the clock while nothing is running, and reads it again, so what it establishes is that a finished execution's
+          * field does not change on its own: **no replay and no crash happen in it**. This leaf supplies both.
+          *
+          * The handoff is real: the first engine's scope closes while the execution is parked on an input after the race, the clock
+          * passes the lease, and a second engine on the same store claims the row and finishes it. The winner is read on both sides
+          * of that.
+          *
+          * **Why the property is not obvious.** A replay re-races: the winner completes instantly from durable state, but the
+          * loser starts again too (see "a race loser's re-execution across resumes stays bounded and does not change the result"),
+          * so the two branches are genuinely in a race again, on a machine whose scheduling nobody controls. What makes the outcome
+          * stable is that the winner's field is already present, so its branch completes without running anything.
+          */
+        "a race replayed by a second engine keeps the first engine's winner" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(0).map { slowRuns =>
+                        val wfId  = Flow.Id.Workflow("replay-handoff")
+                        val quick = Flow.init("replay-handoff").output("winner")(_ => "quick")
+                        val slow = Flow.init("replay-handoff").step[Async]("stall") { _ =>
+                            slowRuns.incrementAndGet.andThen(Async.never)
+                        }.output("winner")(_ => "slow")
+                        val flow = Flow.race(quick, slow).andThen(Flow.input[Int]("go")).output("done")(ctx => ctx.go)
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 2.seconds,
+                            renewEvery = 500.millis,
+                            pollTimeout = 100.millis
+                        )
+                        for
+                            eid <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { first =>
+                                    first.workflows.start(wfId).map { handle =>
+                                        settle(tc, step = 250.millis, maxRounds = 40)(
+                                            store.getField[String](handle.executionId, "winner").map(_.nonEmpty)
+                                        ).andThen(handle.executionId)
+                                    }
+                                }
+                            }
+                            before <- store.getField[String](eid, "winner")
+                            _      <- tc.advance(10.seconds)
+                            _ <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { second =>
+                                    second.executions.signal[Int](eid, "go", 5).andThen(
+                                        settle(tc, step = 250.millis, maxRounds = 80)(
+                                            store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                        )
+                                    )
+                                }
+                            }
+                            after <- store.getField[String](eid, "winner")
+                            state <- store.getExecution(eid)
+                            done  <- store.getField[Int](eid, "done")
+                        yield
+                            assert(before.nonEmpty, s"the premise is that the race resolved on the first engine, got $before")
+                            assert(
+                                state.exists(_.status == Flow.Status.Completed),
+                                s"the premise is that the second engine replayed and finished it, got ${state.map(_.status)}"
+                            )
+                            assert(done == Present(5), s"the premise is that the replay ran the rest of the flow, got $done")
+                            assert(
+                                after == before,
+                                s"a race replayed by another engine must keep the winner the first one picked: it went from " +
+                                    s"$before to $after"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A race resumed from durable state picks the same winner it picked before.
+          *
+          * An execution whose race already resolved carries the winner's completion in its history, so a resume must honour it
+          * rather than re-running the race and possibly choosing the other branch, which would contradict whatever the first winner
+          * already did to the outside world.
+          */
+        "a race resumed from durable state keeps its original winner" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { slowRuns =>
+                    val quick = Flow.init("replay-race").output("winner")(_ => "quick")
+                    val slow = Flow.init("replay-race").output("winner") { _ =>
+                        val body: String < Sync = slowRuns.incrementAndGet.andThen("slow")
+                        body
+                    }
+                    val flow = Flow.race(quick, slow)
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _      <- pump(tc, store, eid, _.isTerminal, 400)
+                        first  <- store.getField[String](eid, "winner")
+                        _      <- Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                        second <- store.getField[String](eid, "winner")
+                    yield assert(
+                        first == second,
+                        s"a resolved race must keep its winner, it went from $first to $second"
+                    )
+                    end for
+                }
+            }
+        }
+
+        /** A GUARD: a race loser's re-execution on resume stays bounded and does not corrupt the outcome.
+          *
+          * A decided race re-runs its losing branch on later resumes, because a race records no durable decision, and that is an
+          * accepted behaviour on the grounds that idempotency makes it survivable. This leaf measures the behaviour rather than
+          * trusting the argument.
+          *
+          * **Re-execution is REAL and INTERMITTENT.** Whether the loser is scheduled at all before the winner's replay resolves the
+          * race is a scheduling fact rather than a property, so "re-runs on every later resume" overstates it: across three resumes
+          * of one execution the loser's body may run twice, three times, or not at all. What is stable is that the count is bounded
+          * by the resumes that cause it and the result is unaffected.
+          *
+          * **So the assertions are the two things that hold.** The execution still finishes with the right value after its loser has
+          * re-executed, which is what the survivability argument rests on and is worth pinning permanently; and the re-execution
+          * stays bounded by the resume count rather than growing on its own, which is what catches a regression into a spin. "At
+          * most once" is false and "the loser had started before the first resume" is flaky, because both assert a scheduling fact.
+          *
+          * **What the loser's node is.** A step that increments and then never returns, so if it starts it never completes, which is
+          * the shape the accepted behaviour describes. A loser whose body completes instantly measures nothing: it is gone before
+          * the first replay, and the counter then reads 0 on both sides of the resume.
+          */
+        "a race loser's re-execution across resumes stays bounded and does not change the result" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { slowRuns =>
+                    val quick = Flow.init("race-resume").output("winner")(_ => "quick")
+                    // The loser's node STARTS and never COMPLETES, which is the shape under test: an incomplete
+                    // node, with nothing durable to skip it on the next pass.
+                    val slow = Flow.init("race-resume").step[Async]("stall") { _ =>
+                        slowRuns.incrementAndGet.andThen(Async.never)
+                    }.output("winner")(_ => "slow")
+                    val flow = Flow.race(quick, slow)
+                        .andThen(Flow.input[Int]("go1"))
+                        .andThen(Flow.input[Int]("go2"))
+                        .andThen(Flow.input[Int]("go3"))
+                        .output("done")(ctx => ctx.go1 + ctx.go2 + ctx.go3)
+                    def parkThenSignal(eid: Flow.Id.Execution, name: String, value: Int) =
+                        pumpState(tc, store, eid, s => !s.status.isTerminal && waitingFor(name)(s), 400)
+                            .andThen(engine.executions.signal[Int](eid, name, value))
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _      <- parkThenSignal(eid, "go1", 10)
+                        before <- slowRuns.get
+                        _      <- parkThenSignal(eid, "go2", 15)
+                        _      <- parkThenSignal(eid, "go3", 17)
+                        status <- pump(tc, store, eid, _.isTerminal, 400)
+                        after  <- slowRuns.get
+                        done   <- store.getField[Int](eid, "done")
+                    yield
+                        assert(
+                            status == Flow.Status.Completed,
+                            s"the premise is that the execution resumed three times and finished, got $status"
+                        )
+                        assert(
+                            done == Present(42),
+                            s"a resumed execution whose race loser re-executes must still finish with the right value, got " +
+                                s"$done after the loser's body ran $after times ($before of them before the second resume)"
+                        )
+                        assert(
+                            after <= 4,
+                            s"the losing branch's re-execution must stay bounded by the resumes that cause it: three resumes " +
+                                s"of one execution ran it $after times"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** A sleep far beyond the representable range of an instant is refused, not silently wrapped.
+          *
+          * A durable sleep is recorded as an absolute deadline, so a duration large enough to overflow that instant produces a
+          * deadline in the past, and an execution that meant to wait a very long time wakes immediately. Refusing the duration and
+          * saturating at the maximum instant are both defensible; wrapping is not, because it turns the longest possible wait into
+          * the shortest.
+          */
+        "a sleep beyond the representable range does not wake immediately" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("far-future").sleep("epoch", Duration.Infinity).output("done")(_ => "ok")
+                for
+                    _       <- engine.register(wf1, flow)
+                    started <- Abort.run[Throwable](engine.workflows.start(wf1))
+                    // Advanced in steps near the poll interval rather than in hour-long jumps. A single jump far past the poll
+                    // timeout makes the engine's timer fire once per interval inside it, so advancing an hour at a time against a
+                    // 100ms poll schedules tens of thousands of callbacks per step and hundreds of thousands over the leaf, which a
+                    // single-threaded runtime does not survive. Ten simulated seconds is ample for a sleep that should never wake.
+                    settled <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(100.millis)).andThen(Kyo.unit)
+                    finalState <- started match
+                        case Result.Success(h) => store.getExecution(h.executionId)
+                        case _                 => Maybe.empty[FlowStore.ExecutionState]: Maybe[FlowStore.ExecutionState] < Any
+                yield
+                    // Refusing the duration outright and accepting it while never waking are both acceptable; waking early is not,
+                    // because that turns the longest possible wait into the shortest.
+                    val acceptable = started match
+                        case Result.Success(_) => !finalState.exists(_.status.isTerminal)
+                        case _                 => true
+                    assert(
+                        acceptable,
+                        s"a sleep of an unbounded duration must not complete, got ${finalState.map(_.status)}"
+                    )
+                end for
+            }
+        }
+
+        /** Racing an input against a sleep is a durable timeout, and completes when the sleep expires.
+          *
+          * The obvious way to write "wait for approval, but give up after five minutes", and the shape most exposed to the single
+          * status cell. Both branches suspend, so both write the status in an order nobody controls, and only the branch named in the
+          * status can wake the execution. When the input wait lands last the deadline becomes invisible and the timeout never fires.
+          *
+          * Driven from seeded state rather than from a live race, and that is not a stylistic choice. Against a live race the leaf
+          * measures which write happened to land last, so it passes or fails by scheduling. Seeding the losing order is what makes
+          * the failure reproduce every time instead of half the time.
+          */
+        "racing an input against a sleep completes when the sleep expires" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId    = Flow.Id.Workflow("timeout-race")
+                    val waiting = Flow.init("timeout-race").input[String]("approval").output("answer")(ctx => ctx.approval)
+                    val timeout = Flow.init("timeout-race").sleep("deadline", 5.seconds).output("answer")(_ => "timed out")
+                    val flow    = Flow.race(waiting, timeout)
+                    Clock.now.map { t0 =>
+                        val eid      = Flow.Id.Execution("timeout-race-1")
+                        val deadline = t0 + 5.seconds
+                        val theHash  = kyo.internal.WorkflowSchema.structuralHash(flow)
+                        for
+                            // Seeded with BOTH parked branches' rows, which is what a finished attempt of this race leaves
+                            // behind. Seeding one and leaving the other as a bare history event would describe a state no
+                            // correct system produces, and readiness would rightly refuse to wake the branch with no row.
+                            _ <- seedExecution(store, eid, wfId, Flow.Status.Running, theHash)
+                            _ <- seedWaits(
+                                store,
+                                eid,
+                                wfId,
+                                theHash,
+                                ("approval", Flow.Wake.OnField("approval")),
+                                ("deadline", Flow.Wake.At(deadline))
+                            )
+                            // The engine is built once the row is already parked. See [[seedWaits]].
+                            _ <- FlowEngine.init(store, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow)
+                            resolved <- settle(tc, step = 100.millis, maxRounds = 100)(
+                                store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                            )
+                            state <- store.getExecution(eid)
+                        yield assert(
+                            resolved,
+                            s"the deadline passed, so the race should have resolved, got ${state.map(_.status)}"
+                        )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A GUARD: a crash after a race is decided leaves the execution claimable.
+          *
+          * The wait ledger is what makes this delicate. Rows are cleared by progress and retired by `finish`, an attempt that dies
+          * calls neither, and a readiness rule that always gated on rows would demand satisfaction of the decided race's loser row
+          * (an `OnField` for an input the flow has already chosen not to wait for) before granting the claim that is the only way
+          * to retire it: circular and permanent, from an ordinary crash. The readiness rule's active-and-expired arm is what keeps
+          * that from happening: a claim that expired without `finish` returns the execution regardless of its rows, and the
+          * recovering attempt's replay and `finish` heal the ledger. The scenario is seeded like the leaf above, and for the same
+          * reason: the premise is that the race was DECIDED by its deadline, which a live race only delivers on the runs where the
+          * sleep won the slot.
+          */
+        "a crash after a race is decided leaves the execution claimable" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId    = Flow.Id.Workflow("decided-race")
+                    val waiting = Flow.init("decided-race").input[String]("approval").output("answer")(ctx => ctx.approval)
+                    val timeout = Flow.init("decided-race").sleep("deadline", 2.seconds).output("answer")(_ => "timed out")
+                    val flow    = Flow.race(waiting, timeout).step("escalate")(_ => Async.sleep(1.hour))
+                    val config = FlowEngine.Config(
+                        workerCount = 1,
+                        lease = 2.seconds,
+                        renewEvery = 500.millis,
+                        pollTimeout = 100.millis
+                    )
+                    def escalations(eid: Flow.Id.Execution) =
+                        store.getHistory(eid, Maybe.empty, 0).map(_.events.count {
+                            case Flow.Event.StepStarted(_, _, name, _, _) => name == "escalate"
+                            case _                                        => false
+                        })
+                    Clock.now.map { t0 =>
+                        val eid      = Flow.Id.Execution("decided-race-1")
+                        val deadline = t0 + 2.seconds
+                        val theHash  = kyo.internal.WorkflowSchema.structuralHash(flow)
+                        for
+                            _ <- seedExecution(store, eid, wfId, Flow.Status.Running, theHash)
+                            _ <- seedWaits(
+                                store,
+                                eid,
+                                wfId,
+                                theHash,
+                                ("approval", Flow.Wake.OnField("approval")),
+                                ("deadline", Flow.Wake.At(deadline))
+                            )
+                            _ <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { _ =>
+                                    settle(tc, step = 250.millis, maxRounds = 60)(escalations(eid).map(_ >= 1))
+                                }
+                            }
+                            answer          <- store.getField[String](eid, "answer")
+                            before          <- escalations(eid)
+                            stateAfterClose <- store.getExecution(eid)
+                            _               <- tc.advance(10.seconds)
+                            _ <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { _ =>
+                                    settle(tc, step = 250.millis, maxRounds = 60)(escalations(eid).map(_ > before))
+                                }
+                            }
+                            after <- escalations(eid)
+                        yield
+                            assert(
+                                answer == Maybe("timed out") && before >= 1,
+                                s"the premise is that the race was decided by its deadline and the next step was mid-flight " +
+                                    s"at the crash, got answer=$answer, escalate starts=$before"
+                            )
+                            assert(
+                                !stateAfterClose.exists(_.status.isTerminal),
+                                s"a crash is not a verdict: the execution must not be terminal, got ${stateAfterClose.map(_.status)}"
+                            )
+                            assert(
+                                after > before,
+                                s"a crashed execution with a decided race must be claimable once its lease lapses, whatever " +
+                                    s"rows the race left behind: escalate ran $after time(s) against $before before the crash"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A GUARD, not a defect: when both branches of a live race park, both waits reach the store.
+          *
+          * The leaf above seeds its durable state and says why in its own comment. This one drives the live path, and it exists
+          * because the property it pins is load-bearing for the wait-ledger design and is not obvious from reading `onRace`.
+          *
+          * Reading `onRace` suggests the opposite. `onZip` wraps each branch in `Abort.run[FlowSuspension]` INSIDE that branch's own
+          * fiber (`internal/StoreInterpreter.scala:184-188`), so a suspension is a value there and cannot disturb a sibling.
+          * `onRace` has no such wrapper (`:212-222`), which reads as: the first branch to suspend finishes its fiber, wins, and gets
+          * its sibling interrupted before the sibling records anything. That reading is WRONG, and this leaf is what makes the
+          * correct one checkable. `Fiber.internal.race` is `Race.success` (`kyo-core/.../Fiber.scala:780`), whose completion rule
+          * gives a success the race immediately but completes on an error only `if last` (`:817-824`). A suspension is an error, so
+          * it resolves nothing while a sibling is pending: the sibling runs on and records its own wait.
+          *
+          * So the durable-timeout idiom is not broken here, and the design needs no interpreter rule to make a parked branch survive
+          * a race, because the runtime already gives it one. The other half is a separate obligation: when a race is decided, the
+          * loser's recorded wait has to be retired. Under one status cell that is invisible, because the winner's next write
+          * overwrites it; under a ledger it is a row that outlives its branch.
+          *
+          * Looped eight times because it is an interleaving, and asserted as a COUNT so a regression that breaks it half the time
+          * reports how partial it is rather than passing on a lucky run. It asserts on the durable RECORD rather than on a wake-up:
+          * asserting "the deadline eventually wakes it" would also depend on the claim cycle for a non-progressing execution being
+          * rate-limited, which it is not, so a leaf written that way advances enough virtual time to trip that second defect and
+          * dies on the suite's thirty second limit, reporting a timeout that names nothing.
+          */
+        "a race driven live records the wait of every branch that parks" in {
+            withEngine { (engine, store, tc) =>
+                val rounds  = 8
+                val wfId    = Flow.Id.Workflow("live-race")
+                val waiting = Flow.init("live-race").input[String]("approval").output("answer")(ctx => ctx.approval)
+                val timeout = Flow.init("live-race").sleep("deadline", 5.seconds).output("answer")(_ => "timed out")
+                val flow    = Flow.race(waiting, timeout)
+                def kinds(page: FlowStore.HistoryPage): Set[Flow.EventKind] = page.events.map(_.kind).toSet
+                for
+                    _ <- engine.register(wfId, flow)
+                    both <- Kyo.foldLeft(Seq.range(0, rounds))(0) { (count, _) =>
+                        for
+                            handle <- engine.workflows.start(wfId)
+                            eid = handle.executionId
+                            _ <- settle(tc, step = 50.millis, maxRounds = 20)(
+                                store.getHistory(eid, Maybe.empty, 0).map(p =>
+                                    kinds(p).contains(Flow.EventKind.InputWaiting) ||
+                                        kinds(p).contains(Flow.EventKind.SleepStarted)
+                                )
+                            )
+                            page <- store.getHistory(eid, Maybe.empty, 0)
+                            recorded = kinds(page)
+                        yield count + (if recorded.contains(Flow.EventKind.InputWaiting) && recorded.contains(Flow.EventKind.SleepStarted)
+                                       then 1
+                                       else 0)
+                    }
+                yield assert(
+                    both == rounds,
+                    s"both branches park, so both waits must be recorded, got $both of $rounds runs recording both"
+                )
+                end for
+            }
+        }
+
+        /** A failing branch beside a suspended one runs its retry schedule once.
+          *
+          * If a zip's suspension outranked its sibling's failure, the failure would be deferred until the other branch finishes, and
+          * the failing branch would be re-executed from the start on every intermediate resume, with its full retry schedule and
+          * every side effect that goes with it, rather than once.
+          */
+        "a failing branch beside a suspended one runs its retry schedule once" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { attempts =>
+                    val failing = Flow.init("zip-failure")
+                        .output("charge", retry = Maybe(Schedule.fixed(10.millis).repeat(2))) { _ =>
+                            val body: String < (Sync & Abort[FlowException]) =
+                                attempts.incrementAndGet.andThen(Abort.fail(FlowEngineTest.ChargeDeclined("o1", 1L)))
+                            body
+                        }
+                    val waiting = Flow.init("zip-failure").input[String]("approval").output("answer")(ctx => ctx.approval)
+                    val flow    = failing.zip(waiting)
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _     <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(10.millis))
+                        first <- attempts.get
+                        _     <- Abort.run[Throwable](engine.executions.signal[String](eid, "approval", "yes"))
+                        _     <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(10.millis))
+                        total <- attempts.get
+                    yield assert(
+                        total <= 3,
+                        s"the failing branch should run its schedule once (3 attempts), it ran $total times " +
+                            s"($first of them before the input arrived)"
+                    )
+                    end for
+                }
+            }
+        }
+
+        /** A zip branch's failure decides the zip immediately.
+          *
+          * `zip` requires every branch, so once one branch fails the composition's result is unreachable and waiting on the other
+          * branch buys nothing: the flow must reach terminal `Failed` while the sibling's input is still pending, not park until
+          * the answer to a question that no longer matters arrives. Let suspension outrank failure in the join and the failed
+          * branch is discarded and re-run from the start on every resume while the execution sits waiting on the input forever. The
+          * join decides on the failure, and the parked sibling's rows are retired by the transition that ends the attempt
+          * (`internal/StoreInterpreter.scala`'s `onZip`). The rule is the opposite of the race's, where a parked sibling can still
+          * win the composition; here it cannot.
+          */
+        "a zip branch that fails beside a parked sibling fails the flow" in {
+            withEngine { (engine, store, tc) =>
+                val failing = Flow.init("zip-fail-fast").output("charge") { _ =>
+                    throw new RuntimeException("charge declined"); 0
+                }
+                val waiting = Flow.init("zip-fail-fast").input[String]("approval").output("answer")(ctx => ctx.approval)
+                val flow    = failing.zip(waiting)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    settled <- settle(tc)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                    after   <- store.getExecution(eid)
+                    _       <- Abort.run[Throwable](engine.executions.signal[String](eid, "approval", "too late"))
+                    _       <- Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                    finalSt <- store.getExecution(eid)
+                yield
+                    assert(
+                        settled && after.exists(s =>
+                            s.status match
+                                case Flow.Status.Failed(_, _) => true
+                                case _                        => false
+                        ),
+                        s"a zip whose branch failed is unreachable and must fail without waiting on the sibling, " +
+                            s"got ${after.map(_.status)}"
+                    )
+                    assert(
+                        !finalSt.exists(_.status == Flow.Status.Completed),
+                        s"a late input must not resurrect a zip a failure already decided, got ${finalSt.map(_.status)}"
+                    )
+                end for
+            }
+        }
+
+        /** The failure is painted on the branch that failed, not on whichever node the walk reaches first.
+          *
+          * **The discriminating order is the whole point of the fixture.** The waiting branch is zipped FIRST, so its `approval`
+          * input is the first node that is neither completed nor waiting once the terminal ending retires every row. A surface that
+          * decided the failed node by position would paint that input, telling an operator a node failed that never ran, while the
+          * node that actually threw reads pending beside it. Reversing the two branches would hide the defect, because then the guess
+          * and the record agree by accident.
+          *
+          * Both directions are asserted, since painting the right node matters only if the wrong one stays unpainted.
+          */
+        "a failed zip branch is the node reported failed, not the sibling the walk reaches first" in {
+            withEngine { (engine, store, tc) =>
+                val failing = Flow.init("zip-fail-paint").output("charge") { _ =>
+                    throw new RuntimeException("charge declined"); 0
+                }
+                val waiting = Flow.init("zip-fail-paint").input[String]("approval").output("answer")(ctx => ctx.approval)
+                val flow    = waiting.zip(failing)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    settled <- settle(tc)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                    detail  <- engine.executions.describe(eid)
+                yield
+                    assert(settled, "the premise is that the zip failed and the execution is over")
+                    assert(
+                        detail.progress.nodeByName("charge").map(_.status) ==
+                            Maybe(FlowEngine.Progress.NodeStatus.Failed("charge declined")),
+                        s"the branch that threw must be the one reported failed, got ${detail.progress.nodeByName("charge").map(_.status)}"
+                    )
+                    assert(
+                        detail.progress.nodeByName("approval").map(_.status) == Maybe(FlowEngine.Progress.NodeStatus.Pending),
+                        s"and the input nobody delivered must not be reported failed, got " +
+                            s"${detail.progress.nodeByName("approval").map(_.status)}"
+                    )
+                end for
+            }
+        }
+
+        /** A sleep that was not the one woken keeps its original deadline.
+          *
+          * A resumed attempt replays every branch, and the branch that was not woken reaches its sleep node again with no completion
+          * event to skip on, so it re-records the wait. Recomputing `until` as `now + duration` there would make a branch sleeping an
+          * hour alongside a branch sleeping a minute wait an hour from the minute mark rather than an hour from the start, compounding
+          * on every pass of a loop.
+          *
+          * What prevents it is a rule of the row rather than of the caller: a wait row is written only if the path has none
+          * (`internal/MemoryFlowStore.scala`'s `recordWait`), so the deadline a sleep is first given is the deadline it keeps, however
+          * many attempts replay past it. The event is appended either way, because a replay that re-records is something the history
+          * should show.
+          */
+        "a sleep that was not woken keeps its original deadline" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId  = Flow.Id.Workflow("two-sleeps")
+                    val left  = Flow.init("two-sleeps").sleep("a", 10.seconds).output("l")(_ => "l")
+                    val right = Flow.init("two-sleeps").sleep("b", 1.seconds).output("r")(_ => "r")
+                    val flow  = left.zip(right)
+                    Clock.now.map { t0 =>
+                        val eid     = Flow.Id.Execution("two-sleeps-1")
+                        val untilA  = t0 + 10.seconds
+                        val untilB  = t0 + 1.seconds
+                        val theHash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                        for
+                            // Both branches' rows, because both branches parked: seeding one and leaving the other as a bare
+                            // history event describes a state no correct attempt produces.
+                            _ <- seedExecution(store, eid, wfId, Flow.Status.Running, theHash)
+                            _ <- seedWaits(store, eid, wfId, theHash, ("a", Flow.Wake.At(untilA)), ("b", Flow.Wake.At(untilB)))
+                            // The engine is built once the row is already parked. See [[seedWaits]]: a poller and this fixture are
+                            // two claimants of one row, and the order is what keeps them from being competitors.
+                            _ <- FlowEngine.init(store, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow)
+                            // The woken branch's own progress, which is the observable that survives: the row it was woken by is
+                            // discharged and gone, while the branch it woke runs on to its output.
+                            reached <- settle(tc, step = 100.millis, maxRounds = 50) {
+                                store.getField[String](eid, "r").map(_.isDefined)
+                            }
+                            state <- store.getExecution(eid)
+                        yield
+                            assert(reached, s"the shorter sleep should have woken its branch, got ${state.map(_.waits)}")
+                            deadlineOf(state.get, "a") match
+                                case Present(until) =>
+                                    assert(
+                                        until == untilA,
+                                        s"the sleep that was not woken must keep the deadline it was started with, " +
+                                            s"expected $untilA but the execution now sleeps until $until"
+                                    )
+                                case Absent =>
+                                    assert(false, s"expected the execution to still be sleeping on 'a', got ${state.map(_.waits)}")
+                            end match
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** An execution waiting on an input AND a sleep is woken by the sleep.
+          *
+          * With both branches suspended and the input wait recorded last, the sleep's deadline is no longer anything the store can
+          * see: readiness for `WaitingForInput` is the presence of the field, so the execution waits for an input that may never
+          * come while its own timer passes unnoticed.
+          */
+        "a sleep still wakes an execution whose status records an input wait" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId  = Flow.Id.Workflow("input-and-sleep")
+                    val left  = Flow.init("input-and-sleep").input[String]("x").output("l")(ctx => ctx.x)
+                    val right = Flow.init("input-and-sleep").sleep("b", 1.seconds).output("r")(_ => "r")
+                    val flow  = left.zip(right)
+                    Clock.now.map { t0 =>
+                        val eid     = Flow.Id.Execution("input-and-sleep-1")
+                        val untilB  = t0 + 1.seconds
+                        val theHash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                        for
+                            // Both branches' rows, for the same reason as the leaf above.
+                            _ <- seedExecution(store, eid, wfId, Flow.Status.Running, theHash)
+                            _ <- seedWaits(store, eid, wfId, theHash, ("x", Flow.Wake.OnField("x")), ("b", Flow.Wake.At(untilB)))
+                            // The engine is built once the row is already parked. See [[seedWaits]].
+                            _ <- FlowEngine.init(store, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow)
+                            // The sleeping branch's own progress: the output past the sleep it was woken by.
+                            woken <- settle(tc, step = 100.millis, maxRounds = 50)(
+                                store.getField[String](eid, "r").map(_.isDefined)
+                            )
+                            state <- store.getExecution(eid)
+                        yield assert(
+                            woken,
+                            s"a sleep whose deadline passed must still wake the execution, which is stuck at " +
+                                s"${state.map(_.waits)} with no input coming"
+                        )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** The mirror of the leaf above: an execution waiting on an input AND a sleep is woken by the input.
+          *
+          * With the sleep's wait recorded last, a signal that arrives on day one writes its field and wakes nothing: readiness
+          * for `Sleeping` is the deadline and only the deadline, so the answer sits delivered while the execution sleeps out
+          * its full timeout, then resolves the race for the input it should have taken days earlier. The result is right and
+          * the wake is silently late, which is why this direction needs its own leaf: the loud direction (the timeout never
+          * firing at all) is the leaf above, and a fix that carries only the winning branch's wait passes exactly one of the
+          * two.
+          */
+        "an input still wakes an execution whose status records a sleep" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId  = Flow.Id.Workflow("sleep-and-input")
+                    val left  = Flow.init("sleep-and-input").input[String]("x").output("l")(ctx => ctx.x)
+                    val right = Flow.init("sleep-and-input").sleep("b", 5.days).output("r")(_ => "r")
+                    val flow  = left.zip(right)
+                    Clock.now.map { t0 =>
+                        val eid     = Flow.Id.Execution("sleep-and-input-1")
+                        val untilB  = t0 + 5.days
+                        val theHash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                        for
+                            // Both branches' rows, for the same reason as the leaf above.
+                            _         <- seedExecution(store, eid, wfId, Flow.Status.Running, theHash)
+                            _         <- seedWaits(store, eid, wfId, theHash, ("x", Flow.Wake.OnField("x")), ("b", Flow.Wake.At(untilB)))
+                            now       <- Clock.now
+                            delivered <- store.signal(eid, "x", "answered", Flow.Event.InputReceived(wfId, eid, "x", now))
+                            // The engine is built once the row is already parked. See [[seedWaits]].
+                            _ <- FlowEngine.init(store, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow)
+                            // The input branch's own progress: the output past the input it was woken by.
+                            woken <- settle(tc, step = 100.millis, maxRounds = 50)(
+                                store.getField[String](eid, "l").map(_.isDefined)
+                            )
+                            state <- store.getExecution(eid)
+                        yield
+                            assert(
+                                delivered == FlowStore.SignalOutcome.Delivered,
+                                "the premise is that the input was delivered while the sleep was pending"
+                            )
+                            assert(
+                                woken,
+                                s"a delivered input must wake the execution promptly, not after the sleep runs out: " +
+                                    s"stuck at ${state.map(_.waits)} with its answer sitting delivered"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** An engine that goes away between two parking branches still honours the sleep the second one was about to record.
+          *
+          * The window only exists because each branch records its own wait: the first branch's row is written, and the engine's scope
+          * closes before the second's is. The rows the attempt left are therefore NOT a finished statement of what the execution waits
+          * for, and the claim says so, because the transition that ends an attempt is the only thing that frees one. Readiness reads
+          * that: an active claim that has expired returns the execution regardless of its rows, so the replay re-records the sleep and
+          * the durable timeout still fires. A rule that gated on the rows instead would wait forever on an input nobody is going to
+          * send, with the deadline it was racing lost in the window.
+          */
+        "an engine shut down between two parking branches still honours the sleep" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId    = Flow.Id.Workflow("half-parked")
+                    val waiting = Flow.init("half-parked").input[String]("approval").output("answer")(ctx => ctx.approval)
+                    val timeout = Flow.init("half-parked").sleep("deadline", 30.seconds).output("answer")(_ => "timed out")
+                    val flow    = Flow.race(waiting, timeout)
+                    val theHash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                    val config  = FlowEngine.Config(workerCount = 1, lease = 5.seconds, renewEvery = 1.second, pollTimeout = 100.millis)
+                    Clock.now.map { t0 =>
+                        val eid = Flow.Id.Execution("half-parked-1")
+                        for
+                            // The first engine's attempt died with the input's row written, the sleep's not, and the claim still
+                            // named: exactly what a shutdown between the two branches leaves behind.
+                            _ <- seedExecution(store, eid, wfId, Flow.Status.Running, theHash)
+                            claimed <-
+                                store.claimReady(Set((wfId, theHash)), Flow.Id.Executor("first-engine"), 5.seconds, 10, Duration.Zero)
+                            _ = assert(claimed.size == 1, "the premise is that an executor held the execution when it died")
+                            now <- Clock.now
+                            _ <- claimed.head.recordWait(
+                                "approval",
+                                Flow.Wake.OnField("approval"),
+                                Flow.Event.InputWaiting(wfId, eid, "approval", now)
+                            )
+                            // The first engine's claim lapses, which is what tells the next one its ledger was never finished.
+                            _ <- tc.advance(10.seconds)
+                            _ <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { _ =>
+                                    settle(tc, step = 1.second, maxRounds = 120)(
+                                        store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                    )
+                                }
+                            }
+                            state  <- store.getExecution(eid)
+                            answer <- store.getField[String](eid, "answer")
+                        yield
+                            assert(
+                                answer == Maybe("timed out"),
+                                s"the sleep the shutdown swallowed must still fire, got $answer with ${state.map(_.waits)}"
+                            )
+                            assert(
+                                state.exists(_.status == Flow.Status.Completed),
+                                s"and the execution must finish on it, got ${state.map(_.status)}"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** The same window, driven rather than seeded, and what the engine writes when it closes on one: nothing.
+          *
+          * The leaf above seeds the state a mid-park shutdown leaves and asserts that readiness heals it. This one produces the state:
+          * a live engine stopped with one branch's row written and the other's call suspended inside the store, so the window is
+          * driven rather than described, and the recovery that follows is the same recovery a real deployment gets.
+          *
+          * What the shutdown itself writes is nothing, in both halves. The closing scope interrupts the fiber supervising the attempt
+          * along with the attempt, so no ending transition runs: no status, no event, and no release, which leaves the claim named and
+          * unexpired at the moment the engine goes away. That is what makes the leftover row untrustworthy and the lapsed claim the
+          * only thing that says so, which is the rule the recovery below depends on. The gate that keeps a VERDICT-less ending from
+          * releasing is pinned separately, on "an executor that has lost its claim writes nothing more", where the supervisor outlives
+          * the work it stopped and a release would therefore be reachable.
+          */
+        "an engine stopped between two parking branches releases nothing and still honours the sleep" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    AtomicInt.init(0).map { calls =>
+                        Channel.init[Unit](1).map { parked =>
+                            val store   = new ParkedWaitStore(plain, calls, parked)
+                            val wfId    = Flow.Id.Workflow("half-parked-live")
+                            val waiting = Flow.init("half-parked-live").input[String]("approval").output("answer")(ctx => ctx.approval)
+                            val timeout = Flow.init("half-parked-live").sleep("deadline", 30.seconds).output("answer")(_ => "timed out")
+                            val flow    = Flow.race(waiting, timeout)
+                            val config =
+                                FlowEngine.Config(workerCount = 1, lease = 5.seconds, renewEvery = 1.second, pollTimeout = 100.millis)
+                            for
+                                eid <- Scope.run {
+                                    FlowEngine.init(store, config, flow).map { engine =>
+                                        for
+                                            handle <- engine.workflows.start(wfId)
+                                            eid = handle.executionId
+                                            // One branch's row is written and the other's call is suspended in the store, so the
+                                            // scope closing below is what ends the attempt, with its ledger half stated.
+                                            reached <- settle(tc)(calls.get.map(_ >= 2))
+                                            _ = assert(
+                                                reached,
+                                                "the premise is that one branch recorded its wait and the second reached the store"
+                                            )
+                                        yield eid
+                                    }
+                                }
+                                held <- store.getExecution(eid)
+                                _    <- tc.advance(10.seconds)
+                                _ <- Scope.run {
+                                    FlowEngine.init(store, config, flow).map { _ =>
+                                        settle(tc, step = 1.second, maxRounds = 120)(
+                                            store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                        )
+                                    }
+                                }
+                                state  <- store.getExecution(eid)
+                                answer <- store.getField[String](eid, "answer")
+                            yield
+                                assert(
+                                    held.exists(_.waits.size == 1),
+                                    s"the premise is one branch's row written and one never landed, got ${held.map(_.waits)}"
+                                )
+                                assert(
+                                    held.exists(s => s.executor.isDefined && s.claimExpiry.isDefined),
+                                    s"an interrupted ending releases nothing, so the claim must still be held when the engine " +
+                                        s"closes, got executor=${held.map(_.executor)} expiry=${held.map(_.claimExpiry)}"
+                                )
+                                assert(
+                                    answer == Maybe("timed out"),
+                                    s"the sleep the shutdown swallowed must still fire, got $answer with ${state.map(_.waits)}"
+                                )
+                                assert(
+                                    state.exists(_.status == Flow.Status.Completed),
+                                    s"and the execution must finish on it, got ${state.map(_.status)}"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A race's losing branch does not leave a row behind the attempt that re-recorded it.
+          *
+          * Nothing discharges a branch that was decided against: it was abandoned rather than satisfied, so no progress write clears
+          * its row, and the general clearing rule does not reach it. What removes it is the transition that ends the attempt, which
+          * keeps exactly the parks the execution is still waiting on. A leftover row is not inert: the moment it becomes satisfiable
+          * it makes the execution ready again with nothing to do, which is the poll spin the ledger exists to close.
+          */
+        "a decided race's loser row does not outlive the attempt that re-recorded it" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val wfId    = Flow.Id.Workflow("loser-row")
+                    val waiting = Flow.init("loser-row").input[String]("approval").output("answer")(ctx => ctx.approval)
+                    val timeout = Flow.init("loser-row").sleep("deadline", 5.seconds).output("answer")(_ => "timed out")
+                    // A race decided by its deadline, and then a wait downstream, so the attempt ends parked on something ELSE:
+                    // the loser's row can only be removed by the ending's retirement, never by the next park's own write.
+                    val downstream = Flow.init("loser-row").input[String]("ack").output("done")(ctx => ctx.ack)
+                    val flow       = Flow.race(waiting, timeout).andThen(downstream)
+                    val theHash    = kyo.internal.WorkflowSchema.structuralHash(flow)
+                    Clock.now.map { t0 =>
+                        val eid = Flow.Id.Execution("loser-row-1")
+                        for
+                            _ <- seedExecution(store, eid, wfId, Flow.Status.Running, theHash)
+                            _ <- seedWaits(
+                                store,
+                                eid,
+                                wfId,
+                                theHash,
+                                ("approval", Flow.Wake.OnField("approval")),
+                                ("deadline", Flow.Wake.At(t0 + 5.seconds))
+                            )
+                            // The engine is built once the row is already parked. See [[seedWaits]].
+                            _ <- FlowEngine.init(store, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow)
+                            parked <- settle(tc, step = 100.millis, maxRounds = 100)(
+                                store.getExecution(eid).map(_.exists(waitingFor("ack")))
+                            )
+                            state <- store.getExecution(eid)
+                        yield
+                            assert(
+                                parked,
+                                s"the premise is that the race resolved and the execution parked downstream, got ${state.map(_.waits)}"
+                            )
+                            assert(
+                                !state.exists(_.waits.contains("approval")),
+                                s"the losing branch's row must not outlive the attempt that decided against it, got ${state.map(_.waits)}"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** Every parked branch of a nested composition wakes on its own condition.
+          *
+          * Two branches are not enough to see this: a merge that flattens one level satisfies the two-branch leaves above and still
+          * loses a branch one level down, because the composition that reaches the engine is a race of a zip. Three branches with
+          * three different conditions, asserted in both directions, is what distinguishes a recursive merge from a single-level one.
+          */
+        "every parked branch of a nested composition wakes on its own condition" in {
+            withEngine { (engine, store, tc) =>
+                val wfId       = Flow.Id.Workflow("nested-parks")
+                val innerInput = Flow.init("nested-parks").input[String]("inner").output("answer")(ctx => ctx.inner)
+                val innerSleep = Flow.init("nested-parks").sleep("deadline", 5.seconds).output("slept")(_ => "slept")
+                val outerInput = Flow.init("nested-parks").input[String]("outer").output("answer")(ctx => ctx.outer)
+                val flow       = Flow.race(innerInput.zip(innerSleep), outerInput)
+                def parkedOnAll(eid: Flow.Id.Execution)(using Frame) =
+                    settle(tc, step = 100.millis, maxRounds = 100) {
+                        store.getExecution(eid).map(_.exists(s =>
+                            waitingFor("inner")(s) && waitingFor("outer")(s) && sleeping(s)
+                        ))
+                    }
+                def start(using Frame) =
+                    engine.workflows.start(wfId).map(_.executionId).map(eid => parkedOnAll(eid).map(all => (eid, all)))
+                for
+                    _ <- engine.register(wfId, flow)
+                    // One execution per direction, because a wake resolves the composition it woke.
+                    innerRun <- start
+                    sleepRun <- start
+                    outerRun <- start
+                    _ = assert(
+                        innerRun._2 && sleepRun._2 && outerRun._2,
+                        "the premise is that all three branches parked, each recording its own wait"
+                    )
+                    // The zip's input branch, one level down inside the race.
+                    _ <- engine.executions.signal[String](innerRun._1, "inner", "from-inner")
+                    innerWoke <- settle(tc, step = 100.millis, maxRounds = 100)(
+                        store.getField[String](innerRun._1, "answer").map(_.contains("from-inner"))
+                    )
+                    // The zip's sleep branch, the other one level down.
+                    _ <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(100.millis))
+                    sleepWoke <- settle(tc, step = 100.millis, maxRounds = 100)(
+                        store.getField[String](sleepRun._1, "slept").map(_.isDefined)
+                    )
+                    // The race's own branch, at the top level.
+                    _ <- engine.executions.signal[String](outerRun._1, "outer", "from-outer")
+                    outerWoke <- settle(tc, step = 100.millis, maxRounds = 100)(
+                        store.getExecution(outerRun._1).map(_.exists(_.status == Flow.Status.Completed))
+                    )
+                    innerState <- store.getExecution(innerRun._1)
+                    sleepState <- store.getExecution(sleepRun._1)
+                    outerState <- store.getExecution(outerRun._1)
+                yield
+                    assert(
+                        innerWoke,
+                        s"the input nested inside the zip must wake its own branch, got ${innerState.map(_.waits)}"
+                    )
+                    assert(
+                        sleepWoke,
+                        s"the sleep nested inside the zip must wake its own branch, got ${sleepState.map(_.waits)}"
+                    )
+                    assert(
+                        outerWoke,
+                        s"the race's own input branch must wake the composition, got ${outerState.map(_.status)}"
+                    )
+                end for
+            }
+        }
+
+        /** A settled execution costs nothing while it waits.
+          *
+          * The end-to-end half of the clearing rule. A satisfied wait that is never removed keeps the execution ready forever after the
+          * branch that recorded it has moved on: every poll claims it, the replay finds nothing to do, the claim is released, and the
+          * next poll claims it again at full speed, writing a claim and a release into the history each time. The execution looks
+          * perfectly healthy the whole while, which is why the observable is the history's own size across two equal idle stretches
+          * rather than anything about the rows.
+          *
+          * The input kind is what this drives, because an input's discharge is the one progress a node records with no value of its
+          * own: a satisfied input proceeds with the value already in its record, so the row it wrote while parking is cleared by that
+          * transition or by nothing at all.
+          */
+        "a settled execution's history does not grow while it waits" in {
+            withEngine { (engine, store, tc) =>
+                val wfId = Flow.Id.Workflow("settled")
+                val flow = Flow.init("settled")
+                    .input[String]("first")
+                    .step("between")(_ => ())
+                    .input[String]("second")
+                    .output("done")(ctx => ctx.second)
+                def idle(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+                    Kyo.foreachDiscard(1 to 100)(_ => tc.advance(10.millis))
+                for
+                    _      <- engine.register(wfId, flow)
+                    handle <- engine.workflows.start(wfId)
+                    eid = handle.executionId
+                    _ <- pumpState(tc, store, eid, waitingFor("first"))
+                    // The first wait is satisfied and consumed; the execution then settles on the second.
+                    _      <- engine.executions.signal[String](eid, "first", "go")
+                    _      <- pumpState(tc, store, eid, waitingFor("second"))
+                    _      <- idle
+                    first  <- store.getHistory(eid, Maybe.empty, 0)
+                    _      <- idle
+                    second <- store.getHistory(eid, Maybe.empty, 0)
+                    state  <- store.getExecution(eid)
+                yield
+                    assert(
+                        second.events.size == first.events.size,
+                        s"a settled execution must not be re-claimed: history grew from ${first.events.size} to " +
+                            s"${second.events.size}, ending ${second.events.drop(first.events.size).map(_.kind)}"
+                    )
+                    assert(
+                        state.exists(_.waits.toChunk.map(_._1).toSet == Set("second")),
+                        s"the discharged wait must be gone and the outstanding one kept, got ${state.map(_.waits)}"
+                    )
+                    assert(
+                        state.exists(_.executor.isEmpty),
+                        s"and nothing must be holding a claim on it, got ${state.map(_.executor)}"
+                    )
+                end for
+            }
+        }
+    }
+
+    /** Defects reachable through the ordinary public API that no group above covers.
+      *
+      * Each leaf here pins one behaviour the module documents or implies and does not deliver. They are grouped together because they
+      * cut across the engine, the interpreter, and the flow DSL rather than belonging to any single one.
+      */
+    "contract gaps" - {
+
+        /** A wait is recorded only by an executor that holds the claim.
+          *
+          * Neither durable-wait writer decides this for itself: `onInput` and `onSleep` both record through `claimed.recordWait`
+          * under `fenced` (`internal/StoreInterpreter.scala`), so the write is applied only under a claim the store still regards as
+          * active, unexpired, and of the generation presented, and a refusal ends the attempt instead. A writer that checked the
+          * claim itself, or read the row and decided from what it saw, would be deciding on a snapshot the store may already have
+          * superseded. It is also the write that most directly steers the future, which is why it is the one pinned here: a wait row
+          * is what readiness reads.
+          */
+        "an executor that does not hold the claim does not record a wait" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    AtomicBoolean.init(false).map { armed =>
+                        AtomicInt.init(0).map { refusals =>
+                            Channel.init[Unit](1).map { parked =>
+                                val leaseSpan = 5.seconds
+                                // The claim dies the moment the attempt announces itself, so everything the interpreter writes
+                                // from there on is presented under a generation the store has stopped honouring. There is no read
+                                // left to lie to, so the lapse is produced rather than reported.
+                                val store = new LapsingClaimStore(plain, tc, leaseSpan, armed, refusals, parked)({
+                                    case _: Flow.Event.ExecutionResumed => true
+                                    case _                              => false
+                                })
+                                val wfId = Flow.Id.Workflow("unfenced-wait")
+                                val flow = Flow.init("unfenced-wait").input[String]("x").output("done")(ctx => ctx.x)
+                                val config = FlowEngine.Config(
+                                    workerCount = 1,
+                                    lease = leaseSpan,
+                                    renewEvery = 1.second,
+                                    pollTimeout = 100.millis
+                                )
+                                for
+                                    eid <- Scope.run {
+                                        FlowEngine.init(store, config, flow).map { engine =>
+                                            for
+                                                handle <- engine.workflows.start(wfId)
+                                                eid = handle.executionId
+                                                refused <- settle(tc)(refusals.get.map(_ > 0))
+                                                _ = assert(
+                                                    refused,
+                                                    "the premise is that the lapsed executor presented a write and was refused"
+                                                )
+                                            yield eid
+                                        }
+                                    }
+                                    page <- plain.getHistory(eid, Maybe.empty, 0)
+                                    waits = page.events.count(_.kind == Flow.EventKind.InputWaiting)
+                                yield assert(
+                                    waits == 0,
+                                    s"the store reports the row as another executor's, so no wait may be recorded under this one, got $waits"
+                                )
+                                end for
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An executor that has lost its claim mid-step records nothing further, retries included.
+          *
+          * Bracketing a step with a claim check leaves everything between the two checks unguarded, and `withTimeoutAndRetry` lives
+          * exactly there, appending `StepTimedOut` and `StepRetried` from a helper with no claim to present and no check to fail. An
+          * executor whose lease is taken while its step is running then keeps writing its retry schedule into another executor's
+          * execution, each retry re-running the step body with whatever side effects it has, and the trailing check catches it only
+          * once the schedule is exhausted.
+          *
+          * Those events go through the claim like every other write: `withTimeoutAndRetry` appends them with `appendEvent`,
+          * which is `claimed.appendEvent` under `fenced` (`internal/StoreInterpreter.scala`), so the FIRST refusal ends the attempt
+          * rather than the last one. What this leaf pins is the outcome that follows, which is what an operator reads: a claim taken
+          * as the step announces itself leaves that step's retries out of the history entirely.
+          */
+        "an executor that lost its claim mid-step does not record its retries" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    AtomicBoolean.init(false).map { armed =>
+                        AtomicInt.init(0).map { refusals =>
+                            Channel.init[Unit](1).map { parked =>
+                                val leaseSpan = 5.seconds
+                                // The claim dies as the step starts, which is the window everything the retry helper writes lives
+                                // in. The renewal parks rather than being refused, so the body keeps running under a lease it no
+                                // longer holds and the writes are the only thing being refused.
+                                val store = new LapsingClaimStore(plain, tc, leaseSpan, armed, refusals, parked)({
+                                    case _: Flow.Event.StepStarted => true
+                                    case _                         => false
+                                })
+                                val wfId = Flow.Id.Workflow("unfenced-retry")
+                                val flow = Flow.init("unfenced-retry")
+                                    .output("y", retry = Maybe(Schedule.fixed(10.millis).repeat(3)))(_ =>
+                                        throw new RuntimeException("boom"); ""
+                                    )
+                                val config = FlowEngine.Config(
+                                    workerCount = 1,
+                                    lease = leaseSpan,
+                                    renewEvery = 1.second,
+                                    pollTimeout = 100.millis
+                                )
+                                for
+                                    eid <- Scope.run {
+                                        FlowEngine.init(store, config, flow).map { engine =>
+                                            for
+                                                handle <- engine.workflows.start(wfId)
+                                                eid = handle.executionId
+                                                refused <- settle(tc)(refusals.get.map(_ > 0))
+                                                _ = assert(
+                                                    refused,
+                                                    "the premise is that the lapsed executor presented a write and was refused"
+                                                )
+                                            yield eid
+                                        }
+                                    }
+                                    page <- plain.getHistory(eid, Maybe.empty, 0)
+                                    retries = page.events.count(_.kind == Flow.EventKind.StepRetried)
+                                yield assert(
+                                    retries == 0,
+                                    s"the claim was taken as the step started, so no retry may be recorded under it, got $retries"
+                                )
+                                end for
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A step's value and the record that it completed are written together, or neither is written.
+          *
+          * Writing them as two separate SPI calls with a clock read between them, a field write and then a status write carrying the
+          * completion event, lets a store fail in that window and leave the value durably present with the history saying the step
+          * never finished.
+          *
+          * That combination is not merely untidy, it is unrecoverable in the direction that matters. `Output` decides it has already
+          * run by looking for its FIELD, so the step would never re-run and never emit the missing event; but `Progress.build`
+          * decides a node is completed from the HISTORY, so the operator surface would report that node as unfinished forever, for an
+          * execution that in fact ran it. Two surfaces, two sources of truth, and a store contract that did not say they must agree.
+          *
+          * One verb carries it: `claimed.recordProgress` writes the field, appends the completion event and clears the rows under
+          * that path in a single transition (`internal/StoreInterpreter.scala`'s `onOutput`). This leaf asserts the invariant rather
+          * than the mechanism: after the blip, the field exists if and only if the completion event does.
+          */
+        "a step's field and its completion event are written together or not at all" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(1).map { blips =>
+                        val flaky = new FailingCompletionStore(store, "y", blips)
+                        val flow  = Flow.init("atomic-step").output("y")(_ => 42).output("z")(ctx => ctx.y + 1)
+                        FlowEngine.init(flaky, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(Flow.Id.Workflow("atomic-step"))
+                                eid = handle.executionId
+                                _ <- settle(tc, step = 100.millis, maxRounds = 50)(
+                                    store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                )
+                                field <- store.getField[Int](eid, "y")
+                                page  <- store.getHistory(eid, Maybe.empty, 0)
+                                completed = page.events.exists {
+                                    case Flow.Event.StepCompleted(_, _, name, _) => name == "y"
+                                    case _                                       => false
+                                }
+                            yield assert(
+                                field.isEmpty == !completed,
+                                s"the value and its completion record must agree: field=$field, StepCompleted(y)=$completed"
+                            )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A stale executor's write must not land on top of the new owner's result.
+          *
+          * Two owners at once needs a lease that lapses WHILE its holder keeps running, which is a state a store that lies about a
+          * row cannot produce: an expired executor still writing is not the same thing as one overwriting somebody else's work.
+          *
+          * **The instrument is a renewal that PARKS, which is the one shape that produces a stale running executor.** A renewal
+          * that FAILS does not: the renewal fiber survives blips, and a failed or refused renewal interrupts the lapsed executor at
+          * its next safepoint, so no stale executor built that way ever comes back. `ParkedRenewalStore` suspends the renewal
+          * round-trip without answering instead: no renewal, no refusal, no interrupt, so the first engine's lease lapses
+          * store-side while its step keeps running. A second engine, on the plain store, claims the row the ordinary way and
+          * completes the flow. When the first engine's step finally returns, it writes its own result over the new owner's, and the
+          * value is derived from having resumed past the gate precisely so a landed stale write reads "stale" rather than
+          * coinciding with the owner's value.
+          *
+          * The assertion is the user-visible harm rather than the mechanism: the field a reader sees must be the one written by the
+          * executor that actually owned the execution.
+          *
+          * **What keeps the owner's data safe is the STORE.** `recordProgress` answers `ClaimLost` for a write presented under a
+          * generation the row has stopped honouring, and it compares GENERATIONS rather than executor identity, so it refuses a
+          * second worker of the same engine just as firmly. A client-side check that read the row and compared its executor against
+          * this one's would refuse the write staged here and miss that case entirely.
+          *
+          * **So this is a GUARD on an ordering, and the most valuable thing it can do is fail.** If the fence ever weakens, to an
+          * identity comparison, to "the highest token wins", or to a check that forgets expiry, this leaf goes red and says exactly
+          * what was lost.
+          *
+          * The premises come first, because a run where the second engine never took over, or where the stale executor's step never
+          * came back, would measure nothing. The second of those needs its own counter: the entry count is satisfied by the new
+          * owner's own entry, so it cannot show that the STALE executor resumed.
+          */
+        "a stale executor's write does not land on top of the new owner's result" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicBoolean.init(false).map { armed =>
+                        AtomicInt.init(0).map { entries =>
+                            AtomicInt.init(0).map { unblocked =>
+                                Channel.init[Unit](1).map { gate =>
+                                    Channel.init[Unit](1).map { renewals =>
+                                        val parking = new ParkedRenewalStore(store, armed, renewals)
+                                        val wfId    = Flow.Id.Workflow("stale-overwrite")
+                                        val flow = Flow.init("stale-overwrite")
+                                            .step[Async]("work") { _ =>
+                                                entries.incrementAndGet.map { n =>
+                                                    if n == 1 then
+                                                        Abort.run[Closed](gate.take).andThen(unblocked.incrementAndGet).unit
+                                                    else Kyo.unit
+                                                }
+                                            }
+                                            .output("result") { _ =>
+                                                unblocked.get.map(u => if u > 0 then "stale" else "owner")
+                                            }
+                                        val config = FlowEngine.Config(
+                                            workerCount = 1,
+                                            lease = 2.seconds,
+                                            renewEvery = 100.millis,
+                                            pollTimeout = 100.millis
+                                        )
+                                        for
+                                            eid <- FlowEngine.init(parking, config, flow)([v] => (c: v < Async) => c).map { first =>
+                                                first.workflows.start(wfId).map { handle =>
+                                                    settle(tc, step = 50.millis, maxRounds = 60)(entries.get.map(_ >= 1))
+                                                        .andThen(handle.executionId)
+                                                }
+                                            }
+                                            _ <- armed.set(true)
+                                            _ <- tc.advance(10.seconds)
+                                            _ <- FlowEngine.init(store, config, flow)([v] => (c: v < Async) => c).map { second =>
+                                                settle(tc, step = 250.millis, maxRounds = 80)(
+                                                    store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                                )
+                                            }
+                                            ownerValue <- store.getField[String](eid, "result")
+                                            _          <- Abort.run[Closed](gate.put(()))
+                                            _          <- settle(tc, step = 100.millis, maxRounds = 80)(unblocked.get.map(_ >= 1))
+                                            finalValue <- store.getField[String](eid, "result")
+                                            seen       <- entries.get
+                                            resumed    <- unblocked.get
+                                        yield
+                                            assert(
+                                                ownerValue == Present("owner"),
+                                                s"the premise is that a second engine took the execution over and finished it, got $ownerValue"
+                                            )
+                                            assert(
+                                                seen >= 2,
+                                                s"the premise is that both executors entered the step, it was entered $seen times"
+                                            )
+                                            assert(
+                                                resumed >= 1,
+                                                s"the premise is that the STALE executor's step came back past its block, and it did not; " +
+                                                    s"this counter is separate from the entry count because the second engine's own entry " +
+                                                    s"satisfies that one on its own"
+                                            )
+                                            assert(
+                                                finalValue == Present("owner"),
+                                                s"a write from an executor whose lease lapsed must not replace the owner's result: the " +
+                                                    s"field went from $ownerValue to $finalValue"
+                                            )
+                                        end for
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A stale executor's failure must not appear in the history of an execution somebody else completed.
+          *
+          * The other side of the write fence, and the half a recover arm makes reachable: wrapping the whole resume in a recover arm
+          * and writing terminal `Failed` from it puts that write outside every claim check the interpreter makes, so a step that
+          * THREW reaches it directly where a step that returned normally is stopped on its way to the field.
+          *
+          * **Both halves are closed by one rule.** A verdict is not a free write: the ending goes through the claim
+          * (`FlowEngine.scala`'s `finish`, which appends `ExecutionReleased` and then calls `claimed.finish`), so a stale executor's
+          * `Failed` is judged by the acceptance rule like everything else and lands nowhere at all. `FlowStoreTest` pins the
+          * store-level half: a terminal status is refused WHOLE, status, history and rows together, rather than the status being
+          * refused and the event appended anyway. That half is worth its own leaf because history is what the operator surfaces
+          * read, and a failed step has to be identifiable from history alone.
+          *
+          * The instrument is the same conforming one the sibling leaf uses, and for the same reason: a renewal that PARKS is the one
+          * shape that still produces a stale RUNNING executor. A refused renewal interrupts the attempt at its next safepoint, so
+          * the blocked step never comes back at all and the leaf would measure nothing; a parked one neither renews nor refuses, the
+          * lease lapses store-side, and the executor keeps going under a claim it no longer holds. A second engine then claims and
+          * completes, and only then is the first engine's step released, this time to throw.
+          *
+          * The premises come first: the second engine really completed it, and the stale executor's step really came back past its
+          * block, which needs its own counter because the new owner's own entry satisfies the entry count.
+          */
+        "a stale executor's failure does not appear in the history of a completed execution" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicBoolean.init(false).map { armed =>
+                        AtomicInt.init(0).map { entries =>
+                            AtomicInt.init(0).map { unblocked =>
+                                Channel.init[Unit](1).map { gate =>
+                                    Channel.init[Unit](1).map { renewals =>
+                                        val parking = new ParkedRenewalStore(store, armed, renewals)
+                                        val wfId    = Flow.Id.Workflow("stale-verdict")
+                                        val flow = Flow.init("stale-verdict")
+                                            .step[Async]("work") { _ =>
+                                                entries.incrementAndGet.map { n =>
+                                                    if n == 1 then
+                                                        Abort.run[Closed](gate.take)
+                                                            .andThen(unblocked.incrementAndGet)
+                                                            .andThen {
+                                                                throw new RuntimeException("the stale executor's verdict"); ()
+                                                            }
+                                                    else Kyo.unit
+                                                }
+                                            }
+                                            .output("result")(_ => entries.get.map(_ => "owner"))
+                                        val config = FlowEngine.Config(
+                                            workerCount = 1,
+                                            lease = 2.seconds,
+                                            renewEvery = 100.millis,
+                                            pollTimeout = 100.millis
+                                        )
+                                        for
+                                            eid <- FlowEngine.init(parking, config, flow)([v] => (c: v < Async) => c).map { first =>
+                                                first.workflows.start(wfId).map { handle =>
+                                                    settle(tc, step = 50.millis, maxRounds = 60)(entries.get.map(_ >= 1))
+                                                        .andThen(handle.executionId)
+                                                }
+                                            }
+                                            _ <- armed.set(true)
+                                            _ <- tc.advance(10.seconds)
+                                            _ <- FlowEngine.init(store, config, flow)([v] => (c: v < Async) => c).map { second =>
+                                                settle(tc, step = 250.millis, maxRounds = 80)(
+                                                    store.getExecution(eid).map(_.exists(_.status.isTerminal))
+                                                )
+                                            }
+                                            ownerState <- store.getExecution(eid)
+                                            _          <- Abort.run[Closed](gate.put(()))
+                                            _          <- settle(tc, step = 100.millis, maxRounds = 80)(unblocked.get.map(_ >= 1))
+                                            resumed    <- unblocked.get
+                                            page       <- store.getHistory(eid, Maybe.empty, 0)
+                                            finalState <- store.getExecution(eid)
+                                        yield
+                                            assert(
+                                                ownerState.exists(_.status == Flow.Status.Completed),
+                                                s"the premise is that a second engine completed it, got ${ownerState.map(_.status)}"
+                                            )
+                                            assert(
+                                                resumed >= 1,
+                                                s"the premise is that the stale executor's step came back past its block, and it did not"
+                                            )
+                                            assert(
+                                                finalState.exists(_.status == Flow.Status.Completed),
+                                                s"the store must keep a terminal status, got ${finalState.map(_.status)}"
+                                            )
+                                            assert(
+                                                !page.events.exists(_.kind == Flow.EventKind.Failed),
+                                                s"an execution completed by its owner must not carry a Failed event written by an " +
+                                                    s"executor that no longer held it, got ${page.events.map(_.kind)}"
+                                            )
+                                        end for
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** The renewal loop survives a transient store failure, the way the poll loop does.
+          *
+          * Leaving `renewClaim`'s error channel unhandled inside the renewal loop ends the fiber on one failed round-trip, and
+          * nothing reads its outcome, so there is no retry, no log, and nothing on `health`. The execution then runs on with a lease
+          * nobody is extending until it lapses, at which point another engine claims the same execution and both write. The poll
+          * loop, which guards nothing but an idle wait, retries and records; the renewal loop guards a live execution and cannot be
+          * less protected than that.
+          */
+        "a renewal that fails once keeps renewing" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(0).map { calls =>
+                        Channel.init[Unit](1).map { gate =>
+                            val flaky = new FlakyRenewalStore(store, calls)
+                            val flow = Flow.init("long-renew")
+                                .step[Async]("work")(_ => Abort.run[Closed](gate.take).unit)
+                                .output("done")(_ => Async.delay(Duration.Zero)("ok"))
+                            val config = FlowEngine.Config(
+                                workerCount = 1,
+                                lease = 5.seconds,
+                                renewEvery = 100.millis,
+                                pollTimeout = 100.millis
+                            )
+                            FlowEngine.init(flaky, config, flow)([v] => (c: v < Async) => c).map { engine =>
+                                for
+                                    _    <- engine.workflows.start(Flow.Id.Workflow("long-renew"))
+                                    kept <- settle(tc)(calls.get.map(_ >= 3))
+                                    seen <- calls.get
+                                    _    <- Abort.run[Closed](gate.put(()))
+                                yield assert(
+                                    kept,
+                                    s"the renewal loop must survive one transient store failure, renewClaim was called $seen times"
+                                )
+                                end for
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A slow execution in a batch does not hold up the rest of it.
+          *
+          * One poll claims up to `batchSize` executions and then runs them one after another, awaiting each before starting the next.
+          * Everything past the first sits claimed with no renewal fiber until its turn comes, so a long first item lets the others'
+          * leases lapse while they wait. With a second engine that means those rows are reclaimed and re-executed, repeating their
+          * side effects; on the reference store it feeds the expired-self-claim starvation instead. When the worker finally reaches a
+          * lapsed item, the refused renewal makes it skip the item WITHOUT releasing the claim.
+          *
+          * **Two flows, and the difference between them is the instrument.** Giving both executions the SAME flow, whose only body
+          * takes from one empty channel, blocks the "fast" execution exactly as the slow one is blocked, and no engine, serial or
+          * concurrent, could finish it: the leaf would then be red for its instrument rather than for the property it names. One
+          * flow blocks on the gate, the other cannot block at all.
+          *
+          * **Both premises are asserted, because either one silently voids the result.** The property is head-of-line blocking
+          * WITHIN one claimed batch, so a setup whose two executions are claimed by two different polls proves nothing: it would pass
+          * on a serial walk too. The store therefore records the widest batch it ever handed back, and the leaf asserts that batch
+          * reached two, which is what makes "in a batch" true rather than assumed. The batch spans two workflows on purpose, since
+          * one poll claims across every registered workflow, and both rows exist before the engine does so the first poll cannot see
+          * one of them and come back for the other. The second premise is that the slow execution really is mid-step when the fast
+          * one finishes; without it the leaf would pass on an engine that simply ran them in sequence, quickly.
+          */
+        "a slow execution in a batch does not hold up the others" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    Channel.init[Unit](1).map { gate =>
+                        AtomicInt.init(0).map { widestBatch =>
+                            val store = new DelegatingStore(plain):
+                                override def claimReady(
+                                    served: Set[(Flow.Id.Workflow, String)],
+                                    executorId: Flow.Id.Executor,
+                                    claimLease: Duration,
+                                    limit: Int,
+                                    timeout: Duration
+                                )(using Frame): Seq[FlowStore.Claimed] < (Async & Abort[FlowStoreException]) =
+                                    super.claimReady(served, executorId, claimLease, limit, timeout).map { batch =>
+                                        widestBatch.updateAndGet(_ max batch.size).andThen(batch)
+                                    }
+                            val slowId = Flow.Id.Workflow("batched-slow")
+                            val fastId = Flow.Id.Workflow("batched-fast")
+                            val slowFlow = Flow.init("batched-slow")
+                                .output("done") { _ =>
+                                    val body: String < Async = Abort.run[Closed](gate.take).unit.andThen("blocked")
+                                    body
+                                }
+                            val fastFlow = Flow.init("batched-fast")
+                                .output("done") { _ =>
+                                    val body: String < Async = "ok"
+                                    body
+                                }
+                            val config = FlowEngine.Config(
+                                workerCount = 1,
+                                lease = 1.second,
+                                renewEvery = 200.millis,
+                                batchSize = 2,
+                                pollTimeout = 100.millis
+                            )
+                            val slow = Flow.Id.Execution("batched-slow-1")
+                            val fast = Flow.Id.Execution("batched-fast-1")
+                            for
+                                _ <- seedExecution(
+                                    plain,
+                                    slow,
+                                    slowId,
+                                    Flow.Status.Running,
+                                    kyo.internal.WorkflowSchema.structuralHash(slowFlow)
+                                )
+                                _ <- seedExecution(
+                                    plain,
+                                    fast,
+                                    fastId,
+                                    Flow.Status.Running,
+                                    kyo.internal.WorkflowSchema.structuralHash(fastFlow)
+                                )
+                                outcome <- FlowEngine.init(store, config, slowFlow, fastFlow)([v] => (c: v < Async) => c).map { _ =>
+                                    for
+                                        fastDone  <- settle(tc)(plain.getExecution(fast).map(_.exists(_.status.isTerminal)))
+                                        claimed   <- widestBatch.get
+                                        slowState <- plain.getExecution(slow)
+                                        fastState <- plain.getExecution(fast)
+                                    yield (fastDone, claimed, slowState, fastState)
+                                }
+                                _ <- Abort.run[Closed](gate.put(()))
+                            yield
+                                val (fastDone, claimed, slowState, fastState) = outcome
+                                assert(
+                                    claimed >= 2,
+                                    s"the premise is that both executions were claimed in ONE batch; the widest batch was $claimed"
+                                )
+                                assert(
+                                    slowState.exists(!_.status.isTerminal),
+                                    s"the premise is that the first execution is still mid-step, it is ${slowState.map(_.status)}"
+                                )
+                                assert(
+                                    fastDone,
+                                    s"a second execution in the batch must not wait on the first: it is still " +
+                                        s"${fastState.map(_.status)} while the first is blocked"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A compensation that outlives the lease does not strand the execution.
+          *
+          * The store-level leaf for this says a `Compensating` row is unclaimable. This is how a flow reaches that state without any
+          * crash at all: compensation handlers get no timeout of their own, so a handler that runs longer than the lease loses the
+          * claim and is interrupted, leaving the row at `Compensating` with the terminal status never written. Nothing can pick it up
+          * afterwards, so the execution is neither finished nor recoverable and its compensations are half-done. The README documents
+          * the path as Running to Compensating to Failed.
+          *
+          * The lapse comes from `UnrenewedCompensationStore`, because a correct engine renews for as long as the handler runs and a
+          * conforming store honours it: the executor that stops being able to renew is the only shape in which this state exists.
+          */
+        "a compensation that outlives the lease does not strand the execution" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { plain =>
+                    AtomicInt.init(0).map { refusals =>
+                        val store = new UnrenewedCompensationStore(plain, refusals)
+                        val wfId  = Flow.Id.Workflow("slow-comp")
+                        val flow = Flow.init("slow-comp")
+                            .outputCompensated("a")(_ => 1)(_ => Async.sleep(10.minutes))
+                            .output("b") { _ =>
+                                throw new RuntimeException("boom"); ""
+                            }
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 5.seconds,
+                            renewEvery = 1.second,
+                            pollTimeout = 100.millis
+                        )
+                        for
+                            eid <- Scope.run {
+                                FlowEngine.init(store, config, flow).map { engine =>
+                                    for
+                                        handle <- engine.workflows.start(wfId)
+                                        eid = handle.executionId
+                                        _ <- pump(
+                                            tc,
+                                            store,
+                                            eid,
+                                            {
+                                                case _: Flow.Status.Compensating => true
+                                                case s                           => s.isTerminal
+                                            },
+                                            600
+                                        )
+                                        // The refusal is what stops the handler, so the leaf waits for it rather than for a
+                                        // number of rounds: reaching it is the premise that the claim was lost mid-unwind. The
+                                        // engine's scope then closes, because an executor that can no longer renew is an
+                                        // executor that is gone, and one still polling would be racing the rescuer below for a
+                                        // row it has already proven it cannot carry.
+                                        lost <- settle(tc)(refusals.get.map(_ > 0))
+                                        _ = assert(
+                                            lost,
+                                            "the premise is that the unwind lost its claim while its handler was still running"
+                                        )
+                                    yield eid
+                                }
+                            }
+                            _     <- Kyo.foreachDiscard(1 to 200)(_ => tc.advance(100.millis))
+                            state <- store.getExecution(eid)
+                            rescued <- store.claimReady(
+                                Set((wfId, kyo.internal.WorkflowSchema.structuralHash(flow))),
+                                Flow.Id.Executor("rescuer"),
+                                30.seconds,
+                                10,
+                                Duration.Zero
+                            )
+                        yield assert(
+                            state.exists(_.status.isTerminal) || rescued.map(_.state.executionId) == Seq(eid),
+                            s"an execution left mid-unwind must either finish or be claimable by another executor, " +
+                                s"got ${state.map(_.status)} held by ${state.map(_.executor)} until " +
+                                s"${state.map(_.claimExpiry)} and rescuer claimed ${rescued.map(_.state.executionId)}"
+                        )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A compensation that already ran must not run again when a stopped executor's execution is recovered.
+          *
+          * The property that decides whether compensation handlers need to be idempotent or merely re-entrant. Reaching it at all
+          * takes three things: readiness hands a `Compensating` execution back, which is the premise here; a per-handler completion
+          * record lets the resumed unwind tell a handler that already ran from one that did not; and the re-entry takes a resumed
+          * `Compensating` execution back into its unwind rather than replaying it forward.
+          *
+          * The assertion is deliberately closed on the count. Recovery re-runs only the handlers with no recorded completion, and
+          * asserting the count is what stops this passing on either reading of the contract.
+          */
+        "a recovered compensation does not re-run handlers that already ran" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { firstHandler =>
+                    val flow = Flow.init("resumed-unwind")
+                        .outputCompensated("a")(_ => "held")(_ => firstHandler.incrementAndGet.unit)
+                        .output("b") { _ =>
+                            throw new RuntimeException("boom"); ""
+                        }
+                    val theHash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                    val cause   = Flow.Cause.Failure("boom")
+                    for
+                        eid <- Sync.defer(Flow.Id.Execution("resumed-unwind-1"))
+                        now <- Clock.now
+                        // The durable state a stopped executor leaves behind: the forward step ran, the unwind began carrying the
+                        // verdict that started it, and that step's own handler already completed. The seed goes in BEFORE the
+                        // workflow is registered, so the engine serves no version this row could be claimed under and the fixture
+                        // takes the claim without racing a worker for it.
+                        _       <- seedExecution(store, eid, wf1, Flow.Status.Compensating(cause), theHash)
+                        claimed <- seedClaim(store, eid, wf1, theHash)
+                        _ <- claimed.recordProgress[String](
+                            "a",
+                            Maybe("held"),
+                            Flow.Event.StepCompleted(wf1, eid, "a", now)
+                        )
+                        _ <- claimed.appendEvent(Flow.Event.CompensationStarted(wf1, eid, cause, now))
+                        // The per-handler completion, which is what "no recorded completion" reads. It is a progress record of its
+                        // own key rather than an event beside the node's, because the node's own path already carries the forward
+                        // completion and progress is write-once per path.
+                        _ <- claimed.recordProgress(
+                            kyo.internal.FlowInterpreter.compensatedKey("a"),
+                            Flow.Event.NodeCompensated(wf1, eid, "a", now)
+                        )
+                        _         <- claimed.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                        _         <- engine.register(wf1, flow)
+                        recovered <- settle(tc)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                        ran       <- firstHandler.get
+                    yield
+                        assert(recovered, "a compensating execution left by a stopped executor must be recoverable")
+                        assert(ran == 0, "a handler whose completion is already recorded must not run a second time")
+                    end for
+                }
+            }
+        }
+
+        /** An execution that crashed mid-unwind still ends terminal, even when the step that failed would now succeed.
+          *
+          * **The one outcome nobody would choose.** A resumed `Compensating` execution that knows only that it is unwinding, not
+          * what from, has no recovery left but to replay forward and hope the failing step fails again. For a TRANSIENT failure
+          * that is a silent correctness bug rather than a slow path: the step succeeds the second time, the execution
+          * carries on and COMPLETES, with some of its compensations already run and the work they undid still undone. A reservation
+          * released and the order shipped anyway. It also produces `Compensating` to `Completed`, which this module's own README
+          * says cannot happen, so the first symptom is a transition the documentation forbids.
+          *
+          * The leaf asserts the OUTCOME rather than the mechanism: the step is rigged to succeed on its second entry, so a forward
+          * replay would complete the execution and only a re-entry into the unwind can keep it terminal. The counter is a premise,
+          * not the property: it says the rigged step was never re-entered at all.
+          */
+        "an execution resumed mid-unwind does not complete when its failing step would now succeed" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { entries =>
+                    AtomicInt.init(0).map { undone =>
+                        val flow = Flow.init("resumed-verdict")
+                            .outputCompensated("a")(_ => "held")(_ => undone.incrementAndGet.unit)
+                            .output("b") { _ =>
+                                // Fails once and succeeds ever after, which is what a transient failure looks like on the way back.
+                                entries.incrementAndGet.map { n =>
+                                    if n == 1 then throw new RuntimeException("boom") else "recovered"
+                                }
+                            }
+                        val theHash = kyo.internal.WorkflowSchema.structuralHash(flow)
+                        val cause   = Flow.Cause.Failure("boom", Maybe.empty)
+                        for
+                            eid <- Sync.defer(Flow.Id.Execution("resumed-verdict-1"))
+                            now <- Clock.now
+                            // What an executor interrupted mid-unwind leaves: the forward step done, the unwind entered carrying
+                            // the verdict that started it, and no handler recorded yet. Seeded before the workflow is registered,
+                            // so the engine serves no version this row could be claimed under while the fixture writes it.
+                            _       <- seedExecution(store, eid, wf1, Flow.Status.Compensating(cause), theHash)
+                            claimed <- seedClaim(store, eid, wf1, theHash)
+                            _ <- claimed.recordProgress[String](
+                                "a",
+                                Maybe("held"),
+                                Flow.Event.StepCompleted(wf1, eid, "a", now)
+                            )
+                            _      <- claimed.appendEvent(Flow.Event.CompensationStarted(wf1, eid, cause, now))
+                            _      <- claimed.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                            _      <- engine.register(wf1, flow)
+                            status <- pump(tc, store, eid, _.isTerminal, 400)
+                            ran    <- entries.get
+                            undoes <- undone.get
+                        yield
+                            assert(
+                                ran == 0,
+                                s"the premise is that the resumed attempt never replayed forward into the step that failed, it entered it $ran times"
+                            )
+                            assert(
+                                undoes == 1,
+                                s"the handler with no recorded completion must run on the resumed unwind, it ran $undoes times"
+                            )
+                            assert(
+                                status != Flow.Status.Completed,
+                                "an execution that was unwinding must never complete: its compensations have already half run"
+                            )
+                            assert(
+                                status match
+                                    case Flow.Status.Failed(error, _) => error == "boom"
+                                    case _                            => false,
+                                s"it must end on the verdict its interrupted attempt recorded, got $status"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** Two workers of one engine never run the same execution.
+          *
+          * Every worker fiber of an engine shares one executor id, so the store's exclusivity guarantee, which is stated per caller,
+          * has to hold between callers that are indistinguishable to it. Eight executions, two workers, a batch of one: each step
+          * body increments a counter, so a total above eight means an execution was handed to both workers and its side effect ran
+          * twice.
+          */
+        "two workers of one engine never run the same execution" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(0).map { runs =>
+                        val wfId   = Flow.Id.Workflow("shared-workers")
+                        val flow   = Flow.init("shared-workers").output("done")(_ => runs.incrementAndGet)
+                        val config = FlowEngine.Config(workerCount = 2, batchSize = 1, pollTimeout = 100.millis)
+                        FlowEngine.init(store, config, flow).map { engine =>
+                            for
+                                handles <- Kyo.foreach(1 to 8)(_ => engine.workflows.start(wfId))
+                                allDone <- settle(tc) {
+                                    Kyo.foreach(handles)(h => store.getExecution(h.executionId))
+                                        .map(_.count(_.exists(_.status == Flow.Status.Completed)) == 8)
+                                }
+                                total  <- runs.get
+                                states <- Kyo.foreach(handles)(h => store.getExecution(h.executionId))
+                                completed = states.count(_.exists(_.status == Flow.Status.Completed))
+                            yield
+                                assert(allDone, s"every execution should finish, $completed of 8 did")
+                                assert(total == 8, s"no execution may run twice: the step body ran $total times for 8 executions")
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** Two concurrent starts on one explicit execution id produce exactly one execution.
+          *
+          * Reading the execution and then creating it, with nothing making the pair atomic (`FlowEngine.scala:114-125`), leaves the
+          * outcome to scheduling, and the SPI does not say what `createExecution` does for an id that already exists. The suite's
+          * other leaf for this runs the two starts one after the other, so it passes on ordering rather than on a guarantee.
+          *
+          * **The interleaving is forced, not sampled.** A single round of a check-then-act race passes about half the time, on an
+          * idle machine as much as a busy one, which is a coin flip rather than a guarantee. Looping it twenty times is worse than
+          * either, because twenty green rounds report the scheduler's mood and call it evidence.
+          *
+          * So the store holds the first two readers of this id until both have arrived (`RendezvousStore`). Both then read `Absent`,
+          * both create, and the window is open on every run rather than on some of them. The leaf passes only when the read and the
+          * create are atomic, which is what `createExecutionIfAbsent` is for.
+          *
+          * **The premise is asserted before the outcome, and that ordering is the point.** A barrier that fails to engage turns this
+          * leaf back into a sample, and a sample of a race passes about half the time; a `Gate` whose `Closed` is swallowed is
+          * exactly such a barrier, a no-op with nothing saying so. The leaf counts arrivals and fails with "this run measured
+          * nothing" when they are not two, so a green can only mean the read and the create were atomic.
+          *
+          * Note what is deliberately NOT asserted: that the history holds one `Created` event. `createExecution` overwrites the row
+          * and REPLACES the history with a single event (`internal/MemoryFlowStore.scala:135-155`), so a double create leaves exactly
+          * one `Created` too, and asserting it would look like coverage while detecting nothing.
+          *
+          * Both halves matter, because a second `createExecution` on a live id does not merely duplicate: it resets the row and the
+          * history, which the store's own suite pins separately.
+          */
+        "two concurrent starts on the same execution id yield exactly one execution" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { plain =>
+                    val wfId = Flow.Id.Workflow("dup-start")
+                    val eid  = Flow.Id.Execution("dup-start-1")
+                    val flow = Flow.init("dup-start").output("done")(_ => "ok")
+                    Latch.init(2).map { barrier =>
+                        AtomicInt.init(2).map { rendezvous =>
+                            AtomicInt.init(0).map { arrived =>
+                                AtomicInt.init(0).map { absent =>
+                                    val store = new RendezvousStore(plain, eid, barrier, rendezvous, arrived, absent)
+                                    FlowEngine.init(store, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map {
+                                        engine =>
+                                            for
+                                                pair <- Async.zip(
+                                                    Abort.run[Throwable](engine.workflows.start(wfId, eid)),
+                                                    Abort.run[Throwable](engine.workflows.start(wfId, eid))
+                                                )
+                                                wins = Seq(pair._1, pair._2).count(_.isSuccess)
+                                                both      <- arrived.get
+                                                sawAbsent <- absent.get
+                                            yield
+                                                assert(
+                                                    both == 2 && sawAbsent == 2,
+                                                    s"the premise is that both reads complete, and both see nothing, before either " +
+                                                        s"write: $both reached the rendezvous and $sawAbsent read Absent, so this run " +
+                                                        "measured nothing and the result below is not evidence"
+                                                )
+                                                assert(
+                                                    wins == 1,
+                                                    s"exactly one of two concurrent starts on one id may succeed, $wins did"
+                                                )
+                                            end for
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An input whose stored value cannot be read back does not spin the poll loop.
+          *
+          * Readiness for a waiting execution is decided by whether the field is PRESENT, and the interpreter decides whether to carry
+          * on by whether it DECODES. A stored value that no longer decodes, after a type changed or a row was written by an older
+          * version, satisfies the first and fails the second, so the execution is permanently ready and permanently unable to
+          * progress. Each cycle claims it, resumes it, finds no usable input, and releases at once, at full poll speed, writing
+          * several events every time. This is the same shape as the parked-execution spin the group above already guards against.
+          */
+        "an input whose stored value cannot be decoded does not spin the poll loop" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val undecodable = new UndecodableFieldStore(store, "x")
+                    val flow        = Flow.input[Int]("x").output("y")(ctx => ctx.x * 2)
+                    def idle(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+                        Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                    FlowEngine.init(undecodable, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map { engine =>
+                        for
+                            handle <- engine.workflows.start(Flow.Id.Workflow("x"))
+                            eid = handle.executionId
+                            _      <- engine.executions.signal[Int](eid, "x", 7)
+                            _      <- idle
+                            first  <- store.getHistory(eid, Maybe.empty, 0)
+                            _      <- idle
+                            second <- store.getHistory(eid, Maybe.empty, 0)
+                        yield assert(
+                            second.events.size == first.events.size,
+                            s"an execution that cannot progress must not be re-claimed on every poll: " +
+                                s"history grew from ${first.events.size} to ${second.events.size}"
+                        )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A fan-out asked to run concurrently does not run one item at a time.
+          *
+          * `foreach` takes a `concurrency` parameter, hashes it into the structural hash, and renders it in the generated diagrams,
+          * so a reader of either is told the items run in parallel. The interpreter folds over the collection sequentially and never
+          * reads the value. Either the parameter does something or it should not be offered.
+          */
+        "a foreach with concurrency runs more than one item at a time" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { inFlight =>
+                    AtomicInt.init(0).map { maxSeen =>
+                        val flow = Flow.init("fanout")
+                            .foreach[
+                                "items",
+                                Int,
+                                Int,
+                                Async
+                            ]("items", concurrency = 4)(_ => Seq(1, 2, 3, 4)) { item =>
+                                for
+                                    n <- inFlight.incrementAndGet
+                                    _ <- maxSeen.updateAndGet(m => if n > m then n else m)
+                                    _ <- Async.sleep(10.millis)
+                                    _ <- inFlight.decrementAndGet
+                                yield item
+                            }
+                        for
+                            _      <- engine.register(wf1, flow)([v] => (c: v < Async) => c)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            status <- pump(tc, store, eid, _.isTerminal, 400)
+                            peak   <- maxSeen.get
+                        yield
+                            assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                            assert(peak > 1, s"a foreach with concurrency 4 must overlap its items, peak in flight was $peak")
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A panic on the resume path is reported somewhere, rather than looping in silence.
+          *
+          * The handler that records an execution's failure is `Abort.recover`, which handles failures and re-raises panics, and the
+          * outcome of the fiber it wraps is discarded. So a deterministic panic before that handler leaves the execution at Running:
+          * it is reclaimed, panics again, and repeats forever, adding a claim/resume/release triplet to the history each time, while
+          * `health` shows nothing and no status ever changes. Either outcome is acceptable to this leaf, failing the execution or
+          * recording it on health; silence with unbounded history growth is not.
+          */
+        "a panic on the resume path is not swallowed forever" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    val panicking = new PanickingResumeStore(store)
+                    val flow      = Flow.init("panics").output("done")(_ => "ok")
+                    FlowEngine.init(panicking, FlowEngine.Config(workerCount = 1, pollTimeout = 100.millis), flow).map { engine =>
+                        for
+                            handle <- engine.workflows.start(Flow.Id.Workflow("panics"))
+                            eid = handle.executionId
+                            // Deliberately a short window. The defect is an unbounded loop, so the leaf pays for every round it
+                            // watches: a hundred rounds of it produced over a quarter of a million history events, which is more
+                            // than a single-threaded runtime survives. A handful of rounds already shows the loop turning without
+                            // the status moving or the health signal registering, which is the whole claim.
+                            noticed <- settle(tc, maxRounds = 5) {
+                                store.getExecution(eid).map(_.exists(_.status.isTerminal)).map {
+                                    case true  => true
+                                    case false => engine.health.map(_.pollFailures > 0)
+                                }
+                            }
+                            state   <- store.getExecution(eid)
+                            health  <- engine.health
+                            history <- store.getHistory(eid, Maybe.empty, 0)
+                        yield assert(
+                            noticed,
+                            s"a repeating panic must reach a status or the health signal, got ${state.map(_.status)}, " +
+                                s"${health.pollFailures} recorded failures, and ${history.events.length} history events"
+                        )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** Two nodes sharing a name are refused at registration, because no outcome of accepting them is defensible.
+          *
+          * Replay decides what is already done from the set of NAMES with a completion event, so two nodes sharing a name share one
+          * marker: the first one's completion makes the second look already done, and after any suspension the second is skipped
+          * forever. They share one field too, so the second's result overwrites the first's. Neither node is addressable, and there
+          * is no contract under which "both run" and "the record is readable" are true at once: whichever way the tie is broken, one
+          * of the two nodes does not mean what it says. `FlowLint` detects this and `Flow.lint` reports it, but a registration that
+          * does not ask accepts the flow and lets the corruption stay silent. Refusing the definition is the only answer that leaves
+          * nothing ambiguous.
+          */
+        "two nodes sharing a name are refused at registration" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("dup-names")
+                    .step("dup")(_ => ())
+                    .input[String]("gate")
+                    .step("dup")(_ => ())
+                    .output("done")(_ => "ok")
+                Abort.run[FlowException](engine.register(wf1, flow)).map { res =>
+                    assert(
+                        res.isFailure,
+                        "two nodes sharing a name cannot both be addressable, so registration must refuse the definition " +
+                            s"rather than accept one whose second node is skipped forever, got $res"
+                    )
+                }
+            }
+        }
+
+        /** The race exemption's boundary: a race's shared name is exempt only WITHIN the race's branches.
+          *
+          * The lint exempts a name shared by a race's branches because the union result type forces the sharing. It does not
+          * exempt the same name written by a node OUTSIDE the race: with the field already present when the race replays,
+          * both branches skip-complete on it instantly and neither body ever runs, a dead race accepted at registration.
+          * The exemption is only-among-race-branches, so a share that reaches outside them is refused.
+          */
+        "a race's shared name also written outside the race is refused at registration" in {
+            withEngine { (engine, store, tc) =>
+                val left  = Flow.init("outside-share").output("answer")(_ => "left")
+                val right = Flow.init("outside-share").output("answer")(_ => "right")
+                val flow  = Flow.init("outside-share").output("answer")(_ => "pre").andThen(Flow.race(left, right))
+                Abort.run[FlowException](engine.register(Flow.Id.Workflow("outside-share"), flow)).map { res =>
+                    assert(
+                        res.isFailure,
+                        "a name written both outside a race and by its branches makes the race dead on replay " +
+                            "(both branches skip on the pre-existing field), and registration must refuse it"
+                    )
+                }
+            }
+        }
+
+        /** A name both written and read is a written name, and the sequential read-write share is refused.
+          *
+          * `input("x") ... output("x")`: the output's write lands on the path the input's field already occupies, so the
+          * output forever skips on the input's value and the record's `x` silently aliases the raw input, the corruption
+          * class the leaf above documents for two writers. "Reads are exempt" must not un-refuse this: the exemption is for
+          * names ONLY read.
+          */
+        "an output named after an input is refused at registration" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("read-write-share").input[String]("x").output("x")(ctx => ctx.x)
+                Abort.run[FlowException](engine.register(Flow.Id.Workflow("read-write-share"), flow)).map { res =>
+                    assert(
+                        res.isFailure,
+                        "an output named after an input forever skips on the input's field and silently aliases it; " +
+                            "registration must refuse the share"
+                    )
+                }
+            }
+        }
+
+        /** An in-flight execution can be signalled through the definition it was started under.
+          *
+          * Signals are resolved against the CURRENTLY registered definition, not against the one the execution is running. So
+          * replacing a definition strands every execution already waiting on an input that the new one renamed: the value can never
+          * be delivered, and the execution waits forever for something no caller is able to send. The reverse is true too, an input
+          * only the new definition declares would be accepted for an execution whose own definition has no such field.
+          *
+          * Note the execution here is NOT parked, and cannot be: an execution waiting for an input is not ready until its field
+          * arrives, so nothing claims it and nothing notices the version changed. It sits in the old definition's world while the
+          * only method that could feed it looks exclusively at the new one.
+          */
+        "an in-flight execution can be signalled through the definition it was started under" in {
+            withEngine { (engine, store, tc) =>
+                val v1 = Flow.init("renamed-input").input[String]("approval").output("done")(ctx => ctx.approval)
+                val v2 = Flow.init("renamed-input").input[String]("signoff").output("done")(ctx => ctx.signoff)
+                for
+                    _      <- engine.register(wf1, v1)
+                    v1Info <- store.getWorkflow(wf1)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _         <- pumpState(tc, store, eid, waitingFor("approval"))
+                    _         <- engine.register(wf1, v2)
+                    delivered <- Abort.run[Throwable](engine.executions.signal[String](eid, "approval", "yes"))
+                yield assert(
+                    delivered.isSuccess,
+                    s"an input the execution's own definition declares must be deliverable to it, got $delivered"
+                )
+                end for
+            }
+        }
+
+        /** A loop that has finished one iteration of many is not reported as a completed node.
+          *
+          * Deciding a loop is done with `completedSteps.exists(IterationName.isIteration(_, name))` lets ANY recorded iteration mark
+          * the whole loop `Completed`, so a scheduled loop on iteration 1 of 50 is drawn as finished, in `describe` and in the
+          * rendered diagram both.
+          *
+          * The error compounds rather than staying local. `assignStatuses` walks the nodes in order and gives the FIRST node that
+          * is neither completed nor suspended the `Running` status. A loop wrongly marked `Completed` is skipped, so `Running`
+          * lands on the node after it, which has not started and may never start. The operator sees a finished loop and a running
+          * downstream step, and the truth is a mid-flight loop and a downstream step that has not been reached.
+          *
+          * The same rule applied to `ForEach` is merely dead rather than wrong: a fan-out records one event under its own name,
+          * never `name#n`, so nothing ever matches.
+          */
+        "a loop that has completed one iteration is not shown as a completed node" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("progress-loop")
+                    .loopOn("acc", Schedule.fixed(100.millis).repeat(1000), 0) { (state: Int, ctx) =>
+                        if state >= 50 then Loop.done(state)
+                        else Loop.continue(state + 1)
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    ran <- settle(tc, maxRounds = 200)(
+                        store.getHistory(eid, Maybe.empty, 0).map(_.events.exists {
+                            case Flow.Event.StepCompleted(_, _, n, _) => n == kyo.internal.IterationName.step("acc", 0)
+                            case _                                    => false
+                        })
+                    )
+                    state  <- store.getExecution(eid)
+                    detail <- engine.executions.describe(eid)
+                yield
+                    assert(ran, "the loop should have recorded its first iteration")
+                    assert(
+                        !state.exists(_.status.isTerminal),
+                        s"the loop needs 50 iterations and must still be running, got ${state.map(_.status)}"
+                    )
+                    val node = detail.progress.nodeByName("acc")
+                    assert(
+                        node.exists(_.status != FlowEngine.Progress.NodeStatus.Completed),
+                        s"a loop on its first of fifty iterations must not be reported completed, got ${node.map(_.status)}"
+                    )
+                end for
+            }
+        }
+
+        /** `describe` reports the execution's own definition, not whichever one is registered now.
+          *
+          * Resolving the definition with `defs.use(_.get(state.flowId))`, the CURRENTLY registered one, and building both halves of
+          * the answer from it, the `inputs` list and `Progress.build(defn.flow, ...)`, describes every in-flight execution against a
+          * flow it is not running once a redeployment has happened.
+          *
+          * This is the same version-blindness as the signal leaf above, in a surface where it does more damage. `describe` is the
+          * operator's primary diagnostic, the thing reached for when an execution is stuck, and here it is stuck precisely BECAUSE
+          * the definition changed. Answering with the new flow's input names leaves the input the execution is actually waiting on
+          * out of the list, and rendering the new flow's node graph with the old execution's completed events mapped onto it is a
+          * progress diagram of a flow that never ran. An operator reading it concludes the execution is waiting for something nobody
+          * can send, which is true, but the reason is invisible and the evidence points at the wrong flow.
+          *
+          * Note the execution is NOT parked and cannot be: it waits on an input, so it is never ready, so nothing claims it and
+          * nothing notices the version changed.
+          */
+        "describe reports the inputs of the definition the execution was started under" in {
+            withEngine { (engine, store, tc) =>
+                val v1 = Flow.init("renamed-input").input[String]("approval").output("done")(ctx => ctx.approval)
+                val v2 = Flow.init("renamed-input").input[String]("signoff").output("done")(ctx => ctx.signoff)
+                for
+                    _      <- engine.register(wf1, v1)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _       <- pumpState(tc, store, eid, waitingFor("approval"))
+                    _       <- engine.register(wf1, v2)
+                    detail  <- engine.executions.describe(eid)
+                    diagram <- engine.executions.diagram(eid)
+                yield
+                    val names = detail.inputs.map(_.name)
+                    assert(
+                        names.contains("approval"),
+                        s"describe must report the input this execution is actually waiting on, got $names"
+                    )
+                    // Same lookup, same defect, different surface. Asserted in one leaf rather than two because one fix closes
+                    // both: a fix that keyed describe by the execution's own version but left diagram alone would be caught here.
+                    assert(
+                        diagram.contains("approval"),
+                        s"the execution's diagram must render the flow it is running, and it does not mention approval: $diagram"
+                    )
+                end for
+            }
+        }
+
+        /** A fan-out's declared concurrency shows up as elapsed time.
+          *
+          * The companion to the in-flight count: four items that each sleep a second finish in about a second when they overlap and
+          * about four when they do not, and virtual time makes that exact rather than a benchmark. Asserting both shapes is what
+          * distinguishes "concurrency does something" from "the counter happened to move".
+          */
+        "a foreach's declared concurrency shows up as elapsed time" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("timed-fanout")
+                    .foreach("items", concurrency = 4)(_ => Seq(1, 2, 3, 4)) { item =>
+                        val body: Int < Async = Async.sleep(1.second).andThen(item)
+                        body
+                    }
+                for
+                    _      <- engine.register(wf1, flow)([v] => (c: v < Async) => c)
+                    before <- Clock.now
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status <- pump(tc, store, eid, _.isTerminal, 2000)
+                    after  <- Clock.now
+                yield
+                    assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                    val elapsed = after - before
+                    assert(
+                        elapsed < 3.seconds,
+                        s"four one-second items at concurrency 4 should overlap, they took $elapsed"
+                    )
+                end for
+            }
+        }
+
+        /** A signal that arrives after the execution finished is refused, not absorbed.
+          *
+          * The race a caller cannot avoid: an approval sent at the moment the execution completes on its own. Accepting it would
+          * write a field into a terminal execution that nothing will ever read, and would tell the caller their value was delivered
+          * when it had no effect. The refusal has to be visible, because "delivered" and "arrived too late" are different answers
+          * for whoever sent it.
+          */
+        "a signal to a finished execution is refused" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("signal-after").input[String]("gate").output("done")(ctx => ctx.gate)
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- pumpState(tc, store, eid, waitingFor("gate"))
+                    _      <- engine.executions.signal[String](eid, "gate", "yes")
+                    status <- pump(tc, store, eid, _.isTerminal, 400)
+                    late   <- Abort.run[Throwable](engine.executions.signal[String](eid, "gate", "too late"))
+                    value  <- store.getField[String](eid, "gate")
+                yield
+                    assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                    assert(!late.isSuccess, s"a signal to a finished execution must be refused, got $late")
+                    assert(value == Present("yes"), s"the late value must not overwrite the delivered one, got $value")
+                end for
+            }
+        }
+
+        /** A wedged execution is findable by an operator.
+          *
+          * Where no recovery path reaches a stranded compensating execution, the observability path is the only thing standing
+          * between an operator and an execution that has silently stopped existing as far as the engine is concerned. If searching
+          * by status cannot even list it, nobody learns it is there.
+          */
+        "an execution stuck mid-unwind can be found by searching for its status" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("findable").output("done")(_ => "ok")
+                for
+                    _ <- engine.register(wf1, flow)
+                    eid = Flow.Id.Execution("stuck-compensating")
+                    _     <- seedExecution(store, eid, wf1, Flow.Status.Compensating(Flow.Cause.Failure("boom")), "")
+                    found <- engine.executions.search(filter = Maybe(FlowStore.ExecutionFilter.Compensating))
+                yield assert(
+                    found.items.exists(_.executionId == eid),
+                    s"an operator must be able to find a compensating execution, search returned " +
+                        s"${found.items.map(_.executionId)}"
+                )
+                end for
+            }
+        }
+
+        /** A failed step is identifiable from the history alone.
+          *
+          * The status carries one message for the whole execution, so the only place that records WHICH step failed is the event
+          * stream. An operator triaging a failure, or any tool built over the HTTP surface, reads the history: if the failure event
+          * does not name the step, the answer to "where did this stop" is not recoverable from durable state at all.
+          */
+        "a failed step is identifiable from the history alone" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("which-step")
+                    .step("first")(_ => ())
+                    .output("second") { _ =>
+                        throw new RuntimeException("boom"); ""
+                    }
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status  <- pump(tc, store, eid, _.isTerminal, 400)
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    assert(status.isTerminal, s"the execution should have failed, got $status")
+                    val started    = history.events.collect { case Flow.Event.StepStarted(_, _, name, _, _) => name }
+                    val completed  = history.events.collect { case Flow.Event.StepCompleted(_, _, name, _) => name }
+                    val unfinished = started.filterNot(completed.contains)
+                    assert(
+                        unfinished.contains("second"),
+                        s"the history must show which step did not finish, started=$started completed=$completed"
+                    )
+                end for
+            }
+        }
+
+        /** Bookkeeping does not outweigh the work in an execution's history.
+          *
+          * Every claim writes `ExecutionClaimed`, `ExecutionResumed`, and `ExecutionReleased` around whatever the execution actually
+          * did. For a flow that suspends often, or for any execution reclaimed repeatedly, those three can outnumber the events that
+          * describe the work, and the history is the audit trail and the replay input at once. This leaf keeps the ratio honest for a
+          * simple flow, so a change that adds another bookkeeping write per cycle is visible.
+          */
+        "bookkeeping events do not outnumber the work in a simple execution" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("ratio")
+                    .step("one")(_ => ())
+                    .step("two")(_ => ())
+                    .output("done")(_ => "ok")
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _       <- pump(tc, store, eid, _.isTerminal, 400)
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    val bookkeeping = history.events.count(e =>
+                        e.kind == Flow.EventKind.ExecutionClaimed ||
+                            e.kind == Flow.EventKind.ExecutionResumed ||
+                            e.kind == Flow.EventKind.ExecutionReleased
+                    )
+                    val work = history.events.count(e =>
+                        e.kind == Flow.EventKind.StepStarted ||
+                            e.kind == Flow.EventKind.StepCompleted
+                    )
+                    assert(
+                        bookkeeping <= work,
+                        s"bookkeeping should not outweigh the work: $bookkeeping bookkeeping events against $work step " +
+                            s"events, in ${history.events.map(_.kind)}"
+                    )
+                end for
+            }
+        }
+
+        /** An engine configured to claim nothing per poll is refused.
+          *
+          * `batchSize = 0` builds an engine whose polls ask the store for zero executions, so it spins forever finding nothing. It is
+          * one of a family of tunings: unchecked, a value that makes the engine inert is indistinguishable at construction from one
+          * that works.
+          */
+        "an engine configured to claim nothing per poll is refused at init" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { store =>
+                    Abort.run[Throwable] {
+                        FlowEngine.init(store, FlowEngine.Config(batchSize = 0))
+                    }.map { result =>
+                        assert(!result.isSuccess, "an engine that claims nothing per poll can never run anything")
+                    }
+                }
+            }
+        }
+
+        /** A negative lease is refused.
+          *
+          * The last of the unchecked tuning values, and the one whose consequence is least obvious: a negative lease makes every
+          * claim expire before it is written, so an execution is claimed and instantly reclaimable, by this engine or any other.
+          */
+        "an engine configured with a negative lease is refused at init" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { store =>
+                    Abort.run[Throwable] {
+                        FlowEngine.init(store, FlowEngine.Config(lease = -1.seconds, renewEvery = -2.seconds))
+                    }.map { result =>
+                        assert(!result.isSuccess, "a negative lease expires before it is written and must not be accepted")
+                    }
+                }
+            }
+        }
+
+        /** A change inside a subflow parks the parent's in-flight executions.
+          *
+          * The engine-level consequence of the hash ignoring subflow internals. The top-level case is already covered: change a
+          * parent's own steps and its in-flight executions park rather than replaying against a definition they were not started
+          * under. Change a CHILD flow's steps and nothing parks, because the parent's hash is unchanged, so the execution replays
+          * against a definition that moved underneath it.
+          */
+        "a change inside a subflow parks the parent's in-flight executions" in {
+            withEngine { (engine, store, tc) =>
+                val childV1 = Flow.input[Int]("a").output("b")(ctx => ctx.a)
+                val childV2 = Flow.input[Int]("a").step("extra")(_ => ()).output("b")(ctx => ctx.a)
+                val parentV1 = Flow.input[Int]("x")
+                    .subflow("sub", childV1)(ctx => "a" ~ ctx.x)
+                    .output("done")(_ => "ok")
+                val parentV2 = Flow.input[Int]("x")
+                    .subflow("sub", childV2)(ctx => "a" ~ ctx.x)
+                    .output("done")(_ => "ok")
+                val v1Hash = kyo.internal.WorkflowSchema.structuralHash(parentV1)
+                for
+                    _ <- engine.register(wf1, parentV2)
+                    eid = Flow.Id.Execution("subflow-changed")
+                    _    <- seedExecution(store, eid, wf1, Flow.Status.Running, v1Hash)
+                    _    <- Kyo.foreachDiscard(1 to 200)(_ => tc.advance(10.millis))
+                    held <- engine.parked(wf1)
+                yield assert(
+                    held.exists(_.executionId == eid),
+                    s"an execution started under the previous subflow must be held, got ${held.map(_.executionId)}"
+                )
+                end for
+            }
+        }
+
+        /** A saga cancelled while it waits still runs its compensations.
+          *
+          * Whether cancelling runs compensations is a contract decision, and writing the terminal status from the caller's own call
+          * answers it differently depending on where the execution happens to be. Cancel while it is actively replaying and the
+          * cancellation arrives as a `FlowException`, so the unwind runs and the handlers fire. Cancel while it is SUSPENDED, which
+          * is the common case for a saga waiting on an approval or a timer, and the row goes straight to a terminal status that is
+          * never claimed again, so no handler ever runs and the reserved resources are held forever.
+          *
+          * **One answer, because cancelling is a REQUEST.** `requestCancel` records the request against the row, readiness hands
+          * that row back whatever it was waiting for, and the attempt that claims it unwinds and writes the terminal status at the
+          * END of the unwind. A parked saga and a running one therefore take the same path to the same place, which is what makes
+          * the answer a contract rather than a scheduling outcome. This leaf asserts the compensating answer, which is the defensible
+          * one for a saga: the whole point of registering a compensation is that the resource is released when the flow does not
+          * complete.
+          */
+        "a saga cancelled while it waits still runs its compensations" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { compensated =>
+                    val flow = Flow.init("cancel-saga")
+                        .outputCompensated("reserved")(_ => "held")(_ => compensated.incrementAndGet.unit)
+                        .input[String]("approval")
+                        .output("done")(ctx => ctx.approval)
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _     <- pumpState(tc, store, eid, waitingFor("approval"))
+                        _     <- engine.executions.cancel(eid)
+                        _     <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(10.millis))
+                        ran   <- compensated.get
+                        state <- store.getExecution(eid)
+                    yield
+                        assert(state.exists(_.status == Flow.Status.Cancelled), s"expected Cancelled, got ${state.map(_.status)}")
+                        assert(
+                            ran == 1,
+                            s"a cancelled saga must release what it reserved, the compensation ran $ran times"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** A sleep whose deadline has not passed is not treated as done.
+          *
+          * The store decides a sleeping execution is ready by comparing its recorded deadline against now, and the engine writes the
+          * completion on resume. A leaf asserting the negative case is what keeps a readiness predicate from being loosened into
+          * "any sleeping execution", which would wake every timer immediately and is the kind of change that passes every other
+          * test in this suite.
+          */
+        "a sleep whose deadline has not passed is not woken" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("still-sleeping").sleep("nap", 1.hour).output("done")(_ => "ok")
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _       <- pumpState(tc, store, eid, sleeping)
+                    _       <- Kyo.foreachDiscard(1 to 100)(_ => tc.advance(1.second))
+                    state   <- store.getExecution(eid)
+                    history <- store.getHistory(eid, Maybe.empty, 0)
+                yield
+                    assert(
+                        state.exists(sleeping),
+                        s"a sleep with an hour to run must still be sleeping after 100 seconds, got ${state.map(_.waits)}"
+                    )
+                    assert(
+                        !history.events.exists(_.kind == Flow.EventKind.SleepCompleted),
+                        "a sleep whose deadline has not passed must not be recorded complete"
+                    )
+                end for
+            }
+        }
+
+        /** Two engines sharing one store never run an execution twice.
+          *
+          * Two engines polling one store is the arrangement the claim lease exists for, and the only one where its guarantees are
+          * observable end to end rather than through durable state a fixture wrote itself. This is the control for any fencing work:
+          * it has to hold before the writes are fenced and after.
+          */
+        "two engines on one store never run an execution twice" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(0).map { runs =>
+                        val wfId = Flow.Id.Workflow("two-engines")
+                        val flow = Flow.init("two-engines").output("done")(_ => runs.incrementAndGet)
+                        val config =
+                            FlowEngine.Config(workerCount = 1, lease = 2.seconds, renewEvery = 500.millis, pollTimeout = 100.millis)
+                        for
+                            e1      <- FlowEngine.init(store, config, flow)
+                            e2      <- FlowEngine.init(store, config, flow)
+                            handles <- Kyo.foreach(1 to 6)(_ => e1.workflows.start(wfId))
+                            allDone <- settle(tc) {
+                                Kyo.foreach(handles)(h => store.getExecution(h.executionId))
+                                    .map(_.count(_.exists(_.status == Flow.Status.Completed)) == 6)
+                            }
+                            total  <- runs.get
+                            states <- Kyo.foreach(handles)(h => store.getExecution(h.executionId))
+                            completed = states.count(_.exists(_.status == Flow.Status.Completed))
+                        yield
+                            assert(allDone, s"every execution should finish, $completed of 6 did")
+                            assert(
+                                total == 6,
+                                s"no execution may run on both engines: the step body ran $total times for 6 executions"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A long step's claim keeps being renewed while it runs.
+          *
+          * The renewal loop is what keeps an executor authorised for the whole of a step, and the deadline advancing is the only
+          * observable that says it is still running. A recovery leaf driven from state a fixture wrote, rather than from a lease
+          * that really lapsed, passes whether or not the renewal loop is alive, so this one watches the deadline directly.
+          */
+        "a long step's claim keeps being renewed" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    Channel.init[Unit](1).map { gate =>
+                        val wfId = Flow.Id.Workflow("long-lease")
+                        val flow = Flow.init("long-lease").output("done") { _ =>
+                            val body: String < Async = Abort.run[Closed](gate.take).unit.andThen("ok")
+                            body
+                        }
+                        val config = FlowEngine.Config(
+                            workerCount = 1,
+                            lease = 2.seconds,
+                            renewEvery = 200.millis,
+                            pollTimeout = 100.millis
+                        )
+                        FlowEngine.init(store, config, flow)([v] => (c: v < Async) => c).map { engine =>
+                            for
+                                handle <- engine.workflows.start(wfId)
+                                eid = handle.executionId
+                                _     <- settle(tc)(store.getExecution(eid).map(_.exists(_.claimExpiry.nonEmpty)))
+                                early <- store.getExecution(eid)
+                                advanced <- settle(tc) {
+                                    store.getExecution(eid).map { s =>
+                                        (s.flatMap(_.claimExpiry), early.flatMap(_.claimExpiry)) match
+                                            case (Present(now), Present(then0)) => then0 < now
+                                            case _                              => false
+                                    }
+                                }
+                                late <- store.getExecution(eid)
+                                _    <- Abort.run[Closed](gate.put(()))
+                            yield
+                                val earlyExpiry = early.flatMap(_.claimExpiry)
+                                val lateExpiry  = late.flatMap(_.claimExpiry)
+                                assert(earlyExpiry.nonEmpty, s"the execution should be claimed while its step runs, got $early")
+                                assert(
+                                    advanced,
+                                    s"the claim deadline must advance while a long step runs, it went from $earlyExpiry to $lateExpiry"
+                                )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** A fan-out's results can be read back, in collection order.
+          *
+          * Two properties in one leaf because the same read establishes both. The ordering half is the regression guard this suite
+          * needs the day `concurrency` starts doing something, since collecting results as they complete rather than as they were
+          * ordered is the obvious way to break it.
+          *
+          * The readability half is what a status-only assertion misses. Persisting a fan-out's results through `onOutput` under
+          * `Tag[Any]` and a `Schema[Seq[Any]]` cast, rather than under the element type the caller declared, stores the values
+          * correctly and in order while leaving no typed read able to match them, because a typed read compares the reader's tag
+          * against the stored one: a caller cannot get their own fan-out results back out of the store.
+          */
+        "a foreach's results can be read back, in collection order" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("ordered")
+                    .foreach("items", concurrency = 4)(_ => Seq(1, 2, 3, 4)) { item =>
+                        val body: Int < Async = Async.sleep((5 - item).millis).andThen(item * 10)
+                        body
+                    }
+                for
+                    _      <- engine.register(wf1, flow)([v] => (c: v < Async) => c)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    status  <- pump(tc, store, eid, _.isTerminal, 400)
+                    asChunk <- store.getField[Chunk[Int]](eid, "items")
+                    asSeq   <- store.getField[Seq[Int]](eid, "items")
+                    all     <- store.getAllFields(eid)
+                yield
+                    assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                    assert(
+                        all.contains("items"),
+                        s"the fan-out's results must be persisted, the stored field count is ${all.size}"
+                    )
+                    val items = asChunk.map(_.toSeq).orElse(asSeq)
+                    assert(
+                        items == Present(Seq(10, 20, 30, 40)),
+                        s"results must be readable and in collection order, got chunk=$asChunk seq=$asSeq " +
+                            s"while the raw stored value is ${all.get("items").map(_.value)}"
+                    )
+                end for
+            }
+        }
+
+        /** A GUARD for the regression the leaf above invites.
+          *
+          * Persisting a `foreach` node under `Tag[Any]` with a `Schema[Seq[Any]]` cast leaves no typed read able to match it, and
+          * the obvious fix is to persist under the element type's real evidence. Done alone, that fix breaks something no other leaf
+          * watches: `WorkflowSchema` builds the schema's `byName` entry for a `ForEach` node under `Tag[Any]` with a `Seq` schema
+          * too, and replay rebuilds an execution's record by matching stored fields against those entries. Change one side and the
+          * tags stop agreeing, so `rebuildRecord` silently drops the field, and a resumed execution's downstream nodes stop seeing
+          * results that are sitting in the store.
+          *
+          * The leaf above cannot detect that, because it reads through `store.getField` rather than through a resume. This one
+          * forces the resume: the fan-out completes, the execution suspends on an input, and only after the signal does a
+          * downstream node read the results out of the rebuilt record. If it goes red, the write side moved without the schema
+          * entry.
+          */
+        "a foreach's results survive a resume and reach a downstream node" in {
+            withEngine { (engine, store, tc) =>
+                val flow = Flow.init("foreach-resume")
+                    .foreach("items")(_ => Seq(1, 2, 3))(item => item * 10)
+                    .input[String]("gate")
+                    .output("total")(ctx => ctx.items.foldLeft(0)(_ + _))
+                for
+                    _      <- engine.register(wf1, flow)
+                    handle <- engine.workflows.start(wf1)
+                    eid = handle.executionId
+                    _      <- pumpState(tc, store, eid, waitingFor("gate"))
+                    _      <- engine.executions.signal[String](eid, "gate", "go")
+                    status <- pump(tc, store, eid, _.isTerminal, 400)
+                    total  <- store.getField[Int](eid, "total")
+                yield
+                    assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                    assert(
+                        total == Present(60),
+                        s"a resumed execution's downstream node must still see the fan-out's results, got $total"
+                    )
+                end for
+            }
+        }
+
+        /** A store failure the store itself marked retryable does not destroy the execution.
+          *
+          * `FlowStoreException.Retryable` is the marker a store puts on a failure its backend classifies as transient, a deadlock or
+          * a dropped connection, so the engine can tell "try again" from "this will fail identically forever" without knowing what a
+          * backend's error codes mean. An engine that does not consult it routes every store failure on the resume path to the
+          * handler that writes terminal `Failed`, which cannot be reverted, so one transient blip destroys a durable execution in an
+          * engine whose whole purpose is surviving transient failure.
+          */
+        "a retryable store failure does not permanently fail the execution" in {
+            Clock.withTimeControl { tc =>
+                FlowStore.initMemory.map { store =>
+                    AtomicInt.init(1).map { blips =>
+                        val flaky = new TransientFieldReadStore(store, blips)
+                        val flow  = Flow.init("transient").output("done")(_ => "ok")
+                        // A short lease, because an attempt that could not reach the store leaves the claim to expire rather than
+                        // releasing it: an ending that never reached a verdict must not bless its ledger as a finished statement.
+                        val config = FlowEngine.Config(workerCount = 1, lease = 1.second, renewEvery = 500.millis, pollTimeout = 100.millis)
+                        FlowEngine.init(flaky, config, flow).map { engine =>
+                            for
+                                handle <- engine.workflows.start(Flow.Id.Workflow("transient"))
+                                eid = handle.executionId
+                                status <- pump(tc, store, eid, _.isTerminal, 400)
+                            yield assert(
+                                status == Flow.Status.Completed,
+                                s"a transient store failure the store marked retryable must not fail the execution, got $status"
+                            )
+                            end for
+                        }
+                    }
+                }
+            }
+        }
+
+        /** An engine configured with no workers is refused.
+          *
+          * `workerCount = 0` builds an engine that starts nothing, so every execution it is asked to run sits at Running forever and
+          * the only signal is that nothing happens. It belongs with the renewal-interval check as one more tuning that cannot work.
+          */
+        "an engine configured with no workers is refused at init" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { store =>
+                    Abort.run[Throwable] {
+                        FlowEngine.init(store, FlowEngine.Config(workerCount = 0))
+                    }.map { result =>
+                        assert(!result.isSuccess, "an engine with no workers can never run anything, and must not be accepted")
+                    }
+                }
+            }
+        }
+
+        /** An unnamed flow's refusal travels the typed channel.
+          *
+          * The module advertises precise `Abort` union types, "so you can handle exactly the errors each method can produce".
+          * Refusing a flow with an empty name through `Flow.init`'s `require` makes that refusal a thrown
+          * `IllegalArgumentException`, which arrives as a panic no union names; the engine-side guard for a missing `Init` node is
+          * unreachable from the public API, since every public constructor roots one. A refusal the API is right to make still has
+          * to arrive the way the API says errors arrive: as a typed `FlowException` failure a caller can handle, not as an untyped
+          * crash.
+          */
+        "an unnamed flow is refused at init with a typed error" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { store =>
+                    Abort.run[Throwable] {
+                        Sync.defer(Flow.init("").output("y")(_ => 1)).map { unnamed =>
+                            FlowEngine.init(store, FlowEngine.Config(workerCount = 1), unnamed)
+                        }
+                    }.map { result =>
+                        assert(!result.isSuccess, "a flow with no name cannot be registered and must be refused")
+                        val typed = result match
+                            case Result.Failure(_: FlowException) => true
+                            case _                                => false
+                        assert(typed, s"the refusal must arrive as a typed FlowException failure, not a panic, got $result")
+                    }
+                }
+            }
+        }
+
+        /** Cancelling does not append step events after the execution is already cancelled.
+          *
+          * Separable from whether cancel stops the steps: a partial fix that stops new steps but lets the running one finish still
+          * has to keep its events out of a terminal execution's history. Nothing downstream filters them out, so the two rules that
+          * keep them out are both upstream, and both are the store's: a write presented after the attempt ended is refused with the
+          * claim it was presented under, and a status write on the wrong side of the partition is refused WHOLE, its event included.
+          */
+        "cancelling does not append step events after the cancellation" in {
+            withEngine { (engine, store, tc) =>
+                Channel.init[Unit](1).map { gate =>
+                    val flow = Flow.init("cancel-history")
+                        .step[Async]("a")(_ => Abort.run[Closed](gate.take).unit)
+                        .step[Async]("b")(_ => Async.delay(Duration.Zero)(()))
+                        .output("done")(_ => Async.delay(Duration.Zero)("ok"))
+                    for
+                        _      <- engine.register(wf1, flow)([v] => (c: v < Async) => c)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _       <- Kyo.foreachDiscard(1 to 20)(_ => tc.advance(10.millis))
+                        _       <- engine.executions.cancel(eid)
+                        _       <- Abort.run[Closed](gate.put(()))
+                        _       <- Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                        history <- store.getHistory(eid, Maybe.empty, 0)
+                    yield
+                        val kinds       = history.events.map(_.kind)
+                        val cancelledAt = kinds.indexWhere(_ == Flow.EventKind.Cancelled)
+                        val stepsAfter =
+                            if cancelledAt < 0 then Chunk.empty
+                            else
+                                kinds.drop(cancelledAt + 1).filter(k =>
+                                    k == Flow.EventKind.StepStarted || k == Flow.EventKind.StepCompleted
+                                )
+                        assert(cancelledAt >= 0, s"the execution should have been cancelled, history is $kinds")
+                        assert(
+                            stepsAfter.isEmpty,
+                            s"no step event may be appended after the cancellation, got $stepsAfter in $kinds"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** A step's declared failure is not put through the retry schedule.
+          *
+          * `Meta`'s own scaladoc calls `retry` a schedule "for transient failures", and a `FlowDomainException` is the opposite of
+          * one: a charge declined for being over a limit is a decision, and running it three more times re-fires the step's side
+          * effects to reach the same answer. A wrapper that catches every `Throwable` cannot tell the two apart, and the code then
+          * contradicts that promise. The sort is explicit (`internal/StoreInterpreter.scala`'s `isAccident`, which answers true for
+          * a timeout and false for anything the flow declared), and a declared failure goes straight out rather than round the
+          * schedule.
+          */
+        "a step's domain failure is not retried" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { attempts =>
+                    val flow = Flow.init("declines")
+                        .output("charge", retry = Maybe(Schedule.fixed(10.millis).repeat(3))) { _ =>
+                            val body: String < (Sync & Abort[FlowException]) =
+                                attempts.incrementAndGet.andThen(Abort.fail(FlowEngineTest.ChargeDeclined("o1", 100L)))
+                            body
+                        }
+                    for
+                        _      <- engine.register(wf1, flow)
+                        handle <- engine.workflows.start(wf1)
+                        eid = handle.executionId
+                        _     <- pump(tc, store, eid, _.isTerminal, 400)
+                        tries <- attempts.get
+                    yield assert(
+                        tries == 1,
+                        s"a deterministic domain failure must not be retried, the step body ran $tries times"
+                    )
+                    end for
+                }
+            }
+        }
+
+        /** A tuning whose renewal never precedes its lease is refused.
+          *
+          * `renewEvery >= lease` means the claim expires before the first renewal is ever attempted, so every renewal is refused. A
+          * refused renewal interrupts the execution, so any step longer than the lease is interrupted, released, reclaimed and
+          * re-run on a permanent loop that makes no progress and writes several history events per turn. It belongs to the same
+          * family of unusable tunings as zero workers, zero batch size, and negative durations.
+          */
+        "a renewal interval at least as long as the lease is refused at init" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { store =>
+                    Abort.run[Throwable] {
+                        FlowEngine.init(store, FlowEngine.Config(lease = 1.second, renewEvery = 5.seconds))
+                    }.map { result =>
+                        assert(
+                            !result.isSuccess,
+                            "a renewal interval no shorter than the lease can never renew, and must not be accepted"
+                        )
+                    }
+                }
+            }
+        }
+
+        /** A refused tuning arrives typed, and names every setting at fault rather than the first one found.
+          *
+          * The four leaves above ask only that the engine is refused, which a thrown `IllegalArgumentException` would satisfy just
+          * as well. The module advertises precise `Abort` unions "so you can handle exactly the errors each method can produce", and
+          * a refusal the API is right to make still has to arrive the way the API says errors arrive, which is the same property the
+          * unnamed-flow leaf pins for definitions.
+          *
+          * Reporting all of them at once is the other half. A caller fixing one setting per run pays a process start per problem,
+          * and the settings here are exactly the ones a deployment gets wrong together, out of one configuration file.
+          */
+        "a refused tuning names every setting at fault" in {
+            Clock.withTimeControl { _ =>
+                FlowStore.initMemory.map { store =>
+                    Abort.run[FlowInvalidConfigException] {
+                        FlowEngine.init(store, FlowEngine.Config(workerCount = 0, batchSize = 0, lease = -1.seconds))
+                    }.map { result =>
+                        val settings = result match
+                            case Result.Failure(e) => e.problems.map(_.setting).toSet
+                            case _                 => Set.empty[String]
+                        assert(
+                            result.isFailure,
+                            s"the refusal must arrive on the typed channel a caller can handle, got $result"
+                        )
+                        assert(
+                            settings == Set("workerCount", "batchSize", "lease"),
+                            s"every setting at fault must be named, and only those, got $settings"
+                        )
+                    }
+                }
+            }
+        }
+
+        /** Cancelling an execution stops the steps that have not started.
+          *
+          * `cancel`'s own documentation says "In-flight steps complete; no new steps start". Consulting the cancelled flag only
+          * between scheduled-loop iterations and at input nodes leaves the second half unmet for a straight-line flow: every
+          * remaining step runs, side effects included, and only the final status write is suppressed.
+          */
+        "cancelling an execution stops the steps that have not started" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { bRuns =>
+                    Channel.init[Unit](1).map { gate =>
+                        val flow = Flow.init("cancel-midway")
+                            .step[Async]("a")(_ => Abort.run[Closed](gate.take).unit)
+                            .step[Async]("b")(_ => bRuns.incrementAndGet.unit)
+                            .output("done")(_ => Async.delay(Duration.Zero)("ok"))
+                        for
+                            _      <- engine.register(wf1, flow)([v] => (c: v < Async) => c)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            _ <- pump(
+                                tc,
+                                store,
+                                eid,
+                                _ => true
+                            ).andThen(Kyo.foreachDiscard(1 to 20)(_ => tc.advance(10.millis)))
+                            _     <- engine.executions.cancel(eid)
+                            _     <- gate.put(())
+                            _     <- Kyo.foreachDiscard(1 to 50)(_ => tc.advance(10.millis))
+                            after <- bRuns.get
+                        yield assert(
+                            after == 0,
+                            s"a step that had not started when the execution was cancelled must not run, ran $after times"
+                        )
+                        end for
+                    }
+                }
+            }
         }
     }
 
@@ -3208,6 +9605,40 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     // Var starts at 10, adds x=5, so result = 15
                     assert(y.get == 15, s"Expected 15, got ${y.get}")
                 end for
+            }
+        }
+
+        /** A step that allocates a scoped resource completes, and the resource is released.
+          *
+          * The runner's declared result carries `Scope`, so a step body is allowed to acquire one, and a flow whose steps touch a
+          * resource is the reason a runner exists at all. A runner that casts that row away rather than handling it
+          * (`FlowRunner.erased`) leaves the suspension pending inside an execution typed as though it were not, and where the
+          * execution runs then decides whether anything is left to handle it. The other two runner leaves discharge their effect
+          * completely (`Env.run`, `Var.run`) and so never reach this.
+          */
+        "runner handles a scoped resource in step body" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { acquired =>
+                    AtomicInt.init(0).map { released =>
+                        val flow = Flow.init("scoped").output("y") { _ =>
+                            Scope.acquireRelease(acquired.incrementAndGet.andThen("resource"))(_ => released.incrementAndGet.unit)
+                        }
+                        for
+                            _      <- engine.register(wf1, flow)([v] => c => c)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            status <- pump(tc, store, eid, _.isTerminal)
+                            y      <- store.getField[String](eid, "y")
+                            a      <- acquired.get
+                            r      <- released.get
+                        yield
+                            assert(status == Flow.Status.Completed, s"expected Completed, got $status")
+                            assert(y == Present("resource"), s"expected the step's value, got $y")
+                            assert(a == 1, s"expected exactly one acquire, got $a")
+                            assert(r == 1, s"expected the resource to be released, got $r")
+                        end for
+                    }
+                }
             }
         }
     }
@@ -3292,7 +9723,7 @@ class FlowEngineTest extends kyo.test.Test[Any]:
                     _      <- engine.executions.signal[Int](eid, "x", 42)
                     status <- pump(tc, store, eid, _.isTerminal)
                 yield status match
-                    case Flow.Status.Failed(msg) =>
+                    case Flow.Status.Failed(msg, _) =>
                         assert(msg.contains("boom"), s"Error message should contain 'boom', got: '$msg'")
                     case other =>
                         fail(s"Expected Failed containing 'boom' but got $other")
@@ -3302,4 +9733,156 @@ class FlowEngineTest extends kyo.test.Test[Any]:
 
     }
 
+    // =========================================================================
+    // Node compensation
+    // =========================================================================
+    //
+    // `Dispatch` and `LoopNode` register a compensation handler the way `Output` and `Step` do. Without one, work done inside a
+    // dispatch branch or a loop cannot be undone at all, because no interpreter arm has a handler to push for it.
+    //
+    // The fan-out's per-item handler is NOT here. It needs per-item durable identity, and a node-level handler on a fan-out fails on
+    // its own terms: it would receive the node's stored value, which exists only once every item finished, so a fan-out that failed
+    // part-way would hand its handler nothing at the one moment unwinding matters.
+    "node compensation" - {
+
+        /** A dispatch branch that charges is undone when a later step fails.
+          *
+          * The handler is node level, and on a dispatch that is exactly the right level: one branch runs and produces one value, so
+          * the handler receives the record that value is in and undoes what the branch that ran did. The branch that did not run
+          * wrote nothing, so there is no per-branch identity question to answer. What the handler reads to decide is the stored
+          * value itself, which is the whole of what a dispatch records about its choice of work.
+          */
+        "a dispatch branch's work is undone when a later step fails" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { charged =>
+                    AtomicInt.init(0).map { refunded =>
+                        val flow = Flow.init("premium-route")
+                            .output("amount")(_ => 500)
+                            .dispatch[String]("route")
+                            .when(ctx => ctx.amount > 100, name = "premium")(_ => charged.incrementAndGet.andThen("premium-fee"))
+                            .otherwiseCompensated(_ => "no-fee", name = "standard") { ctx =>
+                                if ctx.route == "premium-fee" then refunded.incrementAndGet.unit else ()
+                            }
+                            .step("ship")(_ => throw new RuntimeException("carrier refused"))
+                        for
+                            _      <- engine.register(wf1, flow)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            status <- pump(tc, store, eid, _.isTerminal, 400)
+                            paid   <- charged.get
+                            back   <- refunded.get
+                        yield
+                            val failed = status match
+                                case Flow.Status.Failed(_, _) => true
+                                case _                        => false
+                            assert(paid == 1, s"the premise is that the premium branch ran and charged, it ran $paid time(s)")
+                            assert(failed, s"the premise is that a later step failed the execution, got $status")
+                            assert(
+                                back == 1,
+                                s"a dispatch's handler must undo the branch that ran, and it ran $back time(s)"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A dispatch's handler is registered when its value is replayed rather than computed.
+          *
+          * The half that is easy to get wrong. An execution that suspends after the dispatch and fails after resuming never computes
+          * the branch a second time, because the field is already stored and the node is skipped, so a handler pushed only on the
+          * forward path would silently not exist on the attempt that actually unwinds. The work the branch did is just as done
+          * either way. This is the same rule `output` already follows, pinned here because the dispatch arm is new.
+          */
+        "a dispatch's compensation runs after the execution resumed past it" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { charged =>
+                    AtomicInt.init(0).map { refunded =>
+                        val flow = Flow.init("route-then-wait")
+                            .dispatch[String]("route")
+                            .when(_ => true, name = "premium")(_ => charged.incrementAndGet.andThen("premium-fee"))
+                            .otherwiseCompensated(_ => "no-fee", name = "standard")(_ => refunded.incrementAndGet.unit)
+                            .input[String]("gate")
+                            .step("ship")(_ => throw new RuntimeException("carrier refused"))
+                        for
+                            _      <- engine.register(wf1, flow)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            _      <- pumpState(tc, store, eid, waitingFor("gate"))
+                            _      <- engine.executions.signal[String](eid, "gate", "go")
+                            status <- pump(tc, store, eid, _.isTerminal, 400)
+                            paid   <- charged.get
+                            back   <- refunded.get
+                        yield
+                            assert(
+                                paid == 1,
+                                s"the premise is that the branch ran once, before the suspension and not again after it, and it " +
+                                    s"ran $paid time(s)"
+                            )
+                            assert(status != Flow.Status.Completed, s"the premise is that the step after the resume failed, got $status")
+                            assert(
+                                back == 1,
+                                s"a dispatch whose value was replayed rather than computed must still be undone, and its handler " +
+                                    s"ran $back time(s)"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+
+        /** A loop's handler undoes the value it converged on.
+          *
+          * The loop's handler is node level too, and what it receives is the loop's own result: one accumulated value, meaningful
+          * whenever it exists. It is pushed only once that value exists, which is why a loop that stopped between iterations
+          * registers nothing: there is no result to undo, and a handler handed an absent one could only guess.
+          */
+        "a loop's compensation undoes the value it converged on" in {
+            withEngine { (engine, store, tc) =>
+                AtomicInt.init(0).map { booked =>
+                    AtomicInt.init(0).map { released =>
+                        val flow = Flow.init("book-then-confirm")
+                            .loopCompensated("total") { _ =>
+                                val next: Loop.Outcome[Unit, Int] < Sync =
+                                    booked.incrementAndGet.map(n =>
+                                        if n >= 3 then Loop.done[Unit, Int](n) else Loop.continue[Int]
+                                    )
+                                next
+                            } { ctx =>
+                                released.set(ctx.total)
+                            }
+                            .step("confirm")(_ => throw new RuntimeException("no capacity"))
+                        for
+                            _      <- engine.register(wf1, flow)
+                            handle <- engine.workflows.start(wf1)
+                            eid = handle.executionId
+                            status <- pump(tc, store, eid, _.isTerminal, 400)
+                            runs   <- booked.get
+                            undone <- released.get
+                        yield
+                            assert(runs == 3, s"the premise is that the loop converged after three iterations, it ran $runs")
+                            assert(status != Flow.Status.Completed, s"the premise is that the step after the loop failed, got $status")
+                            assert(
+                                undone == 3,
+                                s"a loop's handler must receive the value the loop converged on, and it was handed $undone"
+                            )
+                        end for
+                    }
+                }
+            }
+        }
+    }
+
 end FlowEngineTest
+
+/** An input type whose encoder raises something encoding never raises on its own.
+  *
+  * Seeding a start encodes each supplied value through its declared input's schema, and the only failures that are an answer ABOUT the
+  * value are the ones encoding itself produces: a wrong type, or a structure the codec refuses. A schema whose write throws an
+  * [[kyo.Interrupted]] stands for everything else that can pass through that call, and there is no other way to put one there: the
+  * schema the builder uses is derived from the declared type, so the throwing one has to BE the declared type's schema.
+  */
+private case class SeedProbe(value: Int) derives CanEqual
+
+private given seedProbeSchema: Schema[SeedProbe] =
+    Schema[Int].transform[SeedProbe](SeedProbe(_))(_ => throw Interrupted(summon[Frame]))

--- a/kyo-flow/shared/src/test/scala/kyo/FlowStoreTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/FlowStoreTest.scala
@@ -18,101 +18,395 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
 
     val lease = 30.seconds
 
+    /** The versions a poll in this suite serves.
+      *
+      * Readiness gates on `(workflowId, hash)`, and every fixture here is created under the empty hash, so serving that pair is what
+      * "this caller can interpret these executions" means for the suite. A store that ignored the gate would pass nothing extra, and one
+      * that got it wrong returns nothing at all.
+      */
+    val served: Set[(Flow.Id.Workflow, String)]     = Set((wf1, ""))
+    val servedBoth: Set[(Flow.Id.Workflow, String)] = Set((wf1, ""), (wf2, ""))
+
+    /** One execution row, in whatever lifecycle the fixture needs it.
+      *
+      * `hash` defaults to the empty one the suite serves, so a fixture that says nothing about versions gets an execution every claim
+      * in this file can take. A leaf about the version gate passes one this caller does not serve.
+      */
     private def mkExecution(
         store: FlowStore,
         eid: Flow.Id.Execution,
         flowId: Flow.Id.Workflow,
-        status: Flow.Status
-    )(using Frame): Unit < Async =
+        status: Flow.Status,
+        hash: String = ""
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
         Clock.now.map { now =>
-            store.createExecution(
+            store.createExecutionIfAbsent(
                 eid,
                 status,
                 Flow.Event.Created(flowId, eid, now),
-                ""
-            )
+                hash,
+                Dict.empty
+            ).unit
         }
 
-    // =========================================================================
-    // I1 — Claim exclusivity
-    // =========================================================================
-    "I1 — claim exclusivity" - {
+    /** Takes the claim on one execution, the way a poll does, for a fixture that needs to write to it.
+      *
+      * Every run-time write is a method on the claim, so a fixture that writes to a row has to hold one first. A poll claims a BATCH,
+      * and a fixture wants one row, so the others go back exactly as they were found: an ending that keeps precisely the rows they
+      * already held, which is the one shape that neither retires a row nor blesses one.
+      */
+    private def claim(
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        executor: Flow.Id.Executor = ex1,
+        servedSet: Set[(Flow.Id.Workflow, String)] = servedBoth,
+        leaseFor: Duration = lease
+    )(using Frame): FlowStore.Claimed < (Async & Abort[FlowStoreException]) =
+        store.claimReady(servedSet, executor, leaseFor, 10, Duration.Zero).map { batch =>
+            Kyo.foreachDiscard(batch.filter(_.state.executionId != eid)) { other =>
+                other.finish(FlowStore.Claimed.Outcome.Suspended(other.state.waits.toChunk.map(_._1).toSet)).unit
+            }.andThen {
+                Maybe.fromOption(batch.find(_.state.executionId == eid)) match
+                    case Present(claimed) => claimed
+                    case Absent =>
+                        Abort.panic(new IllegalStateException(
+                            s"the fixture could not claim ${eid.value}: readiness handed back ${batch.map(_.state.executionId.value)}"
+                        ))
+            }
+        }
 
-        "two concurrent claimReady, 1 ready — exactly one gets it" in {
+    private def waitEvent(flowId: Flow.Id.Workflow, eid: Flow.Id.Execution, path: String, wake: Flow.Wake, now: Instant): Flow.Event =
+        wake match
+            case Flow.Wake.At(instant)   => Flow.Event.SleepStarted(flowId, eid, path, instant, now)
+            case Flow.Wake.OnField(name) => Flow.Event.InputWaiting(flowId, eid, name, now)
+
+    /** Seeds a parked execution the way the system parks one: claim the row, record each branch's wait, end the attempt on them.
+      *
+      * The rows a fixture wants are exactly the rows a suspending ending blesses, so seeding through the public recipe is what makes the
+      * seeded state one a real attempt could have produced. A row written and left under a live claim is a different state entirely, and
+      * readiness reads the difference.
+      */
+    private def mkWaits(
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        flowId: Flow.Id.Workflow,
+        waits: (String, Flow.Wake)*
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        claim(store, eid).map { claimed =>
+            Kyo.foreachDiscard(waits) { (path, wake) =>
+                Clock.nowWith(now => claimed.recordWait(path, wake, waitEvent(flowId, eid, path, wake, now)))
+            }.andThen(claimed.finish(FlowStore.Claimed.Outcome.Suspended(waits.map(_._1).toSet)))
+        }.unit
+
+    private def mkWait(
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        flowId: Flow.Id.Workflow,
+        path: String,
+        wake: Flow.Wake
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        mkWaits(store, eid, flowId, (path, wake))
+
+    /** Records one node's value the way a step does: field, completion event and clearing in one transition, then end the attempt. */
+    private def mkField[V: Tag: Schema](
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        flowId: Flow.Id.Workflow,
+        name: String,
+        value: V
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        claim(store, eid).map { claimed =>
+            Clock.nowWith(ts => claimed.recordProgress[V](name, Maybe(value), Flow.Event.StepCompleted(flowId, eid, name, ts)))
+                .andThen(claimed.finish(FlowStore.Claimed.Outcome.Suspended(claimed.state.waits.toChunk.map(_._1).toSet)))
+        }.unit
+
+    /** Delivers a value to a named input, which is how a field an execution WAITS for arrives. */
+    private def deliver[V: Tag: Schema](
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        flowId: Flow.Id.Workflow,
+        name: String,
+        value: V
+    )(using Frame): FlowStore.SignalOutcome < (Async & Abort[FlowStoreException]) =
+        Clock.nowWith(ts => store.signal[V](eid, name, value, Flow.Event.InputReceived(flowId, eid, name, ts)))
+
+    /** A row carrying nothing but the wait ledger under test, for the equality leaves. */
+    private def stateWith(waits: Dict[String, Flow.Wake]): FlowStore.ExecutionState =
+        FlowStore.ExecutionState(
+            eid1,
+            wf1,
+            Flow.Status.Running,
+            hash = "",
+            created = Instant.Epoch,
+            updated = Instant.Epoch,
+            waits = waits
+        )
+
+    private val sleeping = Flow.Wake.At(Instant.Epoch + 1.hour)
+    private val waiting  = Flow.Wake.OnField("x")
+
+    /** Ends an attempt terminally, which is the only way a claimed execution reaches a terminal status. */
+    private def terminate(
+        store: FlowStore,
+        eid: Flow.Id.Execution,
+        flowId: Flow.Id.Workflow,
+        status: Flow.Status,
+        event: Instant => Flow.Event
+    )(using Frame): Unit < (Async & Abort[FlowStoreException]) =
+        claim(store, eid).map { claimed =>
+            Clock.nowWith(ts => claimed.finish(FlowStore.Claimed.Outcome.Terminal(status, event(ts))))
+        }.unit
+
+    // =========================================================================
+    // I1: claim exclusivity
+    // =========================================================================
+    "I1: claim exclusivity" - {
+
+        "two concurrent claimReady, 1 ready, exactly one gets it" in {
             makeStore.map { store =>
                 for
                     _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
                     r1 <- Async.race(
-                        store.claimReady(Set(wf1), ex1, lease, 10, 1.second),
-                        store.claimReady(Set(wf1), ex2, lease, 10, 1.second)
+                        store.claimReady(served, ex1, lease, 10, 1.second),
+                        store.claimReady(served, ex2, lease, 10, 1.second)
                     )
-                    r2 <- store.claimReady(Set(wf1), ex1, lease, 10, 100.millis)
-                    r3 <- store.claimReady(Set(wf1), ex2, lease, 10, 100.millis)
+                    r2 <- store.claimReady(served, ex1, lease, 10, 100.millis)
+                    r3 <- store.claimReady(served, ex2, lease, 10, 100.millis)
                 yield
                     assert(r1.size == 1, "race winner gets exactly 1")
                     assert(r2.isEmpty || r3.isEmpty, "second caller gets nothing")
             }
         }
 
+        /** Two concurrent polls by the SAME executor must not both be handed one execution.
+          *
+          * I1 says "never returns the same execution to two concurrent callers" without qualifying who the callers are, and the engine
+          * makes this the ordinary case rather than an exotic one: every worker fiber of an engine shares one `executorId`
+          * (`FlowEngine.init` derives a single random id), and the default tuning runs two workers. So two workers of one engine polling
+          * at the same time are two concurrent callers with equal ids, and an execution handed to both is executed twice concurrently.
+          */
+        "two concurrent claimReady from the SAME executor, exactly one gets it" in {
+            makeStore.map { store =>
+                for
+                    _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    pair <- Async.zip(
+                        store.claimReady(served, ex1, lease, 10, Duration.Zero),
+                        store.claimReady(served, ex1, lease, 10, Duration.Zero)
+                    )
+                yield
+                    val handed = (pair._1.map(_.state.executionId) ++ pair._2.map(_.state.executionId)).count(_ == eid1)
+                    assert(
+                        handed <= 1,
+                        s"one execution must not be handed to two concurrent callers sharing an executor id, handed $handed times"
+                    )
+            }
+        }
+
+        /** Two callers BLOCKED in `claimReady`, woken by the same execution, and only one may get it.
+          *
+          * The leaf above runs two `claimReady` calls under `Async.zip` and asserts at most one was handed the row. It cannot tell
+          * the store being atomic from the two calls never having overlapped, and with a ready row and a zero timeout they do not
+          * overlap: `tryOnce` returns without suspending, so the first call finishes before the second starts and `handed <= 1`
+          * passes having measured nothing. A leaf that can pass without the two calls ever overlapping hides a non-atomic store
+          * behind a green.
+          *
+          * **This one forces the overlap without needing to interpose on the store.** Both callers start with NO ready execution
+          * and a real timeout, so both block on the store's wake path; the execution is created while they are both inside
+          * `claimReady`; and the clock is advanced to let the wake and the timeout resolve. Whatever the store does about waking,
+          * both callers were genuinely inside it when the row appeared.
+          *
+          * The premise is asserted first: at least one caller must have been handed the row, or the run says nothing about
+          * exclusivity, it just says nobody was woken.
+          */
+        "two callers blocked in claimReady, one execution appears, exactly one gets it" in {
+            Clock.withTimeControl { tc =>
+                makeStore.map { store =>
+                    for
+                        one    <- Fiber.init(store.claimReady(served, ex1, lease, 10, 2.seconds))
+                        two    <- Fiber.init(store.claimReady(served, ex2, lease, 10, 2.seconds))
+                        _      <- tc.advance(50.millis)
+                        _      <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        _      <- tc.advance(3.seconds)
+                        first  <- one.get
+                        second <- two.get
+                    yield
+                        val handed = (first.map(_.state.executionId) ++ second.map(_.state.executionId)).count(_ == eid1)
+                        assert(
+                            handed >= 1,
+                            "the premise is that the execution reached one of the two blocked callers; neither was woken"
+                        )
+                        assert(
+                            handed == 1,
+                            s"one execution must reach exactly one of two callers blocked inside claimReady, it reached $handed"
+                        )
+                    end for
+                }
+            }
+        }
+
+        /** A wait that came due during the wait is handed over at the deadline, not dropped because time ran out.
+          *
+          * **Nothing writes when a sleep comes due**, which is what separates this from every other way a row becomes
+          * ready. A create, a signal and a cancel request all wake a blocked caller; a `Wake.At` instant simply passes, and so
+          * does a claim's expiry. A caller that answered empty on its deadline without asking one more time would leave such a
+          * row sitting ready until somebody polled again, which is a whole poll cycle of latency on the one path that has no
+          * writer to announce it. The rule the call is held to admits no exception for its last instant: either it hands the row
+          * over or it leaves the row as it found it.
+          *
+          * **The scenario is repeated rather than run once, and that is what makes the failure reliable rather than the leaf
+          * flaky.** Each iteration is deterministic under a correct store, so a correct store answers the row every time; against
+          * one that answers empty on its deadline the result turns on whether the caller had reached its wait before the clock
+          * jumped, which one run samples and twenty do not. The loop is sized to catch that, not to tolerate it.
+          */
+        "a row that came due while a caller waited is handed over at the deadline" in {
+            def once(round: Int)(using Frame): Unit < (Async & Abort[FlowStoreException] & Scope) =
+                Clock.withTimeControl { tc =>
+                    makeStore.map { store =>
+                        for
+                            now <- Clock.now
+                            _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                            // Due one second in, while a caller that starts now is still waiting out its two.
+                            _      <- mkWait(store, eid1, wf1, "timer", Flow.Wake.At(now + 1.second))
+                            caller <- Fiber.init(store.claimReady(served, ex1, lease, 10, 2.seconds))
+                            // A small step first, so the caller reaches its wait while nothing is due yet. Without it the
+                            // jump below lands before the caller has looked once, and it finds the row on its way in
+                            // rather than at the deadline, which is not the moment this leaf is about.
+                            _   <- tc.advance(10.millis)
+                            _   <- tc.advance(3.seconds)
+                            got <- caller.get
+                        yield assert(
+                            got.map(_.state.executionId) == Seq(eid1),
+                            s"round $round: the sleep came due while the caller waited, and nothing writes when one does, so " +
+                                s"the deadline must ask once more rather than answer empty over a ready row, got " +
+                                s"${got.map(_.state.executionId)}"
+                        )
+                        end for
+                    }
+                }
+            Kyo.foreachDiscard(1 to 20)(once).andThen(assert(true))
+        }
+
         "repeated calls with same executor get different executions" in {
             makeStore.map { store =>
                 for
-                    _      <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _      <- mkExecution(store, eid2, wf1, Flow.Status.Running)
-                    batch1 <- store.claimReady(Set(wf1), ex1, lease, 1, 1.second)
-                    batch2 <- store.claimReady(Set(wf1), ex1, lease, 1, 1.second)
+                    _  <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _  <- mkExecution(store, eid2, wf1, Flow.Status.Running)
+                    r1 <- store.claimReady(served, ex1, lease, 1, 1.second)
+                    r2 <- store.claimReady(served, ex1, lease, 1, 1.second)
                 yield
-                    assert(batch1.size == 1)
-                    assert(batch2.size == 1)
-                    assert(batch1.head.executionId != batch2.head.executionId)
+                    assert(r1.size == 1)
+                    assert(r2.size == 1)
+                    assert(r1.head.state.executionId != r2.head.state.executionId)
             }
         }
     }
 
     // =========================================================================
-    // I2 — Atomic status + event
+    // I2: atomic status + event
     // =========================================================================
-    "I2 — atomic status + event" - {
+    "I2: atomic status + event" - {
 
         "updateStatus: getExecution and getHistory both reflect change" in {
             makeStore.map { store =>
+                val cause = Flow.Cause.Failure("boom", Maybe("Domain"))
                 for
-                    _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    now <- Clock.now
-                    _ <- store.updateStatus(
-                        eid1,
-                        Flow.Status.Sleeping("wait", now + 1.hour),
-                        Flow.Event.SleepStarted(wf1, eid1, "wait", now + 1.hour, now)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _ <- claimed.updateStatus(
+                        Flow.Status.Compensating(cause),
+                        Flow.Event.CompensationStarted(wf1, eid1, cause, now)
                     )
                     state   <- store.getExecution(eid1)
-                    history <- store.getHistory(eid1, 100, 0)
+                    history <- store.getHistory(eid1, Maybe(100), 0)
                 yield
                     assert(state.get.status match
-                        case Flow.Status.Sleeping(_, _) => true
-                        case _                          => false)
+                        case Flow.Status.Compensating(_) => true
+                        case _                           => false)
+                    assert(history.events.exists(_.kind == Flow.EventKind.CompensationStarted))
+                end for
+            }
+        }
+
+        /** Recording a wait writes its row and its event together, the same atomicity I2 demands of every transition.
+          *
+          * The rule reaches wider than `updateStatus`: a reader must never see the row without the event or the event without the row.
+          * A store that wrote them separately would let a poll see an execution as ready for a wait no history explains, or hold an
+          * execution against a wait nothing recorded.
+          */
+        "recordWait: getExecution and getHistory both reflect the wait" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    now     <- Clock.now
+                    _       <- mkWait(store, eid1, wf1, "pause", Flow.Wake.At(now + 1.hour))
+                    state   <- store.getExecution(eid1)
+                    history <- store.getHistory(eid1, Maybe(100), 0)
+                yield
+                    assert(
+                        state.get.waits.get("pause").contains(Flow.Wake.At(now + 1.hour)),
+                        s"the row must carry the deadline it was recorded with, got ${state.get.waits}"
+                    )
                     assert(history.events.exists(_.kind == Flow.EventKind.SleepStarted))
+                    assert(
+                        state.get.status == Flow.Status.Running,
+                        s"waiting is not a lifecycle change, got ${state.get.status}"
+                    )
+            }
+        }
+
+        /** A wait re-recorded on a later attempt keeps the deadline it was first given.
+          *
+          * Put-if-absent in shape, and load-bearing rather than a convenience: a replay recomputes a sleep's deadline as `now +
+          * duration`, so a store that overwrote would push the deadline forward on every attempt and turn a finite sleep into one that
+          * never fires.
+          *
+          * Both writes ride ONE claim, because that is the whole of what the store can tell apart: a re-record is a second
+          * `recordWait` on a path that already has a row, and which attempt issued it is not a fact the store holds.
+          */
+        "recordWait leaves an existing row's wake alone" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    first  = now + 1.hour
+                    second = now + 5.hours
+                    _     <- claimed.recordWait("pause", Flow.Wake.At(first), waitEvent(wf1, eid1, "pause", Flow.Wake.At(first), now))
+                    _     <- claimed.recordWait("pause", Flow.Wake.At(second), waitEvent(wf1, eid1, "pause", Flow.Wake.At(second), now))
+                    state <- store.getExecution(eid1)
+                yield assert(
+                    state.get.waits.get("pause").contains(Flow.Wake.At(first)),
+                    s"a re-recorded wait must keep its original deadline of $first, got ${state.get.waits}"
+                )
             }
         }
     }
 
     // =========================================================================
-    // I3 — Atomic field check-and-write
+    // I3: atomic delivery check-and-write
     // =========================================================================
-    "I3 — atomic field check-and-write" - {
+    "I3: atomic delivery check-and-write" - {
 
-        "two concurrent putFieldIfAbsent, same key — exactly one returns true" in {
+        "two concurrent signals, same input, exactly one is Delivered" in {
             makeStore.map { store =>
                 for
                     _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
                     results <- Async.zip(
-                        store.putFieldIfAbsent[Int](eid1, "field1", 1),
-                        store.putFieldIfAbsent[Int](eid1, "field1", 2)
+                        deliver[Int](store, eid1, wf1, "field1", 1),
+                        deliver[Int](store, eid1, wf1, "field1", 2)
                     )
                 yield
                     val (r1, r2) = results
+                    val wrote1   = r1 == FlowStore.SignalOutcome.Delivered
+                    val wrote2   = r2 == FlowStore.SignalOutcome.Delivered
                     assert(
-                        (r1 && !r2) || (!r1 && r2),
+                        (wrote1 && !wrote2) || (!wrote1 && wrote2),
                         s"exactly one should succeed: r1=$r1, r2=$r2"
+                    )
+                    assert(
+                        r1 == FlowStore.SignalOutcome.AlreadyDelivered || r2 == FlowStore.SignalOutcome.AlreadyDelivered,
+                        s"the loser must be told the input already has a value rather than merely told no: r1=$r1, r2=$r2"
                     )
             }
         }
@@ -121,33 +415,33 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _      <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    wrote1 <- store.putFieldIfAbsent[String](eid1, "key", "first")
-                    wrote2 <- store.putFieldIfAbsent[String](eid1, "key", "second")
+                    wrote1 <- deliver[String](store, eid1, wf1, "key", "first")
+                    wrote2 <- deliver[String](store, eid1, wf1, "key", "second")
                     value  <- store.getField[String](eid1, "key")
                 yield
-                    assert(wrote1)
-                    assert(!wrote2)
+                    assert(wrote1 == FlowStore.SignalOutcome.Delivered)
+                    assert(wrote2 == FlowStore.SignalOutcome.AlreadyDelivered)
                     assert(value.get == "first")
             }
         }
     }
 
     // =========================================================================
-    // I4 — Claim lease integrity
+    // I4: claim lease integrity
     // =========================================================================
-    "I4 — claim lease integrity" - {
+    "I4: claim lease integrity" - {
 
         "A expires, B claims, A renewClaim → false" in {
             Clock.withTimeControl { tc =>
                 makeStore.map { store =>
                     for
                         _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                        claimed <- store.claimReady(Set(wf1), ex1, 5.seconds, 10, 1.second)
+                        claimed <- store.claimReady(served, ex1, 5.seconds, 10, 1.second)
                         _ = assert(claimed.size == 1)
                         _        <- tc.advance(10.seconds)
-                        claimedB <- store.claimReady(Set(wf1), ex2, lease, 10, 1.second)
+                        claimedB <- store.claimReady(served, ex2, lease, 10, 1.second)
                         _ = assert(claimedB.size == 1)
-                        renewA <- store.renewClaim(eid1, ex1, lease)
+                        renewA <- claimed.head.renewClaim(lease)
                     yield assert(!renewA, "A should not be able to renew expired claim")
                 }
             }
@@ -157,34 +451,48 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _       <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                    renewed <- store.renewClaim(eid1, ex1, lease)
+                    claimed <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    renewed <- claimed.head.renewClaim(lease)
                 yield assert(renewed)
             }
         }
 
-        "B tries renewClaim on A's valid claim → false" in {
+        /** A renewal presented on a dead generation is refused while the row's claim is live, and the executor id proves nothing.
+          *
+          * A caller that never claimed holds no capability to present, so a non-owner's renewal is unexpressible and the generation is
+          * the only thing left to judge a renewal on. The case staged here is the stronger one, because the two workers of one engine
+          * share an executor id: the same executor claims, finishes, and claims again, and its FIRST handle is refused against a claim
+          * that is active, unexpired, and bears its own name. An implementation that judged a renewal by the executor would accept it
+          * and run the execution twice at once.
+          */
+        "a renewal on a superseded generation → false, even for the same executor" in {
             makeStore.map { store =>
                 for
-                    _      <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _      <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                    renewB <- store.renewClaim(eid1, ex2, lease)
+                    _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    first <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    _ = assert(first.size == 1, "the premise is that the first claim was granted")
+                    _      <- first.head.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                    second <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    _ = assert(second.size == 1, "and that the same executor took the row again")
+                    renewB <- first.head.renewClaim(lease)
                 yield assert(!renewB)
             }
         }
     }
 
     // =========================================================================
-    // I5 — Terminal irreversibility
+    // I5: terminal irreversibility
     // =========================================================================
-    "I5 — terminal irreversibility" - {
+    "I5: terminal irreversibility" - {
 
         "updateStatus on Completed with Running → stays Completed" in {
             makeStore.map { store =>
                 for
-                    now   <- Clock.now
-                    _     <- store.createExecution(eid1, Flow.Status.Completed, Flow.Event.Completed(wf1, eid1, now), "")
-                    _     <- store.updateStatus(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now))
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _     <- claimed.finish(FlowStore.Claimed.Outcome.Terminal(Flow.Status.Completed, Flow.Event.Completed(wf1, eid1, now)))
+                    _     <- claimed.updateStatus(Flow.Status.Running, Flow.Event.Created(wf1, eid1, now))
                     state <- store.getExecution(eid1)
                 yield assert(state.get.status == Flow.Status.Completed)
             }
@@ -193,13 +501,18 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "updateStatus on Failed → stays Failed" in {
             makeStore.map { store =>
                 for
-                    now   <- Clock.now
-                    _     <- store.createExecution(eid1, Flow.Status.Failed("err"), Flow.Event.Failed(wf1, eid1, "err", now), "")
-                    _     <- store.updateStatus(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now))
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _ <- claimed.finish(FlowStore.Claimed.Outcome.Terminal(
+                        Flow.Status.Failed("err"),
+                        Flow.Event.Failed(wf1, eid1, "err", now)
+                    ))
+                    _     <- claimed.updateStatus(Flow.Status.Running, Flow.Event.Created(wf1, eid1, now))
                     state <- store.getExecution(eid1)
                 yield assert(state.get.status match
-                    case Flow.Status.Failed(_) => true
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true
+                    case _                        => false)
             }
         }
 
@@ -207,25 +520,95 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     now     <- Clock.now
-                    _       <- store.updateStatus(eid1, Flow.Status.Completed, Flow.Event.Completed(wf1, eid1, now))
-                    _       <- store.updateStatus(eid2, Flow.Status.Failed("err"), Flow.Event.Failed(wf1, eid2, "err", now))
-                    _       <- store.updateStatus(eid3, Flow.Status.Cancelled, Flow.Event.Cancelled(wf1, eid3, now))
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 100.millis)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Completed)
+                    _       <- mkExecution(store, eid2, wf1, Flow.Status.Failed("err"))
+                    _       <- mkExecution(store, eid3, wf1, Flow.Status.Cancelled)
+                    results <- store.claimReady(served, ex1, lease, 10, 100.millis)
                 yield assert(results.isEmpty)
+            }
+        }
+
+        /** The two status-writing verbs partition the lifecycle, and each refuses the other's side.
+          *
+          * `finish` is the only verb that makes a claim absent and the only one that retires every row, so a terminal status written
+          * through `updateStatus` would be terminal WITHOUT either, leaving a finished execution holding rows and a claim. The refusal
+          * has to leave nothing behind, event included: history is append-only, and a status write that lands its event anyway is how a
+          * refused verdict reaches the surfaces that read history as authoritative.
+          */
+        "updateStatus refuses a terminal status and writes nothing" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _       <- mkWait(store, eid1, wf1, "x", Flow.Wake.OnField("x"))
+                    _       <- deliver[String](store, eid1, wf1, "x", "here")
+                    claimed <- claim(store, eid1)
+                    before  <- store.getHistory(eid1, Maybe.empty, 0)
+                    now     <- Clock.now
+                    outcome <- claimed.updateStatus(Flow.Status.Completed, Flow.Event.Completed(wf1, eid1, now))
+                    state   <- store.getExecution(eid1)
+                    after   <- store.getHistory(eid1, Maybe.empty, 0)
+                yield
+                    assert(
+                        outcome == FlowStore.StatusOutcome.WrongSideOfTerminal,
+                        s"a terminal status belongs to finish, and updateStatus must say so, got $outcome"
+                    )
+                    assert(state.get.status == Flow.Status.Running, s"the refused write must not move the status, got ${state.get.status}")
+                    assert(
+                        after.events.length == before.events.length,
+                        s"a refused write leaves no event behind, history went from ${before.events.length} to ${after.events.length}"
+                    )
+                    assert(
+                        state.get.waits.toChunk.map(_._1).toSet == Set("x"),
+                        s"and it retires nothing, got ${state.get.waits.toChunk.map(_._1).toSet}"
+                    )
+            }
+        }
+
+        "finish refuses a non-terminal status and writes nothing" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _       <- mkWait(store, eid1, wf1, "x", Flow.Wake.OnField("x"))
+                    _       <- deliver[String](store, eid1, wf1, "x", "here")
+                    claimed <- claim(store, eid1)
+                    before  <- store.getHistory(eid1, Maybe.empty, 0)
+                    cause = Flow.Cause.Failure("boom")
+                    now <- Clock.now
+                    outcome <- claimed.finish(FlowStore.Claimed.Outcome.Terminal(
+                        Flow.Status.Compensating(cause),
+                        Flow.Event.CompensationStarted(wf1, eid1, cause, now)
+                    ))
+                    state <- store.getExecution(eid1)
+                    after <- store.getHistory(eid1, Maybe.empty, 0)
+                yield
+                    assert(
+                        outcome == FlowStore.StatusOutcome.WrongSideOfTerminal,
+                        s"a non-terminal status belongs to updateStatus, and finish must say so, got $outcome"
+                    )
+                    assert(state.get.status == Flow.Status.Running, s"the refused write must not move the status, got ${state.get.status}")
+                    assert(
+                        after.events.length == before.events.length,
+                        s"a refused write leaves no event behind, history went from ${before.events.length} to ${after.events.length}"
+                    )
+                    assert(
+                        state.get.waits.toChunk.map(_._1).toSet == Set("x"),
+                        s"it retires nothing, got ${state.get.waits.toChunk.map(_._1).toSet}"
+                    )
+                    assert(state.get.executor.isDefined, "and it does not consume the claim either")
             }
         }
     }
 
     // =========================================================================
-    // I6 — Read-your-writes
+    // I6: read-your-writes
     // =========================================================================
-    "I6 — read-your-writes" - {
+    "I6: read-your-writes" - {
 
-        "putField then getField → returns value" in {
+        "recordProgress then getField → returns value" in {
             makeStore.map { store =>
                 for
                     _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _ <- store.putField[Int](eid1, "step1", 42)
+                    _ <- mkField[Int](store, eid1, wf1, "step1", 42)
                     v <- store.getField[Int](eid1, "step1")
                 yield assert(v.get == 42)
             }
@@ -233,41 +616,49 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
 
         "updateStatus then getExecution → returns new status" in {
             makeStore.map { store =>
+                val cause = Flow.Cause.Failure("boom")
                 for
-                    _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    now   <- Clock.now
-                    _     <- store.updateStatus(eid1, Flow.Status.Completed, Flow.Event.Completed(wf1, eid1, now))
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _ <- claimed.updateStatus(
+                        Flow.Status.Compensating(cause),
+                        Flow.Event.CompensationStarted(wf1, eid1, cause, now)
+                    )
                     state <- store.getExecution(eid1)
-                yield assert(state.get.status == Flow.Status.Completed)
+                yield assert(state.get.status == Flow.Status.Compensating(cause))
+                end for
             }
         }
 
         "appendEvent then getHistory → event appears" in {
             makeStore.map { store =>
                 for
-                    _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    now <- Clock.now
-                    _   <- store.appendEvent(eid1, Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
-                    h   <- store.getHistory(eid1, 100, 0)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
+                    h       <- store.getHistory(eid1, Maybe(100), 0)
                 yield assert(h.events.exists(_.kind == Flow.EventKind.StepStarted))
             }
         }
     }
 
     // =========================================================================
-    // I7 — Event ordering
+    // I7: event ordering
     // =========================================================================
-    "I7 — event ordering" - {
+    "I7: event ordering" - {
 
         "three sequential appendEvent → getHistory returns in order" in {
             makeStore.map { store =>
                 for
-                    _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    now <- Clock.now
-                    _   <- store.appendEvent(eid1, Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
-                    _   <- store.appendEvent(eid1, Flow.Event.StepCompleted(wf1, eid1, "s1", now + 1.second))
-                    _   <- store.appendEvent(eid1, Flow.Event.StepStarted(wf1, eid1, "s2", ex1, now + 2.seconds))
-                    h   <- store.getHistory(eid1, 100, 0)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
+                    _       <- claimed.appendEvent(Flow.Event.StepCompleted(wf1, eid1, "s1", now + 1.second))
+                    _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s2", ex1, now + 2.seconds))
+                    h       <- store.getHistory(eid1, Maybe(100), 0)
                 yield
                     // +1 for the Created event from mkExecution
                     assert(h.events.length == 4)
@@ -279,20 +670,17 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
     }
 
     // =========================================================================
-    // I8 — Readiness correctness
+    // I8: readiness correctness
     // =========================================================================
-    "I8 — readiness correctness" - {
+    "I8: readiness correctness" - {
 
         "Sleeping with until in the future → not returned" in {
             makeStore.map { store =>
                 for
-                    now <- Clock.now
-                    _ <- store.updateStatus(
-                        eid1,
-                        Flow.Status.Sleeping("wait", now + 1.hour),
-                        Flow.Event.SleepStarted(wf1, eid1, "wait", now + 1.hour, now)
-                    )
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 100.millis)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    now     <- Clock.now
+                    _       <- mkWait(store, eid1, wf1, "wait", Flow.Wake.At(now + 1.hour))
+                    results <- store.claimReady(served, ex1, lease, 10, 100.millis)
                 yield assert(results.isEmpty)
             }
         }
@@ -301,15 +689,11 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             Clock.withTimeControl { tc =>
                 makeStore.map { store =>
                     for
-                        now <- Clock.now
-                        _   <- store.createExecution(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "")
-                        _ <- store.updateStatus(
-                            eid1,
-                            Flow.Status.Sleeping("wait", now + 1.second),
-                            Flow.Event.SleepStarted(wf1, eid1, "wait", now + 1.second, now)
-                        )
+                        _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        now     <- Clock.now
+                        _       <- mkWait(store, eid1, wf1, "wait", Flow.Wake.At(now + 1.second))
                         _       <- tc.advance(2.seconds)
-                        results <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
+                        results <- store.claimReady(served, ex1, lease, 10, 1.second)
                     yield assert(results.size == 1)
                 }
             }
@@ -318,13 +702,9 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "WaitingForInput with field absent → not returned" in {
             makeStore.map { store =>
                 for
-                    now <- Clock.now
-                    _ <- store.updateStatus(
-                        eid1,
-                        Flow.Status.WaitingForInput("myInput"),
-                        Flow.Event.Created(wf1, eid1, now)
-                    )
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 100.millis)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _       <- mkWait(store, eid1, wf1, "myInput", Flow.Wake.OnField("myInput"))
+                    results <- store.claimReady(served, ex1, lease, 10, 100.millis)
                 yield assert(results.isEmpty)
             }
         }
@@ -332,16 +712,190 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "WaitingForInput with field present → returned" in {
             makeStore.map { store =>
                 for
-                    now <- Clock.now
-                    _   <- store.createExecution(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "")
-                    _ <- store.updateStatus(
-                        eid1,
-                        Flow.Status.WaitingForInput("myInput"),
-                        Flow.Event.Created(wf1, eid1, now)
-                    )
-                    _       <- store.putField[String](eid1, "myInput", "hello")
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _       <- mkWait(store, eid1, wf1, "myInput", Flow.Wake.OnField("myInput"))
+                    _       <- deliver[String](store, eid1, wf1, "myInput", "hello")
+                    results <- store.claimReady(served, ex1, lease, 10, 1.second)
                 yield assert(results.size == 1)
+            }
+        }
+
+        /** The claim carries the rows the store judged satisfied, so the caller discharges what it was woken for.
+          *
+          * An engine that re-judged the rows against its own clock would make one decision on two clocks: against a store whose clock
+          * runs ahead, readiness returns the execution while the caller finds nothing due, re-parks, and is handed the row again at
+          * full speed until it catches up. Saying which rows were satisfied is what removes the second judgement.
+          */
+        "a claim says which of its rows the store judged satisfied" in {
+            Clock.withTimeControl { tc =>
+                makeStore.map { store =>
+                    for
+                        _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        now <- Clock.now
+                        _ <- mkWaits(
+                            store,
+                            eid1,
+                            wf1,
+                            ("due", Flow.Wake.At(now + 1.second)),
+                            ("later", Flow.Wake.At(now + 1.hour)),
+                            ("input", Flow.Wake.OnField("input"))
+                        )
+                        _       <- tc.advance(2.seconds)
+                        results <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    yield
+                        assert(results.size == 1, s"the due sleep must make it ready, got ${results.size}")
+                        assert(
+                            results.head.satisfied == Set("due"),
+                            s"exactly the rows the store judged satisfied ride the claim, got ${results.head.satisfied}"
+                        )
+                }
+            }
+        }
+
+        /** The version gate stands on its own, outside the disjunction over wait rows and cancel requests.
+          *
+          * An execution nobody serves is not ready for anybody, whatever its rows say, because a caller that cannot resolve the
+          * definition can neither run it nor unwind it while holding a perfectly valid claim. Inside the disjunction the gate leaks
+          * twice, for an execution with no rows and for one with a cancel request, which is why it is stated as a separate clause.
+          */
+        "an execution whose version the caller does not serve → not returned" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    results <- store.claimReady(Set((wf1, "some-other-version")), ex1, lease, 10, 100.millis)
+                yield assert(
+                    results.isEmpty,
+                    s"an execution held for a version this caller does not serve must not be handed over, got $results"
+                )
+            }
+        }
+
+        /** A cancel request overrides every wait row, because a suspended execution nobody claims never runs its handlers.
+          *
+          * Cancelling runs the compensations, and the terminal `Cancelled` is written only when they have run, so an execution parked on
+          * an input nobody will ever deliver has to become claimable the moment somebody asks for it to stop. Without the arm the
+          * request is outstanding forever and the handlers never fire.
+          */
+        "a cancel request makes a parked execution ready whatever it waits for" in {
+            makeStore.map { store =>
+                for
+                    _      <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _      <- mkWait(store, eid1, wf1, "never", Flow.Wake.OnField("never"))
+                    before <- store.claimReady(served, ex1, lease, 10, 100.millis)
+                    _ = assert(before.isEmpty, s"the premise is that an unsatisfied wait holds it, got $before")
+                    outcome <- store.requestCancel(eid1)
+                    after   <- store.claimReady(served, ex1, lease, 10, 100.millis)
+                yield
+                    assert(outcome == FlowStore.CancelOutcome.Accepted, s"the request must be taken, got $outcome")
+                    assert(
+                        after.map(_.state.executionId) == Seq(eid1),
+                        s"a cancel request must make a parked execution claimable, got ${after.map(_.state.executionId)}"
+                    )
+                    assert(after.head.state.cancelRequested, "and the claimed row must carry the request")
+            }
+        }
+
+        /** A satisfied wait that was DISCHARGED does not keep handing the execution back.
+          *
+          * The rows are what readiness reads, so a row that outlives the branch that wrote it keeps the execution permanently ready:
+          * the poll claims it, the replay finds nothing to do, the claim is released, and the next poll claims it again at full speed.
+          * The input kind is the one that matters here, because an input's discharge is the one progress a node records with no value
+          * of its own, so it is the discharge a store is most likely to leave out.
+          */
+        "an execution whose satisfied wait was discharged → not returned" in {
+            makeStore.map { store =>
+                for
+                    _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _     <- mkWait(store, eid1, wf1, "first", Flow.Wake.OnField("first"))
+                    _     <- deliver[String](store, eid1, wf1, "first", "hello")
+                    now   <- Clock.now
+                    ready <- store.claimReady(served, ex1, lease, 10, 100.millis)
+                    _ = assert(ready.size == 1, s"the premise is that the satisfied wait made it ready, got $ready")
+                    // The node consumed the value and went on, which is the transition that clears the row it was waiting on, and
+                    // then the execution waited on something else. Nothing retires the first row here: only the clearing can remove
+                    // it, so a store that left it behind answers the next poll with a satisfied row nobody is waiting on.
+                    _ <- ready.head.recordProgress("first", Flow.Event.InputDischarged(wf1, eid1, "first", now))
+                    _ <- ready.head.recordWait(
+                        "second",
+                        Flow.Wake.OnField("second"),
+                        Flow.Event.InputWaiting(wf1, eid1, "second", now)
+                    )
+                    state <- store.getExecution(eid1)
+                    _ = assert(
+                        !state.get.waits.contains("first"),
+                        s"the discharged row must be gone, got ${state.get.waits}"
+                    )
+                    again <- store.claimReady(served, ex2, lease, 10, 100.millis)
+                yield assert(
+                    again.isEmpty,
+                    s"a discharged wait must not keep the execution ready, it was handed over again as $again"
+                )
+            }
+        }
+
+        /** A claim that is still named and has expired means the last attempt died without ending, so the rows cannot be trusted.
+          *
+          * Rows gate wake-up only when they are a finished attempt's statement of what the execution waits for, and only the transition
+          * that ends an attempt makes a claim absent. Demanding a row's satisfaction here is circular and permanent: the rows can only
+          * be retired by an attempt, and the attempt needs the claim the rule would refuse.
+          */
+        "a claim that expired without ending the attempt → returned regardless of its rows" in {
+            Clock.withTimeControl { tc =>
+                makeStore.map { store =>
+                    for
+                        _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        claimed <- store.claimReady(served, ex1, 5.seconds, 10, Duration.Zero)
+                        _ = assert(claimed.size == 1, "the premise is that an executor took the execution")
+                        // The attempt records a wait nothing will ever satisfy, then dies: no release, no retirement.
+                        now <- Clock.now
+                        _ <- claimed.head.recordWait(
+                            "never",
+                            Flow.Wake.OnField("never"),
+                            Flow.Event.InputWaiting(wf1, eid1, "never", now)
+                        )
+                        _       <- tc.advance(10.seconds)
+                        results <- store.claimReady(served, ex2, lease, 10, Duration.Zero)
+                    yield assert(
+                        results.map(_.state.executionId) == Seq(eid1),
+                        s"an execution whose attempt died mid-flight must be recoverable whatever rows it left, got " +
+                            s"${results.map(_.state.executionId)}"
+                    )
+                }
+            }
+        }
+
+        /** The transition that ends an attempt keeps exactly the rows the execution is still waiting on, and retires the rest.
+          *
+          * A race decided by one branch leaves the losing branch's row behind, and nothing discharged it: the branch was abandoned
+          * rather than satisfied, so no progress write clears it. A row that outlives the branch that wrote it keeps the execution
+          * permanently ready the moment it happens to be satisfiable.
+          */
+        "ending an attempt retires the rows the execution is no longer waiting on" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- store.claimReady(served, ex1, lease, 10, Duration.Zero)
+                    _ = assert(claimed.size == 1, "the premise is that an executor took the execution")
+                    now <- Clock.now
+                    _ <- claimed.head.recordWait(
+                        "loser",
+                        Flow.Wake.OnField("loser"),
+                        Flow.Event.InputWaiting(wf1, eid1, "loser", now)
+                    )
+                    _ <- claimed.head.recordWait(
+                        "winner",
+                        Flow.Wake.OnField("winner"),
+                        Flow.Event.InputWaiting(wf1, eid1, "winner", now)
+                    )
+                    // The attempt ended still waiting on one of them, so the other is not part of its final statement.
+                    _     <- claimed.head.finish(FlowStore.Claimed.Outcome.Suspended(Set("winner")))
+                    state <- store.getExecution(eid1)
+                yield
+                    assert(
+                        state.get.waits.toChunk.map(_._1).toSet == Set("winner"),
+                        s"the attempt's ending must keep exactly what it still waits on, got ${state.get.waits.toChunk.map(_._1).toSet}"
+                    )
+                    assert(state.get.executor.isEmpty, "and it must give the claim back")
             }
         }
 
@@ -349,7 +903,7 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
+                    results <- store.claimReady(served, ex1, lease, 10, 1.second)
                 yield assert(results.size == 1)
             }
         }
@@ -358,8 +912,8 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _       <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                    results <- store.claimReady(Set(wf1), ex2, lease, 10, 100.millis)
+                    _       <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    results <- store.claimReady(served, ex2, lease, 10, 100.millis)
                 yield assert(results.isEmpty)
             }
         }
@@ -369,28 +923,144 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                 makeStore.map { store =>
                     for
                         _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                        _       <- store.claimReady(Set(wf1), ex1, 5.seconds, 10, 1.second)
+                        _       <- store.claimReady(served, ex1, 5.seconds, 10, 1.second)
                         _       <- tc.advance(10.seconds)
-                        results <- store.claimReady(Set(wf1), ex2, lease, 10, 1.second)
+                        results <- store.claimReady(served, ex2, lease, 10, 1.second)
                     yield assert(results.size == 1)
+                }
+            }
+        }
+
+        /** An execution left mid-unwind by a stopped executor must be claimable.
+          *
+          * `Compensating` is not terminal, and the terminal `Failed` is written only after every handler has run, so an executor that
+          * stops between those two writes leaves the row in it. The readiness predicate has no case for `Compensating` and falls
+          * through to not-ready, so nothing can ever claim it again: the execution is neither finished nor recoverable, and its
+          * compensations are half-done. Reachable without a crash, since a handler that runs longer than the lease loses the claim and
+          * is interrupted. I8's own text never mentions `Compensating`, so the reference store is stricter here than the invariant it
+          * documents, and an implementor following the prose would diverge.
+          */
+        "Compensating → returned (an executor stopped mid-unwind must be recoverable)" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Compensating(Flow.Cause.Failure("boom")))
+                    results <- store.claimReady(served, ex1, lease, 10, Duration.Zero)
+                yield assert(
+                    results.map(_.state.executionId) == Seq(eid1),
+                    s"a compensating execution whose executor stopped must be claimable, got ${results.map(_.state.executionId)}"
+                )
+            }
+        }
+
+        /** An executor whose OWN claim expired is given the execution back.
+          *
+          * The case above covers reclaim by a different executor. This is the same expiry seen from the side of the executor that
+          * still owns the row, and it is the ordinary state of any execution whose holder was starved for longer than its lease:
+          * nothing in the SPI clears an owner on expiry, so the row still names it. A store that treats "already mine" as "nothing
+          * to do here" strands the execution, because its owner is by definition not working on it any more.
+          */
+        "Running whose own claim expired → returned to the same executor" in {
+            Clock.withTimeControl { tc =>
+                makeStore.map { store =>
+                    for
+                        _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        first <- store.claimReady(served, ex1, 5.seconds, 10, Duration.Zero)
+                        _     <- tc.advance(10.seconds)
+                        again <- store.claimReady(served, ex1, 5.seconds, 10, Duration.Zero)
+                    yield
+                        assert(
+                            first.map(_.state.executionId) == Seq(eid1),
+                            s"the first claim must hand over the execution, got ${first.map(_.state.executionId)}"
+                        )
+                        assert(
+                            again.map(_.state.executionId) == Seq(eid1),
+                            s"an executor whose own claim expired must be given the execution back, got ${again.map(_.state.executionId)}"
+                        )
+                }
+            }
+        }
+
+        /** The row is never invisible to everyone, and no poll holds it past one lease without renewing.
+          *
+          * The damaging half of the case above, and the pair has to be asserted together because each half alone admits a store that
+          * strands the execution the other way. If the owner's poll hands the expired row back but nothing then makes the row lapse
+          * again, the owner has a claim it will not renew and nobody else may take, which strands the execution just as thoroughly. If
+          * the row lapses to everyone but the owner never gets it, the store is running the exclusion heuristic this pair rules out:
+          * re-claim the row on every poll, push its expiry forward by a full lease, and filter it out of the answer, so nobody receives
+          * it and from outside the lease never lapses.
+          *
+          * **Why the pair, rather than the narrower reading that a poll returning NOTHING leaves the row claimable by another
+          * executor.** That reading has no scenario against a correct store: the owner's poll returns the row, so there is no
+          * withholding poll to observe, and I9 makes a returned row carry `claimExpiry = now + lease`, so a competitor asking at
+          * that instant is right to get nothing. Only the passage of a second unrenewed lease separates a lapse from a withhold,
+          * which is what the pair states.
+          */
+        "a reclaimed row that is never renewed lapses to another executor" in {
+            Clock.withTimeControl { tc =>
+                makeStore.map { store =>
+                    for
+                        _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        _     <- store.claimReady(served, ex1, 5.seconds, 10, Duration.Zero)
+                        _     <- tc.advance(10.seconds)
+                        mine  <- store.claimReady(served, ex1, 5.seconds, 10, Duration.Zero)
+                        _     <- tc.advance(10.seconds)
+                        other <- store.claimReady(served, ex2, 5.seconds, 10, Duration.Zero)
+                    yield
+                        assert(
+                            mine.map(_.state.executionId) == Seq(eid1),
+                            s"an executor whose own claim expired must be given the execution back rather than have it withheld, " +
+                                s"got ${mine.map(_.state.executionId)}"
+                        )
+                        assert(
+                            other.map(_.state.executionId) == Seq(eid1),
+                            s"a claim nobody renewed must lapse to the next executor to ask, got ${other.map(_.state.executionId)}"
+                        )
                 }
             }
         }
     }
 
     // =========================================================================
-    // I9 — Claim sets executor and expiry
+    // I9: claim records its holder, its deadline and its generation
     // =========================================================================
-    "I9 — claim sets executor and expiry" - {
+    "I9: claim records its holder, its deadline and its generation" - {
+
+        /** The deadline is measured on the store's clock, and the caller can predict it.
+          *
+          * I9 says a returned execution carries `claimExpiry = now + lease`, which only means something if "now" is a clock both
+          * sides agree on. The engine compares that instant against its own clock when it decides whether it still holds a claim, so
+          * an implementation that stamped the deadline from a database's clock while the engine read a process clock would put the
+          * whole lease mechanism at the mercy of skew between them, silently. Pinning the caller's prediction is what makes that a
+          * contract rather than an accident of both running in one process.
+          */
+        "the claim deadline is one lease past the caller's own now" in {
+            Clock.withTimeControl { _ =>
+                makeStore.map { store =>
+                    for
+                        _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        before  <- Clock.now
+                        results <- store.claimReady(served, ex1, 30.seconds, 10, Duration.Zero)
+                        after   <- Clock.now
+                    yield
+                        assert(results.size == 1, s"the execution should be claimed, got ${results.size}")
+                        val expiry = results.head.state.claimExpiry
+                        assert(
+                            expiry.exists(e => !(e < (before + 30.seconds)) && !((after + 30.seconds) < e)),
+                            s"the deadline must sit one lease past a now the caller can observe: got $expiry, " +
+                                s"expected between ${before + 30.seconds} and ${after + 30.seconds}"
+                        )
+                }
+            }
+        }
 
         "returned execution has executor = caller's ID" in {
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
+                    results <- store.claimReady(served, ex1, lease, 10, 1.second)
                 yield
                     assert(results.size == 1)
-                    assert(results.head.executor == Maybe(ex1))
+                    assert(results.head.state.executor == Maybe(ex1))
             }
         }
 
@@ -398,8 +1068,40 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                yield assert(results.head.claimExpiry.isDefined)
+                    results <- store.claimReady(served, ex1, lease, 10, 1.second)
+                yield assert(results.head.state.claimExpiry.isDefined)
+            }
+        }
+
+        /** Each claim's generation is strictly greater than any the row has carried, which is what a write is judged against.
+          *
+          * The recording obligation, stated as a leaf because a rule nothing exercises is a rule a store can quietly not have. It is
+          * the token and not the executor that decides a write: an executor that claims, lapses and reclaims the same row is a
+          * different generation, and the two workers of one engine share an id, so nothing about who holds a claim can tell a dead
+          * generation from a live one.
+          */
+        "each claim carries a generation greater than the last" in {
+            makeStore.map { store =>
+                for
+                    _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    first <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    _ = assert(first.size == 1, "the premise is that the first claim was granted")
+                    _      <- first.head.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                    second <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    _ = assert(second.size == 1, "and that the row was claimable again")
+                    released <- store.getExecution(eid1)
+                yield
+                    val before = first.head.state.claimToken
+                    val after  = second.head.state.claimToken
+                    assert(before.isDefined, s"an active claim must record its generation, got $before")
+                    assert(
+                        after.exists(a => before.exists(b => a > b)),
+                        s"a new claim must carry a generation strictly greater than the last, got $before then $after"
+                    )
+                    assert(
+                        released.exists(_.claimToken.isDefined),
+                        "and the row carries the live generation, which is what a write is judged against"
+                    )
             }
         }
     }
@@ -409,11 +1111,65 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
     // =========================================================================
     "field operations" - {
 
-        "putField then getField returns the value" in {
+        /** A store author can use the whole of the vocabulary the SPI hands them, on both dictionaries it hands back.
+          *
+          * `getAllFields` answers a `Dict[String, FieldData]` and `ExecutionState.waits` carries a `Dict[String, Flow.Wake]`, and
+          * filtering or searching one is the first thing an implementation does with either: which of these fields is mine, which of
+          * these rows is a sleep. Both are a cast hazard. Under its threshold a `Dict` is a `Span` over an `Object[]`, and `Dict`'s
+          * inline operations cast that array to `Array[K | V]`, a cast emitted at the CALLER's site against the erased lub of the
+          * caller's concrete types. `String` with a case class or an enum case is `Serializable` on both sides, so an unguarded
+          * `exists`, `filter` or sibling throws `[Ljava.lang.Object; cannot be cast to [Ljava.io.Serializable;` on exactly the two
+          * types this SPI publishes.
+          *
+          * Nothing in this module calls them, so the engine's own coverage says nothing about them: the surface a store author writes
+          * against is not the surface the engine happens to exercise. The guard is in kyo-data, in `Dict`'s own `reduce`, with its own
+          * leaves; this pins the consequence at the boundary that publishes the type.
+          */
+        "the dictionaries the SPI answers with support the operations a store author writes" in {
             makeStore.map { store =>
                 for
                     _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _ <- store.putField[String](eid1, "name", "hello")
+                    _ <- mkField[Int](store, eid1, wf1, "a", 1)
+                    _ <- mkField[Int](store, eid1, wf1, "b", 2)
+                    _ <- mkWaits(
+                        store,
+                        eid1,
+                        wf1,
+                        "sleeping" -> Flow.Wake.At(Instant.Epoch + 1.hour),
+                        "waiting"  -> Flow.Wake.OnField("x")
+                    )
+                    fields <- store.getAllFields(eid1)
+                    state  <- store.getExecution(eid1)
+                yield
+                    assert(fields.exists((name, _) => name == "a"), s"a field search must answer, got ${fields.toChunk}")
+                    assert(
+                        fields.filter((name, _) => name == "a").toChunk.map(_._1) == Chunk("a"),
+                        s"and a field filter must answer, got ${fields.filter((name, _) => name == "a").toChunk}"
+                    )
+                    assert(!fields.forall((name, _) => name == "a"), "and so must the predicate over all of them")
+                    val waits = state.map(_.waits).getOrElse(Dict.empty)
+                    assert(
+                        waits.exists((_, wake) =>
+                            wake match
+                                case _: Flow.Wake.At => true
+                                case _               => false
+                        ),
+                        s"a wait search must answer, got ${waits.toChunk}"
+                    )
+                    assert(
+                        waits.filter((path, _) => path == "waiting").toChunk.map(_._1) == Chunk("waiting"),
+                        s"and a wait filter must answer, got ${waits.filter((path, _) => path == "waiting").toChunk}"
+                    )
+                    assert(waits.count((_, _) => true) == 2, s"and so must a count, got ${waits.toChunk}")
+                end for
+            }
+        }
+
+        "recordProgress then getField returns the value" in {
+            makeStore.map { store =>
+                for
+                    _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _ <- mkField[String](store, eid1, wf1, "name", "hello")
                     v <- store.getField[String](eid1, "name")
                 yield assert(v.get == "hello")
             }
@@ -428,14 +1184,93 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             }
         }
 
-        "putField overwrites existing value" in {
+        /** Progress is WRITE-ONCE per path.
+          *
+          * The first writer decides the field, and a second write on a path that already carries one is answered already-recorded and
+          * changes nothing at all. It is what makes the race exemption safe, since two live branches completing a shared output name
+          * resolve to the first writer at the store rather than to whichever write the scheduler landed last, and it is the same answer
+          * replay already derives from the field's presence. A store implementing this as an upsert would look correct until two
+          * branches raced.
+          *
+          * **Changing nothing at all is three things, and the third one needs a row to be about.** The answer, the standing value
+          * and the unchanged history are read from what the writes touch, but "retires nothing" is a statement about the wait ledger,
+          * and an execution with no rows satisfies it however wrongly a store behaves. So a row is recorded at a SECOND path before
+          * the refused write, one the writes never name: a store that treated a refusal as an ending and swept the ledger would clear
+          * it, and the assertion below is what notices.
+          */
+        "a second recordProgress on a present path is answered already-recorded" in {
             makeStore.map { store =>
                 for
-                    _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _ <- store.putField[Int](eid1, "step1", 1)
-                    _ <- store.putField[Int](eid1, "step1", 2)
-                    v <- store.getField[Int](eid1, "step1")
-                yield assert(v.get == 2)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _ <- claimed.recordWait(
+                        "gate",
+                        Flow.Wake.OnField("gate"),
+                        waitEvent(wf1, eid1, "gate", Flow.Wake.OnField("gate"), now)
+                    )
+                    first <- claimed.recordProgress[Int](
+                        "step1",
+                        Maybe(1),
+                        Flow.Event.StepCompleted(wf1, eid1, "step1", now)
+                    )
+                    before <- store.getHistory(eid1, Maybe.empty, 0)
+                    second <- claimed.recordProgress[Int](
+                        "step1",
+                        Maybe(2),
+                        Flow.Event.StepCompleted(wf1, eid1, "step1", now + 1.second)
+                    )
+                    v     <- store.getField[Int](eid1, "step1")
+                    after <- store.getHistory(eid1, Maybe.empty, 0)
+                    state <- store.getExecution(eid1)
+                yield
+                    assert(first == FlowStore.ProgressOutcome.Recorded, s"the first write must land, got $first")
+                    assert(
+                        second == FlowStore.ProgressOutcome.AlreadyRecorded,
+                        s"a second write on a present path must be answered already-recorded, got $second"
+                    )
+                    assert(v.get == 1, s"the first writer's value stands, got $v")
+                    assert(
+                        after.events.length == before.events.length,
+                        s"and the refused write leaves no event, history went from ${before.events.length} to ${after.events.length}"
+                    )
+                    assert(
+                        state.get.waits.get("gate").contains(Flow.Wake.OnField("gate")),
+                        s"and it retires nothing: the row waiting at another path stands exactly as it was recorded, got " +
+                            s"${state.get.waits}"
+                    )
+            }
+        }
+
+        /** A valueless progress is refused only by its own recorded completion, never by the field on its path.
+          *
+          * The input discharge is by construction a valueless progress at a path the signalled value already occupies, so a store that
+          * refused it on field presence would silently drop the discharge event AND the row clearing, which is the producer the
+          * clearing rule exists for. The second one is still refused, because the node recorded its completion the first time.
+          */
+        "a valueless recordProgress lands on a path that already carries a field, once" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _       <- mkWait(store, eid1, wf1, "answer", Flow.Wake.OnField("answer"))
+                    _       <- deliver[String](store, eid1, wf1, "answer", "yes")
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    first   <- claimed.recordProgress("answer", Flow.Event.InputDischarged(wf1, eid1, "answer", now))
+                    state   <- store.getExecution(eid1)
+                    second  <- claimed.recordProgress("answer", Flow.Event.InputDischarged(wf1, eid1, "answer", now + 1.second))
+                    value   <- store.getField[String](eid1, "answer")
+                yield
+                    assert(
+                        first == FlowStore.ProgressOutcome.Recorded,
+                        s"a valueless progress must not be refused by the field it discharges, got $first"
+                    )
+                    assert(state.get.waits.isEmpty, s"and it must clear the row, got ${state.get.waits}")
+                    assert(
+                        second == FlowStore.ProgressOutcome.AlreadyRecorded,
+                        s"a second valueless progress on the same path is its own completion twice, got $second"
+                    )
+                    assert(value == Present("yes"), s"and the signalled value is untouched throughout, got $value")
             }
         }
 
@@ -443,8 +1278,8 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _   <- store.putField[Int](eid1, "a", 1)
-                    _   <- store.putField[String](eid1, "b", "two")
+                    _   <- mkField[Int](store, eid1, wf1, "a", 1)
+                    _   <- mkField[String](store, eid1, wf1, "b", "two")
                     all <- store.getAllFields(eid1)
                 yield
                     assert(all.contains("a"))
@@ -466,8 +1301,8 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                 for
                     _  <- mkExecution(store, eid1, wf1, Flow.Status.Running)
                     _  <- mkExecution(store, eid2, wf1, Flow.Status.Running)
-                    _  <- store.putField[Int](eid1, "x", 10)
-                    _  <- store.putField[Int](eid2, "x", 20)
+                    _  <- mkField[Int](store, eid1, wf1, "x", 10)
+                    _  <- mkField[Int](store, eid2, wf1, "x", 20)
                     v1 <- store.getField[Int](eid1, "x")
                     v2 <- store.getField[Int](eid2, "x")
                 yield
@@ -478,31 +1313,31 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
     }
 
     // =========================================================================
-    // putFieldIfAbsent
+    // signal
     // =========================================================================
-    "putFieldIfAbsent" - {
+    "signal" - {
 
-        "returns true and stores value when field is absent" in {
+        "returns Delivered and stores value when the input is absent" in {
             makeStore.map { store =>
                 for
                     _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    wrote <- store.putFieldIfAbsent[Int](eid1, "key", 42)
+                    wrote <- deliver[Int](store, eid1, wf1, "key", 42)
                     v     <- store.getField[Int](eid1, "key")
                 yield
-                    assert(wrote)
+                    assert(wrote == FlowStore.SignalOutcome.Delivered)
                     assert(v.get == 42)
             }
         }
 
-        "returns false and preserves original value when field exists" in {
+        "returns AlreadyDelivered and preserves the original value when the input has one" in {
             makeStore.map { store =>
                 for
                     _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _     <- store.putField[Int](eid1, "key", 1)
-                    wrote <- store.putFieldIfAbsent[Int](eid1, "key", 2)
+                    _     <- deliver[Int](store, eid1, wf1, "key", 1)
+                    wrote <- deliver[Int](store, eid1, wf1, "key", 2)
                     v     <- store.getField[Int](eid1, "key")
                 yield
-                    assert(!wrote)
+                    assert(wrote == FlowStore.SignalOutcome.AlreadyDelivered)
                     assert(v.get == 1)
             }
         }
@@ -512,11 +1347,60 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                 for
                     _  <- mkExecution(store, eid1, wf1, Flow.Status.Running)
                     _  <- mkExecution(store, eid2, wf1, Flow.Status.Running)
-                    w1 <- store.putFieldIfAbsent[Int](eid1, "key", 10)
-                    w2 <- store.putFieldIfAbsent[Int](eid2, "key", 20)
+                    w1 <- deliver[Int](store, eid1, wf1, "key", 10)
+                    w2 <- deliver[Int](store, eid2, wf1, "key", 20)
                 yield
-                    assert(w1)
-                    assert(w2)
+                    assert(w1 == FlowStore.SignalOutcome.Delivered)
+                    assert(w2 == FlowStore.SignalOutcome.Delivered)
+            }
+        }
+
+        /** A delivery records its arrival in the same transition that writes the field.
+          *
+          * A value that is durable and invisible is the shape an operator cannot diagnose: the execution holds an input nothing in its
+          * history says arrived, so "when did this come in" has no answer and "was it ever delivered" is a field read rather than a
+          * story.
+          */
+        "a delivery records its arrival in history" in {
+            makeStore.map { store =>
+                for
+                    _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _ <- deliver[Int](store, eid1, wf1, "key", 42)
+                    h <- store.getHistory(eid1, Maybe.empty, 0)
+                yield assert(
+                    h.events.exists(e => e.kind == Flow.EventKind.InputReceived && e.detail == "key"),
+                    s"the delivery must be in the history that records it, got ${h.events.map(_.kind)}"
+                )
+            }
+        }
+
+        /** A delivery to an execution that is over is refused, and says so with what it ended as.
+          *
+          * A boolean answer cannot express this refusal: put-if-absent says `false` for an input that already carries a value and
+          * `true` for one written onto a finished execution, which tells a caller its delivery succeeded when nothing will ever
+          * consume it. The two refusals are different instructions, and the caller can act on the difference: stop retrying this
+          * name, or stop entirely and read the result.
+          */
+        "a delivery to a terminal execution is refused and writes nothing" in {
+            makeStore.map { store =>
+                for
+                    _      <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    now    <- Clock.now
+                    _      <- terminate(store, eid1, wf1, Flow.Status.Completed, ts => Flow.Event.Completed(wf1, eid1, ts))
+                    before <- store.getHistory(eid1, Maybe.empty, 0)
+                    wrote  <- deliver[Int](store, eid1, wf1, "key", 42)
+                    v      <- store.getField[Int](eid1, "key")
+                    after  <- store.getHistory(eid1, Maybe.empty, 0)
+                yield
+                    assert(
+                        wrote == FlowStore.SignalOutcome.AlreadyTerminal(Flow.Status.Completed),
+                        s"a delivery to a finished execution must be refused with what it ended as, got $wrote"
+                    )
+                    assert(v.isEmpty, s"and the field must not land, got $v")
+                    assert(
+                        after.events.length == before.events.length,
+                        s"and nothing is recorded, history went from ${before.events.length} to ${after.events.length}"
+                    )
             }
         }
     }
@@ -534,11 +1418,11 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             }
         }
 
-        "updateStatus creates execution if not exists" in {
+        "createExecutionIfAbsent creates the execution when the id is free" in {
             makeStore.map { store =>
                 for
                     now   <- Clock.now
-                    _     <- store.createExecution(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "")
+                    _     <- store.createExecutionIfAbsent(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "", Dict.empty)
                     state <- store.getExecution(eid1)
                 yield
                     assert(state.isDefined)
@@ -547,23 +1431,22 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             }
         }
 
-        "multiple updateStatus calls append events in order" in {
+        "multiple status writes append events in order" in {
             makeStore.map { store =>
                 for
                     now <- Clock.now
-                    _   <- store.createExecution(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "")
-                    _ <- store.updateStatus(
-                        eid1,
-                        Flow.Status.Sleeping("wait", now + 1.hour),
-                        Flow.Event.SleepStarted(wf1, eid1, "wait", now + 1.hour, now)
-                    )
-                    _ <- store.updateStatus(
-                        eid1,
-                        Flow.Status.Running,
-                        Flow.Event.SleepCompleted(wf1, eid1, "wait", now + 1.hour)
-                    )
-                    _ <- store.updateStatus(eid1, Flow.Status.Completed, Flow.Event.Completed(wf1, eid1, now + 2.hours))
-                    h <- store.getHistory(eid1, 100, 0)
+                    _   <- store.createExecutionIfAbsent(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "", Dict.empty)
+                    // The sleep is already due, so the row that records it is satisfied and the next attempt can take the claim,
+                    // which is the shape the walk below needs: park, wake, discharge, finish.
+                    _ <- mkWait(store, eid1, wf1, "wait", Flow.Wake.At(now))
+                    _ <- claim(store, eid1, leaseFor = lease).map { claimed =>
+                        claimed.recordProgress("wait", Flow.Event.SleepCompleted(wf1, eid1, "wait", now + 1.hour))
+                            .andThen(claimed.finish(FlowStore.Claimed.Outcome.Terminal(
+                                Flow.Status.Completed,
+                                Flow.Event.Completed(wf1, eid1, now + 2.hours)
+                            )))
+                    }
+                    h <- store.getHistory(eid1, Maybe(100), 0)
                 yield
                     assert(h.events.length == 4)
                     assert(h.events(0).kind == Flow.EventKind.Created)
@@ -573,27 +1456,31 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             }
         }
 
-        "status transitions: Running → Sleeping → Running → Completed" in {
-            makeStore.map { store =>
-                for
-                    now <- Clock.now
-                    _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _ <- store.updateStatus(
-                        eid1,
-                        Flow.Status.Sleeping("s", now + 1.hour),
-                        Flow.Event.SleepStarted(wf1, eid1, "s", now + 1.hour, now)
-                    )
-                    s1 <- store.getExecution(eid1)
-                    _  <- store.updateStatus(eid1, Flow.Status.Running, Flow.Event.SleepCompleted(wf1, eid1, "s", now))
-                    s2 <- store.getExecution(eid1)
-                    _  <- store.updateStatus(eid1, Flow.Status.Completed, Flow.Event.Completed(wf1, eid1, now))
-                    s3 <- store.getExecution(eid1)
-                yield
-                    assert(s1.get.status match
-                        case Flow.Status.Sleeping(_, _) => true;
-                        case _                          => false)
-                    assert(s2.get.status == Flow.Status.Running)
-                    assert(s3.get.status == Flow.Status.Completed)
+        /** An execution that sleeps and wakes walks two facts, not one: the lifecycle it keeps, and the wait it holds and discharges. */
+        "status transitions: Running → waiting on a sleep → Running → Completed" in {
+            Clock.withTimeControl { tc =>
+                makeStore.map { store =>
+                    for
+                        now   <- Clock.now
+                        _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        _     <- mkWait(store, eid1, wf1, "s", Flow.Wake.At(now + 1.hour))
+                        s1    <- store.getExecution(eid1)
+                        _     <- tc.advance(2.hours)
+                        woken <- claim(store, eid1)
+                        _     <- woken.recordProgress("s", Flow.Event.SleepCompleted(wf1, eid1, "s", now))
+                        s2    <- store.getExecution(eid1)
+                        _ <- woken.finish(FlowStore.Claimed.Outcome.Terminal(
+                            Flow.Status.Completed,
+                            Flow.Event.Completed(wf1, eid1, now)
+                        ))
+                        s3 <- store.getExecution(eid1)
+                    yield
+                        assert(s1.get.status == Flow.Status.Running, s"sleeping is not a lifecycle change, got ${s1.get.status}")
+                        assert(s1.get.waits.contains("s"), s"the sleep must be recorded as a wait row, got ${s1.get.waits}")
+                        assert(s2.get.status == Flow.Status.Running)
+                        assert(!s2.get.waits.contains("s"), s"the discharged sleep must be gone, got ${s2.get.waits}")
+                        assert(s3.get.status == Flow.Status.Completed)
+                }
             }
         }
     }
@@ -606,11 +1493,12 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "getHistory returns events in append order" in {
             makeStore.map { store =>
                 for
-                    _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    now <- Clock.now
-                    _   <- store.appendEvent(eid1, Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
-                    _   <- store.appendEvent(eid1, Flow.Event.StepCompleted(wf1, eid1, "s1", now))
-                    h   <- store.getHistory(eid1, 100, 0)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
+                    _       <- claimed.appendEvent(Flow.Event.StepCompleted(wf1, eid1, "s1", now))
+                    h       <- store.getHistory(eid1, Maybe(100), 0)
                 yield
                     assert(h.events.length == 3) // Created + 2
                     assert(h.events(1).detail == "s1")
@@ -622,12 +1510,13 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "getHistory with limit returns at most N events" in {
             makeStore.map { store =>
                 for
-                    _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    now <- Clock.now
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
                     _ <- Kyo.foreach(1 to 10)(i =>
-                        store.appendEvent(eid1, Flow.Event.StepStarted(wf1, eid1, s"s$i", ex1, now))
+                        claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, s"s$i", ex1, now))
                     )
-                    h <- store.getHistory(eid1, 3, 0)
+                    h <- store.getHistory(eid1, Maybe(3), 0)
                 yield
                     assert(h.events.length == 3)
                     assert(h.hasMore)
@@ -637,12 +1526,13 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "getHistory with offset skips events" in {
             makeStore.map { store =>
                 for
-                    _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    now <- Clock.now
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
                     _ <- Kyo.foreach(1 to 5)(i =>
-                        store.appendEvent(eid1, Flow.Event.StepStarted(wf1, eid1, s"s$i", ex1, now))
+                        claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, s"s$i", ex1, now))
                     )
-                    h <- store.getHistory(eid1, 100, 3)
+                    h <- store.getHistory(eid1, Maybe(100), 3)
                 yield
                     // 6 total (1 Created + 5 appended), skip 3 → 3 remaining
                     assert(h.events.length == 3)
@@ -650,13 +1540,248 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             }
         }
 
+        /** A second create for an id that already exists must not erase what is there.
+          *
+          * The SPI does not say what `createExecutionIfAbsent` does for an existing id, and a duplicate guard built as a read followed
+          * by a write with nothing between them lets two concurrent starts on the same explicit id both pass. A store that answered by
+          * replacing the row AND resetting the entire event chunk to a single `Created` would let the loser's create wipe a running
+          * execution's history. Replay reads that history to decide what is already done, so the execution would silently re-run every
+          * completed step and repeat their side effects. Either outcome is defensible, refusing the create or leaving the row alone;
+          * destroying the history is not.
+          */
+        "createExecution on an existing id does not destroy the history" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _       <- claimed.appendEvent(Flow.Event.StepCompleted(wf1, eid1, "s1", now))
+                    _       <- Abort.run[FlowStoreException](mkExecution(store, eid1, wf1, Flow.Status.Running))
+                    h       <- store.getHistory(eid1, Maybe.empty, 0)
+                yield assert(
+                    h.events.exists(_.kind == Flow.EventKind.StepCompleted),
+                    s"a second create must not erase a completed step from the history, got ${h.events.map(_.kind)}"
+                )
+            }
+        }
+
+        /** The last page says it is the last page, even at the largest page size a caller can express.
+          *
+          * The SPI warns an implementor in as many words that the obvious way to answer `hasMore`, adding the limit to the offset,
+          * overflows to a negative number, and `Int.MaxValue` is where that happens: at any positive offset, `offset + limit` wraps
+          * and every page compares as "more follow". A `hasMore` of true on the final page is an infinite pagination loop for any
+          * client that trusts it, and the HTTP surface passes `limit` and `offset` through from query parameters.
+          *
+          * **The bound is passed as `Present`, which is the arm that can overflow.** `Absent` says "every event" and is answered
+          * without arithmetic at all, so a leaf asking through it cannot fail on any implementation that special-cases it, and the
+          * store's own way of staying safe (bounding on what is left rather than adding to the limit) would go unpinned. `Absent`
+          * is what the ENGINE passes for every event; `Int.MaxValue` is what a caller passing a very large number passes, and it is
+          * the value this leaf is named for.
+          */
+        "getHistory reports no more pages on the last one, with limit = Int.MaxValue" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
+                    h       <- store.getHistory(eid1, Maybe(Int.MaxValue), 1)
+                yield
+                    assert(h.events.length == 1, s"one event should remain after skipping one, got ${h.events.length}")
+                    assert(!h.hasMore, "the last page must not claim there is another")
+            }
+        }
+
+        /** A negative page size does not produce an empty page that claims more follow.
+          *
+          * The HTTP surface passes `limit` and `offset` straight through from query parameters without validating either, so a
+          * client can reach this. An empty page with `hasMore` set is an infinite pagination loop for anything that trusts the flag,
+          * which is what the flag is for. Rejecting the argument is equally acceptable to this leaf; producing that pair is not.
+          */
+        "getHistory does not answer an empty page that claims more, for a negative limit" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
+                    r       <- Abort.run[FlowStoreException](store.getHistory(eid1, Maybe(-1), 0))
+                yield
+                    // Refusing the argument and answering a sane page are both acceptable; answering an empty page that claims
+                    // another follows is not, because that is the pair a paging client loops on forever.
+                    val acceptable = r match
+                        case Result.Success(h) => !(h.events.isEmpty && h.hasMore)
+                        case _                 => true
+                    assert(
+                        acceptable,
+                        s"a negative limit must not answer an empty page that claims more follow, got $r"
+                    )
+            }
+        }
+
+        /** `listExecutions` validates its page arguments, rather than inheriting a paragraph that describes a different method.
+          *
+          * `listExecutions`'s scaladoc defines `limit` and `offset` entirely by reference: "as [[getHistory]] documents them". That
+          * paragraph is about `getHistory`'s `hasMore` overflow, which `listExecutions` cannot have, because it answers a bare
+          * `Chunk` with no more-pages flag. So the one method that DOES document its pagination says nothing that applies here, and
+          * what is left undocumented is the case a caller can actually reach: a negative limit.
+          *
+          * Scala's `take(-1)` answers an empty collection and `drop(-1)` is a no-op, so a negative limit silently reports that a
+          * workflow has no executions at all. That is the worst available answer, because "none" is a legitimate result the caller
+          * has no way to distinguish from "your argument was nonsense". Refusing is equally acceptable to this leaf; answering an
+          * empty page for a workflow that demonstrably has executions is not.
+          */
+        "listExecutions does not answer an empty page for a negative limit" in {
+            makeStore.map { store =>
+                for
+                    _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _ <- mkExecution(store, eid2, wf1, Flow.Status.Running)
+                    r <- Abort.run[FlowStoreException](store.listExecutions(wf1, Maybe.empty, Maybe(-1), 0))
+                yield
+                    // Refusing the argument and clamping to a sane page are both acceptable; reporting an empty workflow is not,
+                    // because the caller cannot tell that answer from a workflow that genuinely has nothing in it.
+                    val acceptable = r match
+                        case Result.Success(execs) => execs.nonEmpty
+                        case _                     => true
+                    assert(
+                        acceptable,
+                        s"a negative limit must not report an empty workflow that has two executions, got $r"
+                    )
+            }
+        }
+
+        /** Paging exactly to the end reports that it is the end. */
+        "getHistory reports no more pages when the offset lands exactly at the end" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- claim(store, eid1)
+                    now     <- Clock.now
+                    _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
+                    h       <- store.getHistory(eid1, Maybe(10), 2)
+                yield
+                    assert(h.events.isEmpty, s"there are two events, so an offset of two is past the end, got ${h.events.length}")
+                    assert(!h.hasMore, "an offset at the end must not claim another page follows")
+            }
+        }
+
         "getHistory returns empty for unknown execution" in {
             makeStore.map { store =>
                 for
-                    h <- store.getHistory(Flow.Id.Execution("unknown"), 100, 0)
+                    h <- store.getHistory(Flow.Id.Execution("unknown"), Maybe(100), 0)
                 yield
                     assert(h.events.isEmpty)
                     assert(!h.hasMore)
+            }
+        }
+    }
+
+    // =========================================================================
+    // The acceptance rule: which writes a claim carries
+    // =========================================================================
+    "the acceptance rule" - {
+
+        /** A write presented under a claim the row no longer carries is refused, in every shape that can produce one.
+          *
+          * Three shapes, and each defeats an implementation that has only half the rule. SUPERSEDED: somebody else claimed the row, so
+          * the generation is dead while the row's claim is live. EXPIRED: nobody else claimed it, so the dead generation is still the
+          * highest one the row has carried, and a store that recorded only the highest token would accept the write. RELEASED: the
+          * attempt ended, so the claim is absent, and the write was issued before that ending and delivered after it, which is neither
+          * superseded nor expired: a store that checks only those two accepts it.
+          */
+        "a write presented under a stale claim is refused" in {
+            Clock.withTimeControl { tc =>
+                makeStore.map { store =>
+                    for
+                        _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        stale <- store.claimReady(served, ex1, 5.seconds, 10, Duration.Zero)
+                        _ = assert(stale.size == 1, "the premise is that the first executor took the execution")
+                        _     <- tc.advance(10.seconds)
+                        fresh <- store.claimReady(served, ex2, 30.seconds, 10, Duration.Zero)
+                        // Superseded: the row's claim is live and belongs to somebody else.
+                        superseded <- stale.head.recordProgress[String](
+                            "receipt",
+                            Maybe("paid"),
+                            Flow.Event.StepCompleted(wf1, eid1, "receipt", Instant.Epoch)
+                        )
+                        receipt <- store.getField[String](eid1, "receipt")
+
+                        // Expired with no competitor: the dead generation is still the highest the row has carried.
+                        _      <- mkExecution(store, eid2, wf1, Flow.Status.Running)
+                        lapsed <- store.claimReady(served, ex1, 5.seconds, 10, Duration.Zero)
+                        _ = assert(lapsed.exists(_.state.executionId == eid2), "the premise is that the second row was claimed")
+                        _ <- tc.advance(10.seconds)
+                        expired <- lapsed.head.recordProgress[String](
+                            "receipt",
+                            Maybe("paid"),
+                            Flow.Event.StepCompleted(wf1, eid2, "receipt", Instant.Epoch)
+                        )
+                        expiredField <- store.getField[String](eid2, "receipt")
+
+                        // Released: the attempt ended, so the claim is absent whenever the write was issued.
+                        _        <- mkExecution(store, eid3, wf1, Flow.Status.Running)
+                        released <- store.claimReady(served, ex1, 30.seconds, 10, Duration.Zero)
+                        _ = assert(released.exists(_.state.executionId == eid3), "the premise is that the third row was claimed")
+                        _ <- released.head.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                        afterRelease <- released.head.recordProgress[String](
+                            "receipt",
+                            Maybe("paid"),
+                            Flow.Event.StepCompleted(wf1, eid3, "receipt", Instant.Epoch)
+                        )
+                        releasedField <- store.getField[String](eid3, "receipt")
+                    yield
+                        assert(fresh.size == 1, "the second executor should have taken the expired claim")
+                        assert(
+                            superseded == FlowStore.ProgressOutcome.ClaimLost,
+                            "a write under a claim the store no longer holds must be refused"
+                        )
+                        assert(receipt.isEmpty, s"and it must write nothing, got $receipt")
+                        assert(
+                            expired == FlowStore.ProgressOutcome.ClaimLost,
+                            "a write under a lapsed claim must be refused even when nobody else took the row"
+                        )
+                        assert(expiredField.isEmpty, s"and it must write nothing, got $expiredField")
+                        assert(
+                            afterRelease == FlowStore.ProgressOutcome.ClaimLost,
+                            "a write delivered after the attempt released must be refused, whenever it was issued"
+                        )
+                        assert(releasedField.isEmpty, s"and it must write nothing, got $releasedField")
+                    end for
+                }
+            }
+        }
+
+        /** A lapsed executor cannot drive an execution another executor now owns to a terminal status.
+          *
+          * The refusal has to leave NOTHING, and the event is the half that matters: history is append-only and the operator surfaces
+          * read it as authoritative for failure, so a `Failed` event written by an executor that no longer held the row sits in the
+          * history of an execution its owner completed and cannot be taken back.
+          */
+        "a stale executor cannot mark an execution failed after another took it" in {
+            Clock.withTimeControl { tc =>
+                makeStore.map { store =>
+                    for
+                        _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        stale <- store.claimReady(served, ex1, 5.seconds, 10, Duration.Zero)
+                        _ = assert(stale.size == 1, "the premise is that the first executor took the execution")
+                        _   <- tc.advance(10.seconds)
+                        _   <- store.claimReady(served, ex2, 30.seconds, 10, Duration.Zero)
+                        now <- Clock.now
+                        refused <- stale.head.finish(FlowStore.Claimed.Outcome.Terminal(
+                            Flow.Status.Failed("the stale executor's verdict"),
+                            Flow.Event.Failed(wf1, eid1, "the stale executor's verdict", now)
+                        ))
+                        state   <- store.getExecution(eid1)
+                        history <- store.getHistory(eid1, Maybe.empty, 0)
+                    yield
+                        assert(refused == FlowStore.StatusOutcome.ClaimLost, "a terminal write under a lapsed claim must be refused")
+                        assert(!state.exists(_.status.isTerminal), "the execution must still belong to its new owner")
+                        assert(
+                            !history.events.exists(_.kind == Flow.EventKind.Failed),
+                            "a refused write must not leave its event in the history either"
+                        )
+                    end for
+                }
             }
         }
     }
@@ -669,7 +1794,7 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "returns empty when no executions exist" in {
             makeStore.map { store =>
                 for
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 100.millis)
+                    results <- store.claimReady(served, ex1, lease, 10, 100.millis)
                 yield assert(results.isEmpty)
             }
         }
@@ -678,19 +1803,18 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
+                    results <- store.claimReady(served, ex1, lease, 10, 1.second)
                 yield
                     assert(results.size == 1)
-                    assert(results.head.executionId == eid1)
+                    assert(results.head.state.executionId == eid1)
             }
         }
 
         "does not return terminal executions" in {
             makeStore.map { store =>
                 for
-                    now     <- Clock.now
-                    _       <- store.updateStatus(eid1, Flow.Status.Completed, Flow.Event.Completed(wf1, eid1, now))
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 100.millis)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Completed)
+                    results <- store.claimReady(served, ex1, lease, 10, 100.millis)
                 yield assert(results.isEmpty)
             }
         }
@@ -701,7 +1825,7 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
                     _       <- mkExecution(store, eid2, wf1, Flow.Status.Running)
                     _       <- mkExecution(store, eid3, wf1, Flow.Status.Running)
-                    results <- store.claimReady(Set(wf1), ex1, lease, 2, 1.second)
+                    results <- store.claimReady(served, ex1, lease, 2, 1.second)
                 yield assert(results.size == 2)
             }
         }
@@ -711,10 +1835,10 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
                     _       <- mkExecution(store, eid2, wf2, Flow.Status.Running)
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
+                    results <- store.claimReady(served, ex1, lease, 10, 1.second)
                 yield
                     assert(results.size == 1)
-                    assert(results.head.executionId == eid1)
+                    assert(results.head.state.executionId == eid1)
             }
         }
     }
@@ -728,18 +1852,25 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _       <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                    renewed <- store.renewClaim(eid1, ex1, lease)
+                    claimed <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    renewed <- claimed.head.renewClaim(lease)
                 yield assert(renewed)
             }
         }
 
-        "returns false for non-owner" in {
+        /** A renewal presented after the attempt ended is refused.
+          *
+          * The verb has no non-owner shape: a caller that never claimed holds no capability to present. What it does have is a
+          * capability that STOPS being current, and a release is the way that happens without a clock: the claim is absent, so the
+          * rule's first half fails whatever the token says.
+          */
+        "returns false once the attempt has ended" in {
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _       <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                    renewed <- store.renewClaim(eid1, ex2, lease)
+                    claimed <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    _       <- claimed.head.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                    renewed <- claimed.head.renewClaim(lease)
                 yield assert(!renewed)
             }
         }
@@ -749,9 +1880,9 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                 makeStore.map { store =>
                     for
                         _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                        _       <- store.claimReady(Set(wf1), ex1, 5.seconds, 10, 1.second)
+                        claimed <- store.claimReady(served, ex1, 5.seconds, 10, 1.second)
                         _       <- tc.advance(10.seconds)
-                        renewed <- store.renewClaim(eid1, ex1, lease)
+                        renewed <- claimed.head.renewClaim(lease)
                     yield assert(!renewed)
                 }
             }
@@ -759,17 +1890,17 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
     }
 
     // =========================================================================
-    // releaseClaim
+    // finish
     // =========================================================================
-    "releaseClaim" - {
+    "finish" - {
 
         "clears executor and claimExpiry for valid owner" in {
             makeStore.map { store =>
                 for
-                    _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _     <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                    _     <- store.releaseClaim(eid1, ex1)
-                    state <- store.getExecution(eid1)
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    claimed <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    _       <- claimed.head.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                    state   <- store.getExecution(eid1)
                 yield
                     assert(state.get.executor.isEmpty)
                     assert(state.get.claimExpiry.isEmpty)
@@ -780,21 +1911,82 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             makeStore.map { store =>
                 for
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _       <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                    _       <- store.releaseClaim(eid1, ex1)
-                    results <- store.claimReady(Set(wf1), ex2, lease, 10, 1.second)
+                    claimed <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    _       <- claimed.head.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                    results <- store.claimReady(served, ex2, lease, 10, 1.second)
                 yield assert(results.size == 1)
             }
         }
 
-        "no-op for non-owner" in {
+        /** An ending presented on a claim the row no longer carries changes nothing.
+          *
+          * A release by somebody who never claimed has no expression under the capability split, so the shape that matters is an
+          * ending arriving twice, or arriving from a generation the row has moved past: it must not give away a claim its successor
+          * is holding.
+          */
+        "an ending presented twice leaves the second claim alone" in {
             makeStore.map { store =>
                 for
                     _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _     <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                    _     <- store.releaseClaim(eid1, ex2) // non-owner
-                    state <- store.getExecution(eid1)
-                yield assert(state.get.executor == Maybe(ex1)) // still claimed by ex1
+                    first <- store.claimReady(served, ex1, lease, 10, 1.second)
+                    _     <- first.head.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                    // The row is claimed again, this time by somebody else, and the first attempt's ending arrives late.
+                    second <- store.claimReady(served, ex2, lease, 10, 1.second)
+                    _      <- first.head.finish(FlowStore.Claimed.Outcome.Suspended(Set.empty))
+                    state  <- store.getExecution(eid1)
+                yield
+                    assert(second.size == 1, "the premise is that a second executor took the row")
+                    assert(state.get.executor == Maybe(ex2)) // still claimed by ex2
+            }
+        }
+    }
+
+    // =========================================================================
+    // requestCancel
+    // =========================================================================
+    "requestCancel" - {
+
+        "the first request is Accepted and rides the row" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    outcome <- store.requestCancel(eid1)
+                    state   <- store.getExecution(eid1)
+                yield
+                    assert(outcome == FlowStore.CancelOutcome.Accepted, s"the first ask must be taken, got $outcome")
+                    assert(state.get.cancelRequested, "and the row must carry the request")
+                    assert(
+                        state.get.status == Flow.Status.Running,
+                        s"a request is not a terminal write: the handlers run first, got ${state.get.status}"
+                    )
+            }
+        }
+
+        "a repeat is AlreadyRequested" in {
+            makeStore.map { store =>
+                for
+                    _      <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _      <- store.requestCancel(eid1)
+                    repeat <- store.requestCancel(eid1)
+                yield assert(
+                    repeat == FlowStore.CancelOutcome.AlreadyRequested,
+                    s"an idempotent repeat must be distinguishable from the first ask, got $repeat"
+                )
+            }
+        }
+
+        "a request on a finished execution answers what it ended as" in {
+            makeStore.map { store =>
+                for
+                    _       <- mkExecution(store, eid1, wf1, Flow.Status.Completed)
+                    outcome <- store.requestCancel(eid1)
+                    state   <- store.getExecution(eid1)
+                yield
+                    assert(
+                        outcome == FlowStore.CancelOutcome.AlreadyTerminal(Flow.Status.Completed),
+                        s"there is nothing to cancel, and the answer carries what it ended as, got $outcome"
+                    )
+                    assert(!state.get.cancelRequested, "and nothing is written to a finished execution")
             }
         }
     }
@@ -810,7 +2002,7 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
                     _       <- mkExecution(store, eid2, wf1, Flow.Status.Running)
                     _       <- mkExecution(store, eid3, wf2, Flow.Status.Running)
-                    results <- store.listExecutions(wf1, Maybe.empty, 100, 0)
+                    results <- store.listExecutions(wf1, Maybe.empty, Maybe(100), 0)
                 yield assert(results.length == 2)
             }
         }
@@ -818,13 +2010,232 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "filters by status when provided" in {
             makeStore.map { store =>
                 for
-                    now     <- Clock.now
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                    _       <- store.updateStatus(eid2, Flow.Status.Completed, Flow.Event.Completed(wf1, eid2, now))
-                    results <- store.listExecutions(wf1, Maybe(Flow.Status.Running), 100, 0)
+                    _       <- mkExecution(store, eid2, wf1, Flow.Status.Completed)
+                    results <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Running), Maybe(100), 0)
                 yield
                     assert(results.length == 1)
                     assert(results.head.executionId == eid1)
+            }
+        }
+
+        /** A wait-kind filter asks what an execution is waiting FOR, which no lifecycle status can answer.
+          *
+          * A caller asking for the sleeping executions has no `until` to guess and no name to guess either, so the question is about the
+          * kind of wait rather than about a value, and it is answered from the rows: an execution matches when ANY of its rows does.
+          */
+        "filters by the kind of wait, whatever its deadline" in {
+            makeStore.map { store =>
+                for
+                    now      <- Clock.now
+                    _        <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _        <- mkExecution(store, eid2, wf1, Flow.Status.Running)
+                    _        <- mkExecution(store, eid3, wf1, Flow.Status.Running)
+                    _        <- mkWait(store, eid2, wf1, "wait", Flow.Wake.At(now + 30.seconds))
+                    _        <- mkWait(store, eid3, wf1, "settle", Flow.Wake.At(now + 90.seconds))
+                    sleeping <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Sleeping), Maybe(100), 0)
+                    running  <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Running), Maybe(100), 0)
+                yield
+                    assert(
+                        sleeping.map(_.executionId).toSet == Set(eid2, eid3),
+                        s"both sleeping executions must match, whatever deadline each holds, got ${sleeping.map(_.executionId)}"
+                    )
+                    assert(
+                        running.length == 3,
+                        s"the lifecycle filter is a different question and all three are Running, got ${running.length}"
+                    )
+            }
+        }
+
+        /** An input wait can be asked for by name, because an input's name is the caller's own vocabulary. */
+        "filters input waits by name" in {
+            makeStore.map { store =>
+                for
+                    _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _     <- mkExecution(store, eid2, wf1, Flow.Status.Running)
+                    _     <- mkWait(store, eid1, wf1, "approval", Flow.Wake.OnField("approval"))
+                    _     <- mkWait(store, eid2, wf1, "receipt", Flow.Wake.OnField("receipt"))
+                    named <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.WaitingForInput(Maybe("approval"))), Maybe(100), 0)
+                    any   <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.WaitingForInput(Maybe.empty)), Maybe(100), 0)
+                yield
+                    assert(
+                        named.map(_.executionId) == Chunk(eid1),
+                        s"a named input filter must narrow to that row, got ${named.map(_.executionId)}"
+                    )
+                    assert(
+                        any.map(_.executionId).toSet == Set(eid1, eid2),
+                        s"an unnamed input filter must match any input wait, got ${any.map(_.executionId)}"
+                    )
+            }
+        }
+
+        /** An execution somebody asked to cancel reads as cancelling until it has finished unwinding. */
+        "filters the executions somebody asked to cancel" in {
+            makeStore.map { store =>
+                for
+                    _          <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _          <- mkExecution(store, eid2, wf1, Flow.Status.Running)
+                    _          <- store.requestCancel(eid1)
+                    cancelling <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Cancelling), Maybe(100), 0)
+                    _          <- terminate(store, eid1, wf1, Flow.Status.Cancelled, ts => Flow.Event.Cancelled(wf1, eid1, ts))
+                    after      <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Cancelling), Maybe(100), 0)
+                yield
+                    assert(
+                        cancelling.map(_.executionId) == Chunk(eid1),
+                        s"an outstanding request must be visible while the execution is still unwinding, got ${cancelling.map(_.executionId)}"
+                    )
+                    assert(after.isEmpty, s"and it stops being outstanding once the execution is over, got ${after.map(_.executionId)}")
+            }
+        }
+
+        /** The completed lifecycle answers its own filter, and only it.
+          *
+          * One leaf per lifecycle arm rather than one leaf over all of them, so a store that collapsed two of them is named by the
+          * failure rather than by a set comparison a reader has to decode. Each asserts the exact result rather than membership: a
+          * store that ignored the filter and answered everything passes a membership check.
+          */
+        "filters the executions that completed" in {
+            makeStore.map { store =>
+                for
+                    _         <- mkExecution(store, eid1, wf1, Flow.Status.Completed)
+                    _         <- mkExecution(store, eid2, wf1, Flow.Status.Running)
+                    _         <- mkExecution(store, eid3, wf1, Flow.Status.Cancelled)
+                    completed <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Completed), Maybe(100), 0)
+                yield assert(
+                    completed.map(_.executionId) == Chunk(eid1),
+                    s"only the completed execution answers the completed filter, got ${completed.map(_.executionId)}"
+                )
+            }
+        }
+
+        /** The cancelled lifecycle answers its own filter, and is not the same question as an outstanding cancel request. */
+        "filters the executions that were cancelled" in {
+            makeStore.map { store =>
+                for
+                    _         <- mkExecution(store, eid1, wf1, Flow.Status.Cancelled)
+                    _         <- mkExecution(store, eid2, wf1, Flow.Status.Completed)
+                    _         <- mkExecution(store, eid3, wf1, Flow.Status.Running)
+                    cancelled <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Cancelled), Maybe(100), 0)
+                yield assert(
+                    cancelled.map(_.executionId) == Chunk(eid1),
+                    s"only the cancelled execution answers the cancelled filter, got ${cancelled.map(_.executionId)}"
+                )
+            }
+        }
+
+        /** An unwinding execution answers the compensating filter whatever cause it is unwinding for.
+          *
+          * The arm carries no payload while the status does, so a store matching on the case rather than on the whole value is what
+          * the rule asks for: a failure-caused unwind and a cancellation-caused one are both compensating.
+          */
+        "filters the executions that are unwinding" in {
+            makeStore.map { store =>
+                for
+                    _ <- mkExecution(store, eid1, wf1, Flow.Status.Compensating(Flow.Cause.Failure("boom", Maybe("ChargeDeclined"))))
+                    _ <- mkExecution(store, eid2, wf1, Flow.Status.Compensating(Flow.Cause.Cancellation))
+                    _ <- mkExecution(store, eid3, wf1, Flow.Status.Running)
+                    unwinding <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Compensating), Maybe(100), 0)
+                yield assert(
+                    unwinding.map(_.executionId).toSet == Set(eid1, eid2),
+                    s"both unwinds answer the compensating filter, whatever each is unwinding for, got ${unwinding.map(_.executionId)}"
+                )
+            }
+        }
+
+        /** An unnarrowed failure filter matches every failure, including one that carries no kind.
+          *
+          * A panic has no declared kind, and it is still a failed execution. A store reading the absent ask as "failures whose kind is
+          * absent", or as a narrowing on the empty string, hides exactly the executions an operator sweeping for failures most needs.
+          */
+        "an unnarrowed failure filter matches every failure, including one with no kind" in {
+            makeStore.map { store =>
+                for
+                    _      <- mkExecution(store, eid1, wf1, Flow.Status.Failed("declined", Maybe("ChargeDeclined")))
+                    _      <- mkExecution(store, eid2, wf1, Flow.Status.Failed("boom", Maybe.empty))
+                    _      <- mkExecution(store, eid3, wf1, Flow.Status.Running)
+                    failed <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Failed(Maybe.empty)), Maybe(100), 0)
+                yield assert(
+                    failed.map(_.executionId).toSet == Set(eid1, eid2),
+                    s"an unnarrowed ask must match a kind-less failure too, got ${failed.map(_.executionId)}"
+                )
+            }
+        }
+
+        /** A narrowed failure filter matches that kind and nothing else.
+          *
+          * The kind exists so an operator can ask "how many failed for payment reasons", and a store that accepted the parameter and
+          * ignored it makes the field decorative while answering 200 to every ask. Both directions are here: the kind that exists
+          * narrows to its own execution, and a kind nobody carries answers nothing rather than everything.
+          */
+        "a narrowed failure filter matches only that kind" in {
+            makeStore.map { store =>
+                for
+                    _        <- mkExecution(store, eid1, wf1, Flow.Status.Failed("declined", Maybe("ChargeDeclined")))
+                    _        <- mkExecution(store, eid2, wf1, Flow.Status.Failed("boom", Maybe.empty))
+                    _        <- mkExecution(store, eid3, wf1, Flow.Status.Failed("late", Maybe("FlowStepTimeoutException")))
+                    declined <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Failed(Maybe("ChargeDeclined"))), Maybe(100), 0)
+                    absent   <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Failed(Maybe("NoSuchKind"))), Maybe(100), 0)
+                yield
+                    assert(
+                        declined.map(_.executionId) == Chunk(eid1),
+                        s"a narrowed ask must answer only that kind, got ${declined.map(_.executionId)}"
+                    )
+                    assert(
+                        absent.isEmpty,
+                        s"and a kind nobody carries must answer nothing, not everything, got ${absent.map(_.executionId)}"
+                    )
+            }
+        }
+
+        /** The orphan predicate is two halves, and a store that drops either one answers the wrong population.
+          *
+          * It names the non-terminal executions whose version the caller does not serve, which is what `FlowEngine.parked` reports.
+          * Without the non-terminal half every execution that ever ran under a retired version is reported as stuck forever; without
+          * the hash half the report is every execution the caller is running perfectly well.
+          */
+        "filters the non-terminal executions no caller serves" in {
+            makeStore.map { store =>
+                for
+                    _        <- mkExecution(store, eid1, wf1, Flow.Status.Running, hash = "v2")
+                    _        <- mkExecution(store, eid2, wf1, Flow.Status.Completed, hash = "v2")
+                    _        <- mkExecution(store, eid3, wf1, Flow.Status.Running)
+                    orphaned <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Orphaned(Set(""))), Maybe(100), 0)
+                yield assert(
+                    orphaned.map(_.executionId) == Chunk(eid1),
+                    s"only the non-terminal execution on an unserved version is orphaned: a terminal one needs nobody to serve it, " +
+                        s"and a served one is not stranded, got ${orphaned.map(_.executionId)}"
+                )
+            }
+        }
+
+        /** An execution waiting on two kinds of row at once answers both wait filters.
+          *
+          * `race(input("x"), sleep(t))` is the idiom the wait ledger exists for, and it holds an `At` row and an `OnField` row at the
+          * same time. A filter derived from a single "current wait" would have to pick one, which rebuilds inside the query path the
+          * single-slot cell the ledger exists to replace: whichever it picked, the execution would be invisible to the other ask.
+          */
+        "an execution waiting on two kinds of row matches both wait filters" in {
+            makeStore.map { store =>
+                for
+                    now <- Clock.now
+                    _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                    _   <- mkWaits(store, eid1, wf1, ("timer", Flow.Wake.At(now + 30.seconds)), ("gate", Flow.Wake.OnField("approval")))
+                    sleeping <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.Sleeping), Maybe(100), 0)
+                    waiting  <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.WaitingForInput(Maybe.empty)), Maybe(100), 0)
+                    named <- store.listExecutions(wf1, Maybe(FlowStore.ExecutionFilter.WaitingForInput(Maybe("approval"))), Maybe(100), 0)
+                yield
+                    assert(
+                        sleeping.map(_.executionId) == Chunk(eid1),
+                        s"the sleep row must answer the sleeping filter, got ${sleeping.map(_.executionId)}"
+                    )
+                    assert(
+                        waiting.map(_.executionId) == Chunk(eid1),
+                        s"and the same execution's input row must answer the waiting filter, got ${waiting.map(_.executionId)}"
+                    )
+                    assert(
+                        named.map(_.executionId) == Chunk(eid1),
+                        s"and it must still be reachable by that input's name, got ${named.map(_.executionId)}"
+                    )
             }
         }
 
@@ -834,7 +2245,7 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                     _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
                     _       <- mkExecution(store, eid2, wf1, Flow.Status.Running)
                     _       <- mkExecution(store, eid3, wf1, Flow.Status.Running)
-                    results <- store.listExecutions(wf1, Maybe.empty, 1, 1)
+                    results <- store.listExecutions(wf1, Maybe.empty, Maybe(1), 1)
                 yield assert(results.length == 1)
             }
         }
@@ -842,7 +2253,7 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "returns empty for unknown flowId" in {
             makeStore.map { store =>
                 for
-                    results <- store.listExecutions(Flow.Id.Workflow("unknown"), Maybe.empty, 100, 0)
+                    results <- store.listExecutions(Flow.Id.Workflow("unknown"), Maybe.empty, Maybe(100), 0)
                 yield assert(results.isEmpty)
             }
         }
@@ -901,31 +2312,38 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
     }
 
     // =========================================================================
-    // Additional missing scenarios from plan
+    // Cross-cutting scenarios, each spanning more than one SPI method
     // =========================================================================
 
-    "I1 — 10 concurrent callers, 5 ready — all disjoint" in {
+    "I1: 10 concurrent callers, 5 ready, all disjoint" in {
         makeStore.map { store =>
             for
                 _ <- Kyo.foreach(1 to 5)(i => mkExecution(store, Flow.Id.Execution(s"e$i"), wf1, Flow.Status.Running))
                 executors = (1 to 10).map(i => Flow.Id.Executor(s"ex$i"))
-                results <- Kyo.foreach(executors)(ex => store.claimReady(Set(wf1), ex, lease, 10, 1.second))
+                results <- Kyo.foreach(executors)(ex => store.claimReady(served, ex, lease, 10, 1.second))
                 allClaimed = results.flatten
             yield
                 assert(allClaimed.size == 5, s"Expected 5 claimed, got ${allClaimed.size}")
-                assert(allClaimed.map(_.executionId).distinct.size == 5, "All disjoint")
+                assert(allClaimed.map(_.state.executionId).distinct.size == 5, "All disjoint")
         }
     }
 
-    "I7 — events from different callers on same execution" in {
+    /** One claim's events keep their append order whatever executor id each of them names.
+      *
+      * There is one caller here, which is the only shape the claimed capability admits: a second caller cannot write to an execution
+      * it does not hold, so "events from different callers" is not a state this SPI can be in. What the three appends do vary is the
+      * `executorId` each EVENT carries, and the pin is that the ordering is the store's, not the payloads'.
+      */
+    "I7: events keep their append order across the executor ids they name" in {
         makeStore.map { store =>
             for
-                _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                now <- Clock.now
-                _   <- store.appendEvent(eid1, Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
-                _   <- store.appendEvent(eid1, Flow.Event.StepCompleted(wf1, eid1, "s1", now + 1.second))
-                _   <- store.appendEvent(eid1, Flow.Event.StepStarted(wf1, eid1, "s2", ex2, now + 2.seconds))
-                h   <- store.getHistory(eid1, 100, 0)
+                _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                claimed <- claim(store, eid1)
+                now     <- Clock.now
+                _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s1", ex1, now))
+                _       <- claimed.appendEvent(Flow.Event.StepCompleted(wf1, eid1, "s1", now + 1.second))
+                _       <- claimed.appendEvent(Flow.Event.StepStarted(wf1, eid1, "s2", ex2, now + 2.seconds))
+                h       <- store.getHistory(eid1, Maybe(100), 0)
             yield
                 assert(h.events.length == 4) // Created + 3
                 val details = h.events.drop(1).map(_.detail).toSeq
@@ -933,24 +2351,24 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         }
     }
 
-    "field operations — getField with wrong type tag returns empty" in {
+    "field operations: getField with wrong type tag returns empty" in {
         makeStore.map { store =>
             for
                 _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                _ <- store.putField[Int](eid1, "x", 42)
+                _ <- mkField[Int](store, eid1, wf1, "x", 42)
                 v <- store.getField[String](eid1, "x")
             yield assert(v.isEmpty)
         }
     }
 
-    "renewClaim — same executor can renew multiple times" in {
+    "renewClaim: same executor can renew multiple times" in {
         makeStore.map { store =>
             for
-                _  <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                _  <- store.claimReady(Set(wf1), ex1, lease, 10, 1.second)
-                r1 <- store.renewClaim(eid1, ex1, lease)
-                r2 <- store.renewClaim(eid1, ex1, lease)
-                r3 <- store.renewClaim(eid1, ex1, lease)
+                _       <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                claimed <- store.claimReady(served, ex1, lease, 10, 1.second)
+                r1      <- claimed.head.renewClaim(lease)
+                r2      <- claimed.head.renewClaim(lease)
+                r3      <- claimed.head.renewClaim(lease)
             yield
                 assert(r1)
                 assert(r2)
@@ -958,33 +2376,43 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         }
     }
 
-    "execution state — WaitingForInput → Running → Failed" in {
+    /** Waiting for an input is two facts, and the round trip asserts both: the lifecycle it keeps and the row that records the node. */
+    "execution state: waiting on an input, then Running, then Failed" in {
         makeStore.map { store =>
             for
-                now <- Clock.now
-                _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                _   <- store.updateStatus(eid1, Flow.Status.WaitingForInput("x"), Flow.Event.InputWaiting(wf1, eid1, "x", now))
-                s1  <- store.getExecution(eid1)
-                _   <- store.updateStatus(eid1, Flow.Status.Running, Flow.Event.StepStarted(wf1, eid1, "y", ex1, now))
-                s2  <- store.getExecution(eid1)
-                _   <- store.updateStatus(eid1, Flow.Status.Failed("err"), Flow.Event.Failed(wf1, eid1, "err", now))
-                s3  <- store.getExecution(eid1)
+                now   <- Clock.now
+                _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                _     <- mkWait(store, eid1, wf1, "x", Flow.Wake.OnField("x"))
+                s1    <- store.getExecution(eid1)
+                _     <- deliver[String](store, eid1, wf1, "x", "here")
+                woken <- claim(store, eid1)
+                _     <- woken.recordProgress("x", Flow.Event.InputDischarged(wf1, eid1, "x", now))
+                s2    <- store.getExecution(eid1)
+                _ <- woken.finish(FlowStore.Claimed.Outcome.Terminal(
+                    Flow.Status.Failed("err"),
+                    Flow.Event.Failed(wf1, eid1, "err", now)
+                ))
+                s3 <- store.getExecution(eid1)
             yield
-                assert(s1.get.status == Flow.Status.WaitingForInput("x"))
+                assert(s1.get.status == Flow.Status.Running, s"waiting is not a lifecycle change, got ${s1.get.status}")
+                assert(
+                    s1.get.waits.get("x").contains(Flow.Wake.OnField("x")),
+                    s"the node it waits on must be recorded as a row, got ${s1.get.waits}"
+                )
                 assert(s2.get.status == Flow.Status.Running)
+                assert(s2.get.waits.isEmpty, s"the discharged wait must be gone, got ${s2.get.waits}")
                 assert(s3.get.status match
-                    case Flow.Status.Failed(_) => true;
-                    case _                     => false)
+                    case Flow.Status.Failed(_, _) => true;
+                    case _                        => false)
         }
     }
 
-    "execution state — Running → Cancelled" in {
+    "execution state: Running → Cancelled" in {
         makeStore.map { store =>
             for
-                now <- Clock.now
-                _   <- mkExecution(store, eid1, wf1, Flow.Status.Running)
-                _   <- store.updateStatus(eid1, Flow.Status.Cancelled, Flow.Event.Cancelled(wf1, eid1, now))
-                s   <- store.getExecution(eid1)
+                _ <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                _ <- terminate(store, eid1, wf1, Flow.Status.Cancelled, ts => Flow.Event.Cancelled(wf1, eid1, ts))
+                s <- store.getExecution(eid1)
             yield assert(s.get.status == Flow.Status.Cancelled)
         }
     }
@@ -997,20 +2425,25 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
         "returns empty on timeout when nothing ready" in {
             makeStore.map { store =>
                 for
-                    results <- store.claimReady(Set(wf1), ex1, lease, 10, 100.millis)
+                    results <- store.claimReady(served, ex1, lease, 10, 100.millis)
                 yield assert(results.isEmpty)
             }
         }
 
-        "wakes when signal makes execution ready (putField on WaitingForInput)" in {
+        "wakes when signal makes execution ready" in {
             Clock.withTimeControl { tc =>
                 makeStore.map { store =>
                     for
-                        now     <- Clock.now
-                        _       <- store.createExecution(eid1, Flow.Status.WaitingForInput("x"), Flow.Event.Created(wf1, eid1, now), "")
-                        fiber   <- Fiber.init(store.claimReady(Set(wf1), ex1, lease, 10, 5.seconds))
+                        now   <- Clock.now
+                        _     <- mkExecution(store, eid1, wf1, Flow.Status.Running)
+                        _     <- mkWait(store, eid1, wf1, "x", Flow.Wake.OnField("x"))
+                        fiber <- Fiber.init(store.claimReady(served, ex1, lease, 10, 5.seconds))
+                        // Load-bearing, not padding: it is what lets the caller reach its wait before the delivery lands. Without
+                        // it the spawned fiber has not run when the field is written, so it finds the value on its way IN and the
+                        // leaf passes having measured a plain poll rather than a wake. Removing it does not fail this leaf; it
+                        // silently changes what the leaf is about.
                         _       <- tc.advance(100.millis)
-                        _       <- store.putField[Int](eid1, "x", 42)
+                        _       <- deliver[Int](store, eid1, wf1, "x", 42)
                         _       <- tc.advance(200.millis)
                         results <- fiber.get
                     yield assert(results.size == 1)
@@ -1018,15 +2451,17 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
             }
         }
 
-        "wakes when status changes to Running via updateStatus" in {
+        "wakes when an execution is created" in {
             Clock.withTimeControl { tc =>
                 makeStore.map { store =>
                     for
-                        fiber   <- Fiber.init(store.claimReady(Set(wf1), ex1, lease, 10, 5.seconds))
-                        _       <- tc.advance(100.millis)
-                        now     <- Clock.now
-                        _       <- store.createExecution(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "")
-                        _       <- tc.advance(200.millis)
+                        fiber <- Fiber.init(store.claimReady(served, ex1, lease, 10, 5.seconds))
+                        // Load-bearing for the same reason as the leaf above: without it the caller has not reached its wait when
+                        // the row is created, so it finds the row on its way in and the leaf measures a plain poll, not a wake.
+                        _   <- tc.advance(100.millis)
+                        now <- Clock.now
+                        _   <- store.createExecutionIfAbsent(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "", Dict.empty)
+                        _   <- tc.advance(200.millis)
                         results <- fiber.get
                     yield assert(results.size == 1)
                 }
@@ -1038,14 +2473,10 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                 makeStore.map { store =>
                     for
                         now <- Clock.now
-                        _   <- store.createExecution(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "")
-                        _ <- store.updateStatus(
-                            eid1,
-                            Flow.Status.Sleeping("s", now + 500.millis),
-                            Flow.Event.SleepStarted(wf1, eid1, "s", now + 500.millis, now)
-                        )
+                        _   <- store.createExecutionIfAbsent(eid1, Flow.Status.Running, Flow.Event.Created(wf1, eid1, now), "", Dict.empty)
+                        _   <- mkWait(store, eid1, wf1, "s", Flow.Wake.At(now + 500.millis))
                         // First poll: sleep not expired, times out
-                        fiber1 <- Fiber.init(store.claimReady(Set(wf1), ex1, lease, 10, 100.millis))
+                        fiber1 <- Fiber.init(store.claimReady(served, ex1, lease, 10, 100.millis))
                         _      <- tc.advance(50.millis)
                         _      <- tc.advance(50.millis)
                         _      <- tc.advance(50.millis)
@@ -1053,12 +2484,80 @@ abstract class FlowStoreTest extends kyo.test.Test[Any]:
                         // Advance past sleep expiry
                         _ <- tc.advance(500.millis)
                         // Second poll: sleep expired, found immediately
-                        found <- store.claimReady(Set(wf1), ex1, lease, 10, 100.millis)
+                        found <- store.claimReady(served, ex1, lease, 10, 100.millis)
                     yield
                         assert(empty.isEmpty)
                         assert(found.size == 1)
                 }
             }
+        }
+    }
+
+    // =========================================================================
+    // Execution state equality
+    // =========================================================================
+    /** Two rows describing the same execution are equal, which is what `CanEqual` on the row advertises.
+      *
+      * A conformance suite compares states: it reads a row, does something it expects to change nothing, reads again and asserts the
+      * two are the same. That comparison has to mean what it says, and the wait ledger is where it can quietly stop meaning it. Under
+      * its threshold a `Dict` is a span over an array and its `==` is the array's, so two ledgers holding the same rows would be equal
+      * only when they happened to share the array, which a store that rebuilds the row (any store over a database, decoding it afresh)
+      * never does. A store author's own test would fail for a reason that has nothing to do with their store.
+      *
+      * `Dict.is` is the structural test, and the row uses it. The hash goes with it: equal rows hash alike, and because the ledger's
+      * equality does not depend on the order its entries were added, the hash may not either.
+      */
+    "execution state equality" - {
+
+        "two rows with the same wait ledger are equal and hash alike" in {
+            // Built separately and in opposite orders, so neither the array identity nor the insertion order can carry the answer.
+            val a = stateWith(Dict("sleeping" -> sleeping, "waiting" -> waiting))
+            val b = stateWith(Dict("waiting" -> waiting, "sleeping" -> sleeping))
+            assert(a == b, s"same rows, so the states are the same: ${a.waits.toChunk} against ${b.waits.toChunk}")
+            assert(a.hashCode == b.hashCode, s"and equal states hash alike, got ${a.hashCode} and ${b.hashCode}")
+        }
+
+        "two rows with different wait ledgers are not equal" in {
+            val a = stateWith(Dict("waiting" -> waiting))
+            val b = stateWith(Dict("waiting" -> Flow.Wake.OnField("y")))
+            val c = stateWith(Dict("waiting" -> waiting, "sleeping" -> sleeping))
+            assert(a != b, "a row waiting on another input is another state")
+            assert(a != c, "and so is one waiting on more than it does")
+        }
+
+        /** Every field the override compares by hand, varied one at a time.
+          *
+          * A hand-written `equals` is only as complete as its author's attention, and the failure it invites is silent: a dropped
+          * field makes two different rows equal, which no other leaf here would notice. So each field gets its own variant and its
+          * own message, and the arithmetic at the end is what keeps the leaf honest as the row grows. A field added to
+          * `ExecutionState` fails this leaf until somebody adds a case for it, which is the moment to notice the override needs an
+          * arm too, rather than discovering it from a comparison that quietly answered true.
+          */
+        "a row differing outside its wait ledger is not equal either" in {
+            val base = stateWith(Dict("waiting" -> waiting))
+            val varied = Seq(
+                "executionId"     -> base.copy(executionId = eid2),
+                "flowId"          -> base.copy(flowId = wf2),
+                "status"          -> base.copy(status = Flow.Status.Completed),
+                "executor"        -> base.copy(executor = Maybe(ex1)),
+                "claimExpiry"     -> base.copy(claimExpiry = Maybe(Instant.Epoch + 1.hour)),
+                "hash"            -> base.copy(hash = "other"),
+                "created"         -> base.copy(created = Instant.Epoch + 1.second),
+                "updated"         -> base.copy(updated = Instant.Epoch + 1.second),
+                "cancelRequested" -> base.copy(cancelRequested = true),
+                "claimToken"      -> base.copy(claimToken = Maybe(1L))
+            )
+            varied.foreach { (field, other) =>
+                assert(
+                    base != other,
+                    s"a row differing only in '$field' is another state, and the override must compare it"
+                )
+            }
+            assert(
+                base.productArity == varied.size + 1,
+                s"ExecutionState carries ${base.productArity} fields and this leaf varies ${varied.size} of them beside the " +
+                    "ledger, so one is unguarded: give it a case here and an arm in the override"
+            )
         }
     }
 

--- a/kyo-flow/shared/src/test/scala/kyo/FlowTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/FlowTest.scala
@@ -320,7 +320,10 @@ class FlowTest extends kyo.test.Test[Any]:
                 .otherwise(ctx => "zero", name = "default")
             var branchCount = 0
             FlowFold(flow)(new FlowVisitorCollect[Unit]((), (_, _) => ()):
-                override def onDispatch(name: String, infos: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) =
+                override def onDispatch[V](name: String, infos: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using
+                    Tag[V],
+                    Schema[V]
+                ) =
                     branchCount = infos.size)
             assert(branchCount == 3)
         }
@@ -329,7 +332,12 @@ class FlowTest extends kyo.test.Test[Any]:
             val flow     = Flow.input[Int]("x").loop("r") { ctx => Loop.done(ctx.x - 1) }
             var loopName = ""
             FlowFold(flow)(new FlowVisitorCollect[Unit]((), (_, _) => ()):
-                override def onLoop(name: String, frame: Frame, meta: Flow.Meta) = loopName = name)
+                override def onLoop[V, State](name: String, frame: Frame, meta: Flow.Meta)(using
+                    Tag[V],
+                    Schema[V],
+                    Tag[State],
+                    Schema[State]
+                ) = loopName = name)
             assert(loopName == "r")
         }
 
@@ -368,7 +376,7 @@ class FlowTest extends kyo.test.Test[Any]:
             var foreachName = ""
             var foreachConc = 0
             FlowFold(flow)(new FlowVisitorCollect[Unit]((), (_, _) => ()):
-                override def onForEach(name: String, conc: Int, frame: Frame, meta: Flow.Meta) =
+                override def onForEach[V](name: String, conc: Int, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) =
                     foreachName = name; foreachConc = conc)
             assert(foreachName == "items")
             assert(foreachConc == 5)
@@ -390,7 +398,7 @@ class FlowTest extends kyo.test.Test[Any]:
             var subflowName             = ""
             var childRef: Flow[?, ?, ?] = null
             FlowFold(flow)(new FlowVisitorCollect[Unit]((), (_, _) => ()):
-                override def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta) =
+                override def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Unit, frame: Frame, meta: Flow.Meta) =
                     subflowName = name; childRef = childFlow)
             assert(subflowName == "result")
             assert(childRef eq child, "visitor should receive the same child flow instance")
@@ -417,10 +425,14 @@ class FlowTest extends kyo.test.Test[Any]:
                 .otherwise(ctx => "small", name = "default")
                 .output("z")(ctx => ctx.d)
             val names = FlowFold(flow)(new FlowVisitorCollect[Chunk[String]](Chunk.empty, _ ++ _):
-                override def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V])        = Chunk(name)
-                override def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V])       = Chunk(name)
-                override def onDispatch(name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta) = Chunk(name)
-                override def onSubflow(name: String, childFlow: Flow[?, ?, ?], frame: Frame, meta: Flow.Meta)        = Chunk(name))
+                override def onInput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V])  = Chunk(name)
+                override def onOutput[V](name: String, frame: Frame, meta: Flow.Meta)(using Tag[V], Schema[V]) = Chunk(name)
+                override def onDispatch[V](name: String, branches: Seq[Flow.BranchInfo], frame: Frame, meta: Flow.Meta)(using
+                    Tag[V],
+                    Schema[V]
+                ) = Chunk(name)
+                override def onSubflow(name: String, childFlow: Flow[?, ?, ?], child: Chunk[String], frame: Frame, meta: Flow.Meta) =
+                    Chunk(name))
             assert(names.toSeq == Seq("x", "y", "d", "z"))
         }
     }
@@ -512,7 +524,7 @@ class FlowTest extends kyo.test.Test[Any]:
 
     "compile errors" - {
 
-        "dispatch without otherwise — output" in {
+        "dispatch without otherwise, over an output" in {
             typeCheckFailure("""
                 import kyo.*
                 val flow = Flow.init("test").input[Int]("x")
@@ -522,7 +534,7 @@ class FlowTest extends kyo.test.Test[Any]:
             """)("dispatch requires .otherwise")
         }
 
-        "dispatch without otherwise — step" in {
+        "dispatch without otherwise, over a step" in {
             typeCheckFailure("""
                 import kyo.*
                 val flow = Flow.init("test").input[Int]("x")
@@ -532,7 +544,7 @@ class FlowTest extends kyo.test.Test[Any]:
             """)("dispatch requires .otherwise")
         }
 
-        "dispatch without otherwise — input" in {
+        "dispatch without otherwise, over an input" in {
             typeCheckFailure("""
                 import kyo.*
                 val flow = Flow.init("test").input[Int]("x")
@@ -542,7 +554,7 @@ class FlowTest extends kyo.test.Test[Any]:
             """)("dispatch requires .otherwise")
         }
 
-        "dispatch without otherwise — sleep" in {
+        "dispatch without otherwise, over a sleep" in {
             typeCheckFailure("""
                 import kyo.*
                 val flow = Flow.init("test").input[Int]("x")
@@ -561,15 +573,6 @@ class FlowTest extends kyo.test.Test[Any]:
 
             "Running" in {
                 assert(Flow.Status.Running.show == "running")
-            }
-
-            "WaitingForInput" in {
-                assert(Flow.Status.WaitingForInput("x").show == "waiting:x")
-            }
-
-            "Sleeping" in {
-                val until = Instant.Epoch + 1.hour
-                assert(Flow.Status.Sleeping("pause", until).show == "sleeping:pause")
             }
 
             "Completed" in {
@@ -593,10 +596,6 @@ class FlowTest extends kyo.test.Test[Any]:
 
         "isTerminal for non-terminal statuses" - {
             "Running is not terminal" in { assert(!Flow.Status.Running.isTerminal); () }
-            "WaitingForInput is not terminal" in { assert(!Flow.Status.WaitingForInput("x").isTerminal); () }
-            "Sleeping is not terminal" in {
-                assert(!Flow.Status.Sleeping("pause", Instant.Epoch + 1.hour).isTerminal); ()
-            }
         }
     }
 

--- a/kyo-flow/shared/src/test/scala/kyo/internal/FlowApiTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/internal/FlowApiTest.scala
@@ -4,6 +4,15 @@ import kyo.*
 
 class FlowApiTest extends kyo.test.Test[Any]:
 
+    // This suite is real-time by nature (a live HTTP server and client; Clock.withTimeControl does not reach it),
+    // and in a full-module run it executes concurrently with sibling suites whose leaves each spin engines, workers
+    // and renewal fibers on the shared scheduler. Its slowest leaf, "rejects signal to completed execution", is three
+    // assertEventually polls over real round-trips and takes 1.5s standalone; under that contention it starves past
+    // the 120-second default budget. The larger budget absorbs the starvation without touching what any leaf asserts;
+    // a genuinely stuck leaf still stops. Suite-level isolation would be the sharper fix, but test parallelism is a
+    // build-level setting, not this suite's.
+    override def timeout = 300.seconds
+
     // Socket-only opt-out: this suite runs an HttpServer/HttpClient on the NIO transport, whose closed-channel fd
     // close is deferred to the idle selector's next select() (an opaque socket:[inode] no allowlist matches), the
     // same transport-deferred reason as BaseHttpTest. Thread, fiber, and file-descriptor detection stay on.
@@ -11,21 +20,19 @@ class FlowApiTest extends kyo.test.Test[Any]:
 
     given CanEqual[Any, Any] = CanEqual.derived
 
-    // Skip on Native: under Linux Native CI the embedded HTTP server stops responding when
-    // a FlowEngine worker is running concurrently (every request hits the 30s client timeout).
-    // The test passes on JVM, JS, and macOS Native locally; the failure is specific to the
-    // Linux epoll-driven IO driver and has not been reproduced locally. Tracking separately.
-    // Ported from the ScalaTest base's `run` override to kyo-test's `aroundLeaf` hook; the cancel is
-    // deferred into a Sync so the runner discharges it as a Cancelled result rather than running the body.
-    override def aroundLeaf[A](body: A < (Async & Abort[Any] & Scope))(using Frame): A < (Async & Abort[Any] & Scope) =
-        if kyo.internal.Platform.isNative then
-            Sync.defer(
-                cancel("skipped on Native: the Linux epoll IO driver hangs the embedded HTTP server under a concurrent FlowEngine worker")
-            )
-        else body
-
     private def withFlowServer[A](
         f: Int => A < (Async & Scope & Abort[Any])
+    )(using Frame): A < (Async & Scope & Abort[Any]) =
+        withFlowServerStore((port, _) => f(port))
+
+    /** The same server, with the store it is backed by.
+      *
+      * A leaf that needs an execution the engine will never claim has to write one, and the only way to write one is the store: every
+      * execution reachable over HTTP belongs to the workflow this engine serves, and therefore terminalises on its own the moment
+      * anything asks it to stop.
+      */
+    private def withFlowServerStore[A](
+        f: (Int, FlowStore) => A < (Async & Scope & Abort[Any])
     )(using Frame): A < (Async & Scope & Abort[Any]) =
         val flow = Flow.input[Int]("x")
             .output("y")(ctx => ctx.x * 2)
@@ -37,12 +44,12 @@ class FlowApiTest extends kyo.test.Test[Any]:
                 engine.register(Flow.Id.Workflow("test-flow"), flow).map { _ =>
                     val handlers = FlowApi.handlers(engine)
                     HttpServer.init(0, "127.0.0.1")(handlers.toSeq*).map { server =>
-                        HttpClient.withConfig(_.timeout(30.seconds))(f(server.port))
+                        HttpClient.withConfig(_.timeout(30.seconds))(f(server.port, store))
                     }
                 }
             }
         }
-    end withFlowServer
+    end withFlowServerStore
 
     private def url(port: Int, path: String): String =
         s"http://127.0.0.1:$port$path"
@@ -54,6 +61,14 @@ class FlowApiTest extends kyo.test.Test[Any]:
     private def jsonFieldInt(body: String, field: String): Int =
         val pattern = s""""$field"\\s*:\\s*(\\d+)""".r
         pattern.findFirstMatchIn(body).map(_.group(1).toInt).getOrElse(-1)
+
+    /** Whether an execution-detail body says the execution is waiting for the named input.
+      *
+      * The lifecycle string cannot answer it: an execution waiting for an input is `running`, and what it waits for is one row per
+      * waiting node, which the body carries beside the status.
+      */
+    private def waitsFor(name: String)(body: String): Boolean =
+        body.replace(" ", "").contains(s""""path":"$name"""")
 
     private def awaitStatus(port: Int, eid: String)(pred: String => Boolean)(using
         Frame,
@@ -158,6 +173,54 @@ class FlowApiTest extends kyo.test.Test[Any]:
             }
         }
 
+        /** The detail endpoint answers what an execution is doing, not only that it is running.
+          *
+          * `FlowEngine.ExecutionDetail` carries the per-node progress and the input delivery state, and the endpoint must pass both
+          * through. An endpoint projecting it down to a few scalars sends anyone asking "which node is it on" to the store instead.
+          */
+        "returns the per-node progress and the input state" in {
+            withFlowServer { port =>
+                for
+                    createBody <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    eid = jsonField(createBody, "executionId")
+                    _    <- Async.sleep(500.millis)
+                    _    <- HttpClient.postText(url(port, s"/api/v1/executions/$eid/signal/x"), "42")
+                    _    <- Async.sleep(500.millis)
+                    body <- HttpClient.getText(url(port, s"/api/v1/executions/$eid"))
+                yield
+                    assert(body.contains("\"progress\""), s"the detail must carry progress: $body")
+                    assert(body.contains("\"inputs\""), s"the detail must carry the inputs: $body")
+                    // The flow's own nodes, by name, each with the status the engine derived for it.
+                    assert(body.contains("\"y\""), s"progress must name the flow's nodes: $body")
+                    assert(body.contains("\"greeting\""), s"progress must name the flow's nodes: $body")
+                    // `x` was signalled and `name` was not, so the two inputs disagree on delivery.
+                    assert(body.contains("\"delivered\":true"), s"a delivered input must say so: $body")
+                    assert(body.contains("\"delivered\":false"), s"a pending input must say so: $body")
+                    assert(body.contains("completed") || body.contains("running"), s"a node must carry a status: $body")
+            }
+        }
+
+        /** The detail says what the execution is WAITING for, which its lifecycle cannot.
+          *
+          * `status` answers `running` for an execution that is working and for one that is waiting alike, and an execution can be
+          * waiting on several things at once, so the answer is a row per waiting node: which node, what kind of wait, and the
+          * condition.
+          */
+        "reports what a waiting execution is waiting for" in {
+            withFlowServer { port =>
+                for
+                    createBody <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    eid = jsonField(createBody, "executionId")
+                    body <- awaitStatus(port, eid)(waitsFor("x"))
+                yield
+                    val compact = body.replace(" ", "")
+                    assert(compact.contains("\"status\":\"running\""), s"a waiting execution is running: $body")
+                    assert(compact.contains("\"path\":\"x\""), s"the wait must name the node waiting: $body")
+                    assert(compact.contains("\"kind\":\"waiting\""), s"the wait must say what kind it is: $body")
+                    assert(compact.contains("\"cancelRequested\":false"), s"and whether somebody asked it to stop: $body")
+            }
+        }
+
         "404 for unknown execution" in {
             withFlowServer { port =>
                 HttpClient.getTextResponse(url(port, "/api/v1/executions/nonexistent"), failOnError = false).map { resp =>
@@ -195,6 +258,32 @@ class FlowApiTest extends kyo.test.Test[Any]:
             }
         }
 
+        /** A signal delivered over HTTP is recorded in the execution's history, like one delivered through the engine.
+          *
+          * The endpoint delivers through `engine.executions.signal`, which records `Flow.Event.InputReceived` in the same
+          * transition as the write. Writing the field directly instead is durable but not auditable: the input simply appears,
+          * with nothing in history saying when it arrived or that it arrived at all. One verb, one set of guards, one event.
+          *
+          * History is the operator's account of what happened to an execution, and this is the only surface that can put a value into
+          * a running execution from outside. `InputWaiting` is recorded when the flow starts waiting, so a history that never shows
+          * the matching `InputReceived` reads as an execution still blocked on an input it has already been given.
+          */
+        "records the delivery in history" in {
+            withFlowServer { port =>
+                for
+                    createBody <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    eid = jsonField(createBody, "executionId")
+                    _        <- Async.sleep(500.millis)
+                    _        <- HttpClient.postText(url(port, s"/api/v1/executions/$eid/signal/x"), "42")
+                    _        <- Async.sleep(500.millis)
+                    histBody <- HttpClient.getText(url(port, s"/api/v1/executions/$eid/history"))
+                yield assert(
+                    histBody.contains("InputReceived"),
+                    s"a signal delivered over HTTP must be recorded like any other, history was: $histBody"
+                )
+            }
+        }
+
         "400 for unknown input name" in {
             withFlowServer { port =>
                 for
@@ -211,9 +300,9 @@ class FlowApiTest extends kyo.test.Test[Any]:
                 for
                     createBody <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
                     eid = jsonField(createBody, "executionId")
-                    _    <- awaitStatus(port, eid)(_.contains("waiting:x"))
+                    _    <- awaitStatus(port, eid)(waitsFor("x"))
                     _    <- HttpClient.postText(url(port, s"/api/v1/executions/$eid/signal/x"), "42")
-                    _    <- awaitStatus(port, eid)(_.contains("waiting:name"))
+                    _    <- awaitStatus(port, eid)(waitsFor("name"))
                     _    <- HttpClient.postText(url(port, s"/api/v1/executions/$eid/signal/name"), "\"hello\"")
                     _    <- awaitStatus(port, eid)(_.contains("completed"))
                     resp <- HttpClient.postTextResponse(url(port, s"/api/v1/executions/$eid/signal/x"), "99", failOnError = false)
@@ -239,17 +328,126 @@ class FlowApiTest extends kyo.test.Test[Any]:
                     assert(body.contains("\"hasMore\""))
             }
         }
+
+        /** A negative page offset is refused here too, for the reason the search route refuses it.
+          *
+          * This is the route where forwarding hurts most: it has no error mapping of its own, so a store that rejects `OFFSET -1`
+          * would surface a client's typo as a 500. The check is at the wire because the wire is the only layer that can tell a bad
+          * query parameter from a store fault.
+          */
+        "a negative history offset is refused" in {
+            withFlowServer { port =>
+                for
+                    createBody <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    eid = jsonField(createBody, "executionId")
+                    _    <- Async.sleep(200.millis)
+                    resp <- HttpClient.getTextResponse(url(port, s"/api/v1/executions/$eid/history?offset=-1"), failOnError = false)
+                yield assert(
+                    resp.status.code >= 400 && resp.status.code < 500,
+                    s"a negative offset is a client error, got ${resp.status.code} with ${resp.fields.body.take(200)}"
+                )
+            }
+        }
     }
 
     "POST /api/v1/executions/:eid/cancel" - {
 
+        /** A cancel the store took answers that it took it, and says so with a code of its own.
+          *
+          * Answering `ok: true` to all three outcomes leaves no HTTP caller able to tell a request that was taken from one that
+          * fell on an execution which finished last week. Nothing about a cancel is observable on return (the execution runs its
+          * compensations afterwards), so this response is the only thing the caller has.
+          */
         "cancels execution" in {
             withFlowServer { port =>
                 for
                     createBody <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
                     eid = jsonField(createBody, "executionId")
-                    body <- HttpClient.postText(url(port, s"/api/v1/executions/$eid/cancel"), "")
-                yield assert(body.contains("true"))
+                    _    <- Async.sleep(500.millis)
+                    resp <- HttpClient.postTextResponse(url(port, s"/api/v1/executions/$eid/cancel"), "", failOnError = false)
+                    body = resp.fields.body
+                yield
+                    assert(
+                        resp.status.code == 202,
+                        s"a request taken whose work has not been done answers 202, got ${resp.status.code} with $body"
+                    )
+                    assert(
+                        jsonField(body, "outcome") == "accepted",
+                        s"the outcome must say the request was taken, got $body"
+                    )
+                end for
+            }
+        }
+
+        /** Asking twice answers that somebody already asked, which is a different instruction to the caller.
+          *
+          * Staged on an execution no engine here serves, so it is unclaimable and cannot terminalise between the two asks: the leaf is
+          * about which answer a repeat gets, and racing an unwind would make it about scheduling instead.
+          */
+        "a repeated cancel answers already-requested" in {
+            withFlowServerStore { (port, store) =>
+                val eid = Flow.Id.Execution("api-cancel-twice")
+                for
+                    now <- Clock.now
+                    _ <- store.createExecutionIfAbsent(
+                        eid,
+                        Flow.Status.Running,
+                        Flow.Event.Created(Flow.Id.Workflow("unserved-flow"), eid, now),
+                        "",
+                        Dict.empty
+                    )
+                    first  <- HttpClient.postTextResponse(url(port, s"/api/v1/executions/${eid.value}/cancel"), "", failOnError = false)
+                    second <- HttpClient.postTextResponse(url(port, s"/api/v1/executions/${eid.value}/cancel"), "", failOnError = false)
+                yield
+                    assert(
+                        jsonField(first.fields.body, "outcome") == "accepted",
+                        s"the premise is that the first ask was taken, got ${first.fields.body}"
+                    )
+                    assert(
+                        second.status.code == 200,
+                        s"a repeat changed nothing and is not an error, got ${second.status.code}"
+                    )
+                    assert(
+                        jsonField(second.fields.body, "outcome") == "already-requested",
+                        s"the repeat must say somebody asked first, got ${second.fields.body}"
+                    )
+                end for
+            }
+        }
+
+        /** Cancelling something that is over is answered, not refused, and the answer carries what it ended as.
+          *
+          * The caller got the outcome it wanted, so this is no client error; what it needs back is the terminal status, because its
+          * next call is a read of the result rather than another cancel.
+          */
+        "a cancel on a finished execution answers already-terminal with its status" in {
+            withFlowServerStore { (port, store) =>
+                val eid = Flow.Id.Execution("api-cancel-finished")
+                for
+                    now <- Clock.now
+                    _ <- store.createExecutionIfAbsent(
+                        eid,
+                        Flow.Status.Completed,
+                        Flow.Event.Created(Flow.Id.Workflow("unserved-flow"), eid, now),
+                        "",
+                        Dict.empty
+                    )
+                    resp <- HttpClient.postTextResponse(url(port, s"/api/v1/executions/${eid.value}/cancel"), "", failOnError = false)
+                    body = resp.fields.body
+                yield
+                    assert(
+                        resp.status.code == 200,
+                        s"an execution that is already over is an answer, not a client error, got ${resp.status.code}"
+                    )
+                    assert(
+                        jsonField(body, "outcome") == "already-terminal",
+                        s"the outcome must say there was nothing to cancel, got $body"
+                    )
+                    assert(
+                        jsonField(body, "status") == Flow.Status.Completed.show,
+                        s"and it must carry what the execution ended as, got $body"
+                    )
+                end for
             }
         }
     }
@@ -280,6 +478,182 @@ class FlowApiTest extends kyo.test.Test[Any]:
                 yield assert(result.total >= 1)
             }
         }
+
+        /** The wire keeps the kind-scoped failure filter, not just the bare name.
+          *
+          * `Failed`'s kind exists so an operator can ask "how many failed for payment reasons", and the wire syntax is where that ask
+          * is spelled. A parse that dropped the suffix would answer every failure to a caller who asked for one kind, with a 200 and
+          * no way to tell: the same shape as the unrecognized filter refused below, one narrowing further in.
+          */
+        "narrows a failure filter by kind" in {
+            withFlowServerStore { (port, store) =>
+                val declined = Flow.Id.Execution("api-filter-declined")
+                val panicked = Flow.Id.Execution("api-filter-panicked")
+                val wfId     = Flow.Id.Workflow("test-flow")
+                for
+                    now <- Clock.now
+                    _ <- store.createExecutionIfAbsent(
+                        declined,
+                        Flow.Status.Failed("declined", Maybe("ChargeDeclined")),
+                        Flow.Event.Created(wfId, declined, now),
+                        "",
+                        Dict.empty
+                    )
+                    _ <- store.createExecutionIfAbsent(
+                        panicked,
+                        Flow.Status.Failed("boom", Maybe.empty),
+                        Flow.Event.Created(wfId, panicked, now),
+                        "",
+                        Dict.empty
+                    )
+                    narrowed <- HttpClient.postJson[FlowApi.SearchResponse](
+                        url(port, "/api/v1/executions/search"),
+                        FlowApi.SearchRequest(status = Some("failed:ChargeDeclined"))
+                    )
+                    bare <- HttpClient.postJson[FlowApi.SearchResponse](
+                        url(port, "/api/v1/executions/search"),
+                        FlowApi.SearchRequest(status = Some("failed"))
+                    )
+                yield
+                    assert(
+                        narrowed.items.map(_.executionId) == Seq(declined.value),
+                        s"the kind-scoped ask must answer only that kind, got ${narrowed.items.map(_.executionId)}"
+                    )
+                    assert(
+                        bare.items.map(_.executionId).toSet == Set(declined.value, panicked.value),
+                        s"and the bare ask must still answer every failure, got ${bare.items.map(_.executionId)}"
+                    )
+                end for
+            }
+        }
+
+        /** The wire keeps the name-scoped input filter, which is the capability the arm carries its parameter for.
+          *
+          * An operator hunting "stuck waiting for approval" is asking about one input's name, and the names are the caller's own
+          * vocabulary because `signal` takes them. A parse that coarsened `waiting:<name>` to bare `waiting` answers every waiting
+          * execution to that ask.
+          */
+        "narrows an input-wait filter by name" in {
+            withFlowServer { port =>
+                for
+                    firstBody  <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    secondBody <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    onX    = jsonField(firstBody, "executionId")
+                    onName = jsonField(secondBody, "executionId")
+                    // The second is walked past its first input so the two executions hold rows for DIFFERENT names, which is what
+                    // makes the narrowing observable at all.
+                    _ <- awaitStatus(port, onName)(waitsFor("x"))
+                    _ <- HttpClient.postText(url(port, s"/api/v1/executions/$onName/signal/x"), "42")
+                    _ <- awaitStatus(port, onName)(waitsFor("name"))
+                    _ <- awaitStatus(port, onX)(waitsFor("x"))
+                    forName <- HttpClient.postJson[FlowApi.SearchResponse](
+                        url(port, "/api/v1/executions/search"),
+                        FlowApi.SearchRequest(status = Some("waiting:name"))
+                    )
+                    anyWait <- HttpClient.postJson[FlowApi.SearchResponse](
+                        url(port, "/api/v1/executions/search"),
+                        FlowApi.SearchRequest(status = Some("waiting"))
+                    )
+                yield
+                    assert(
+                        forName.items.map(_.executionId) == Seq(onName),
+                        s"the name-scoped ask must answer only the execution waiting on that input, got ${forName.items.map(_.executionId)}"
+                    )
+                    assert(
+                        anyWait.items.map(_.executionId).toSet == Set(onX, onName),
+                        s"and the bare ask must answer both input waits, got ${anyWait.items.map(_.executionId)}"
+                    )
+                end for
+            }
+        }
+
+        /** An unrecognized filter must be refused, not silently dropped.
+          *
+          * `FlowApi.parseFilter` answers `Maybe.empty` for a string it does not know, and a route reading that as NO filter would
+          * return every execution as if it matched the typo: the one answer that is wrong for every caller, delivered with a 200.
+          * A filter the server cannot parse is a client error and answers 4xx, the same contract the signal route keeps for an
+          * unknown input name.
+          */
+        "an unrecognized filter is refused, not ignored" in {
+            withFlowServer { port =>
+                for
+                    _ <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    _ <- Async.sleep(200.millis)
+                    resp <- HttpClient.postTextResponse(
+                        url(port, "/api/v1/executions/search"),
+                        """{"status":"bananas"}""",
+                        headers = Seq("Content-Type" -> "application/json"),
+                        failOnError = false
+                    )
+                yield assert(
+                    resp.status.code >= 400 && resp.status.code < 500,
+                    s"a filter the server cannot parse is a client error, got ${resp.status.code} with body " +
+                        s"${resp.fields.body.take(200)}"
+                )
+            }
+        }
+
+        /** A narrowing prefix with nothing after it is refused the same way an unrecognized filter is.
+          *
+          * A parse that took `failed:` and `waiting:` as a narrowing on the empty string would match nothing, since nothing carries
+          * an empty kind or an empty input name, and the caller would get an empty result set with a 200. That is the same typo as
+          * `bananas` above telling the opposite lie: nothing matched, rather than everything did, and neither answer lets the
+          * caller find the mistake.
+          */
+        "a filter with an empty narrowing is refused" in {
+            withFlowServer { port =>
+                for
+                    _ <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    _ <- Async.sleep(200.millis)
+                    failedEmpty <- HttpClient.postTextResponse(
+                        url(port, "/api/v1/executions/search"),
+                        """{"status":"failed:"}""",
+                        headers = Seq("Content-Type" -> "application/json"),
+                        failOnError = false
+                    )
+                    waitingEmpty <- HttpClient.postTextResponse(
+                        url(port, "/api/v1/executions/search"),
+                        """{"status":"waiting:"}""",
+                        headers = Seq("Content-Type" -> "application/json"),
+                        failOnError = false
+                    )
+                yield
+                    assert(
+                        failedEmpty.status.code >= 400 && failedEmpty.status.code < 500,
+                        s"an empty kind narrows to nothing and must be refused, got ${failedEmpty.status.code}"
+                    )
+                    assert(
+                        waitingEmpty.status.code >= 400 && waitingEmpty.status.code < 500,
+                        s"an empty input name narrows to nothing and must be refused, got ${waitingEmpty.status.code}"
+                    )
+                end for
+            }
+        }
+
+        /** A negative page offset is a client error, and this is the layer that can say so.
+          *
+          * The SPI makes a non-negative `offset` the caller's obligation, and this handler is the caller. Unlike a negative `limit`,
+          * which the whole stack reads as "everything", a negative offset has no reading to fall back on: forwarded, it is tolerated
+          * by a store that drops from a chunk and rejected by one that writes it into SQL, where a client's typo would come back as a
+          * 500 and send an operator hunting a server fault.
+          */
+        "a negative search offset is refused" in {
+            withFlowServer { port =>
+                for
+                    _ <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
+                    _ <- Async.sleep(200.millis)
+                    resp <- HttpClient.postTextResponse(
+                        url(port, "/api/v1/executions/search"),
+                        """{"offset":-1}""",
+                        headers = Seq("Content-Type" -> "application/json"),
+                        failOnError = false
+                    )
+                yield assert(
+                    resp.status.code >= 400 && resp.status.code < 500,
+                    s"a negative offset is a client error, got ${resp.status.code} with ${resp.fields.body.take(200)}"
+                )
+            }
+        }
     }
 
     "POST /api/v1/executions/cancel (cancelAll)" - {
@@ -293,7 +667,10 @@ class FlowApiTest extends kyo.test.Test[Any]:
                         url(port, "/api/v1/executions/cancel"),
                         FlowApi.CancelAllRequest(workflowId = Some("test-flow"))
                     )
-                yield assert(result.cancelled >= 0)
+                yield assert(
+                    result.requested == 2,
+                    s"both executions park on an input nobody delivers, so both are asked to stop, got ${result.requested}"
+                )
             }
         }
     }
@@ -321,9 +698,9 @@ class FlowApiTest extends kyo.test.Test[Any]:
                 for
                     createBody <- HttpClient.postText(url(port, "/api/v1/workflows/test-flow/executions"), "")
                     eid = jsonField(createBody, "executionId")
-                    _        <- awaitStatus(port, eid)(_.contains("waiting:x"))
+                    _        <- awaitStatus(port, eid)(waitsFor("x"))
                     _        <- HttpClient.postText(url(port, s"/api/v1/executions/$eid/signal/x"), "10")
-                    _        <- awaitStatus(port, eid)(_.contains("waiting:name"))
+                    _        <- awaitStatus(port, eid)(waitsFor("name"))
                     _        <- HttpClient.postText(url(port, s"/api/v1/executions/$eid/signal/name"), "\"World\"")
                     _        <- awaitStatus(port, eid)(_.contains("completed"))
                     histBody <- HttpClient.getText(url(port, s"/api/v1/executions/$eid/history"))

--- a/kyo-flow/shared/src/test/scala/kyo/internal/FlowLintTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/internal/FlowLintTest.scala
@@ -22,12 +22,25 @@ class FlowLintTest extends kyo.test.Test[Any]:
             assert(warnings.isEmpty)
         }
 
+        /** Across a composition the warning follows what a name is FOR, and this leaf pins the boundary from both sides.
+          *
+          * Two zip branches READING one input must not warn: that is one wait and one field, so a warning there would teach users
+          * that the shape the design blesses is a mistake. The adjacent case, two branches WRITING one name, is the real ambiguity,
+          * since zip merges into one record with one slot and one of the two writers wins silently. Asserting only the silent half
+          * would let a lint that warns about nothing pass.
+          */
         "detects duplicates across compositions" in {
-            val left     = Flow.input[Int]("x").output("y")(ctx => ctx.x)
-            val right    = Flow.input[Int]("x").output("z")(ctx => ctx.x)
-            val flow     = left.zip(right)
-            val warnings = FlowLint.duplicateNames(flow)
-            assert(warnings.exists(_.message.contains("'x'")))
+            val readLeft    = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+            val readRight   = Flow.input[Int]("x").output("z")(ctx => ctx.x)
+            val readShared  = FlowLint.duplicateNames(readLeft.zip(readRight))
+            val writeLeft   = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+            val writeRight  = Flow.input[Int]("a").output("y")(ctx => ctx.a)
+            val writeShared = FlowLint.duplicateNames(writeLeft.zip(writeRight))
+            assert(readShared.isEmpty, s"two branches waiting on one input is one wait, got $readShared")
+            assert(
+                writeShared.exists(_.message.contains("'y'")),
+                s"two branches writing one name is ambiguous in the merged record, got $writeShared"
+            )
         }
 
         "detects triplicate names" in {
@@ -57,7 +70,7 @@ class FlowLintTest extends kyo.test.Test[Any]:
     "emptyBranches" - {
 
         "detects empty dispatch branches" in {
-            // Construct a dispatch with no conditional branches (only orElse)
+            // A dispatch with no `when` branch at all, closed by `otherwise` alone
             val flow = Flow.input[Int]("x")
                 .dispatch[String]("d")
                 .otherwise(ctx => "default", name = "default")
@@ -225,6 +238,152 @@ class FlowLintTest extends kyo.test.Test[Any]:
         }
     }
 
+    /** The enforced rule, as opposed to [[FlowLint.duplicateNames]]'s advisory warning above.
+      *
+      * Registration refuses what this reports, so its SCOPE is the whole content: it is narrower than the warning in two places, and
+      * both are load-bearing. A name only READ is shared freely, because two branches waiting on one input is one wait and one field. A
+      * name written by the branches of a race is the canonical race rather than a collision, because the result type is the union of the
+      * two branches and is readable only through a field both carry. Everything else two nodes claim is refused.
+      */
+    "nameConflicts" - {
+
+        "no conflicts for a clean flow" in {
+            val flow = Flow.input[Int]("x")
+                .output("y")(ctx => ctx.x + 1)
+                .step("log")(ctx => ())
+                .sleep("wait", 1.second)
+            assert(FlowLint.nameConflicts(flow).isEmpty)
+        }
+
+        "an output named after an input is a conflict" in {
+            val flow      = Flow.input[String]("x").output("x")(ctx => ctx.x)
+            val conflicts = FlowLint.nameConflicts(flow)
+            assert(conflicts.map(_.name) == Seq("x"), s"expected one conflict on 'x', got $conflicts")
+            assert(conflicts.head.composition == "in sequence", s"got ${conflicts.head.composition}")
+        }
+
+        "two nodes sharing a name in sequence are a conflict" in {
+            val flow      = Flow.init("dup").step("a")(_ => ()).step("a")(_ => ()).output("done")(_ => 1)
+            val conflicts = FlowLint.nameConflicts(flow)
+            assert(conflicts.map(_.name) == Seq("a"), s"expected one conflict on 'a', got $conflicts")
+        }
+
+        "two branches waiting on one input are not a conflict" in {
+            val left  = Flow.init("read").input[Int]("x").output("a")(ctx => ctx.x)
+            val right = Flow.init("read").input[Int]("x").output("b")(ctx => ctx.x)
+            assert(FlowLint.nameConflicts(left.zip(right)).isEmpty)
+        }
+
+        "two zip branches sharing a step name are a conflict" in {
+            val left      = Flow.init("z").step("validate")(_ => ()).output("a")(_ => 1)
+            val right     = Flow.init("z").step("validate")(_ => ()).output("b")(_ => 2)
+            val conflicts = FlowLint.nameConflicts(left.zip(right))
+            assert(conflicts.map(_.name) == Seq("validate"), s"expected one conflict on 'validate', got $conflicts")
+            assert(conflicts.head.composition == "by two zip branches", s"got ${conflicts.head.composition}")
+        }
+
+        "a race's shared result name is not a conflict" in {
+            val waiting = Flow.init("r").input[String]("ack").output("answer")(ctx => ctx.ack)
+            val timeout = Flow.init("r").sleep("deadline", 5.seconds).output("answer")(_ => "timed out")
+            assert(FlowLint.nameConflicts(Flow.race(waiting, timeout)).isEmpty)
+        }
+
+        "a race's shared step name is a conflict, though its shared result name is not" in {
+            val left      = Flow.init("r").step("notify")(_ => ()).output("answer")(_ => "a")
+            val right     = Flow.init("r").step("notify")(_ => ()).output("answer")(_ => "b")
+            val conflicts = FlowLint.nameConflicts(Flow.race(left, right))
+            assert(
+                conflicts.map(_.name) == Seq("notify"),
+                s"only the step name is refused; the shared result name is what makes a race readable, got $conflicts"
+            )
+        }
+
+        "a race's shared name written outside the race too is a conflict" in {
+            val left      = Flow.init("o").output("answer")(_ => "left")
+            val right     = Flow.init("o").output("answer")(_ => "right")
+            val flow      = Flow.init("o").output("answer")(_ => "pre").andThen(Flow.race(left, right))
+            val conflicts = FlowLint.nameConflicts(flow)
+            assert(conflicts.map(_.name) == Seq("answer"), s"the share is not only among the race's branches, got $conflicts")
+        }
+
+        /** One entry per NAME, not per join, which a three-branch fan-out is the only way to see.
+          *
+          * `gather` folds its branches pairwise, so a name all three write is found at two separate joins. Reporting both would say
+          * "2 durable names are claimed" about a single name, and would list the same call site twice, since the three branches are
+          * one flow value embedded three times.
+          */
+        "a gather of one flow three times reports the name once" in {
+            val review    = Flow.init("g").output("verdict")(_ => "ok")
+            val conflicts = FlowLint.nameConflicts(Flow.gather(review, review, review))
+            assert(conflicts.map(_.name) == Seq("verdict"), s"expected exactly one conflict entry, got $conflicts")
+            assert(conflicts.head.locations.size == 1, s"one flow value is one call site, got ${conflicts.head.locations}")
+            assert(conflicts.head.composition == "by two gather branches", s"got ${conflicts.head.composition}")
+        }
+
+        "the walk does not descend into a subflow" in {
+            val child = Flow.init("c").output("shared")(_ => 1)
+            val flow  = Flow.init("p").output("shared")(_ => 2).subflow("sub", child)(_ => Record.empty)
+            val names = FlowLint.nameConflicts(flow).map(_.name)
+            assert(
+                !names.contains("shared"),
+                s"a child's node keyed by its bare name is not the parent's collision to refuse, got $names"
+            )
+        }
+    }
+
+    "reservedNames" - {
+
+        "a node name using '#' is reported" in {
+            val flow = Flow.init("res").output("total#chosen")(_ => 1)
+            assert(FlowLint.reservedNames(flow) == Seq("total#chosen"))
+        }
+
+        /** The other reserved character, refused by the same rule and named by the refusal it triggers.
+          *
+          * `~` joins a subflow instance to the nodes inside it, so a node named `a~b` at the top level is indistinguishable from node
+          * `b` inside instance `a`, which is a collision with a key the engine generates rather than one a flow declared. The message
+          * a caller reads must name `~` as well as `#`: naming only `#` tells a flow refused for this that it used a character it
+          * did not.
+          */
+        "a node name using '~' is reported, and the refusal names the character it used" in {
+            val flow = Flow.init("res").output("review~step")(_ => 1)
+            assert(FlowLint.reservedNames(flow) == Seq("review~step"))
+            val message = FlowReservedNameException("res", FlowLint.reservedNames(flow)).getMessage
+            assert(
+                message.contains("'~'") && message.contains("subflow"),
+                s"the refusal must name the character the flow actually used, got: $message"
+            )
+        }
+
+        "a clean flow reports nothing" in {
+            val flow = Flow.init("res").input[Int]("x").output("total")(ctx => ctx.x)
+            assert(FlowLint.reservedNames(flow).isEmpty)
+        }
+
+        "the flow's own name is not a node name" in {
+            val flow = Flow.init("res#1").output("total")(_ => 1)
+            assert(
+                FlowLint.reservedNames(flow).isEmpty,
+                "the reservation protects durable field keys, and a workflow id is not one"
+            )
+        }
+    }
+
+    "flowName" - {
+
+        "answers the name every public constructor roots" in {
+            assert(FlowLint.flowName(Flow.init("named").output("y")(_ => 1)) == Maybe("named"))
+            assert(FlowLint.flowName(Flow.input[Int]("x")) == Maybe("x"))
+        }
+
+        "answers the empty name rather than hiding it" in {
+            assert(
+                FlowLint.flowName(Flow.init("").output("y")(_ => 1)) == Maybe(""),
+                "registration is what refuses an empty name, so this must report it rather than treat it as absent"
+            )
+        }
+    }
+
     "check" - {
 
         "clean flow has no warnings" in {
@@ -236,15 +395,23 @@ class FlowLintTest extends kyo.test.Test[Any]:
             assert(warnings.isEmpty)
         }
 
+        /** Both warning kinds reach the caller from one call.
+          *
+          * The duplicate half is carried by a shared STEP name rather than by a shared input: an input two branches read is one wait
+          * and no duplicate at all, so a fixture built on it would assert a warning the lint is right not to raise. A step name is
+          * written by exactly one node by definition, so two branches claiming it is a collision under any reading, which keeps this
+          * leaf about `check` combining its two sources rather than about which shapes collide.
+          */
         "combines duplicate and empty branch warnings" in {
             val left = Flow.input[Int]("x")
                 .dispatch[String]("d")
                 .otherwise(ctx => "default", name = "default")
-            val right    = Flow.input[Int]("x").output("y")(ctx => ctx.x)
+                .step("shared")(ctx => ())
+            val right    = Flow.input[Int]("x").step("shared")(ctx => ())
             val flow     = left.zip(right)
             val warnings = FlowLint.check(flow)
-            assert(warnings.exists(_.message.contains("Duplicate")))
-            assert(warnings.exists(_.message.contains("no conditional branches")))
+            assert(warnings.exists(_.message.contains("Duplicate")), s"expected a duplicate warning, got $warnings")
+            assert(warnings.exists(_.message.contains("no conditional branches")), s"expected a branch warning, got $warnings")
         }
     }
 

--- a/kyo-flow/shared/src/test/scala/kyo/internal/FlowRenderTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/internal/FlowRenderTest.scala
@@ -31,8 +31,8 @@ class FlowRenderTest extends kyo.test.Test[Any]:
         .step("log")(ctx => ())
         .sleep("wait", 1.hour)
 
-    def sampleProgress(completed: Set[String], status: Flow.Status): FlowEngine.Progress =
-        FlowEngine.Progress.build(sampleFlow, completed, status)
+    def sampleProgress(completed: Set[String], waits: Dict[String, Flow.Wake]): FlowEngine.Progress =
+        FlowEngine.Progress.build(sampleFlow, completed, Flow.Status.Running, waits)
 
     // =============================================================
     // ELK JSON
@@ -84,7 +84,7 @@ class FlowRenderTest extends kyo.test.Test[Any]:
     }
 
     // =============================================================
-    // JSON -- deserialized structural assertions
+    // JSON, deserialized structural assertions
     // =============================================================
 
     "json" - {
@@ -222,7 +222,7 @@ class FlowRenderTest extends kyo.test.Test[Any]:
     "mermaid with progress" - {
 
         "completed nodes get green style" in {
-            val progress = sampleProgress(Set("x", "y", "log", "wait"), Flow.Status.Completed)
+            val progress = sampleProgress(Set("x", "y", "log", "wait"), Dict.empty)
             val result   = FlowRender.renderMermaid(sampleFlow, progress)
             assert(result.startsWith("graph LR"))
             val greenCount = "#90EE90".r.findAllIn(result).length
@@ -230,14 +230,14 @@ class FlowRenderTest extends kyo.test.Test[Any]:
         }
 
         "waiting input gets blue, rest pending grey" in {
-            val progress = sampleProgress(Set.empty, Flow.Status.WaitingForInput("x"))
+            val progress = sampleProgress(Set.empty, Dict("x" -> Flow.Wake.OnField("x")))
             val result   = FlowRender.renderMermaid(sampleFlow, progress)
             assert(result.contains("#87CEEB")) // blue for waiting
             assert(result.contains("#D3D3D3")) // grey for pending
         }
 
         "sleeping node gets purple" in {
-            val progress = sampleProgress(Set("x", "y", "log"), Flow.Status.Sleeping("wait", Instant.Epoch + 1.hour))
+            val progress = sampleProgress(Set("x", "y", "log"), Dict("wait" -> Flow.Wake.At(Instant.Epoch + 1.hour)))
             val result   = FlowRender.renderMermaid(sampleFlow, progress)
             assert(result.contains("#DDA0DD")) // purple for sleeping
         }
@@ -250,7 +250,7 @@ class FlowRenderTest extends kyo.test.Test[Any]:
     "dot with progress" - {
 
         "completed nodes get green fillcolor" in {
-            val progress = sampleProgress(Set("x", "y", "log", "wait"), Flow.Status.Completed)
+            val progress = sampleProgress(Set("x", "y", "log", "wait"), Dict.empty)
             val result   = FlowRender.renderDot(sampleFlow, progress)
             assert(result.startsWith("digraph flow"))
             assert(result.contains("fillcolor=\"#90EE90\""))
@@ -258,7 +258,7 @@ class FlowRenderTest extends kyo.test.Test[Any]:
         }
 
         "running node gets yellow fillcolor" in {
-            val progress = sampleProgress(Set.empty, Flow.Status.Running)
+            val progress = sampleProgress(Set.empty, Dict.empty)
             val result   = FlowRender.renderDot(sampleFlow, progress)
             assert(result.contains("fillcolor=\"#FFD700\""))
         }
@@ -271,47 +271,47 @@ class FlowRenderTest extends kyo.test.Test[Any]:
     "elk with progress" - {
 
         "all completed shows completed status" in {
-            val progress       = sampleProgress(Set("x", "y", "log", "wait"), Flow.Status.Completed)
+            val progress       = sampleProgress(Set("x", "y", "log", "wait"), Dict.empty)
             val result         = FlowRender.renderElk(sampleFlow, progress)
             val completedCount = "\"status\":\"completed\"".r.findAllIn(result).length
             assert(completedCount == 4, s"Expected 4 completed statuses, got $completedCount")
         }
 
         "waiting node shows waiting status" in {
-            val progress = sampleProgress(Set.empty, Flow.Status.WaitingForInput("x"))
+            val progress = sampleProgress(Set.empty, Dict("x" -> Flow.Wake.OnField("x")))
             val result   = FlowRender.renderElk(sampleFlow, progress)
             assert(result.contains("\"status\":\"waiting\""))
             assert(result.contains("\"status\":\"pending\""))
         }
 
         "sleeping node shows sleeping status" in {
-            val progress = sampleProgress(Set("x", "y", "log"), Flow.Status.Sleeping("wait", Instant.Epoch + 1.hour))
+            val progress = sampleProgress(Set("x", "y", "log"), Dict("wait" -> Flow.Wake.At(Instant.Epoch + 1.hour)))
             val result   = FlowRender.renderElk(sampleFlow, progress)
             assert(result.contains("\"status\":\"sleeping\""))
         }
 
         "has layout options" in {
-            val progress = sampleProgress(Set.empty, Flow.Status.Running)
+            val progress = sampleProgress(Set.empty, Dict.empty)
             val result   = FlowRender.renderElk(sampleFlow, progress)
             assert(result.contains("\"layoutOptions\""))
         }
     }
 
     // =============================================================
-    // JSON with progress -- deserialized structural assertions
+    // JSON with progress, deserialized structural assertions
     // =============================================================
 
     "json with progress" - {
 
         "all completed nodes have completed status" in {
-            val progress = sampleProgress(Set("x", "y", "log", "wait"), Flow.Status.Completed)
+            val progress = sampleProgress(Set("x", "y", "log", "wait"), Dict.empty)
             val graph    = parseJson(FlowRender.renderJson(sampleFlow, progress))
             assert(graph.nodes.length == 4)
             assert(graph.nodes.forall(_.status == Some("completed")))
         }
 
         "running status: first node Running, rest Pending" in {
-            val progress = sampleProgress(Set.empty, Flow.Status.Running)
+            val progress = sampleProgress(Set.empty, Dict.empty)
             val graph    = parseJson(FlowRender.renderJson(sampleFlow, progress))
             assert(graph.nodes(0).status == Some("running"))
             assert(graph.nodes(1).status == Some("pending"))
@@ -320,13 +320,13 @@ class FlowRenderTest extends kyo.test.Test[Any]:
         }
 
         "waiting status on correct node" in {
-            val progress = sampleProgress(Set.empty, Flow.Status.WaitingForInput("x"))
+            val progress = sampleProgress(Set.empty, Dict("x" -> Flow.Wake.OnField("x")))
             val graph    = parseJson(FlowRender.renderJson(sampleFlow, progress))
             assert(graph.nodes.find(_.name == "x").get.status == Some("waiting"))
         }
 
         "mixed: completed + running + pending" in {
-            val progress = sampleProgress(Set("x"), Flow.Status.Running)
+            val progress = sampleProgress(Set("x"), Dict.empty)
             val graph    = parseJson(FlowRender.renderJson(sampleFlow, progress))
             assert(graph.nodes.find(_.name == "x").get.status == Some("completed"))
             assert(graph.nodes.find(_.name == "y").get.status == Some("running"))
@@ -335,7 +335,7 @@ class FlowRenderTest extends kyo.test.Test[Any]:
         }
 
         "preserves edge structure" in {
-            val progress = sampleProgress(Set.empty, Flow.Status.Running)
+            val progress = sampleProgress(Set.empty, Dict.empty)
             val graph    = parseJson(FlowRender.renderJson(sampleFlow, progress))
             assert(graph.edges.length == 3)
             // Edges chain consecutive nodes
@@ -345,7 +345,7 @@ class FlowRenderTest extends kyo.test.Test[Any]:
 
         "different-named nodes get independent status" in {
             val flow     = Flow.input[Int]("a").output("b")(ctx => ctx.a + 1)
-            val progress = FlowEngine.Progress.build(flow, Set("a"), Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(flow, Set("a"), Flow.Status.Running, Dict.empty)
             val graph    = parseJson(FlowRender.renderJson(flow, progress))
             assert(graph.nodes.find(_.name == "a").get.status == Some("completed"))
             assert(graph.nodes.find(_.name == "b").get.status == Some("running"))
@@ -354,17 +354,17 @@ class FlowRenderTest extends kyo.test.Test[Any]:
         "duplicate names: both get status from their positional progress entry" in {
             // Both named "x" but at different positions in the flow
             val flow     = Flow.input[Int]("x").output("x")(ctx => ctx.x + 1)
-            val progress = FlowEngine.Progress.build(flow, Set("x"), Flow.Status.Running)
+            val progress = FlowEngine.Progress.build(flow, Set("x"), Flow.Status.Running, Dict.empty)
             val graph    = parseJson(FlowRender.renderJson(flow, progress))
             // Both are "completed" because completedSteps.contains("x") is true for both
-            // This is inherent to name-based tracking -- FlowLint warns about duplicate names
+            // This is inherent to name-based tracking; FlowLint warns about duplicate names
             assert(graph.nodes.length == 2)
             assert(graph.nodes.forall(_.status == Some("completed")))
         }
     }
 
     // =============================================================
-    // New node types rendering
+    // forEach, race, gather, and subflow rendering
     // =============================================================
 
     "foreach rendering" - {

--- a/kyo-flow/shared/src/test/scala/kyo/internal/IterationNameTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/internal/IterationNameTest.scala
@@ -1,0 +1,126 @@
+package kyo.internal
+
+import kyo.*
+
+/** `IterationName` exists to be the ONE place the `name#n` checkpoint scheme is written down.
+  *
+  * The failure a second derivation would permit is silent and total: if the side that WRITES a checkpoint and the side that reads it
+  * back on resume ever disagree by one character, replay stops recognising checkpoints it wrote itself, every completed iteration
+  * looks unrun, and a resumed scheduled loop repeats all of them with their side effects. Nothing fails loudly; the loop just does its
+  * work twice.
+  *
+  * These leaves pin the writing side against the helper rather than against a literal, so the guard breaks if either side moves
+  * without the other. A test asserting `"acc#0"` would keep passing while two derivations drifted apart, which is precisely the bug.
+  */
+class IterationNameTest extends kyo.test.Test[Any]:
+
+    given CanEqual[Any, Any] = CanEqual.derived
+
+    val wf1 = Flow.Id.Workflow("iteration-name-flow")
+
+    private def withEngine[A](
+        f: (FlowEngine, FlowStore, Clock.TimeControl) => A < (Async & Scope & Abort[Any])
+    )(using Frame): A < (Async & Scope & Abort[Any]) =
+        Clock.withTimeControl { tc =>
+            FlowStore.initMemory.map { store =>
+                FlowEngine.init(store, workerCount = 1, lease = 30.seconds, pollTimeout = 100.millis).map { engine =>
+                    f(engine, store, tc)
+                }
+            }
+        }
+
+    private def settle(tc: Clock.TimeControl, maxRounds: Int)(
+        cond: => Boolean < (Async & Abort[FlowStoreException])
+    )(using Frame): Boolean < (Async & Abort[FlowStoreException]) =
+        def go(remaining: Int): Boolean < (Async & Abort[FlowStoreException]) =
+            cond.map {
+                case true                => true
+                case _ if remaining <= 0 => false
+                case _                   => tc.advance(10.millis).andThen(go(remaining - 1))
+            }
+        go(maxRounds)
+    end settle
+
+    private def stepNames(events: Seq[Flow.Event]): Seq[String] =
+        events.collect {
+            case Flow.Event.StepCompleted(_, _, name, _)  => name
+            case Flow.Event.SleepCompleted(_, _, name, _) => name
+        }
+
+    "the interpreter checkpoints iterations under the names IterationName derives" in {
+        withEngine { (engine, store, tc) =>
+            val flow = Flow.init("acc-loop")
+                .loopOn("acc", Schedule.fixed(100.millis).repeat(1000), 0) { (state: Int, ctx) =>
+                    if state >= 2 then Loop.done(state)
+                    else Loop.continue(state + 1)
+                }
+            for
+                _      <- engine.register(wf1, flow)
+                handle <- engine.workflows.start(wf1)
+                eid = handle.executionId
+                _       <- settle(tc, maxRounds = 200)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                history <- store.getHistory(eid, Maybe.empty, 0)
+            yield
+                val recorded = stepNames(history.events)
+                val expected = IterationName.step("acc", 0)
+                assert(
+                    recorded.contains(expected),
+                    s"the first iteration must be checkpointed under ${expected}, the name the resume path looks for; " +
+                        s"the history records $recorded"
+                )
+            end for
+        }
+    }
+
+    "the interpreter checkpoints iteration sleeps under the names IterationName derives" in {
+        withEngine { (engine, store, tc) =>
+            val flow = Flow.init("acc-loop")
+                .loopOn("acc", Schedule.fixed(100.millis).repeat(1000), 0) { (state: Int, ctx) =>
+                    if state >= 2 then Loop.done(state)
+                    else Loop.continue(state + 1)
+                }
+            for
+                _      <- engine.register(wf1, flow)
+                handle <- engine.workflows.start(wf1)
+                eid = handle.executionId
+                _       <- settle(tc, maxRounds = 200)(store.getExecution(eid).map(_.exists(_.status.isTerminal)))
+                history <- store.getHistory(eid, Maybe.empty, 0)
+            yield
+                val recorded = stepNames(history.events)
+                val expected = IterationName.sleep("acc", 0)
+                assert(
+                    recorded.contains(expected),
+                    s"the first iteration's durable sleep must be checkpointed under ${expected}, the name the resume path " +
+                        s"looks for; the history records $recorded"
+                )
+            end for
+        }
+    }
+
+    /** The reader this has to agree with is the progress surface's path resolver, not a predicate `IterationName` carries itself.
+      *
+      * The tracker attributes a checkpoint back to its loop by walking a recorded path up through the reserved characters, because a
+      * fan-out's item (`charges~3`) and an iteration (`acc#3`) are the same shape and only the node set tells them apart. A
+      * predicate on the name alone would have no reader, so it could drift from nothing and would guard nothing; the agreement worth
+      * pinning is between the name the interpreter writes and the node the surface hands it to.
+      */
+    "an iteration's checkpoint is attributed to the loop that wrote it" in {
+        val flow = Flow.input[Int]("x").loopOn("acc", Schedule.fixed(1.hour), 0)((state: Int, ctx) => Loop.done(state))
+        val progress = FlowEngine.Progress.build(
+            flow,
+            Set("x"),
+            Flow.Status.Failed("boom"),
+            Dict.empty,
+            failed = Map(IterationName.step("acc", 7) -> "boom")
+        )
+        assert(
+            progress.nodeByName("acc").map(_.status) == Maybe(FlowEngine.Progress.NodeStatus.Failed("boom")),
+            s"the name the interpreter derives must resolve to its loop, got ${progress.nodeByName("acc").map(_.status)}"
+        )
+        assert(
+            !progress.nodes.exists(n => n.name != "acc" && n.status.isInstanceOf[FlowEngine.Progress.NodeStatus.Failed]),
+            s"and to no other node, got ${progress.nodes.map(n => (n.name, n.status.show))}"
+        )
+    }
+
+end IterationNameTest

--- a/kyo-flow/shared/src/test/scala/kyo/internal/WorkflowSchemaTest.scala
+++ b/kyo-flow/shared/src/test/scala/kyo/internal/WorkflowSchemaTest.scala
@@ -6,6 +6,14 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
 
     given CanEqual[Any, Any] = CanEqual.derived
 
+    /** One field written the way starting an execution writes it, which is the writer that leaves no event behind.
+      *
+      * A fixture that wants a value present without a story about how it arrived seeds it with the row. Delivering it instead would
+      * record the arrival, which is correct for a delivery and wrong for a fixture whose leaf counts the history.
+      */
+    private def seeded[V: Tag: Schema](name: String, value: V): Dict[String, FlowStore.FieldData] =
+        Dict(name -> FlowStore.FieldData(summon[Schema[V]].encodeString[Json](value), Tag[V]))
+
     "structuralHash" - {
 
         "same flow produces same hash" in {
@@ -13,7 +21,149 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
             assert(WorkflowSchema.structuralHash(flow) == WorkflowSchema.structuralHash(flow))
         }
 
-        "identical structure, different closures — same hash" in {
+        /** Two flows that run the same nodes in different SHAPES are different structures.
+          *
+          * The hash contributes a string at each leaf and folds every combinator with the same separator, so sequencing two steps,
+          * zipping them, and racing them all produce one hash. Those are not the same workflow: they differ in what runs
+          * concurrently, in what the execution waits for, and in how replay reconstructs it. The whole parking and version
+          * enforcement mechanism keys on this hash, so an execution started under one shape resumes under another without anything
+          * noticing that the definition changed.
+          */
+        "sequencing, zipping, and racing the same nodes hash differently" in {
+            val a       = Flow.init("f").step("a")(_ => ())
+            val b       = Flow.init("f").step("b")(_ => ())
+            val seq     = Flow.init("f").step("a")(_ => ()).step("b")(_ => ())
+            val zipped  = a.zip(b)
+            val raced   = Flow.race(a, b)
+            val seqHash = WorkflowSchema.structuralHash(seq)
+            val zipHash = WorkflowSchema.structuralHash(zipped)
+            val racHash = WorkflowSchema.structuralHash(raced)
+            assert(seqHash != zipHash, s"a sequence and a zip of the same nodes must differ, both hashed $seqHash")
+            assert(seqHash != racHash, s"a sequence and a race of the same nodes must differ, both hashed $seqHash")
+            assert(zipHash != racHash, s"a zip and a race of the same nodes must differ, both hashed $zipHash")
+        }
+
+        /** A GUARD: gathering is a fourth shape, distinct from all three above.
+          *
+          * `gather` runs every branch and keeps every result, which is not a zip (arity aside, a zip is the two-branch pairing),
+          * not a race (a race keeps one), and not a sequence. The hash gives it its own bracket, and every combinator the hash
+          * brackets separately needs one assertion that the bracket matters, or a later simplification can quietly fold two
+          * shapes back together.
+          */
+        "gathering the same nodes hashes differently from sequencing, zipping, and racing them" in {
+            val a        = Flow.init("f").step("a")(_ => ())
+            val b        = Flow.init("f").step("b")(_ => ())
+            val seq      = Flow.init("f").step("a")(_ => ()).step("b")(_ => ())
+            val gathered = Flow.gather(a, b)
+            val gatHash  = WorkflowSchema.structuralHash(gathered)
+            assert(
+                gatHash != WorkflowSchema.structuralHash(seq),
+                s"a gather and a sequence of the same nodes must differ, both hashed $gatHash"
+            )
+            assert(
+                gatHash != WorkflowSchema.structuralHash(a.zip(b)),
+                s"a gather and a zip of the same nodes must differ, both hashed $gatHash"
+            )
+            assert(
+                gatHash != WorkflowSchema.structuralHash(Flow.race(a, b)),
+                s"a gather and a race of the same nodes must differ, both hashed $gatHash"
+            )
+        }
+
+        /** A change inside a subflow changes the parent's hash.
+          *
+          * The shape walk descends into the child: a subflow contributes its body's whole shape under its own bracket, not just
+          * its name. Rewriting a child, adding a step or renaming one, therefore re-keys every parent that embeds it, and an
+          * in-flight execution parks instead of replaying against a definition that changed underneath it.
+          */
+        "a change inside a subflow changes the parent's hash" in {
+            val childV1  = Flow.input[Int]("a").output("b")(ctx => ctx.a)
+            val childV2  = Flow.input[Int]("a").step("extra")(_ => ()).output("b")(ctx => ctx.a)
+            val parentV1 = Flow.input[Int]("x").subflow("sub", childV1)(ctx => "a" ~ ctx.x)
+            val parentV2 = Flow.input[Int]("x").subflow("sub", childV2)(ctx => "a" ~ ctx.x)
+            assert(
+                WorkflowSchema.structuralHash(parentV1) != WorkflowSchema.structuralHash(parentV2),
+                "a parent embedding a changed subflow must not keep its hash"
+            )
+        }
+
+        /** A GUARD: the stored-TYPES half of the identity descends into subflows too.
+          *
+          * The leaf above cannot pin this: it changes the child's structure, which the shape walk catches on its own, so it
+          * stays green even if the types walk stops at the subflow's name. Here the two parents' shape strings are
+          * byte-identical (a loop contributes only its name to the shape) and ONLY the descending types walk separates them.
+          * This is the leaf that catches a later unification of the two walks dropping descent from the types half.
+          */
+        "a change to a child loop's value type changes the parent's hash" in {
+            val childV1  = Flow.input[Int]("a").loop("acc")(_ => Loop.done(0))
+            val childV2  = Flow.input[Int]("a").loop("acc")(_ => Loop.done("zero"))
+            val parentV1 = Flow.input[Int]("x").subflow("sub", childV1)(ctx => "a" ~ ctx.x)
+            val parentV2 = Flow.input[Int]("x").subflow("sub", childV2)(ctx => "a" ~ ctx.x)
+            val h1       = WorkflowSchema.structuralHash(parentV1)
+            val h2       = WorkflowSchema.structuralHash(parentV2)
+            assert(
+                h1 != h2,
+                s"a child loop storing Int and one storing String must not share the parent's version, both hashed $h1"
+            )
+        }
+
+        /** A node whose stored value changes type changes the hash.
+          *
+          * The identity's second half lists the type of every value the flow persists, one entry per field replay decodes:
+          * inputs, outputs, dispatch choices, loop values with the state they carry between iterations, and foreach collections.
+          * Changing a loop's value type from `Int` to `String` therefore changes the hash even though the composition shape is
+          * byte-identical, and an in-flight execution parks instead of resuming against a schema its persisted fields no longer
+          * decode under, which is what would silently re-run the node, side effects included.
+          */
+        "a loop whose value type changes does not keep its hash" in {
+            val v1 = Flow.init("f").loop("acc")(_ => Loop.done(0))
+            val v2 = Flow.init("f").loop("acc")(_ => Loop.done("zero"))
+            assert(
+                WorkflowSchema.structuralHash(v1) != WorkflowSchema.structuralHash(v2),
+                s"a loop storing Int and one storing String must not share a version, both hashed " +
+                    s"${WorkflowSchema.structuralHash(v1)}"
+            )
+        }
+
+        /** A dispatch's branch names are structure; its predicates are code.
+          *
+          * Changing which branch a row takes changes what the flow does, but a predicate is a lambda, and the hash deliberately
+          * ignores lambdas so that a bug fix inside a step body does not park every in-flight execution. The price of that choice
+          * is what this leaf pins: two flows that route rows differently share a version, so a predicate edit reaches in-flight
+          * executions instead of parking them.
+          */
+        "a changed dispatch predicate leaves the hash alone" in {
+            val v1 = Flow.input[Int]("x")
+                .dispatch[String]("route")
+                .when(ctx => ctx.x > 0, name = "positive")(ctx => "pos")
+                .otherwise(ctx => "other", name = "default")
+            val v2 = Flow.input[Int]("x")
+                .dispatch[String]("route")
+                .when(ctx => ctx.x > 100, name = "positive")(ctx => "pos")
+                .otherwise(ctx => "other", name = "default")
+            assert(
+                WorkflowSchema.structuralHash(v1) == WorkflowSchema.structuralHash(v2),
+                "a dispatch predicate is a lambda, and the hash ignores lambdas by design"
+            )
+        }
+
+        /** A renamed dispatch branch does change the hash, because a branch name IS structure. */
+        "a renamed dispatch branch changes the hash" in {
+            val v1 = Flow.input[Int]("x")
+                .dispatch[String]("route")
+                .when(ctx => ctx.x > 0, name = "positive")(ctx => "pos")
+                .otherwise(ctx => "other", name = "default")
+            val v2 = Flow.input[Int]("x")
+                .dispatch[String]("route")
+                .when(ctx => ctx.x > 0, name = "renamed")(ctx => "pos")
+                .otherwise(ctx => "other", name = "default")
+            assert(
+                WorkflowSchema.structuralHash(v1) != WorkflowSchema.structuralHash(v2),
+                "a branch name is part of the flow's shape and must be part of its version"
+            )
+        }
+
+        "identical structure with different closures keeps the same hash" in {
             val flow1 = Flow.input[Int]("x").output("y")(ctx => ctx.x * 2)
             val flow2 = Flow.input[Int]("x").output("y")(ctx => ctx.x + 100)
             assert(WorkflowSchema.structuralHash(flow1) == WorkflowSchema.structuralHash(flow2))
@@ -67,7 +217,8 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
             val schema = WorkflowSchema.of(flow)
             assert(schema.fromStoreName("x").nonEmpty, "parent input 'x' should be in schema")
             assert(schema.fromStoreName("result").nonEmpty, "parent output 'result' should be in schema")
-            assert(schema.fromStoreName("b").nonEmpty, "child output 'b' should be in schema")
+            // A child's field is keyed by its path, because that is what the store holds it under.
+            assert(schema.fromStoreName("payment~b").nonEmpty, "child output 'payment~b' should be in schema")
         }
 
         "child input field is present in schema" in {
@@ -77,7 +228,7 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
                 .output("y")(ctx => 1)
 
             val schema = WorkflowSchema.of(flow)
-            assert(schema.fromStoreName("a").nonEmpty, "child input 'a' should be in schema")
+            assert(schema.fromStoreName("s~a").nonEmpty, "child input 's~a' should be in schema")
         }
 
         "nested subflow fields are present in schema" in {
@@ -91,8 +242,9 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
 
             val schema = WorkflowSchema.of(flow)
             assert(schema.fromStoreName("x").nonEmpty, "top-level input 'x' should be in schema")
-            assert(schema.fromStoreName("ib").nonEmpty, "inner child output 'ib' should be in schema")
-            assert(schema.fromStoreName("ob").nonEmpty, "outer child output 'ob' should be in schema")
+            // Nested paths compose, so the inner child's field is keyed under both instances that contain it.
+            assert(schema.fromStoreName("outer~inner~ib").nonEmpty, "inner child output 'outer~inner~ib' should be in schema")
+            assert(schema.fromStoreName("outer~ob").nonEmpty, "outer child output 'outer~ob' should be in schema")
         }
     }
 
@@ -107,15 +259,15 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
             val schema = WorkflowSchema.of(flow)
 
             val fields = Dict(
-                "x" -> FlowStore.FieldData(Json.encode(5), Tag[Int].erased),
-                "b" -> FlowStore.FieldData(Json.encode(50), Tag[Int].erased)
+                "x"         -> FlowStore.FieldData(Json.encode(5), Tag[Int].erased),
+                "payment~b" -> FlowStore.FieldData(Json.encode(50), Tag[Int].erased)
             )
 
             val record = rebuildRecord(fields, schema)
             val dict   = record.toDict
 
             assert(dict.get("x").nonEmpty, "parent field 'x' should be in rebuilt record")
-            assert(dict.get("b").nonEmpty, "child field 'b' should survive rebuild")
+            assert(dict.get("payment~b").nonEmpty, "child field 'payment~b' should survive rebuild")
         }
     }
 
@@ -155,8 +307,8 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
             eid: Flow.Id.Execution,
             predicate: Flow.Status => Boolean,
             maxRounds: Int = 200
-        )(using Frame): Flow.Status < Async =
-            def go(remaining: Int): Flow.Status < Async =
+        )(using Frame): Flow.Status < (Async & Abort[FlowStoreException]) =
+            def go(remaining: Int): Flow.Status < (Async & Abort[FlowStoreException]) =
                 if remaining <= 0 then Abort.panic(new AssertionError("pump timed out"))
                 else
                     tc.advance(10.millis).map { _ =>
@@ -193,7 +345,7 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
                     eid = handle.executionId
                     _ <- engine.executions.signal[Int](eid, "x", 42)
                     // Let v1 start processing
-                    _ <- pump(tc, store, eid, s => s == Flow.Status.Completed || s == Flow.Status.WaitingForInput("x"))
+                    _ <- pump(tc, store, eid, s => s == Flow.Status.Completed || s == Flow.Status.Running)
                     // Re-register with v2 (different structure)
                     _ <- engine.register(wf1, flowV2)
                     // Create a NEW execution under v2
@@ -213,7 +365,14 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
             }
         }
 
-        "execution with mismatched hash is not processed" in {
+        /** A hash mismatch holds the execution rather than failing it.
+          *
+          * The property these two leaves pin is that such an execution is neither served nor lost sight of. Failing it would satisfy
+          * the visible half and destroy the rest: `Failed` is terminal, so a version bump would terminalise every execution it
+          * touched and skip their compensations on the way out, with no way back. Being held keeps the execution recoverable, and it
+          * is a report rather than a status: the engine names the executions it does not serve, and writes nothing about them.
+          */
+        "execution with mismatched hash is parked, not processed" in {
             Clock.withTimeControl { tc =>
                 FlowStore.initMemory.map { store =>
                     val flow = Flow.input[Int]("x").output("y")(ctx => ctx.x)
@@ -223,58 +382,74 @@ class WorkflowSchemaTest extends kyo.test.Test[Any]:
                         // Manually create an execution whose stored hash ("") cannot match the registered flow.
                         now <- Clock.now
                         eid = Flow.Id.Execution("hash-mismatch-test")
-                        _ <- store.createExecution(eid, Flow.Status.Running, Flow.Event.Created(wf1, eid, now), "")
-                        _ <- store.putField[Int](eid, "x", 42)
-                        // The worker fails the mismatch asynchronously; pump advances until a terminal status
-                        // lands rather than reading once after a single advance, which races the worker.
-                        status <- pump(tc, store, eid, _.isTerminal)
+                        _ <- store.createExecutionIfAbsent(
+                            eid,
+                            Flow.Status.Running,
+                            Flow.Event.Created(wf1, eid, now),
+                            "",
+                            seeded[Int]("x", 42)
+                        )
+                        // A held execution is written to by nobody, so one advance is a stable read rather than a race.
+                        _     <- tc.advance(2.seconds)
+                        state <- store.getExecution(eid)
+                        held  <- engine.parked(wf1)
                     yield
-                        // Hash mismatch: engine should fail the execution rather than run it.
+                        // Hash mismatch: the engine holds the execution and names it, rather than running it or ignoring it.
                         assert(
-                            status match
-                                case Flow.Status.Failed(_) => true
-                                case _                     => false
-                            ,
-                            s"Execution with mismatched hash should be Failed, but status is $status"
+                            held.exists(e => e.executionId == eid && e.hash.isEmpty),
+                            s"an execution with a mismatched hash must be reported as held, got ${held.map(e => (e.executionId, e.hash))}"
+                        )
+                        assert(
+                            state.get.status == Flow.Status.Running,
+                            s"a held execution must be left exactly as it was, but status is ${state.get.status}"
                         )
                     end for
                 }
             }
         }
 
-        "structural hash mismatch marks execution as failed".notNative in {
+        "structural hash mismatch parks the execution rather than leaving it stuck" in {
             withEngine { (engine, store, tc) =>
                 val flowV1 = Flow.input[Int]("x").output("y")(ctx => ctx.x)
                 val flowV2 = Flow.input[Int]("x").output("y")(ctx => ctx.x).output("z")(ctx => 0)
                 for
-                    _      <- engine.register(wf1, flowV1)
-                    handle <- engine.workflows.start(wf1)
-                    eid = handle.executionId
-                    _ <- engine.executions.signal[Int](eid, "x", 42)
-                    _ <- pump(tc, store, eid, _.isTerminal)
-                    // Now re-register with v2 and create a new execution
-                    _ <- engine.register(wf1, flowV2)
-                    // The old execution completed with v1's hash. Create a manually stuck one:
+                    // Only v2 is registered, so v1 is a version this engine does not serve. An engine that had registered v1 too
+                    // would go on serving it, which is what keeps a rolling deployment's in-flight executions running.
+                    _   <- engine.register(wf1, flowV2)
                     now <- Clock.now
                     stuckEid = Flow.Id.Execution("stuck-version")
-                    _ <- store.createExecution(
+                    _ <- store.createExecutionIfAbsent(
                         stuckEid,
                         Flow.Status.Running,
                         Flow.Event.Created(wf1, stuckEid, now),
-                        WorkflowSchema.structuralHash(flowV1) // v1 hash
+                        WorkflowSchema.structuralHash(flowV1), // v1 hash
+                        seeded[Int]("x", 10)
                     )
-                    _ <- store.putField[Int](stuckEid, "x", 10)
-                    // The engine has v2 but this execution has the v1 hash, so it must reconcile to Failed, not release forever. The pump
-                    // must wait for a terminal status: stopping on the starting Running would race the async fail-on-mismatch transition.
-                    _     <- pump(tc, store, stuckEid, _.isTerminal)
-                    state <- store.getExecution(stuckEid)
-                yield assert(
-                    state.get.status match
-                        case Flow.Status.Failed(_) => true;
-                        case _                     => false
-                    ,
-                    s"Expected Failed but got ${state.get.status} — execution stuck on hash mismatch"
-                )
+                    // Two full poll cycles' worth of virtual time, so a poller that claimed and re-released would have done it twice.
+                    _       <- Kyo.foreachDiscard(1 to 60)(_ => tc.advance(10.millis))
+                    before  <- store.getHistory(stuckEid, Maybe.empty, 0)
+                    _       <- Kyo.foreachDiscard(1 to 60)(_ => tc.advance(10.millis))
+                    history <- store.getHistory(stuckEid, Maybe.empty, 0)
+                    held    <- engine.parked(wf1)
+                yield
+                    assert(
+                        held.exists(e =>
+                            e.executionId == stuckEid && e.hash == WorkflowSchema.structuralHash(flowV1)
+                        ),
+                        s"the held execution must be reported with the hash it was started under, got " +
+                            s"${held.map(e => (e.executionId, e.hash))}"
+                    )
+                    // Stronger than counting one park event: under the version gate no executor ever claims the execution, so it
+                    // accumulates NOTHING while it is held, where a claim-and-re-park loop would leave a trail of events per poll.
+                    assert(
+                        history.events.size == 1 && history.events.head.kind == Flow.EventKind.Created,
+                        s"a held execution must accumulate no events at all, got ${history.events.map(_.kind)}"
+                    )
+                    assert(
+                        history.events.size == before.events.size,
+                        s"and it must still accumulate none over the next poll cycle, grew from ${before.events.size} to " +
+                            s"${history.events.size}"
+                    )
                 end for
             }
         }

--- a/kyo-flow/shared/src/test/tla/.gitignore
+++ b/kyo-flow/shared/src/test/tla/.gitignore
@@ -1,0 +1,4 @@
+tla2tools.jar
+states/
+logs/
+*.old

--- a/kyo-flow/shared/src/test/tla/Designed.cfg
+++ b/kyo-flow/shared/src/test/tla/Designed.cfg
@@ -1,0 +1,41 @@
+\* The design as written, under the honest environment: timers fire, the
+\* operator rolls back, and no field is promised to arrive. Everything below
+\* must hold. EventuallyTerminal is not here because it is false under this
+\* environment for a correct design (an execution waiting for a field that
+\* never comes never finishes); it is checked under Signalled.cfg.
+\*
+\* This config means something only because the controls beside it exist:
+\* check.sh runs every one and fails if any control stays green.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT TypeOK
+INVARIANT Exclusivity
+INVARIANT NoLapsedWrite
+INVARIANT NoUselessClaim
+INVARIANT LedgerBlessed
+INVARIANT ProgressAtomic
+INVARIANT NoWedge
+
+PROPERTY TerminalStable
+PROPERTY CancelTerminates
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/FlowClaim.tla
+++ b/kyo-flow/shared/src/test/tla/FlowClaim.tla
@@ -1,0 +1,802 @@
+-------------------------------- MODULE FlowClaim --------------------------------
+(***************************************************************************)
+(* The claim lifecycle and the readiness rule of the kyo-flow engine: the  *)
+(* part of the design where an execution can be lost, duplicated or        *)
+(* stranded, and where an argument on paper is not evidence. Comments      *)
+(* below use D-A for the readiness rule and D-B for the claim lifecycle    *)
+(* and its write authorisation.                                            *)
+(*                                                                         *)
+(* WHAT THE CONTROLS ARE FOR. Every rule the design states has a control   *)
+(* configuration that removes that rule and names the property which must  *)
+(* then fail. A control that stays green is a defect in the model rather   *)
+(* than a result, so check.sh asserts the polarity of every configuration  *)
+(* instead of leaving it to someone reading a log. Two failures in         *)
+(* particular are what the controls aim at, because both are invisible to  *)
+(* a run without them: a generation token that refuses a SUPERSEDED writer *)
+(* but not a LAPSED one nobody replaced, which lets an executor whose      *)
+(* lease expired with no competitor write through to a terminal status;    *)
+(* and an UNSCOPED cancel arm in readiness, which hands a version-orphaned *)
+(* execution to an executor that cannot interpret it, so it parks,         *)
+(* releases, and is handed back on the next poll forever.                  *)
+(*                                                                         *)
+(* FOUR RULES CARRY THE DESIGN, and each has its own control. Suspension   *)
+(* is a per-branch recordWait under the held claim plus ONE ending         *)
+(* transition. finish is the only maker of an absent claim. Readiness has  *)
+(* an active-and-expired arm. Retirement keeps exactly the rows the        *)
+(* attempt is still waiting on.                                            *)
+(*                                                                         *)
+(* RUNNING IT. ./check.sh runs every configuration and prints one line per *)
+(* config; ./check.sh <Name> runs one. It fetches tla2tools.jar on first   *)
+(* use. Neither the build nor CI runs any of this, so a change to the      *)
+(* claim rule has to re-run it by hand.                                    *)
+(*                                                                         *)
+(* MODELLING DECISIONS.                                                    *)
+(*                                                                         *)
+(* Every write goes through the store's acceptance rule. The anonymous     *)
+(* field write is modelled in flight (issued, then delivered later, so the *)
+(* executor's belief can change in between). recordWait, recordProgress    *)
+(* and both finish arms are modelled as synchronous store-judged           *)
+(* transitions: the store accepts or refuses at the moment of the call,    *)
+(* and a refusal ends the executor's belief, which is the ClaimLost path.  *)
+(*                                                                         *)
+(* An ATTEMPT is: Claim, then any number of recordWait / recordProgress /  *)
+(* decide-against steps under the held claim, then ONE ending. The ending  *)
+(* is FinishTerminal or FinishSuspended, and those are the only makers of  *)
+(* an absent claim. Every other way an attempt can end (a crash, the store *)
+(* failing under it, a shutdown interrupting it, a lost claim) writes      *)
+(* NOTHING and leaves the claim to expire: Crash and Relinquish stand for  *)
+(* all of them, and both are bounded or guarded, because an unbounded      *)
+(* supply of attempts that end without finishing is a starvation the       *)
+(* design's liveness assumptions already exclude.                          *)
+(*                                                                         *)
+(* Ground truth is separate from the mechanism. The mechanism is the       *)
+(* validity bit the store keeps per token (heldValid, pendValid), updated  *)
+(* by the design's rules and by whichever mutation a control switches on.  *)
+(* The ground truth is a staleness bit per belief and per issued write     *)
+(* (heldStale, pendStale): set by every event that ends the claim instance *)
+(* it was formed under (a new claim on the row, a finish), and never read  *)
+(* by any guard or touched by any constant. It is the same fact an epoch   *)
+(* counter would record, without the counter's state cost. A write is      *)
+(* stale when its bit is set or the claim has lapsed.                      *)
+(*                                                                         *)
+(* The interpreter's live parks (pending) and the store's ledger (waits)   *)
+(* are separate variables, and the design's claim is that they agree at    *)
+(* every point where anyone reads the ledger, which is when the claim is   *)
+(* absent (LedgerBlessed). They diverge legitimately DURING an attempt: a  *)
+(* raced branch the composition decides against leaves pending while its   *)
+(* row stays in the ledger until the ending retires it (DecideAgainst).    *)
+(* That divergence is what makes the wedge and the loser row reachable,    *)
+(* and a model without it can check neither.                               *)
+(*                                                                         *)
+(* Time is abstracted away. A claim may lapse. ExpireAbandoned is FAIR and *)
+(* fires only when nobody holds the claim, which is what makes recovery    *)
+(* work. ExpireHeld is UNFAIR and bounded, and models the renewal loop     *)
+(* failing under a live holder; it is the only way a stale belief becomes  *)
+(* reachable, and the Vacuity control checks that it is.                   *)
+(*                                                                         *)
+(* Signals are environment. A timer always fires (fair). A field may never *)
+(* arrive, so Spec puts no fairness on it; SpecSignals adds it, and is the *)
+(* explicit assumption under which every execution terminates.             *)
+(*                                                                         *)
+(* One deployment. Every execution runs the same version; versionServed    *)
+(* says whether the engine currently serves it. A redeploy stops serving   *)
+(* it and a rollback resumes. There is no wait row for a definition: an    *)
+(* execution whose version is not served is simply never returned, which   *)
+(* is the readiness rule's third condition.                                *)
+(*                                                                         *)
+(* NOT MODELLED. Compensations: a cancel finishes as Cancelled, and the    *)
+(* model does not check that handlers ran, nor an unwind that itself parks *)
+(* (see FinishSuspended). Renewal as an action: its failure is ExpireHeld, *)
+(* its success is the absence of that. Multiple deployments serving        *)
+(* different versions at once. A wake's CONTENT: a row is a name, so "a    *)
+(* re-recorded sleep keeps its original deadline" is modelled as the row's *)
+(* satisfaction surviving the re-record, and the OverwriteWake control     *)
+(* abstracts a deadline pushed forward on every replay into a row the      *)
+(* model's clock can no longer reach.                                      *)
+(***************************************************************************)
+EXTENDS Integers, FiniteSets
+
+CONSTANTS
+    Executions,      \* finite set of execution ids
+    Executors,       \* finite set of executor ids
+    MaxCrashes,      \* how often the environment may crash an executor
+    MaxLapses,       \* how often a renewal may fail under a live holder
+    MaxSuspends,     \* how many suspension points the flows collectively reach
+    MaxRedeploys,    \* how many times the environment may stop serving the version
+    ClearsWaits,     \* FALSE reintroduces the missing wait-row clearing
+    TokenOnlyWrites, \* the write kinds whose acceptance omits the expiry check
+    OwnerWitness,    \* TRUE accepts field writes on owner identity, not the token
+    RetireOnRelease, \* FALSE leaves the generation live after an ending
+    UnscopedCancel,  \* TRUE lets a cancel request bypass the version gate
+    CancelArm,       \* FALSE removes the cancel arm from readiness
+    ExpiredArm,      \* FALSE removes readiness's active-and-expired arm (D-A 4d)
+    KeepExactly,     \* FALSE makes a suspending ending keep what was recorded
+    OverwriteWake,   \* TRUE makes re-recording a wait move it, instead of put-if-absent
+    NoOwner,         \* model value: unclaimed, or holding nothing
+    NoWrite          \* model value: no write in flight
+
+WriteKinds == {"field", "finish", "recordWait", "progress"}
+ASSUME TokenOnlyWrites \subseteq WriteKinds
+
+Terminal  == {"Completed", "Cancelled"}
+Lifecycle == {"Running"} \cup Terminal
+
+\* Wait rows are keyed by node, as the ledger is. Two sleeps can coexist on one
+\* execution (two sibling branches, or a sleep racing an input), which is the
+\* plural case D-A exists for.
+Rows     == {"sleepA", "sleepB", "input"}
+Timer(r) == r \in {"sleepA", "sleepB"}
+
+\* Machine variables.
+VARIABLES
+    status,        \* [Executions -> Lifecycle]
+    pending,       \* [Executions -> SUBSET Rows]  the interpreter's live parks
+    waits,         \* [Executions -> SUBSET Rows]  the store's wait ledger
+    satisfied,     \* [Executions -> SUBSET Rows]  rows whose wake condition the environment has met
+    fields,        \* [Executions -> SUBSET Rows]  paths that carry a recorded progress field
+    moved,         \* [Executions -> SUBSET Rows]  rows whose wake was pushed out of reach
+    owner,         \* [Executions -> Executors \cup {NoOwner}]
+    expired,       \* [Executions -> BOOLEAN]
+    cancelReq,     \* [Executions -> BOOLEAN]
+    versionServed, \* BOOLEAN: does the deployment serve the version the executions run
+    heldExec,      \* [Executors -> Executions \cup {NoOwner}]  what x believes it holds
+    heldValid,     \* [Executors -> BOOLEAN]  is that belief still the live claim (the token)
+    heldServed,    \* [Executors -> BOOLEAN]  could x resolve the definition when it claimed
+    pendExec,      \* [Executors -> Executions \cup {NoWrite}]  an issued, undelivered field write
+    pendValid      \* [Executors -> BOOLEAN]  was it issued under a generation still live (the token)
+
+\* Auxiliary: ground truth read only by properties, and the adversary budgets.
+VARIABLES
+    heldStale,     \* [Executors -> BOOLEAN]  x's belief was formed under a claim instance the row has left
+    pendStale,     \* [Executors -> BOOLEAN]  x's in-flight write was issued under such an instance
+    lapsedWrite,   \* a write ground truth refuses was applied
+    uselessClaim,  \* the store returned an execution the claimer could do nothing with
+    refusedEver,   \* the store refused at least one write (a reachability probe)
+    crashes, lapses, suspends, redeploys
+
+vars == <<status, pending, waits, satisfied, fields, moved, owner, expired, cancelReq,
+          versionServed, heldExec, heldValid, heldServed, pendExec, pendValid,
+          heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+          crashes, lapses, suspends, redeploys>>
+
+TypeOK ==
+    /\ status        \in [Executions -> Lifecycle]
+    /\ pending       \in [Executions -> SUBSET Rows]
+    /\ waits         \in [Executions -> SUBSET Rows]
+    /\ satisfied     \in [Executions -> SUBSET Rows]
+    /\ fields        \in [Executions -> SUBSET Rows]
+    /\ moved         \in [Executions -> SUBSET Rows]
+    /\ owner         \in [Executions -> Executors \cup {NoOwner}]
+    /\ expired       \in [Executions -> BOOLEAN]
+    /\ cancelReq     \in [Executions -> BOOLEAN]
+    /\ versionServed \in BOOLEAN
+    /\ heldExec      \in [Executors -> Executions \cup {NoOwner}]
+    /\ heldValid     \in [Executors -> BOOLEAN]
+    /\ heldServed    \in [Executors -> BOOLEAN]
+    /\ pendExec      \in [Executors -> Executions \cup {NoWrite}]
+    /\ pendValid     \in [Executors -> BOOLEAN]
+    /\ heldStale     \in [Executors -> BOOLEAN]
+    /\ pendStale     \in [Executors -> BOOLEAN]
+    /\ lapsedWrite   \in BOOLEAN
+    /\ uselessClaim  \in BOOLEAN
+    /\ refusedEver   \in BOOLEAN
+    /\ crashes       \in 0..MaxCrashes
+    /\ lapses        \in 0..MaxLapses
+    /\ suspends      \in 0..MaxSuspends
+    /\ redeploys     \in 0..MaxRedeploys
+
+Init ==
+    /\ status        = [e \in Executions |-> "Running"]
+    /\ pending       = [e \in Executions |-> {}]
+    /\ waits         = [e \in Executions |-> {}]
+    /\ satisfied     = [e \in Executions |-> {}]
+    /\ fields        = [e \in Executions |-> {}]
+    /\ moved         = [e \in Executions |-> {}]
+    /\ owner         = [e \in Executions |-> NoOwner]
+    /\ expired       = [e \in Executions |-> FALSE]
+    /\ cancelReq     = [e \in Executions |-> FALSE]
+    /\ versionServed = TRUE
+    /\ heldExec      = [x \in Executors |-> NoOwner]
+    /\ heldValid     = [x \in Executors |-> FALSE]
+    /\ heldServed    = [x \in Executors |-> FALSE]
+    /\ pendExec      = [x \in Executors |-> NoWrite]
+    /\ pendValid     = [x \in Executors |-> FALSE]
+    /\ heldStale     = [x \in Executors |-> FALSE]
+    /\ pendStale     = [x \in Executors |-> FALSE]
+    /\ lapsedWrite   = FALSE
+    /\ uselessClaim  = FALSE
+    /\ refusedEver   = FALSE
+    /\ crashes       = 0
+    /\ lapses        = 0
+    /\ suspends      = 0
+    /\ redeploys     = 0
+
+(***************************************************************************)
+(* Readiness: D-A's four conditions, evaluated by the store over its own    *)
+(* ledger. The version gate is universal (condition 3); the cancel arm and  *)
+(* the active-and-expired arm each override every wait row (4a and 4d).     *)
+(***************************************************************************)
+ClaimAbsent(e) == owner[e] = NoOwner
+
+\* The claim is active and expired: the last attempt DIED mid-flight, because
+\* finish is the only maker of an absent claim. Its rows may describe waits the
+\* execution is no longer in, and only a new attempt's replay and finish can
+\* heal them, so the rows do not gate.
+Dead(e) == owner[e] /= NoOwner /\ expired[e]
+
+ClaimFree(e)   == ClaimAbsent(e) \/ expired[e]
+VersionGate(e) == versionServed \/ (UnscopedCancel /\ cancelReq[e])
+Wake(e) ==
+    \/ (CancelArm /\ cancelReq[e])
+    \/ waits[e] = {}
+    \/ \E r \in waits[e] : r \in satisfied[e]
+    \/ (ExpiredArm /\ Dead(e))
+Ready(e) ==
+    /\ status[e] \notin Terminal
+    /\ ClaimFree(e)
+    /\ VersionGate(e)
+    /\ Wake(e)
+
+\* Ground truth for "the claimer has something to do", stated over the
+\* interpreter's state rather than the ledger: it can resolve the definition,
+\* and either a cancel is outstanding, or the last attempt died and the replay
+\* is the work that heals the ledger, or nothing is parked, or a parked
+\* branch's wake condition is met.
+\*
+\* The Dead arm is what arm (d) buys and what it costs, stated once: the store
+\* cannot know whether a dead attempt's rows need healing, so it returns the
+\* execution and the replay decides. It cannot spin, because Dead is false
+\* immediately after the claim and becomes true again only through a lapse or an
+\* abandonment, both of which cost the adversary a budgeted step.
+HasWork(e) ==
+    /\ versionServed
+    /\ \/ cancelReq[e]
+       \/ Dead(e)
+       \/ pending[e] = {}
+       \/ \E r \in pending[e] : r \in satisfied[e]
+
+(***************************************************************************)
+(* Write authorisation: D-B's rule, judged by the store. The token is the   *)
+(* validity bit; TokenOnlyWrites names the write kinds that drop the expiry *)
+(* check, which is defect 1 for whichever kind is named.                    *)
+(***************************************************************************)
+HeldAuthorised(x) == heldValid[x] /\ ~expired[heldExec[x]]
+
+StoreAccepts(x, kind) ==
+    heldValid[x] /\ (kind \in TokenOnlyWrites \/ ~expired[heldExec[x]])
+
+\* Ground truth, independent of the mechanism: the belief was formed under a
+\* claim instance the row has since left, or the claim has lapsed.
+StaleBelief(x) == heldStale[x] \/ expired[heldExec[x]]
+
+Drop(x) ==
+    /\ heldExec'  = [heldExec  EXCEPT ![x] = NoOwner]
+    /\ heldValid' = [heldValid EXCEPT ![x] = FALSE]
+
+\* The row's claim instance ends (a finish by x): x's own in-flight write, if
+\* any, is now stale in ground truth. Any other executor's write on the row was
+\* already stale, since x held the instance.
+EndInstance(x) ==
+    pendStale' = [pendStale EXCEPT ![x] = TRUE]
+
+(***************************************************************************)
+(* Actions                                                                 *)
+(***************************************************************************)
+
+\* The store grants a claim: a fresh generation on the row, which invalidates
+\* every belief and every in-flight write that referred to the previous one.
+\* Records whether the claimer can resolve the definition, and whether the
+\* store has just returned an execution the claimer can do nothing with.
+\*
+\* heldServed is TRUE at every claim under the design, because Ready already
+\* requires the version to be served; it is FALSE only under UnscopedCancel. The
+\* guards on it in the attempt's verbs therefore never block in Designed.cfg,
+\* and a coverage reader should expect that: they are the statement of what an
+\* executor that cannot resolve the definition cannot do, and the control is
+\* where they bite.
+Claim(x, e) ==
+    /\ heldExec[x] = NoOwner
+    /\ Ready(e)
+    /\ owner'        = [owner    EXCEPT ![e] = x]
+    /\ expired'      = [expired  EXCEPT ![e] = FALSE]
+    /\ heldExec'     = [heldExec   EXCEPT ![x] = e]
+    /\ heldServed'   = [heldServed EXCEPT ![x] = versionServed]
+    /\ heldValid'    = [y \in Executors |->
+                           IF y = x THEN TRUE
+                           ELSE IF heldExec[y] = e THEN FALSE
+                           ELSE heldValid[y]]
+    /\ heldStale'    = [y \in Executors |->
+                           IF y = x THEN FALSE
+                           ELSE IF heldExec[y] = e THEN TRUE
+                           ELSE heldStale[y]]
+    /\ pendValid'    = [y \in Executors |->
+                           IF pendExec[y] = e THEN FALSE ELSE pendValid[y]]
+    /\ pendStale'    = [y \in Executors |->
+                           IF pendExec[y] = e THEN TRUE ELSE pendStale[y]]
+    /\ uselessClaim' = (uselessClaim \/ ~HasWork(e))
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, cancelReq,
+                   versionServed, pendExec, lapsedWrite, refusedEver,
+                   crashes, lapses, suspends, redeploys>>
+
+\* A lease whose holder is GONE always lapses. Fair: this is what makes recovery
+\* work, and modelling it as optional lets a crashed executor's claim starve a
+\* row forever.
+ExpireAbandoned(e) ==
+    /\ owner[e] /= NoOwner
+    /\ \A x \in Executors : heldExec[x] /= e
+    /\ ~expired[e]
+    /\ expired' = [expired EXCEPT ![e] = TRUE]
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, cancelReq,
+                   versionServed, heldExec, heldValid, heldServed, pendExec, pendValid,
+                   heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, lapses, suspends, redeploys>>
+
+\* A lease lapses UNDER a live holder: the renewal loop failed. Unfair and
+\* bounded, because it is adversary behaviour rather than protocol behaviour.
+\* It is the only way a stale belief becomes reachable; without it every refusal
+\* path is dead and every safety result is worthless. Vacuity.cfg checks that.
+ExpireHeld(e) ==
+    /\ owner[e] /= NoOwner
+    /\ \E x \in Executors : heldExec[x] = e
+    /\ ~expired[e]
+    /\ lapses < MaxLapses
+    /\ lapses'  = lapses + 1
+    /\ expired' = [expired EXCEPT ![e] = TRUE]
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, cancelReq,
+                   versionServed, heldExec, heldValid, heldServed, pendExec, pendValid,
+                   heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, suspends, redeploys>>
+
+\* A field write is issued under whatever the executor believes. No guard on the
+\* row's status: a stale believer does not know it, and the store's job is to
+\* refuse it.
+IssueWrite(x, e) ==
+    /\ heldExec[x] = e
+    /\ pendExec[x] = NoWrite
+    /\ pendExec'  = [pendExec  EXCEPT ![x] = e]
+    /\ pendValid' = [pendValid EXCEPT ![x] = heldValid[x]]
+    /\ pendStale' = [pendStale EXCEPT ![x] = heldStale[x]]
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, expired,
+                   cancelReq, versionServed, heldExec, heldValid, heldServed, heldStale,
+                   lapsedWrite, uselessClaim, refusedEver, crashes, lapses, suspends, redeploys>>
+
+\* The store judges the field write at DELIVERY. The mechanism is the token
+\* (pendValid) plus the expiry check; OwnerWitness swaps the token for owner
+\* identity, which is the witness D-B rejects, and the ABA trace (claim, issue,
+\* lose the claim, reclaim, deliver) is what tells them apart.
+DeliverWrite(x) ==
+    /\ pendExec[x] /= NoWrite
+    /\ LET e       == pendExec[x]
+           token   == IF OwnerWitness THEN owner[e] = x ELSE pendValid[x]
+           accepts == token /\ ("field" \in TokenOnlyWrites \/ ~expired[e])
+           stale   == pendStale[x] \/ expired[e]
+       IN /\ lapsedWrite' = (lapsedWrite \/ (accepts /\ stale))
+          /\ refusedEver' = (refusedEver \/ ~accepts)
+    /\ pendExec'  = [pendExec  EXCEPT ![x] = NoWrite]
+    /\ pendValid' = [pendValid EXCEPT ![x] = FALSE]
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, expired,
+                   cancelReq, versionServed, heldExec, heldValid, heldServed, heldStale,
+                   pendStale, uselessClaim, crashes, lapses, suspends, redeploys>>
+
+\* pending is the EXECUTION's parked set, the durable fact a replay reconstructs,
+\* not any one executor's memory, so the two interpreter-side actions below are
+\* guarded on the actor genuinely holding the live claim. A stale executor keeps
+\* running until its renewal is refused (D-E.8) and its own parks are real to
+\* it, but nothing it does lands: every store write it attempts is refused by
+\* the fence. Without this guard a stale executor parks a branch of an execution
+\* somebody else has already finished, and the model reports a divergence
+\* between ledger and interpreter that no store could ever see. TLC found that
+\* first, and it is a model artifact, not a defect.
+\*
+\* A branch of the flow parks. Interpreter-side only: the store hears nothing
+\* until the branch's recordWait lands, and the gap between the two is the
+\* window an engine shut down between two parking branches dies in, where the
+\* sleep's row was never written and the durable timeout is silently gone. In
+\* the real system the park IS the recordWait call, which is why RecordWait is
+\* fair: the two halves are one call, and they are separate actions here only so
+\* that the state a death between them leaves is reachable at all.
+\*
+\* Write-once (D-B): a path that already carries a progress field never parks
+\* again, because a node's wait is discharged once.
+Park(x, e, r) ==
+    /\ heldExec[x] = e
+    /\ heldServed[x]
+    /\ HeldAuthorised(x)
+    /\ r \notin pending[e]
+    /\ r \notin fields[e]
+    /\ suspends < MaxSuspends
+    /\ suspends' = suspends + 1
+    /\ pending'  = [pending EXCEPT ![e] = @ \cup {r}]
+    /\ UNCHANGED <<status, waits, satisfied, fields, moved, owner, expired, cancelReq,
+                   versionServed, heldExec, heldValid, heldServed, pendExec, pendValid,
+                   heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, lapses, redeploys>>
+
+\* One parking branch records its own row, under the claim, and does NOT
+\* release. This is the split D-B made: a rule that released here would make the
+\* second branch's row unwritable and hand the design F2's pathology back.
+RecordWait(x, e, r) ==
+    /\ heldExec[x] = e
+    /\ heldServed[x]
+    /\ r \in pending[e]
+    /\ r \notin waits[e]
+    /\ IF StoreAccepts(x, "recordWait")
+         THEN /\ lapsedWrite' = (lapsedWrite \/ StaleBelief(x))
+              /\ refusedEver' = refusedEver
+              /\ waits'       = [waits EXCEPT ![e] = @ \cup {r}]
+              /\ UNCHANGED <<heldExec, heldValid>>
+         ELSE /\ refusedEver' = TRUE
+              /\ Drop(x)
+              /\ UNCHANGED <<lapsedWrite, waits>>
+    /\ UNCHANGED <<status, pending, satisfied, fields, moved, owner, expired, cancelReq,
+                   versionServed, heldServed, pendExec, pendValid, heldStale, pendStale,
+                   uselessClaim, crashes, lapses, suspends, redeploys>>
+
+\* A replay re-parks a branch whose row the ledger already has. recordWait is
+\* put-if-absent on the WAKE: the row keeps what it was created with, which is
+\* what "a sleep re-recorded on a later attempt keeps its original deadline"
+\* means. OverwriteWake is the store that moves it instead, and the model's
+\* stand-in for a deadline pushed forward on every replay is a row the clock can
+\* no longer reach.
+ReRecordWait(x, e, r) ==
+    /\ heldExec[x] = e
+    /\ heldServed[x]
+    /\ r \in pending[e]
+    /\ r \in waits[e]
+    /\ IF StoreAccepts(x, "recordWait")
+         THEN /\ lapsedWrite' = (lapsedWrite \/ StaleBelief(x))
+              /\ refusedEver' = refusedEver
+              /\ IF OverwriteWake
+                   THEN /\ satisfied' = [satisfied EXCEPT ![e] = @ \ {r}]
+                        /\ moved'     = [moved     EXCEPT ![e] = @ \cup {r}]
+                   ELSE UNCHANGED <<satisfied, moved>>
+              /\ UNCHANGED <<heldExec, heldValid>>
+         ELSE /\ refusedEver' = TRUE
+              /\ Drop(x)
+              /\ UNCHANGED <<lapsedWrite, satisfied, moved>>
+    /\ UNCHANGED <<status, pending, waits, fields, owner, expired, cancelReq, versionServed,
+                   heldServed, pendExec, pendValid, heldStale, pendStale, uselessClaim,
+                   crashes, lapses, suspends, redeploys>>
+
+\* The environment meets a row's wake condition: a timer fires, or a field
+\* arrives. A row whose wake was moved out of reach is never met again.
+SatisfyWait(e, r) ==
+    /\ r \in waits[e]
+    /\ r \notin satisfied[e]
+    /\ r \notin moved[e]
+    /\ satisfied' = [satisfied EXCEPT ![e] = @ \cup {r}]
+    /\ UNCHANGED <<status, pending, waits, fields, moved, owner, expired, cancelReq,
+                   versionServed, heldExec, heldValid, heldServed, pendExec, pendValid,
+                   heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, lapses, suspends, redeploys>>
+
+\* recordProgress: ONE transition writes the node's field and clears the node's
+\* wait row, so no interleaving observes the field present with the row still
+\* outstanding. That is the leaf "a step's field and its completion event are
+\* written together or not at all" at this model's grain, and ProgressAtomic is
+\* the property; ClearsWaits = FALSE is the store that writes the field and
+\* leaves the row.
+RecordProgress(x, e, r) ==
+    /\ heldExec[x] = e
+    /\ heldServed[x]
+    /\ r \in pending[e]
+    /\ r \in satisfied[e]
+    /\ r \notin fields[e]
+    /\ IF StoreAccepts(x, "progress")
+         THEN /\ lapsedWrite' = (lapsedWrite \/ StaleBelief(x))
+              /\ refusedEver' = refusedEver
+              /\ fields'      = [fields  EXCEPT ![e] = @ \cup {r}]
+              /\ pending'     = [pending EXCEPT ![e] = @ \ {r}]
+              /\ IF ClearsWaits
+                   THEN /\ waits'     = [waits     EXCEPT ![e] = @ \ {r}]
+                        /\ satisfied' = [satisfied EXCEPT ![e] = @ \ {r}]
+                   ELSE UNCHANGED <<waits, satisfied>>
+              /\ UNCHANGED <<heldExec, heldValid>>
+         ELSE /\ refusedEver' = TRUE
+              /\ Drop(x)
+              /\ UNCHANGED <<lapsedWrite, fields, pending, waits, satisfied>>
+    /\ UNCHANGED <<status, moved, owner, expired, cancelReq, versionServed, heldServed,
+                   pendExec, pendValid, heldStale, pendStale, uselessClaim,
+                   crashes, lapses, suspends, redeploys>>
+
+\* A sibling resolved the composition, so a parked branch is abandoned: a race's
+\* loser, or a branch the unwind drops. Interpreter-side only, no store write.
+\* The row it wrote stays in the ledger until the attempt's ending retires it,
+\* and that gap is the loser row, the state the whole of D-A's arm (d) and D-B's
+\* keep-exactly retirement are about. Bounded without a budget of its own: only
+\* Park puts a branch into pending, and that is what MaxSuspends bounds.
+DecideAgainst(x, e, r) ==
+    /\ heldExec[x] = e
+    /\ heldServed[x]
+    /\ HeldAuthorised(x)
+    /\ r \in pending[e]
+    /\ pending' = [pending EXCEPT ![e] = @ \ {r}]
+    /\ UNCHANGED <<status, waits, satisfied, fields, moved, owner, expired, cancelReq,
+                   versionServed, heldExec, heldValid, heldServed, pendExec, pendValid,
+                   heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, lapses, suspends, redeploys>>
+
+\* finish(Terminal): the terminal write, judged by the store like any other.
+\* Allowed when nothing is parked, or when a cancel is outstanding: the cancel
+\* overrides the rows and the executor unwinds without whatever they waited for.
+\* Consumes the claim and retires every row, because a terminal execution's
+\* waits are dead.
+FinishTerminal(x, e) ==
+    /\ heldExec[x] = e
+    /\ heldServed[x]
+    /\ pending[e] = {} \/ cancelReq[e]
+    /\ IF StoreAccepts(x, "finish")
+         THEN /\ lapsedWrite' = (lapsedWrite \/ StaleBelief(x))
+              /\ refusedEver' = refusedEver
+              /\ status'      = [status    EXCEPT ![e] = IF cancelReq[e] THEN "Cancelled" ELSE "Completed"]
+              /\ pending'     = [pending   EXCEPT ![e] = {}]
+              /\ waits'       = [waits     EXCEPT ![e] = {}]
+              /\ satisfied'   = [satisfied EXCEPT ![e] = {}]
+              /\ fields'      = [fields    EXCEPT ![e] = {}]
+              /\ moved'       = [moved     EXCEPT ![e] = {}]
+              /\ owner'       = [owner     EXCEPT ![e] = NoOwner]
+              /\ pendValid'   = [pendValid EXCEPT ![x] = IF RetireOnRelease THEN FALSE ELSE @]
+              /\ EndInstance(x)
+         ELSE /\ refusedEver' = TRUE
+              /\ UNCHANGED <<lapsedWrite, status, pending, waits, satisfied, fields, moved,
+                             owner, pendValid, pendStale>>
+    /\ Drop(x)
+    /\ UNCHANGED <<expired, cancelReq, versionServed, heldServed, pendExec,
+                   heldStale, uselessClaim, crashes, lapses, suspends, redeploys>>
+
+\* finish(Suspended(waitingOn)): the attempt ends parked. It writes no status,
+\* keeps EXACTLY the rows it is still waiting on, retires the rest, and makes
+\* the claim absent, all in one transition.
+\*
+\* waitingOn is the interpreter's live parks at the ending, which is what D-B
+\* means by "the attempt's end already knows its live parks, because they are
+\* what ended it". It is NOT derived from the rows the episode recorded: those
+\* are `waits`, and deriving from them is precisely KeepExactly = FALSE, the
+\* broken variant this action's control switches on. The two differ exactly when
+\* a branch was decided against or a discharge left its row behind.
+\*
+\* Four guards, all statements about the interpreter rather than restrictions on
+\* the environment. An attempt with nothing parked did not end suspended; it
+\* completed, failed, or died. An attempt does not end leaving a live park whose
+\* wake condition is already met, because the interpreter would have resumed
+\* that branch: the store state that interleaving reaches is reachable anyway by
+\* the field arriving one step later. Every live park has its row, which is
+\* D-E's obligation on the interpreter and the reason the ending can state
+\* waitingOn at all; an attempt whose recordWait was refused ends ClaimLost and
+\* never reaches this verb. And an attempt that finds a cancel request
+\* outstanding unwinds and finishes rather than parking again, which is D-C's
+\* rule for the cancel path: the model does not represent a compensation that
+\* itself parks, and without this guard nothing bounds an execution that is
+\* claimed and re-suspended forever without ever unwinding, which is a false
+\* CancelTerminates violation rather than a defect. TLC found that too.
+FinishSuspended(x, e) ==
+    /\ heldExec[x] = e
+    /\ heldServed[x]
+    /\ ~cancelReq[e]
+    /\ pending[e] /= {}
+    /\ ~\E r \in pending[e] : r \in satisfied[e]
+    /\ pending[e] \subseteq waits[e]
+    /\ IF StoreAccepts(x, "finish")
+         THEN LET keep == IF KeepExactly THEN pending[e] ELSE waits[e]
+              IN /\ lapsedWrite' = (lapsedWrite \/ StaleBelief(x))
+                 /\ refusedEver' = refusedEver
+                 /\ waits'       = [waits     EXCEPT ![e] = keep]
+                 /\ satisfied'   = [satisfied EXCEPT ![e] = @ \cap keep]
+                 /\ moved'       = [moved     EXCEPT ![e] = @ \cap keep]
+                 /\ owner'       = [owner     EXCEPT ![e] = NoOwner]
+                 /\ pendValid'   = [pendValid EXCEPT ![x] = IF RetireOnRelease THEN FALSE ELSE @]
+                 /\ EndInstance(x)
+         ELSE /\ refusedEver' = TRUE
+              /\ UNCHANGED <<lapsedWrite, waits, satisfied, moved, owner, pendValid, pendStale>>
+    /\ Drop(x)
+    /\ UNCHANGED <<status, pending, fields, expired, cancelReq, versionServed, heldServed,
+                   pendExec, heldStale, uselessClaim, crashes, lapses, suspends, redeploys>>
+
+RequestCancel(e) ==
+    /\ ~cancelReq[e]
+    /\ status[e] \notin Terminal
+    /\ cancelReq' = [cancelReq EXCEPT ![e] = TRUE]
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, expired,
+                   versionServed, heldExec, heldValid, heldServed, pendExec, pendValid,
+                   heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, lapses, suspends, redeploys>>
+
+\* The ClaimLost path through renewal: an executor learns its claim is gone and
+\* gives up. Nothing happens store-side (finish is the only verb the store hears
+\* a release through), and the in-flight write is NOT drained: it is exactly
+\* what the store must refuse.
+Relinquish(x) ==
+    /\ heldExec[x] /= NoOwner
+    /\ ~HeldAuthorised(x)
+    /\ Drop(x)
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, expired,
+                   cancelReq, versionServed, heldServed, pendExec, pendValid, heldStale,
+                   pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, lapses, suspends, redeploys>>
+
+\* An attempt ends without a verdict and writes NOTHING: the claim is left to
+\* expire. This is a crash, and it is also Infra, Interrupted and an engine
+\* shutdown, which have the same transition (D1 measured that a scope close
+\* interrupts the supervisor with the attempt, so no ending transition of any
+\* kind runs). Its in-flight write stays in flight, and the claim it held stays
+\* ACTIVE until the lease lapses, which is what makes the row's own state the
+\* fact that says "the last word was never said".
+\*
+\* Bounded, and the bound is the honest one: an unbounded supply of attempts
+\* that end without finishing is a starvation, not a fence question.
+Crash(x) ==
+    /\ heldExec[x] /= NoOwner
+    /\ crashes < MaxCrashes
+    /\ crashes' = crashes + 1
+    /\ Drop(x)
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, expired,
+                   cancelReq, versionServed, heldServed, pendExec, pendValid, heldStale,
+                   pendStale, lapsedWrite, uselessClaim, refusedEver, lapses, suspends, redeploys>>
+
+\* A redeployment stops serving the version every execution runs. Bounded, and
+\* the bound is an environment bound: unbounded, the served flag flickers forever
+\* and Claim, Finish and SatisfyWait are enabled infinitely often but never
+\* continuously, so each needs STRONG fairness, which TLC did not finish in 25
+\* minutes with three families at once. The price is stated in the report: with
+\* the flicker finite, weak fairness on Claim no longer distinguishes a poll that
+\* keeps running from one that eventually runs.
+Unregister ==
+    /\ versionServed
+    /\ redeploys < MaxRedeploys
+    /\ redeploys'     = redeploys + 1
+    /\ versionServed' = FALSE
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, expired,
+                   cancelReq, heldExec, heldValid, heldServed, pendExec, pendValid,
+                   heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, lapses, suspends>>
+
+\* Rolling back. Fair, and that fairness is a claim about the OPERATOR rather than
+\* the engine: the engine cannot promise a version-orphaned execution ever
+\* finishes.
+Register ==
+    /\ ~versionServed
+    /\ versionServed' = TRUE
+    /\ UNCHANGED <<status, pending, waits, satisfied, fields, moved, owner, expired,
+                   cancelReq, heldExec, heldValid, heldServed, pendExec, pendValid,
+                   heldStale, pendStale, lapsedWrite, uselessClaim, refusedEver,
+                   crashes, lapses, suspends, redeploys>>
+
+Next ==
+    \/ \E x \in Executors, e \in Executions : Claim(x, e)
+    \/ \E e \in Executions : ExpireAbandoned(e)
+    \/ \E e \in Executions : ExpireHeld(e)
+    \/ \E x \in Executors, e \in Executions : IssueWrite(x, e)
+    \/ \E x \in Executors : DeliverWrite(x)
+    \/ \E x \in Executors, e \in Executions, r \in Rows : Park(x, e, r)
+    \/ \E x \in Executors, e \in Executions, r \in Rows : RecordWait(x, e, r)
+    \/ \E x \in Executors, e \in Executions, r \in Rows : ReRecordWait(x, e, r)
+    \/ \E e \in Executions, r \in Rows : SatisfyWait(e, r)
+    \/ \E x \in Executors, e \in Executions, r \in Rows : RecordProgress(x, e, r)
+    \/ \E x \in Executors, e \in Executions, r \in Rows : DecideAgainst(x, e, r)
+    \/ \E x \in Executors, e \in Executions : FinishTerminal(x, e)
+    \/ \E x \in Executors, e \in Executions : FinishSuspended(x, e)
+    \/ \E e \in Executions : RequestCancel(e)
+    \/ \E x \in Executors : Relinquish(x)
+    \/ \E x \in Executors : Crash(x)
+    \/ Unregister
+    \/ Register
+
+\* WEAK fairness throughout, sound because every source of flicker is bounded.
+\* Timers are fair; fields are not (Spec), or are (SpecSignals). Park,
+\* ReRecordWait, DecideAgainst, IssueWrite and RequestCancel are the flow's own
+\* choices and unfair; Crash, ExpireHeld and Unregister are the adversary's and
+\* unfair. RecordWait is fair because a parked branch's row write is the same
+\* call as the park. Both finish arms are fair, which is what says an attempt
+\* ends.
+Fairness ==
+    /\ \A e \in Executions : WF_vars(ExpireAbandoned(e))
+    /\ WF_vars(Register)
+    /\ \A x \in Executors, e \in Executions : WF_vars(Claim(x, e))
+    /\ \A x \in Executors, e \in Executions : WF_vars(FinishTerminal(x, e))
+    /\ \A x \in Executors, e \in Executions : WF_vars(FinishSuspended(x, e))
+    /\ \A x \in Executors, e \in Executions, r \in Rows : WF_vars(RecordWait(x, e, r))
+    /\ \A x \in Executors, e \in Executions, r \in Rows : WF_vars(RecordProgress(x, e, r))
+    /\ \A x \in Executors : WF_vars(DeliverWrite(x))
+    /\ \A x \in Executors : WF_vars(Relinquish(x))
+    /\ \A e \in Executions, r \in Rows : Timer(r) => WF_vars(SatisfyWait(e, r))
+
+SignalFairness == \A e \in Executions : WF_vars(SatisfyWait(e, "input"))
+
+Spec        == Init /\ [][Next]_vars /\ Fairness
+SpecSignals == Spec /\ SignalFairness
+
+(***************************************************************************)
+(* Properties                                                              *)
+(***************************************************************************)
+
+\* I1: two executors never both hold an authorised claim on one execution.
+Exclusivity ==
+    \A e \in Executions :
+        \A x1, x2 \in Executors :
+            (/\ heldExec[x1] = e /\ HeldAuthorised(x1)
+             /\ heldExec[x2] = e /\ HeldAuthorised(x2)) => x1 = x2
+
+\* D-B: no write ground truth refuses was ever applied, on any write kind.
+\* Red under TokenOnly (field), TokenOnlyFinish (terminal), OwnerWitness (ABA)
+\* and ReleaseGap (an ending that leaves the generation live).
+NoLapsedWrite == ~lapsedWrite
+
+\* D-A: the store never returns an execution the claimer can do nothing with.
+\* Red under UnscopedCancel (cannot resolve the definition).
+NoUselessClaim == ~uselessClaim
+
+\* D-A: an absent claim means the rows are a finished attempt's blessed
+\* statement of what the execution waits for. This is the sentence the whole
+\* readiness rule rests on: it is why the rows may gate wake-up exactly when the
+\* claim is absent. Red under LoserRow, where a suspending ending keeps what was
+\* recorded instead of exactly what it is still waiting on.
+LedgerBlessed == \A e \in Executions : ClaimAbsent(e) => waits[e] = pending[e]
+
+\* D-B: recordProgress writes the field and clears the node's rows in one
+\* transition, so no state has the field present with the row still outstanding.
+\* Red under NoWaitClearing.
+ProgressAtomic == \A e \in Executions : fields[e] \cap waits[e] = {}
+
+\* D-A's arm (d): an execution nothing can rescue. Its last attempt died (the
+\* claim is active and expired, so no write can land and only a new claim can
+\* move it), the ledger MISDESCRIBES what it is waiting on (a row for a branch
+\* the composition decided against, or a park whose row the death arrived
+\* before), the version is served so this is not the version gate's doing, no
+\* cancel is outstanding to override the rows, every outstanding row waits on a
+\* signal nothing promises to deliver, and readiness refuses it. Nothing in the
+\* design's environment can change any of those: the state is permanent, and
+\* only a claim could heal it.
+\*
+\* The misdescription conjunct is what keeps this a wedge rather than a correct
+\* execution waiting for a field that never comes. Without it the predicate
+\* fires on a died attempt whose rows are a true statement of its live parks,
+\* which the design does not call a defect and which no arm of readiness is
+\* meant to rescue. TLC found exactly that state first, and the conjunct is the
+\* answer to it.
+\* Red under Wedge, which removes the arm.
+Wedged(e) ==
+    /\ status[e] \notin Terminal
+    /\ Dead(e)
+    /\ waits[e] /= pending[e]
+    /\ versionServed
+    /\ ~cancelReq[e]
+    /\ \A r \in waits[e] : ~Timer(r)
+    /\ ~Ready(e)
+
+NoWedge == \A e \in Executions : ~Wedged(e)
+
+\* I5: a terminal status is never revisited.
+TerminalStable ==
+    [][\A e \in Executions : status[e] \in Terminal => status'[e] = status[e]]_vars
+
+\* A cancel request is eventually honoured, with no assumption that any field
+\* ever arrives. Red under NoCancelArm. Written <>[] over stable predicates
+\* (cancelReq and terminal are both stable) so it stays in TLC's efficient
+\* fragment; it is equivalent to cancelReq[e] ~> terminal.
+CancelTerminates == \A e \in Executions : <>[](cancelReq[e] => status[e] \in Terminal)
+
+\* Every execution terminates, under SpecSignals: every timer fires, every field
+\* arrives, the operator rolls back, and crashes, lapses, suspensions and
+\* redeployments are finite. Red under MovedWake, where a re-recorded sleep's
+\* deadline moves out of reach and its execution never wakes again.
+EventuallyTerminal == \A e \in Executions : <>[](status[e] \in Terminal)
+
+(***************************************************************************)
+(* Reachability probes, kept permanently. Each must FAIL.                   *)
+(***************************************************************************)
+
+\* If this HOLDS, no executor can ever hold a stale belief, every refusal path is
+\* unreachable, and every safety result above is worthless. It held on the first
+\* version of this spec across 287,480 states.
+BelieverAlwaysRight ==
+    \A x \in Executors :
+        heldExec[x] /= NoOwner =>
+            /\ owner[heldExec[x]] = x
+            /\ heldValid[x]
+            /\ ~expired[heldExec[x]]
+
+\* If this HOLDS, the store never refused anything, and NoLapsedWrite is true
+\* because there was nothing to refuse.
+NeverRefused == ~refusedEver
+
+==================================================================================

--- a/kyo-flow/shared/src/test/tla/LoserRow.cfg
+++ b/kyo-flow/shared/src/test/tla/LoserRow.cfg
@@ -1,0 +1,42 @@
+\* CONTROL for keep-exactly retirement, the rule that a suspending ending
+\* keeps exactly the rows the attempt is still waiting on.
+\*
+\* The ending keeps what was recorded instead: the ledger it leaves is whatever
+\* rows exist, which is the generation-stamp behaviour the second effectiveness
+\* review showed keeps the wrong rows. A raced branch records its row, the race
+\* decides against it, and the row outlives the attempt that recorded it. If the
+\* row is a satisfied sleep, the execution is instantly ready again with nothing
+\* to do: claim, replay, park, finish, ready, a self-triggered wake loop in
+\* which the row CAUSES the resumes.
+\*
+\* LedgerBlessed is expected to FAIL: an execution whose claim is absent, whose
+\* ledger holds a row the execution is not waiting on.
+\*
+\* This control is not a tautology only because the ending's waitingOn is the
+\* interpreter's live parks and never the rows the episode recorded. Derived
+\* from the ledger, keep-exactly and keep-what-was-recorded are the same
+\* assignment, and that derivation IS this configuration.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = FALSE
+    OverwriteWake   = FALSE
+
+INVARIANT LedgerBlessed
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/MovedWake.cfg
+++ b/kyo-flow/shared/src/test/tla/MovedWake.cfg
@@ -1,0 +1,40 @@
+\* CONTROL for recordWait being put-if-absent on the wake, the other half of the
+\* rule LoserRow.cfg checks: a wait re-recorded on a later attempt keeps its
+\* original deadline.
+\*
+\* Re-recording moves the wake instead of leaving it. A sleep the execution is
+\* still waiting on has its deadline pushed forward by the replay that
+\* re-records it, and the model's abstraction of a deadline pushed forward on
+\* every replay is a row its clock can no longer reach. The durable timeout
+\* never fires and the execution never wakes again.
+\*
+\* EventuallyTerminal is expected to FAIL, and this is checked under SpecSignals
+\* for the same reason Signalled.cfg is: the harm is that a wait nothing can
+\* satisfy survives an environment in which every timer fires and every field
+\* arrives, so the assumption has to be switched on for the failure to mean
+\* anything.
+SPECIFICATION SpecSignals
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = TRUE
+
+INVARIANT TypeOK
+PROPERTY EventuallyTerminal
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/NoCancelArm.cfg
+++ b/kyo-flow/shared/src/test/tla/NoCancelArm.cfg
@@ -1,0 +1,36 @@
+\* CONTROL for the cancel arm of readiness, the condition that a requested
+\* cancel makes an execution ready whatever its rows say.
+\*
+\* Readiness has no cancel arm. An execution suspended on a field, then
+\* cancelled, is never returned, because no field is promised to arrive under
+\* Spec, so its compensations never run. The previous version of this spec put
+\* fairness on every wait kind, under which every execution terminated with or
+\* without the arm; the arm was dead weight and this control would have stayed
+\* green.
+\*
+\* CancelTerminates is expected to FAIL.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = FALSE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT TypeOK
+PROPERTY CancelTerminates
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/NoWaitClearing.cfg
+++ b/kyo-flow/shared/src/test/tla/NoWaitClearing.cfg
@@ -1,0 +1,41 @@
+\* CONTROL for wait-row clearing, the requirement no test can guard.
+\*
+\* recordProgress writes the node's field and leaves the node's wait row in the
+\* ledger, instead of doing both in the one transition the verb defines.
+\*
+\* ProgressAtomic is expected to FAIL: a state exists in which the path carries
+\* a field and its row is still outstanding.
+\*
+\* The property this control names CHANGED with the design, and the change is a
+\* finding rather than a convenience. It used to be NoUselessClaim: a satisfied
+\* row whose branch had moved on kept the execution ready, so the store returned
+\* it to an executor with nothing to do, which let go, and the next poll
+\* returned it again. Under keep-exactly retirement that churn is no longer
+\* reachable, because the attempt's own finish retires every row it is not still
+\* waiting on, including the one the clearing missed. What is left of the
+\* clearing rule at this model's grain is the transition's atomicity, which is
+\* what this control now removes and what ProgressAtomic states.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = FALSE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT ProgressAtomic
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/OwnerWitness.cfg
+++ b/kyo-flow/shared/src/test/tla/OwnerWitness.cfg
@@ -1,0 +1,33 @@
+\* CONTROL for the rejected witness: owner identity in place of the token.
+\*
+\* Field writes are accepted on owner identity plus expiry instead of on the
+\* generation token: the (executorId, claimExpiry) witness the design argues
+\* against. The ABA trace tells them apart: x claims, issues a write, crashes,
+\* the claim lapses, x claims the same row again, and the old write arrives.
+\* Same owner, not expired, and stale.
+\*
+\* NoLapsedWrite is expected to FAIL.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = TRUE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT NoLapsedWrite
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/Refusal.cfg
+++ b/kyo-flow/shared/src/test/tla/Refusal.cfg
@@ -1,0 +1,29 @@
+\* PROBE: the store's refusal path must be reachable.
+\*
+\* NeverRefused is expected to FAIL. If it holds, the store never refused a
+\* write, and NoLapsedWrite holds in Designed.cfg only because there was
+\* nothing to refuse.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT NeverRefused
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/ReleaseGap.cfg
+++ b/kyo-flow/shared/src/test/tla/ReleaseGap.cfg
@@ -1,0 +1,35 @@
+\* CONTROL for design change 1.1: releasing a claim retires its generation.
+\*
+\* Release leaves the generation live. A field write issued just before a
+\* suspend and delivered just after it is neither superseded (nobody claimed
+\* since) nor expired (the claim was let go, not lapsed), so the two-condition
+\* rule applies it after the executor has stopped. Four steps.
+\*
+\* NoLapsedWrite is expected to FAIL. This control exists because the previous
+\* version of this spec "fixed" the same gap by draining the write on release,
+\* which made the gap unrepresentable rather than refused, and every config
+\* still reported its required result.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = FALSE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT NoLapsedWrite
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/Signalled.cfg
+++ b/kyo-flow/shared/src/test/tla/Signalled.cfg
@@ -1,0 +1,29 @@
+\* The design as written, under the explicit assumption that every field
+\* eventually arrives (SpecSignals). Under it every execution terminates.
+\* The assumption is the environment's, not the engine's, which is why it is a
+\* separate config rather than part of Designed.
+SPECIFICATION SpecSignals
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT TypeOK
+PROPERTY EventuallyTerminal
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/TokenOnly.cfg
+++ b/kyo-flow/shared/src/test/tla/TokenOnly.cfg
@@ -1,0 +1,31 @@
+\* CONTROL for defect 1, field writes.
+\*
+\* The store accepts a field write on the generation token alone, without the
+\* expiry check. An executor whose lease lapsed with no competitor still holds
+\* the current token, so its write is applied.
+\*
+\* NoLapsedWrite is expected to FAIL.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {"field"}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT NoLapsedWrite
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/TokenOnlyFinish.cfg
+++ b/kyo-flow/shared/src/test/tla/TokenOnlyFinish.cfg
@@ -1,0 +1,34 @@
+\* CONTROL for defect 1, the terminal write.
+\*
+\* The store's finish verb checks the token but not expiry, while its field
+\* write checks both: the shape of a store author who implements the rule on
+\* putField and forgets it on finish. An executor whose lease lapsed with no
+\* competitor writes terminal status. This is the literal wording of defect 1
+\* ("kept writing through to a terminal status"), and the previous version of
+\* this spec could not see it because finish bypassed the acceptance rule.
+\*
+\* NoLapsedWrite is expected to FAIL.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {"finish"}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT NoLapsedWrite
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/UnscopedCancel.cfg
+++ b/kyo-flow/shared/src/test/tla/UnscopedCancel.cfg
@@ -1,0 +1,34 @@
+\* CONTROL for defect 2.
+\*
+\* A cancel request bypasses the version gate, so a version-orphaned execution
+\* is handed to an executor that cannot resolve its definition. It can neither
+\* resume nor unwind, so it parks and releases, and the next poll returns it
+\* again: the claim-and-release churn the design predicts.
+\*
+\* NoUselessClaim is expected to FAIL. Not EventuallyTerminal: with the
+\* operator's rollback fair, the orphan does eventually terminate, and the
+\* defect is the churn until then.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = TRUE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT NoUselessClaim
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/Vacuity.cfg
+++ b/kyo-flow/shared/src/test/tla/Vacuity.cfg
@@ -1,0 +1,29 @@
+\* PROBE: stale beliefs must be reachable.
+\*
+\* BelieverAlwaysRight is expected to FAIL. If it holds, no executor can ever
+\* hold a stale belief, every refusal path is unreachable, and every safety
+\* result in Designed.cfg is vacuous. It held on the first version of this spec.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT BelieverAlwaysRight
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/Wedge.cfg
+++ b/kyo-flow/shared/src/test/tla/Wedge.cfg
@@ -1,0 +1,43 @@
+\* CONTROL for readiness's active-and-expired arm.
+\*
+\* The arm is removed, so the wait rows gate wake-up even when the claim is
+\* active and expired. That reading, in which rows always gate, wedges the
+\* race-an-input-against-a-timeout idiom permanently. An attempt
+\* records a row for each parked branch, a sibling resolves the composition
+\* against one of them, and the attempt then DIES before its finish could retire
+\* that row. The claim lapses, the stale row is the only thing in the ledger,
+\* nothing will ever satisfy it, and retirement needs the claim the rule refuses
+\* to grant: circular, permanent, and reachable by an ordinary crash.
+\*
+\* NoWedge is expected to FAIL.
+\*
+\* NoWedge is conditioned on the claim being ACTIVE AND EXPIRED rather than on
+\* unclaimability alone, and that is load-bearing rather than fussy. A finish
+\* whose waitingOn omits a row is a claim-ABSENT execution the rows legitimately
+\* gate, and arm (d) deliberately does not heal it; a predicate over
+\* unclaimability alone would fire on those in the designed configuration and
+\* the control would prove nothing.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 1
+    MaxLapses       = 1
+    MaxSuspends     = 2
+    MaxRedeploys    = 1
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = FALSE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT NoWedge
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/Wide.cfg
+++ b/kyo-flow/shared/src/test/tla/Wide.cfg
@@ -1,0 +1,43 @@
+\* The design as written, honest environment, with every adversary and workload
+\* budget doubled or raised: two crashes, two lapses, two redeployments, three
+\* suspension points (so all three rows can be outstanding on one execution, or
+\* two on one and one on the other). Same properties as Designed.cfg.
+\*
+\* This exists because the small-scope argument for Designed.cfg was made at
+\* these sizes and then the budgets were halved for tractability without a run
+\* at the argued sizes. Exhausting a budget disables one action rather than
+\* truncating a behaviour, so this is a strictly larger set of behaviours than
+\* Designed, and everything that holds here holds there.
+SPECIFICATION Spec
+
+CONSTANTS
+    Executions      = {e1, e2}
+    Executors       = {x1, x2}
+    MaxCrashes      = 2
+    MaxLapses       = 2
+    MaxSuspends     = 3
+    MaxRedeploys    = 2
+    NoOwner         = NoOwner
+    NoWrite         = NoWrite
+    ClearsWaits     = TRUE
+    TokenOnlyWrites = {}
+    OwnerWitness    = FALSE
+    RetireOnRelease = TRUE
+    UnscopedCancel  = FALSE
+    CancelArm       = TRUE
+    ExpiredArm      = TRUE
+    KeepExactly     = TRUE
+    OverwriteWake   = FALSE
+
+INVARIANT TypeOK
+INVARIANT Exclusivity
+INVARIANT NoLapsedWrite
+INVARIANT NoUselessClaim
+INVARIANT LedgerBlessed
+INVARIANT ProgressAtomic
+INVARIANT NoWedge
+
+PROPERTY TerminalStable
+PROPERTY CancelTerminates
+
+CHECK_DEADLOCK FALSE

--- a/kyo-flow/shared/src/test/tla/check.sh
+++ b/kyo-flow/shared/src/test/tla/check.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Model-check kyo-flow's claim lifecycle with TLC, enforcing the polarity of
+# every config.
+#
+#   ./check.sh              run every config in the table below except Wide
+#   ./check.sh Designed     run one or more by name, Wide included
+#
+# Run it sequentially. It passes TLC -cleanup, so two runs at once wipe each
+# other's state directory and both die reading the disk.
+#
+# Each config has an expectation: a green config must complete with no error,
+# and a control must report a violation of the property named for it. A control
+# that stays green is a failure of the MODEL, and this script fails on it. That
+# is the enforcement the first version of this spec lacked: it checked clean and
+# proved nothing, and nobody noticed because the controls were a human reading
+# logs.
+#
+# Downloads tla2tools.jar on first use into this directory; it is gitignored.
+# TLC is a JVM tool, so this needs a JDK on PATH and nothing else.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+jar="$here/tla2tools.jar"
+url="https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar"
+
+if [[ ! -f "$jar" ]]; then
+    echo "fetching tla2tools.jar"
+    curl -sSL -o "$jar" "$url"
+fi
+
+# name:expectation. "green" or "invariant <Name>" or "temporal".
+# TLC names a violated invariant; it does not name a violated temporal property,
+# so a temporal control lists exactly one PROPERTY in its config.
+table=(
+    "Designed:green"
+    "Signalled:green"
+    "Wide:green"
+    "Vacuity:invariant BelieverAlwaysRight"
+    "Refusal:invariant NeverRefused"
+    "TokenOnly:invariant NoLapsedWrite"
+    "TokenOnlyFinish:invariant NoLapsedWrite"
+    "OwnerWitness:invariant NoLapsedWrite"
+    "ReleaseGap:invariant NoLapsedWrite"
+    "UnscopedCancel:invariant NoUselessClaim"
+    "NoWaitClearing:invariant ProgressAtomic"
+    "Wedge:invariant NoWedge"
+    "LoserRow:invariant LedgerBlessed"
+    "NoCancelArm:temporal"
+    "MovedWake:temporal"
+)
+
+expectation_of() {
+    local name="$1" row
+    for row in "${table[@]}"; do
+        if [[ "${row%%:*}" == "$name" ]]; then
+            echo "${row#*:}"
+            return 0
+        fi
+    done
+    echo "unknown config: $name" >&2
+    return 1
+}
+
+# Configs the no-argument sweep leaves out. `Wide` is a real config with a real
+# expectation and `./check.sh Wide` runs it and reads its polarity like any
+# other; what it cannot do is REACH a verdict at those sizes. Leaving it in the
+# default sweep would mean the default sweep can never pass, and a runner whose
+# exit code is always non-zero teaches everyone to stop reading it, which is the
+# same failure as a control nobody checks. Run it by name to explore a wider
+# state space than the sweep reaches, expecting to stop it rather than finish it.
+default_skip=("Wide")
+
+if [[ $# -gt 0 ]]; then
+    names=("$@")
+else
+    names=()
+    for row in "${table[@]}"; do
+        name="${row%%:*}"
+        skipped="no"
+        for s in "${default_skip[@]}"; do
+            [[ "$name" == "$s" ]] && skipped="yes"
+        done
+        [[ "$skipped" == "no" ]] && names+=("$name")
+    done
+fi
+
+logs="$here/logs"
+mkdir -p "$logs"
+
+failures=0
+for name in "${names[@]}"; do
+    expect="$(expectation_of "$name")" || { failures=$((failures + 1)); continue; }
+    log="$logs/$name.log"
+    echo
+    echo "=============================================================="
+    echo "  $name    (expected: $expect)"
+    echo "=============================================================="
+    # Three workers, not "auto". This machine runs several sessions at once and
+    # TLC will take every core it is given. Override with TLC_WORKERS.
+    #
+    # Liveness is checked once at the end for every config EXCEPT the temporal
+    # controls, because the periodic passes grow with the state count (on
+    # Wide.cfg they went 1:52, 2:52, 4:17 and were still growing at 30M states)
+    # and pause exploration while they run. A temporal control is the one case
+    # where that trade inverts: its whole purpose is to REACH a violation, the
+    # violation is usually shallow, and "final" makes it build the entire state
+    # graph first. MovedWake passed 54 million distinct states with its queue
+    # still growing before it could report a counterexample that a periodic pass
+    # finds in minutes. Either way the counterexample is the same; what changes
+    # is when it is reported.
+    lncheck=(-lncheck final)
+    [[ "$expect" == "temporal" ]] && lncheck=()
+
+    java -XX:+UseParallelGC -cp "$jar" tlc2.TLC \
+        -config "$here/$name.cfg" \
+        -workers "${TLC_WORKERS:-3}" \
+        "${lncheck[@]}" \
+        -cleanup \
+        "$here/FlowClaim.tla" > "$log" 2>&1
+    grep -E 'states generated|distinct states|Finished in|The depth of' "$log" | sed 's/^/    /'
+
+    verdict="fail"
+    case "$expect" in
+        green)
+            if grep -q 'No error has been found' "$log"; then verdict="ok"; fi
+            ;;
+        "invariant "*)
+            prop="${expect#invariant }"
+            if grep -q "Invariant $prop is violated" "$log"; then verdict="ok"; fi
+            ;;
+        temporal)
+            if grep -q 'Temporal properties were violated' "$log"; then verdict="ok"; fi
+            ;;
+    esac
+
+    if [[ "$verdict" == "ok" ]]; then
+        echo "    [$name] OK: $expect"
+    else
+        failures=$((failures + 1))
+        echo "    [$name] FAILED: expected '$expect'; see $log"
+        grep -E '^Error|violated|No error' "$log" | head -5 | sed 's/^/        /'
+    fi
+done
+
+echo
+if [[ $failures -eq 0 ]]; then
+    echo "all ${#names[@]} configs at their expected result"
+else
+    echo "$failures of ${#names[@]} configs NOT at their expected result"
+fi
+exit $failures


### PR DESCRIPTION

### Problem

The engine did not keep the durability promises its API makes. A step in flight when its executor died was never re-issued: the execution livelocked at `Running`, reclaimed and abandoned on every poll, with nothing reporting a problem. An executor whose lease had lapsed could still write, so two executors could write one field. Readiness was a status whitelist, so the wrong event could wake an execution. A child flow embedded twice shared durable identity with its twin, so after a crash a charge that must happen twice happened once. A store outage was reported as the workflow failing, a redeploy killed running executions rather than parking them, and a field the record type promises, `record.review.amount`, threw `NoSuchElementException`.

### Solution

**Readiness is a rule, not a whitelist.** Wait rows keyed by execution and node path, recorded put-if-absent. An execution is claimable when it is non-terminal, its claim is free or expired, the caller serves its definition, and either a cancel is requested, no row is outstanding, a row is satisfied, or the claim is active and expired, which is what makes a dead executor's rows healable.

**Authority is the claim's state, never its holder.** A claim carries a generation token and the store judges every write against the active claim, so a lapsed executor cannot write. Progress is one write-once transition covering the field, the completion event and the row clearing together. `finish` is the only operation that makes a claim absent, and it keeps exactly the rows the attempt is still waiting on.

**Durable identity is the composition path.** `first~charge` and `second~charge` are two nodes, so a subflow embeds twice, foreach items persist and compensate individually, and loop iterations key their own fields. A subflow records its child's inputs at entry, which makes the promised record field readable and reduces the input mapper's obligation from purity to idempotency.

**One transition function ends every attempt.** It classifies the ending and only the arms that reached a verdict write. A store failure is charged to an engine health signal and leaves the execution claimable, so an outage is not a workflow failure.

**The read surfaces report what the store holds.** A failed node comes from a recorded failure event resolved to one owner rather than from position, search pages once with the match count, and cancellation is a request observed at the next node boundary that runs compensations and terminalises as cancelled.

### Notes

The store SPI changed shape and is not source compatible: a claimed capability, the wait ledger, `Dict` dictionaries and typed refusals. An implementation is rewritten against the conformance suite in `FlowStoreTest`, which every store runs.

Definitions are keyed by workflow id and structural hash, so an execution resumes under the definition it started with; a redeployed workflow parks its in-flight executions until the old definition is registered again.

The TLA+ model of the claim protocol, its configurations and its check script are checked in under `shared/src/test/tla`. Neither the build nor CI runs them.