### PR TITLE
[kyo-data] support builds that compile with -Yretain-trees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Thank you for considering contributing to this project! We welcome all contribut
     - [Markdown Formatting](#markdown-formatting)
     - [Inline Comments](#inline-comments)
   - [File Organization](#file-organization)
+  - [Macros](#macros)
 - [Module READMEs](#module-readmes)
   - [Structure](#structure)
   - [Writing Style](#writing-style)
@@ -754,6 +755,24 @@ export Fiber.Promise   // makes kyo.Promise available without Fiber. prefix
 ```
 
 Use sparingly — only for types that users reference frequently enough that qualification would be noisy.
+
+### Macros
+
+**Never read a type's declaration through `Symbol.tree`.** What that call returns depends on `-Yretain-trees`, a flag the user's build sets and the library does not control. Without it the compiler fabricates a declaration from the symbol info; with it the retained source declaration comes back instead. For a type member the two carry different things: the fabricated one carries the bounds, the real one carries the right-hand side as written, which for an opaque type is its alias and never mentions the bounds. A macro that matches on one shape crashes or answers differently under the other, and the tag or schema it derives stops agreeing with the one every other build derives.
+
+Ask the symbol instead. `kyo.internal.DeclaredBounds` reads a type member's declared bounds through the node's own prefix, which answers the same in both modes, and substitutes the node's own type arguments into a parameterized bound.
+
+Whether that call is stable is a per-symbol question, not a global one, because `Symbols.retainsDefTree` decides it as a disjunction: the flag is one disjunct, `denot.owner.isTerm` is another. For a type local to a term (a method's type parameter) the second holds unconditionally, since such a symbol dies with its term and cannot leak across runs, so both modes read the same declaration and reading it is sound. That case also has no prefix to be a member of, so it is the one place `DeclaredBounds` reads a tree, and it already handles it. For every other symbol the flag is the deciding disjunct, which is exactly what makes the general read unstable.
+
+Reading a *term* definition's body (`ValDef.rhs`, a `given`'s right-hand side) is different: those trees exist only under the flag, so such a macro must degrade gracefully rather than depend on them.
+
+To check a macro answers the same in both modes:
+
+```sh
+KYO_RETAIN_TREES=true sbt 'kyo-dataJVM/test'
+```
+
+The flag is never set in CI. Retaining the trees of every dependency costs a few hundred MB per module (measured at +18% peak live heap on kyo-data's test compile), which the runners do not have to spare, so this is a local check to run when touching a macro that inspects types.
 
 ---
 

--- a/build.sbt
+++ b/build.sbt
@@ -139,6 +139,14 @@ lazy val `kyo-settings` = Seq(
     // expansion reaches users as a broken build in their code, not ours. The Scala 2.13 cross-builds (the
     // kyo-scheduler family) do not have the flag.
     scalacOptions ++= (if (scalaVersion.value.startsWith("3")) Seq("-Xcheck-macros") else Nil),
+    // `KYO_RETAIN_TREES=true sbt <module>/test` compiles with `-Yretain-trees`, which changes what
+    // `Symbol.tree` returns: the retained source declaration instead of one the compiler fabricates
+    // from the symbol info. A macro that reads a declaration through that call sees a different tree
+    // shape under the flag, so a build that enables it (some do project-wide) can crash a derivation
+    // that compiles everywhere else. Kyo's macros must answer the same in both modes; this is how to
+    // check that. Off by default: retaining the trees of every dependency costs a few hundred MB per
+    // module, which CI does not have to spare.
+    scalacOptions ++= (if (sys.env.get("KYO_RETAIN_TREES").contains("true")) Seq("-Yretain-trees") else Nil),
     Test / scalacOptions --= scalacOptionTokens(Set(ScalacOptions.warnNonUnitStatement)).value,
     // Not in CI: parallel cross-version compilations of one module format the same shared
     // sources concurrently, and the loser logs "scalafmt: failed for 1 sources" on every

--- a/kyo-data/shared/src/main/scala/kyo/internal/DeclaredBounds.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/DeclaredBounds.scala
@@ -1,0 +1,84 @@
+package kyo.internal
+
+import scala.quoted.*
+
+/** Reads the bounds a type member declares, the same way in every build.
+  *
+  * A macro that needs an opaque or abstract type's bounds has two ways to ask for them, and only one of them is stable. `Symbol.tree`
+  * returns the retained source declaration when the build sets `-Yretain-trees` and a declaration the compiler fabricates from the symbol
+  * info when it does not, and for a type member those two carry different things: the fabricated one carries the bounds, the real one
+  * carries the right-hand side as written, which for an opaque type is its alias and never mentions the bounds at all. A macro reading that
+  * tree therefore answers differently, or crashes, depending on a flag the library does not control.
+  *
+  * The bounds live on the symbol, so they are read here through the node's own prefix instead. The prefix is part of the question: a member
+  * of a path-dependent type declares different bounds under different prefixes, so the node's own is the only one that describes this type.
+  *
+  * One case has no prefix to ask, a type local to a term, and there the declaration tree is read. That read is sound for exactly the reason
+  * the general one is not: the compiler keeps the trees a term owns whether or not the flag is set, so both modes see the same declaration.
+  * The `declaration` comment below carries the detail.
+  */
+private[kyo] object DeclaredBounds:
+
+    /** The bounds the type member `node` refers to declares, or `None` if `node` does not refer to one. */
+    def apply(using q: Quotes)(node: q.reflect.TypeRepr): Option[q.reflect.TypeBounds] =
+        import quotes.reflect.*
+
+        val symbol = node.typeSymbol
+
+        def prefixOf(current: TypeRepr): Option[TypeRepr] =
+            current match
+                case AppliedType(constructor, _) => prefixOf(constructor)
+                // A wildcard argument bounded by the member, `? <: X`, carries its symbol on the upper bound.
+                case TypeBounds(_, high) => prefixOf(high)
+                case ref: TypeRef        => Some(ref.qualifier)
+                case _                   => None
+
+        // A type local to a term, a method's type parameter being the case that reaches here, has no prefix
+        // to be a member of, so the symbol is all there is to ask and its declaration is read directly. That
+        // read is the one that does not depend on the flag: the compiler retains the trees of everything a
+        // term owns either way (`Symbols.retainsDefTree` is true whenever the owner is a term), so a real
+        // declaration comes back in both modes and spells its bounds as a `TypeBoundsTree`.
+        //
+        // A fabricated declaration is still matched, for the case this is ever reached by a symbol whose
+        // trees the compiler did not keep. That one spells the bounds as a plain `TypeTree` over the symbol
+        // info rather than as a `TypeBoundsTree`, so it needs its own case. The same case rejects a retained
+        // declaration whose right-hand side is an alias, since an alias is not a `TypeBounds`.
+        def declaration: Option[TypeBounds] =
+            symbol.tree match
+                case TypeDef(_, TypeBoundsTree(low, high)) => Some(TypeBounds(low.tpe, high.tpe))
+                case TypeDef(_, tpt: TypeTree) =>
+                    tpt.tpe match
+                        case bounds: TypeBounds => Some(bounds)
+                        case _                  => None
+                case _ => None
+
+        def member(prefix: TypeRepr): Option[TypeBounds] =
+            prefix.memberType(symbol) match
+                case bounds: TypeBounds => Some(bounds)
+                case _                  => None
+
+        if !symbol.exists || !symbol.isTypeDef then None
+        else
+            prefixOf(node) match
+                case Some(NoPrefix()) | None => declaration
+                case Some(prefix)            => member(prefix)
+        end if
+    end apply
+
+    /** The upper bound of the type member `node` refers to, as it constrains `node` itself, or `None` when there is none to look through:
+      * `node` is not a type member, or its upper bound is `Any` and so says nothing about what it holds.
+      *
+      * A parameterized member declares its bounds as type lambdas, which describe the constructor rather than this application of it, so
+      * they only describe `node` once its own arguments are substituted in.
+      */
+    def upper(using q: Quotes)(node: q.reflect.TypeRepr): Option[q.reflect.TypeRepr] =
+        import quotes.reflect.*
+        val args = node.typeArgs
+        def instantiate(bound: TypeRepr) =
+            bound match
+                case lambda: TypeLambda if args.nonEmpty && lambda.paramNames.size == args.size => lambda.appliedTo(args)
+                case other                                                                      => other
+        apply(node).map(bounds => instantiate(bounds.hi)).filterNot(_ =:= TypeRepr.of[Any])
+    end upper
+
+end DeclaredBounds

--- a/kyo-data/shared/src/main/scala/kyo/internal/FieldsMacros.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/FieldsMacros.scala
@@ -53,17 +53,9 @@ object FieldsMacros:
                     if tpe =:= TypeRepr.of[Any] then Vector()
                     else
                         caseClassFields(tpe).getOrElse:
-                            try
-                                tpe.typeSymbol.tree match
-                                    case typeDef: TypeDef =>
-                                        typeDef.rhs match
-                                            case bounds: TypeBoundsTree =>
-                                                val hi = bounds.hi.tpe
-                                                if !(hi =:= TypeRepr.of[Any]) then decompose(hi)
-                                                else Vector(tpe)
-                                            case _ => Vector(tpe)
-                                    case _ => Vector(tpe)
-                            catch case _: Exception => Vector(tpe)
+                            DeclaredBounds.upper(tpe) match
+                                case Some(hi) => decompose(hi)
+                                case None     => Vector(tpe)
 
         def tupled(typs: Vector[TypeRepr]): TypeRepr =
             typs match
@@ -144,17 +136,7 @@ object FieldsMacros:
                         if sym.isClassDef && sym.flags.is(Flags.Case) then
                             sym.caseFields.find(_.name == nameStr).map(f => tpe.memberType(f))
                         else
-                            try
-                                tpe.typeSymbol.tree match
-                                    case typeDef: TypeDef =>
-                                        typeDef.rhs match
-                                            case bounds: TypeBoundsTree =>
-                                                val hi = bounds.hi.tpe
-                                                if !(hi =:= TypeRepr.of[Any]) then findValueType(hi)
-                                                else None
-                                            case _ => None
-                                    case _ => None
-                            catch case _: Exception => None
+                            DeclaredBounds.upper(tpe).flatMap(findValueType)
                         end if
 
         findValueType(TypeRepr.of[F]) match
@@ -185,17 +167,7 @@ object FieldsMacros:
                         if sym.isClassDef && sym.flags.is(Flags.Case) then
                             sym.caseFields.map(f => (f.name, tpe.memberType(f))).toVector
                         else
-                            try
-                                tpe.typeSymbol.tree match
-                                    case typeDef: TypeDef =>
-                                        typeDef.rhs match
-                                            case bounds: TypeBoundsTree =>
-                                                val hi = bounds.hi.tpe
-                                                if !(hi =:= TypeRepr.of[Any]) then decompose(hi)
-                                                else Vector()
-                                            case _ => Vector()
-                                    case _ => Vector()
-                            catch case _: Exception => Vector()
+                            DeclaredBounds.upper(tpe).fold(Vector.empty)(decompose)
                         end if
 
         for (name, valueType) <- decompose(TypeRepr.of[A]) do
@@ -228,17 +200,7 @@ object FieldsMacros:
                         if sym.isClassDef && sym.flags.is(Flags.Case) then
                             sym.caseFields.map(_.name).toSet
                         else
-                            try
-                                tpe.typeSymbol.tree match
-                                    case typeDef: TypeDef =>
-                                        typeDef.rhs match
-                                            case bounds: TypeBoundsTree =>
-                                                val hi = bounds.hi.tpe
-                                                if !(hi =:= TypeRepr.of[Any]) then fieldNames(hi)
-                                                else Set.empty
-                                            case _ => Set.empty
-                                    case _ => Set.empty
-                            catch case _: Exception => Set.empty
+                            DeclaredBounds.upper(tpe).fold(Set.empty)(fieldNames)
                         end if
 
         val namesA = fieldNames(TypeRepr.of[A])

--- a/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
@@ -247,11 +247,8 @@ private[kyo] object TagMacro:
             // opened through its definition. A shape that cannot be opened is not walkable.
             def aliasBody(tycon: TypeRepr): Option[TypeRepr] =
                 if !tycon.typeSymbol.isAliasType then Some(tycon)
-                else
-                    tycon.typeSymbol.tree match
-                        case TypeDef(_, LambdaTypeTree(_, body: TypeTree)) => Some(body.tpe)
-                        case TypeDef(_, rhs: TypeTree)                     => Some(rhs.tpe)
-                        case _                                             => None
+                // An alias declares its body as both bounds, so either one is the definition.
+                else DeclaredBounds(tycon).map(_.hi)
 
             def walkable(tpe: TypeRepr): Boolean =
                 tpe.dealias match
@@ -449,7 +446,12 @@ private[kyo] object TagMacro:
                             // same tree for every application, so reading anything positional off them
                             // describes the declaration rather than this type.
                             val args = applied.typeArgs
-                            applied.typeSymbol.tree.asInstanceOf[TypeDef].rhs.asInstanceOf[TypeTree].tpe match
+                            DeclaredBounds(applied).getOrElse(
+                                report.errorAndAbort(
+                                    s"Cannot derive Tag[${root.show}]: opaque type ${applied.typeSymbol.fullName} " +
+                                        s"reached the macro as ${applied.show}, a shape whose declared bounds cannot be read."
+                                )
+                            ) match
                                 case TypeBounds(lower, upper) =>
                                     // A parameterized opaque type's bounds are type lambdas carrying the
                                     // declared variances. An undeclared lower bound stays a bare Nothing,

--- a/kyo-data/shared/src/test/scala/kyo/FieldsTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/FieldsTest.scala
@@ -3,6 +3,14 @@ package kyo
 import Record.*
 import scala.language.implicitConversions
 
+/** An opaque type whose upper bound is the field intersection it stands for. Every `Fields` derivation has to look through the bound to
+  * find the fields, which is the one path that reads how the type was declared rather than what it is applied to.
+  */
+object OpaqueFields:
+    opaque type Contact <: "name" ~ String & "age" ~ Int   = "name" ~ String & "age" ~ Int
+    opaque type Boxed[A] <: "value" ~ A & "label" ~ String = "value" ~ A & "label" ~ String
+end OpaqueFields
+
 case class Person(name: String, age: Int)
 case class Point(x: Int, y: Int)
 case class Wrapper[A](value: A, label: String)
@@ -146,6 +154,63 @@ class FieldsTest extends kyo.test.Test[Any]:
         val renders = summon[Fields.SummonAll[F, Render]]
         assert(renders.contains("f1"))
         assert(renders.contains("f30"))
+    }
+
+    // --- Types that declare their fields as an upper bound ---
+
+    "bounded opaque: Fields.names" in {
+        val names = Fields.names[OpaqueFields.Contact]
+        assert(names == Set("name", "age"))
+    }
+
+    "bounded opaque: Fields.fields" in {
+        val fs = Fields.fields[OpaqueFields.Contact]
+        assert(fs.size == 2)
+        assert(fs.find(_.name == "name").get.tag =:= Tag[String])
+        assert(fs.find(_.name == "age").get.tag =:= Tag[Int])
+    }
+
+    "bounded opaque: Have resolves value type" in {
+        val have                                                                 = summon[Fields.Have[OpaqueFields.Contact, "name"]]
+        val _: Fields.Have[OpaqueFields.Contact, "name"] { type Value = String } = have
+        succeed("Have resolves the value type through the bound; the ascription above is the compile-time check")
+    }
+
+    "bounded opaque: Have rejects missing field" in {
+        typeCheckFailure("""summon[Fields.Have[OpaqueFields.Contact, "missing"]]""")("Fields.Have")
+    }
+
+    "bounded opaque: Comparable" in {
+        val _ = summon[Fields.Comparable[OpaqueFields.Contact]]
+        succeed("Comparable derives through the bound; the summon above is the compile-time check")
+    }
+
+    "bounded opaque: SameNames matches the case class with the same fields" in {
+        val _ = summon[Fields.SameNames[OpaqueFields.Contact, Person]]
+        succeed("SameNames reads both sides' names through the bound; the summon above is the compile-time check")
+    }
+
+    "parameterized bounded opaque: Fields.names" in {
+        val names = Fields.names[OpaqueFields.Boxed[Int]]
+        assert(names == Set("value", "label"))
+    }
+
+    "parameterized bounded opaque: field types follow the argument" in {
+        val fs = Fields.fields[OpaqueFields.Boxed[Int]]
+        assert(fs.find(_.name == "value").get.tag =:= Tag[Int])
+        assert(fs.find(_.name == "label").get.tag =:= Tag[String])
+        val other = Fields.fields[OpaqueFields.Boxed[Boolean]]
+        assert(other.find(_.name == "value").get.tag =:= Tag[Boolean])
+    }
+
+    "parameterized bounded opaque: Have resolves the substituted value type" in {
+        val have                                                                  = summon[Fields.Have[OpaqueFields.Boxed[Int], "value"]]
+        val _: Fields.Have[OpaqueFields.Boxed[Int], "value"] { type Value = Int } = have
+        succeed("Have substitutes the argument into the bound; the ascription above is the compile-time check")
+    }
+
+    "bounded opaque: SameNames rejects different fields" in {
+        typeCheckFailure("""summon[Fields.SameNames[OpaqueFields.Contact, Point]]""")
     }
 
 end FieldsTest

--- a/kyo-schema-tests/shared/src/test/scala/kyo/SchemaAnnotationTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/SchemaAnnotationTest.scala
@@ -41,6 +41,9 @@ case class SA14bV2(z: Int)              extends SA14bSum derives Schema
 // SA15: @rename on a product field
 case class SA15Prod(@rename("first_name") firstName: String) derives Schema
 
+// SA15b: @rename on a Maybe field, whose schema is built from a tag for an opaque type
+case class SA15bProd(@rename("middle_name") middleName: Maybe[String]) derives Schema
+
 // SA16: @discriminator on sealed trait, @rename on a variant
 @discriminator("type") sealed trait SA16Sum derives Schema
 @rename("para") case class SA16V1(x: Int) extends SA16Sum derives Schema
@@ -355,6 +358,18 @@ class SchemaAnnotationTest extends kyo.test.Test[Any]:
         assert(enc == """{"first_name":"ada"}""", s"@rename must emit the wire name: $enc")
         val dec = Json.decode[SA15Prod]("""{"first_name":"ada"}""")
         assert(dec == Result.succeed(SA15Prod("ada")), s"round-trip must succeed: $dec")
+    }
+
+    "@rename on a Maybe field changes the wire key" in {
+        val enc = Json.encode(SA15bProd(Present("ada")))
+        assert(enc == """{"middle_name":"ada"}""", s"@rename must emit the wire name for a Maybe field: $enc")
+        val dec = Json.decode[SA15bProd]("""{"middle_name":"ada"}""")
+        assert(dec == Result.succeed(SA15bProd(Present("ada"))), s"round-trip must succeed: $dec")
+        val byScalaName = Json.decode[SA15bProd]("""{"middleName":"ada"}""")
+        assert(
+            byScalaName == Result.succeed(SA15bProd(Absent)),
+            s"the Scala name must no longer be read once renamed, leaving the field absent: $byScalaName"
+        )
     }
 
     "@rename on a variant changes the wire tag" in {


### PR DESCRIPTION
Fixes #1883

### Problem

A project that compiles with `-Yretain-trees` cannot use kyo. The flag is not exotic: a build enables it project-wide when something in it needs `Symbol.tree` to return real source trees, as Morphir Scala does.

Under the flag, kyo's own sources stop compiling. `Env.scala`, `Memo.scala`, `Focus.scala` and `SchemaSerializer.scala` each abort macro expansion with a `MatchError` inside `TagMacro`. It was reported as `summon[Tag[Maybe[String]]]` failing (https://github.com/getkyo/kyo/issues/1883), which is the mildest instance of it.

The flag decides what `Symbol.tree` returns for a type member:

- **without it**, the compiler fabricates a `TypeDef` from the symbol info, whose right-hand side is the type's bounds
- **with it**, the retained source declaration comes back, whose right-hand side is the alias as written: `Long` for `Duration`, a type lambda over `Absent | Present[A]` for `Maybe`

An opaque type's public bounds are a derived view of the symbol info, so they appear nowhere in the source declaration. `TagMacro` read the bounds off that tree and matched only the fabricated shape, so under the flag there was nothing for it to match.

### Solution

`DeclaredBounds` reads a type member's bounds from the symbol, through the node's own prefix, which answers the same in both modes, and substitutes the node's own type arguments into a parameterized bound before returning it. `TagMacro` and `FieldsMacros` both go through it.

**The one remaining tree read, and why it is sound**

`DeclaredBounds` still calls `Symbol.tree` in one branch, for a type local to a term: a method's type parameter, which has no prefix to be a member of, so `memberType` cannot be asked. That read is sound for precisely the reason the general one is not.

Whether `Symbol.tree` depends on the flag is a per-symbol question, not a global one. It returns `defTree` when one was kept and fabricates a declaration when none was, and `Symbols.retainsDefTree` decides which:

```scala
def retainsDefTree(using Context): Boolean =
  ctx.settings.YretainTrees.value ||
  denot.owner.isTerm ||                // no risk of leaking memory after a run for these
  ...
```

The flag is one disjunct. `denot.owner.isTerm` is another, and it holds unconditionally, because a term-owned symbol dies with its term and cannot leak across runs, which is the cost the flag exists to control. So for exactly the symbols this branch sees, the tree is kept in both modes and both modes read the same declaration. For everything else the flag is the deciding disjunct, which is what makes the general read unstable. Verified rather than assumed: the branch is reached by one symbol, `RecordTest`'s `getName[F <: "name" ~ String]`, and it arrives as a `TypeBoundsTree` with the flag off.

The fabricated shape is matched too, in case a symbol whose trees were not kept ever reaches it. That one spells the bounds as a plain `TypeTree` over the symbol info rather than as a `TypeBoundsTree`, so it needs its own case, and the same case rejects a retained declaration whose right-hand side is an alias.

**Checking both modes**

`KYO_RETAIN_TREES=true sbt <module>/test` compiles with the flag, so a macro can be checked against both. It is off by default and not set in CI: retaining every dependency's trees costs a few hundred MB per module, measured at +18% peak live heap on kyo-data's test compile, enough to push a 2 GB ceiling into full GCs.

**Also fixed: Fields on a bounded type constructor**

`Fields` aborts the compiler on a type constructor that declares its fields as an upper bound. For `opaque type Boxed[A] <: "value" ~ A & "label" ~ String`, `Fields.names[Boxed[Int]]` fails with "Cannot get tree of no symbol": nothing substituted the argument into the bound, so a symbolless type lambda reached the next recursion, and the guard around that read catches `Exception` while an `AssertionError` is not one. This has nothing to do with the flag and fails the same way without it. The substitution in `DeclaredBounds` fixes it.

**Not a defect: @rename on a Maybe field**

Reported with https://github.com/getkyo/kyo/issues/1883 as silently ignored on `Maybe` while working on `Option`. Annotations are read off the symbol, which the flag does not touch, and the wire name is honored in both modes. That build was hitting the tag crash before rename was ever reached. Covered by a test so the claim stays checked.

### Notes

The encoded tag strings for `Maybe`, `Result`, `Span`, `Duration`, `Frame` and `Tag` are byte-identical to the ones the previous code produced, so tags still agree across separately compiled modules.