### PR TITLE
[kyo-net][kyo-ui][kyo-aeron] stop dropping failures and their resources

### DIFF
--- a/kyo-aeron/shared/src/main/scala/kyo/internal/AeronPlatformTransport.scala
+++ b/kyo-aeron/shared/src/main/scala/kyo/internal/AeronPlatformTransport.scala
@@ -37,6 +37,21 @@ private[kyo] object AeronPlatformTransport:
                 client <- Sync.Unsafe.defer(bindings.clientConnect(dir)).flatMap(_.safe.get)
                 runtime <- Sync.Unsafe.defer {
                     val ffiTransport = new FfiAeronTransport(bindings, client)
+                    // Winning this CAS grants the right to close the driver, the same way FfiAeronTransport's own flag
+                    // grants the right to close the client. `kyo_aeron_driver_close` frees its bundle outright, so a
+                    // second close reads a freed pointer and faults inside the conductor-agent teardown. Guarding only
+                    // the client left the halves asymmetric: a runtime released on both an error path and its scope
+                    // exit survived the repeat on one half and took the process down on the other.
+                    val driverClosed = AtomicBoolean.Unsafe.init(false)
+                    // A live media driver holds descriptors (its CnC mapping and sockets), and the descriptor leak check
+                    // attaches the diagnostics dump to every survivor precisely so it names its owner instead of reporting
+                    // an opaque inode. Without an entry here an abandoned driver is exactly that opaque inode. Registering
+                    // no probe is deliberate: the probe's meaning is a parked LOOP that stopped making progress, which a
+                    // runtime has no notion of, so it reports through the dump alone and can never raise a stranded-op
+                    // finding of its own.
+                    val diagRegistration = kyo.internal.Diagnostics.register(
+                        "AeronRuntime@" + java.lang.System.identityHashCode(ffiTransport)
+                    )(dump = () => s"dir=$dir driverClosed=${driverClosed.get()}")
                     new AeronRuntime:
                         val transport: AeronTransport = ffiTransport
                         def close()(using AllowUnsafe): Unit =
@@ -46,7 +61,8 @@ private[kyo] object AeronPlatformTransport:
                             // and one-shot (it parks the carrier on the JVM and Native, briefly freezes the
                             // event loop on JS and Wasm), unlike the connect that @Ffi.blocking covers.
                             ffiTransport.closeClient()
-                            bindings.driverClose(driver)
+                            if driverClosed.compareAndSet(false, true) then bindings.driverClose(driver)
+                            diagRegistration.close()
                         end close
                     end new
                 }
@@ -65,8 +81,18 @@ private[kyo] object AeronPlatformTransport:
             Sync.Unsafe.defer(bindings.driverStart(dir, clientLivenessNs, publicationUnblockNs)).flatMap(_.safe.get).map {
                 started =>
                     Sync.Unsafe.defer {
+                        // Same one-shot ownership as the embedded runtime above: the shim's driver close frees the
+                        // bundle, so only the caller that wins the flag may perform it.
+                        val driverClosed = AtomicBoolean.Unsafe.init(false)
+                        // Named in the diagnostics dump for the same reason as the embedded runtime: an abandoned driver
+                        // holds descriptors, and the leak check reports them by inode unless something claims them.
+                        val diagRegistration = kyo.internal.Diagnostics.register(
+                            "AeronDriverRuntime@" + java.lang.System.identityHashCode(started)
+                        )(dump = () => s"dir=$dir driverClosed=${driverClosed.get()}")
                         new AeronDriverRuntime:
-                            def close()(using AllowUnsafe): Unit = bindings.driverClose(started)
+                            def close()(using AllowUnsafe): Unit =
+                                if driverClosed.compareAndSet(false, true) then bindings.driverClose(started)
+                                diagRegistration.close()
                         end new
                     }
             }

--- a/kyo-aeron/shared/src/test/scala/kyo/AeronDriverTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/AeronDriverTest.scala
@@ -1,0 +1,48 @@
+package kyo
+
+/** Runtime coverage for the driver-only launch path.
+  *
+  * `AeronDriver.launch` had none: the only reference to it in the suite was a type ascription, and a kyo
+  * computation is a value, so ascribing one never starts a driver. Everything the API promises about the
+  * lifetime it manages was therefore unexercised, on a path that starts a real C media driver and its
+  * conductor threads.
+  */
+class AeronDriverTest extends Test:
+
+    "launch starts a driver and binds its lifetime to the scope" in {
+        Scope.run {
+            AeronDriver.launch().map { driver =>
+                Sync.Unsafe.defer {
+                    val dump = kyo.internal.Diagnostics.dumpAll()
+                    assert(
+                        dump.contains(driver.directory.unsafe.show),
+                        "a launched driver does not name its directory in the diagnostics dump"
+                    )
+                    driver.directory.unsafe.show
+                }
+            }
+        }.map { dir =>
+            Sync.Unsafe.defer {
+                assert(
+                    !kyo.internal.Diagnostics.dumpAll().contains(dir),
+                    "the scope exited without releasing the driver's diagnostics entry"
+                )
+            }
+        }
+    }
+
+    /** The API's contract is that a caller-owned driver is closed exactly once, and closing it twice used to
+      * be a native fault rather than a no-op. A caller that releases on an error path and again at scope exit
+      * is the ordinary shape that hit it, so the repeat is pinned here as harmless.
+      */
+    "a caller-owned driver tolerates being closed twice" in {
+        AeronDriver.launchUnscoped().map { driver =>
+            Sync.Unsafe.defer {
+                driver.unsafe.close()
+                driver.unsafe.close()
+                succeed
+            }
+        }
+    }
+
+end AeronDriverTest

--- a/kyo-aeron/shared/src/test/scala/kyo/AeronTransportTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/AeronTransportTest.scala
@@ -6,6 +6,7 @@ import kyo.internal.AeronBindings
 import kyo.internal.AeronClientHandle
 import kyo.internal.AeronPlatform
 import kyo.internal.AeronPublication
+import kyo.internal.AeronRuntime
 import kyo.internal.AeronSentinels
 import kyo.internal.AeronSubscription
 import kyo.internal.AeronTransport
@@ -34,6 +35,8 @@ class AeronTransportTest extends Test:
 
     val oversizeJvmStreamId   = 104
     val oversizeCrossStreamId = 105
+
+    val tokenOwnershipStreamId = 117
 
     val closedClientPubStreamId = 115
     val closedClientSubStreamId = 116
@@ -194,6 +197,60 @@ class AeronTransportTest extends Test:
       * calls exit(EXIT_FAILURE) and kills the test process. The real FFI add path (Done) is covered by
       * the round-trip and normal-add leaves.
       */
+    /** Transport whose registration poll reports Done and, inside that same synchronous call, interrupts the
+      * fiber that is observing it.
+      *
+      * On a Done poll the C layer frees the async token and hands the client reference to the publication
+      * bundle, so the Scala flag recording that handoff is the only thing standing between the scope
+      * finalizer and a second free of memory the C layer has already released. The question this fake exists
+      * to answer is whether an interrupt can be observed BETWEEN the poll and that flag, which is only
+      * possible if a suspension point separates them. Issuing the interrupt from inside the poll puts a
+      * pending interrupt in place before the caller has decided anything, which is the earliest the window
+      * can open.
+      *
+      * The counter is deliberately gated on `doneObserved`: a free BEFORE any Done is the ordinary
+      * still-owned path and is correct, and counting it would make the leaf pass or fail for the wrong
+      * reason. `interruptTook` and `doneObserved` are asserted by the leaf so a fixture that never armed the
+      * window cannot be read as evidence that the window is closed.
+      */
+    final private class InterruptOnDoneTransport extends AeronTransport:
+        type Publication  = Int
+        type Subscription = Int
+        type AsyncPub     = Int
+        type AsyncSub     = Int
+
+        /** Set by the leaf once it holds the fiber handle; a thunk rather than the fiber itself so the fake
+          * carries no type parameters of the computation it interrupts.
+          */
+        @volatile var interrupter: () => Boolean = () => false
+        @volatile var interruptTook: Boolean     = false
+        @volatile var doneObserved: Boolean      = false
+
+        val freesAfterDone = new java.util.concurrent.atomic.AtomicInteger(0)
+
+        def asyncAddPublication(uri: String, streamId: Int)(using AllowUnsafe): Maybe[AsyncPub] = Present(streamId)
+        def pollAddPublication(async: AsyncPub)(using AllowUnsafe): AeronTransport.AddPoll[Publication] =
+            interruptTook = interrupter()
+            doneObserved = true
+            AeronTransport.AddPoll.Done(async)
+        end pollAddPublication
+        def freeAsyncPub(async: AsyncPub)(using AllowUnsafe): Unit =
+            if doneObserved then discard(freesAfterDone.incrementAndGet())
+        def publicationIsConnected(pub: Publication)(using AllowUnsafe): Boolean                 = false
+        def offer(pub: Publication, message: Array[Byte])(using AllowUnsafe): Long               = 0L
+        def maxMessageLength(pub: Publication)(using AllowUnsafe): Int                           = 0
+        def closePublication(pub: Publication)(using AllowUnsafe): Unit                          = ()
+        def asyncAddSubscription(uri: String, streamId: Int)(using AllowUnsafe): Maybe[AsyncSub] = Present(streamId)
+        def pollAddSubscription(async: AsyncSub)(using AllowUnsafe): AeronTransport.AddPoll[Subscription] =
+            AeronTransport.AddPoll.Awaiting
+        def freeAsyncSub(async: AsyncSub)(using AllowUnsafe): Unit                 = ()
+        def subscriptionIsConnected(sub: Subscription)(using AllowUnsafe): Boolean = false
+        def pollOne(sub: Subscription)(using AllowUnsafe): Maybe[Array[Byte]]      = Absent
+        def closeSubscription(sub: Subscription)(using AllowUnsafe): Unit          = ()
+
+        def fatalError(using AllowUnsafe): Maybe[String] = Absent
+    end InterruptOnDoneTransport
+
     final private class NeverConfirmTransport extends AeronTransport:
         type Publication  = Int
         type Subscription = Int
@@ -257,174 +314,169 @@ class AeronTransportTest extends Test:
 
     "round-trip a known byte payload through AeronPlatform.embedded" in {
         val payload = Array[Byte](1, 2, 3, 4)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, roundTripStreamId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, roundTripStreamId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
-            _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
-            pub = pubMaybe.get
-            sub = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
-            _ = assert(subConnected, "subscription did not connect within 5s")
-            pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
-            _ = assert(pos > 0, s"offer did not succeed within 5000 attempts; last pos=$pos")
-            received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
-            _     = assert(received.isDefined, "no message received within 5000 poll attempts")
-            bytes = received.get
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield assert(
-            java.util.Arrays.equals(bytes, payload),
-            s"payload mismatch: ${bytes.toList} != ${payload.toList}"
-        )
-        end for
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, roundTripStreamId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, roundTripStreamId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
+                _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
+                pub = pubMaybe.get
+                sub = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
+                _ = assert(subConnected, "subscription did not connect within 5s")
+                pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
+                _ = assert(pos > 0, s"offer did not succeed within 5000 attempts; last pos=$pos")
+                received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
+                _     = assert(received.isDefined, "no message received within 5000 poll attempts")
+                bytes = received.get
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield assert(
+                java.util.Arrays.equals(bytes, payload),
+                s"payload mismatch: ${bytes.toList} != ${payload.toList}"
+            )
+            end for
+        }
     }
 
     "offer to not-connected publication takes the not-connected path" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, notConnectedStreamId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
-            pub = pubMaybe.get
-            notConnectedInitially <- Sync.Unsafe.defer(!transport.publicationIsConnected(pub))
-            subTokMaybe           <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, notConnectedStreamId))
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _       = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
-            sub     = subMaybe.get
-            payload = Array[Byte](0)
-            connected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(connected, "publication did not connect after subscriber was added within 5s")
-            connectedPosition <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield
-            assert(notConnectedInitially, "Expected publication to be not-connected with no subscriber")
-            assert(connectedPosition > 0, s"Expected a positive position after connection; got $connectedPosition")
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, notConnectedStreamId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
+                pub = pubMaybe.get
+                notConnectedInitially <- Sync.Unsafe.defer(!transport.publicationIsConnected(pub))
+                subTokMaybe           <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, notConnectedStreamId))
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _       = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
+                sub     = subMaybe.get
+                payload = Array[Byte](0)
+                connected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(connected, "publication did not connect after subscriber was added within 5s")
+                connectedPosition <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield
+                assert(notConnectedInitially, "Expected publication to be not-connected with no subscriber")
+                assert(connectedPosition > 0, s"Expected a positive position after connection; got $connectedPosition")
+            end for
+        }
     }
 
     "pollOne with zero fragments returns Absent" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, absentStreamId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, absentStreamId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
-            _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
-            pub = pubMaybe.get
-            sub = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
-            _ = assert(subConnected, "subscription did not connect within 5s")
-            result <- Sync.Unsafe.defer(transport.pollOne(sub))
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield assert(result.isEmpty, s"Expected Absent when no message published; got $result")
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, absentStreamId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, absentStreamId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
+                _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
+                pub = pubMaybe.get
+                sub = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
+                _ = assert(subConnected, "subscription did not connect within 5s")
+                result <- Sync.Unsafe.defer(transport.pollOne(sub))
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield assert(result.isEmpty, s"Expected Absent when no message published; got $result")
+            end for
+        }
     }
 
     "close releases resources without leak" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, closeStreamId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, closeStreamId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            // The poll helper yields to the event loop between polls (Async.sleep), which the
-            // single-threaded JS runtime needs to converge; a synchronous spin would never advance.
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _ = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
-            _ = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pubMaybe.get)
-                transport.closeSubscription(subMaybe.get)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-            // A second embedded() confirms the close was clean.
-            dir2 <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt2  <- AeronPlatform.embedded(dir2.unsafe.show)
-            transport2 = rt2.transport
-            pub2TokMaybe <- Sync.Unsafe.defer(transport2.asyncAddPublication(ipcUri, closeStreamId))
-            _ = assert(pub2TokMaybe.isDefined, "asyncAddPublication returned Absent on a freshly-started client")
-            // Free the pending token without waiting for registration to complete, then tear down.
-            _ <- Sync.Unsafe.defer {
-                transport2.freeAsyncPub(pub2TokMaybe.get)
-                rt2.close()
-            }
-            _ <- Path.run(dir2.removeAll)
-        // Reaching here without a crash proves the close-and-reopen cycle succeeded.
-        yield succeed
+        // The explicit close in the middle is the behaviour under test, and the scope closes again on the
+        // way out; the driver close is one-shot, so the repeat is a no-op rather than a fault.
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, closeStreamId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, closeStreamId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                // The poll helper yields to the event loop between polls (Async.sleep), which the
+                // single-threaded JS runtime needs to converge; a synchronous spin would never advance.
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _ = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
+                _ = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pubMaybe.get)
+                    transport.closeSubscription(subMaybe.get)
+                    rt.close()
+                }
+                // A second embedded() confirms the close was clean.
+                out <- withEmbeddedRuntime() { rt2 =>
+                    val transport2 = rt2.transport
+                    for
+                        pub2TokMaybe <- Sync.Unsafe.defer(transport2.asyncAddPublication(ipcUri, closeStreamId))
+                        _ = assert(pub2TokMaybe.isDefined, "asyncAddPublication returned Absent on a freshly-started client")
+                        // Free the pending token without waiting for registration to complete.
+                        _ <- Sync.Unsafe.defer(transport2.freeAsyncPub(pub2TokMaybe.get))
+                    // Reaching here without a crash proves the close-and-reopen cycle succeeded.
+                    yield succeed
+                    end for
+                }
+            yield out
+            end for
+        }
     }
 
     "offer result maps through AeronSentinels identically on every platform" in {
         // AeronPlatform.embedded() reaches FfiAeronTransport on every platform, so one leaf covers the
         // single impl. TopicInvariantsTest defers its offer-sentinel coverage here, keeping only a
         // `.onlyJs` leaf for the koffi BigInt->Long sign-marshalling guard.
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubMaybeResult <- Abort.run[TopicTransportException] {
-                Topic.addPublicationDeadline(transport, ipcUri, 11, 10.seconds)
-            }
-            _ = assert(
-                pubMaybeResult.isSuccess,
-                s"addPublicationDeadline failed on a healthy driver: ${describeAddFailure(pubMaybeResult)}"
-            )
-            pubMaybe = pubMaybeResult.getOrThrow
-            _        = assert(pubMaybe.isDefined, "addPublicationDeadline returned Absent on a healthy driver")
-            pub      = pubMaybe.get
-            payload  = Array[Byte](0)
-            result <- Sync.Unsafe.defer(transport.offer(pub, payload))
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield
-            assert(
-                result < 0,
-                s"Expected a negative sentinel from offer to a not-connected publication; got $result"
-            )
-            assert(
-                result == AeronSentinels.NotConnected || result == AeronSentinels.BackPressured,
-                s"Expected NotConnected (-1L) or BackPressured (-2L) but got $result"
-            )
-        end for
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubMaybeResult <- Abort.run[TopicTransportException] {
+                    Topic.addPublicationDeadline(transport, ipcUri, 11, 10.seconds)
+                }
+                _ = assert(
+                    pubMaybeResult.isSuccess,
+                    s"addPublicationDeadline failed on a healthy driver: ${describeAddFailure(pubMaybeResult)}"
+                )
+                pubMaybe = pubMaybeResult.getOrThrow
+                _        = assert(pubMaybe.isDefined, "addPublicationDeadline returned Absent on a healthy driver")
+                pub      = pubMaybe.get
+                payload  = Array[Byte](0)
+                result <- Sync.Unsafe.defer(transport.offer(pub, payload))
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                }
+            yield
+                assert(
+                    result < 0,
+                    s"Expected a negative sentinel from offer to a not-connected publication; got $result"
+                )
+                assert(
+                    result == AeronSentinels.NotConnected || result == AeronSentinels.BackPressured,
+                    s"Expected NotConnected (-1L) or BackPressured (-2L) but got $result"
+                )
+            end for
+        }
     }
 
     "two exact types isolate by stream-id" in {
@@ -433,47 +485,45 @@ class AeronTransportTest extends Test:
         val intId    = Tag[Int].hash.abs
         val stringId = Tag[String].hash.abs
         val payload  = Array[Byte](99)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubIntTokMaybe    <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, intId))
-            subIntTokMaybe    <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, intId))
-            subStringTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, stringId))
-            _ = assert(pubIntTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subIntTokMaybe.isDefined, "asyncAddSubscription (Int) returned Absent on a live client")
-            _ = assert(subStringTokMaybe.isDefined, "asyncAddSubscription (String) returned Absent on a live client")
-            pubIntMaybe    <- pollAddPubUntilDone(transport, pubIntTokMaybe.get, 5000)
-            subIntMaybe    <- pollAddSubUntilDone(transport, subIntTokMaybe.get, 5000)
-            subStringMaybe <- pollAddSubUntilDone(transport, subStringTokMaybe.get, 5000)
-            _         = assert(pubIntMaybe.isDefined, "pollAddPublication (Int) never returned Done")
-            _         = assert(subIntMaybe.isDefined, "pollAddSubscription (Int) never returned Done")
-            _         = assert(subStringMaybe.isDefined, "pollAddSubscription (String) never returned Done")
-            pubInt    = pubIntMaybe.get
-            subInt    = subIntMaybe.get
-            subString = subStringMaybe.get
-            connected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pubInt)))
-            _ = assert(connected, "Int publication did not connect to Int subscriber within 5s")
-            pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pubInt, payload)))
-            _ = assert(pos > 0, s"offer to Int stream did not succeed; last pos=$pos")
-            intReceived <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(subInt)))
-            _ = assert(
-                intReceived.isDefined,
-                "Int subscription did not receive its own message within 5000 poll attempts"
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubIntTokMaybe    <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, intId))
+                subIntTokMaybe    <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, intId))
+                subStringTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, stringId))
+                _ = assert(pubIntTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subIntTokMaybe.isDefined, "asyncAddSubscription (Int) returned Absent on a live client")
+                _ = assert(subStringTokMaybe.isDefined, "asyncAddSubscription (String) returned Absent on a live client")
+                pubIntMaybe    <- pollAddPubUntilDone(transport, pubIntTokMaybe.get, 5000)
+                subIntMaybe    <- pollAddSubUntilDone(transport, subIntTokMaybe.get, 5000)
+                subStringMaybe <- pollAddSubUntilDone(transport, subStringTokMaybe.get, 5000)
+                _         = assert(pubIntMaybe.isDefined, "pollAddPublication (Int) never returned Done")
+                _         = assert(subIntMaybe.isDefined, "pollAddSubscription (Int) never returned Done")
+                _         = assert(subStringMaybe.isDefined, "pollAddSubscription (String) never returned Done")
+                pubInt    = pubIntMaybe.get
+                subInt    = subIntMaybe.get
+                subString = subStringMaybe.get
+                connected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pubInt)))
+                _ = assert(connected, "Int publication did not connect to Int subscriber within 5s")
+                pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pubInt, payload)))
+                _ = assert(pos > 0, s"offer to Int stream did not succeed; last pos=$pos")
+                intReceived <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(subInt)))
+                _ = assert(
+                    intReceived.isDefined,
+                    "Int subscription did not receive its own message within 5000 poll attempts"
+                )
+                stringResult <- Sync.Unsafe.defer(transport.pollOne(subString))
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pubInt)
+                    transport.closeSubscription(subInt)
+                    transport.closeSubscription(subString)
+                }
+            yield assert(
+                stringResult.isEmpty,
+                s"Expected Absent on String subscription after publishing to Int stream; got $stringResult"
             )
-            stringResult <- Sync.Unsafe.defer(transport.pollOne(subString))
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pubInt)
-                transport.closeSubscription(subInt)
-                transport.closeSubscription(subString)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield assert(
-            stringResult.isEmpty,
-            s"Expected Absent on String subscription after publishing to Int stream; got $stringResult"
-        )
-        end for
+            end for
+        }
     }
 
     "pollOne reassembles a multi-fragment message (>MTU) correctly" in {
@@ -481,78 +531,74 @@ class AeronTransportTest extends Test:
         // the JVM FragmentAssembler and the C shim's aeron_fragment_assembler.
         val multiFragId = 98 // distinct stream-id; no cross-test bleed
         val payload     = Array.tabulate[Byte](4096)(i => (i & 0xff).toByte)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, multiFragId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, multiFragId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done")
-            _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done")
-            pub = pubMaybe.get
-            sub = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
-            _ = assert(subConnected, "subscription did not connect within 5s")
-            pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
-            _ = assert(pos > 0, s"multi-fragment offer did not succeed; last pos=$pos")
-            received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
-            _ = assert(received.isDefined, "no reassembled message received within 5000 poll attempts")
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield assert(
-            java.util.Arrays.equals(received.get, payload),
-            s"multi-fragment payload mismatch: expected 4096 bytes, got ${received.get.length}"
-        )
-        end for
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, multiFragId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, multiFragId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done")
+                _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done")
+                pub = pubMaybe.get
+                sub = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
+                _ = assert(subConnected, "subscription did not connect within 5s")
+                pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
+                _ = assert(pos > 0, s"multi-fragment offer did not succeed; last pos=$pos")
+                received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
+                _ = assert(received.isDefined, "no reassembled message received within 5000 poll attempts")
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield assert(
+                java.util.Arrays.equals(received.get, payload),
+                s"multi-fragment payload mismatch: expected 4096 bytes, got ${received.get.length}"
+            )
+            end for
+        }
     }
 
     // Messages between 1 MiB and Aeron's protocol ceiling must round-trip on all platforms.
     "pollOne reassembles a 2 MiB multi-fragment message identically on all platforms" in {
         val largeFragId = 99 // distinct stream-id; no cross-test bleed
         val large       = Array.tabulate[Byte](2 * 1024 * 1024)(i => (i & 0xff).toByte)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, largeFragId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, largeFragId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done")
-            _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done")
-            pub = pubMaybe.get
-            sub = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
-            _ = assert(subConnected, "subscription did not connect within 5s")
-            pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, large)))
-            _ = assert(pos > 0, s"2 MiB offer did not succeed; last pos=$pos")
-            received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
-            _ = assert(received.isDefined, "no reassembled 2 MiB message received within 5000 poll attempts")
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield assert(
-            java.util.Arrays.equals(received.get, large),
-            s"2 MiB payload mismatch: expected ${large.length} bytes, got ${received.get.length}"
-        )
-        end for
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, largeFragId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, largeFragId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done")
+                _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done")
+                pub = pubMaybe.get
+                sub = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
+                _ = assert(subConnected, "subscription did not connect within 5s")
+                pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, large)))
+                _ = assert(pos > 0, s"2 MiB offer did not succeed; last pos=$pos")
+                received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
+                _ = assert(received.isDefined, "no reassembled 2 MiB message received within 5000 poll attempts")
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield assert(
+                java.util.Arrays.equals(received.get, large),
+                s"2 MiB payload mismatch: expected ${large.length} bytes, got ${received.get.length}"
+            )
+            end for
+        }
     }
 
     // Slot reuse / regrow correctness: large then small on the same subscription.
@@ -560,47 +606,45 @@ class AeronTransportTest extends Test:
         val reuseStreamId = 100 // distinct stream-id; no cross-test bleed
         val large         = Array.tabulate[Byte](256 * 1024)(i => ((i * 31) & 0xff).toByte)
         val small         = Array[Byte](9, 8, 7, 6, 5)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, reuseStreamId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, reuseStreamId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done")
-            _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done")
-            pub = pubMaybe.get
-            sub = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
-            _ = assert(subConnected, "subscription did not connect within 5s")
-            posLarge <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, large)))
-            _ = assert(posLarge > 0, s"large offer did not succeed; last pos=$posLarge")
-            receivedLarge <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
-            _ = assert(receivedLarge.isDefined, "no reassembled large message received within 5000 poll attempts")
-            _ = assert(
-                java.util.Arrays.equals(receivedLarge.get, large),
-                s"large payload mismatch: expected ${large.length} bytes, got ${receivedLarge.get.length}"
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, reuseStreamId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, reuseStreamId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done")
+                _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done")
+                pub = pubMaybe.get
+                sub = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                subConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.subscriptionIsConnected(sub)))
+                _ = assert(subConnected, "subscription did not connect within 5s")
+                posLarge <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, large)))
+                _ = assert(posLarge > 0, s"large offer did not succeed; last pos=$posLarge")
+                receivedLarge <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
+                _ = assert(receivedLarge.isDefined, "no reassembled large message received within 5000 poll attempts")
+                _ = assert(
+                    java.util.Arrays.equals(receivedLarge.get, large),
+                    s"large payload mismatch: expected ${large.length} bytes, got ${receivedLarge.get.length}"
+                )
+                posSmall <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, small)))
+                _ = assert(posSmall > 0, s"small offer did not succeed; last pos=$posSmall")
+                receivedSmall <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
+                _ = assert(receivedSmall.isDefined, "no small message received within 5000 poll attempts")
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield assert(
+                java.util.Arrays.equals(receivedSmall.get, small),
+                s"small payload mismatch after large: expected ${small.toList}, got ${receivedSmall.get.toList}"
             )
-            posSmall <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, small)))
-            _ = assert(posSmall > 0, s"small offer did not succeed; last pos=$posSmall")
-            receivedSmall <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
-            _ = assert(receivedSmall.isDefined, "no small message received within 5000 poll attempts")
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield assert(
-            java.util.Arrays.equals(receivedSmall.get, small),
-            s"small payload mismatch after large: expected ${small.toList}, got ${receivedSmall.get.toList}"
-        )
-        end for
+            end for
+        }
     }
 
     // Use-after-free regression guard: kyo_aeron_async_add_publication checks the registry (bundle still
@@ -636,6 +680,103 @@ class AeronTransportTest extends Test:
     // ---------------------------------------------------------------------------
     // Bounded Scala Async poll loop (add-deadline behavior)
     // ---------------------------------------------------------------------------
+
+    "an interrupt on a completed add does not free a token the transport has already taken" in {
+        val transport = new InterruptOnDoneTransport
+        Latch.initWith(1) { gate =>
+            Fiber.initUnscoped(
+                gate.await.andThen(
+                    Abort.run[TopicTransportException](
+                        Topic.addPublicationDeadline(transport, ipcUri, tokenOwnershipStreamId, 10.seconds)
+                    )
+                )
+            ).flatMap { fiber =>
+                Sync.Unsafe.defer {
+                    // Unsafe: the fake has to interrupt from inside a synchronous transport call, which is the
+                    // only vantage point where the window under test is open.
+                    transport.interrupter = () => fiber.unsafe.interrupt()
+                }
+                    .andThen(gate.release)
+                    .andThen(fiber.getResult)
+                    .map { result =>
+                        assert(transport.doneObserved, "the poll never reported Done, so the fixture never armed the window")
+                        assert(
+                            transport.interruptTook,
+                            "the fixture's interrupt did not take, so a zero free count says nothing about the window"
+                        )
+                        // The outcome is what separates the two readings of a zero free count: an interrupted add proves the
+                        // interrupt was OBSERVED and the flag still won, while a completed add proves only that the add
+                        // outran the interrupt and the window was never entered at all.
+                        assert(
+                            result.isPanic,
+                            s"the add was not interrupted, so this leaf did not exercise the ownership window: $result"
+                        )
+                        assert(
+                            transport.freesAfterDone.get() == 0,
+                            s"the async token was freed ${transport.freesAfterDone.get()} time(s) after the transport had " +
+                                "already taken ownership of it on a Done poll"
+                        )
+                    }
+            }
+        }
+    }
+
+    /** Closing an embedded runtime twice must not take the process down.
+      *
+      * The client half already treats this as a real caller shape: its close wins a CAS before touching the
+      * handle, because the shim's client close calls `aeron_close` unconditionally and a second one tears
+      * down freed memory. The driver half has the same shim contract, `kyo_aeron_driver_close` frees its
+      * bundle outright, and had no such guard, so the second close read a freed pointer and faulted inside
+      * the conductor-agent stop. A resource released on both an error path and its scope exit is exactly the
+      * caller this protects, and it is not exotic: this leaf closes explicitly and lets the scope close again.
+      */
+    "closing an embedded runtime twice does not tear down freed driver state" in {
+        withEmbeddedRuntime() { rt =>
+            Sync.Unsafe.defer(rt.close()).andThen(succeed)
+        }
+    }
+
+    /** A body that throws must still release its driver.
+      *
+      * This is the property the scoped helper exists for, and it is the one that cannot be read off the
+      * source: whether the finalizer actually runs is a fact about execution. Every leaf in this module
+      * depends on it, because the alternative is a live C media driver and its conductor thread surviving a
+      * failed assertion for the rest of the process.
+      */
+    "a driver is released even when the body that uses it throws" in {
+        val before = embeddedRuntimeReleases.get()
+        Abort.run[Throwable](
+            withEmbeddedRuntime() { _ =>
+                Sync.defer[Unit, Any](throw new RuntimeException("the body fails after the driver is up"))
+            }
+        ).map { result =>
+            assert(result.isPanic, s"the fixture must fail inside the scope for this to prove anything, got $result")
+            assert(
+                embeddedRuntimeReleases.get() == before + 1,
+                s"the driver was not released: releases went from $before to ${embeddedRuntimeReleases.get()}"
+            )
+        }
+    }
+
+    /** A live driver must name itself where a descriptor leak is reported.
+      *
+      * The leak check attaches the diagnostics dump to every surviving descriptor so the survivor says who
+      * owns it. A media driver holds descriptors and, until it registered, contributed nothing to that dump,
+      * so an abandoned one was reported as a bare inode with no owner. Asserting on this leaf's own unique
+      * directory rather than on the entry name keeps it specific while other suites run in parallel.
+      */
+    "a live driver names itself in the diagnostics dump" in {
+        val probeDir = "kyo-aeron-diagnostics-probe"
+        withEmbeddedRuntime(probeDir) { rt =>
+            Sync.Unsafe.defer {
+                val whileLive = kyo.internal.Diagnostics.dumpAll()
+                rt.close()
+                val afterClose = kyo.internal.Diagnostics.dumpAll()
+                assert(whileLive.contains(probeDir), "a live driver is not named in the diagnostics dump")
+                assert(!afterClose.contains(probeDir), "a closed driver is still named in the diagnostics dump")
+            }
+        }
+    }
 
     "a never-confirming add aborts with TopicAddTimeoutException at the deadline" in {
         val deadline  = 200.millis
@@ -747,65 +888,58 @@ class AeronTransportTest extends Test:
     // Failure(Timeout) if not); what matters is that it never hangs past 100ms, proving the poll loop is
     // interruptible.
     "an interrupt during a pending add is honored and does not hang" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            result <- Abort.run[Timeout | TopicTransportException] {
+        // The runtime close cleans up any publication the add produced; the Sync.ensure inside
+        // addPublicationDeadline frees the async token if interrupted mid-poll.
+        withEmbeddedRuntime() { rt =>
+            Abort.run[Timeout | TopicTransportException] {
                 Async.timeout(100.millis) {
-                    Topic.addPublicationDeadline(transport, ipcUri, interruptStreamId, 10.seconds)
+                    Topic.addPublicationDeadline(rt.transport, ipcUri, interruptStreamId, 10.seconds)
                 }
-            }
-            // The runtime close cleans up any publication the add produced; the Sync.ensure inside
-            // addPublicationDeadline frees the async token if interrupted mid-poll.
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield succeed
+            }.andThen(succeed)
+        }
     }
 
     "a normal add via addPublicationDeadline completes and round-trips bytes" in {
         val payload = Array[Byte](42, 43, 44)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubMaybeResult <- Abort.run[TopicTransportException] {
-                Topic.addPublicationDeadline(transport, ipcUri, regressionAddStreamId, 10.seconds)
-            }
-            _ = assert(
-                pubMaybeResult.isSuccess,
-                s"addPublicationDeadline failed on a healthy driver: ${describeAddFailure(pubMaybeResult)}"
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubMaybeResult <- Abort.run[TopicTransportException] {
+                    Topic.addPublicationDeadline(transport, ipcUri, regressionAddStreamId, 10.seconds)
+                }
+                _ = assert(
+                    pubMaybeResult.isSuccess,
+                    s"addPublicationDeadline failed on a healthy driver: ${describeAddFailure(pubMaybeResult)}"
+                )
+                pubMaybe = pubMaybeResult.getOrThrow
+                _        = assert(pubMaybe.isDefined, "addPublicationDeadline returned Absent on a healthy driver")
+                pub      = pubMaybe.get
+                subMaybeResult <- Abort.run[TopicTransportException] {
+                    Topic.addSubscriptionDeadline(transport, ipcUri, regressionAddStreamId, 10.seconds)
+                }
+                _ = assert(
+                    subMaybeResult.isSuccess,
+                    s"addSubscriptionDeadline failed on a healthy driver: ${describeAddFailure(subMaybeResult)}"
+                )
+                subMaybe = subMaybeResult.getOrThrow
+                _        = assert(subMaybe.isDefined, "addSubscriptionDeadline returned Absent on a healthy driver")
+                sub      = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
+                _ = assert(pos > 0, s"offer did not succeed; pos=$pos")
+                received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
+                _ = assert(received.isDefined, "no message received within 5000 poll attempts")
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield assert(
+                java.util.Arrays.equals(received.get, payload),
+                s"round-trip payload mismatch: got ${received.get.toList}"
             )
-            pubMaybe = pubMaybeResult.getOrThrow
-            _        = assert(pubMaybe.isDefined, "addPublicationDeadline returned Absent on a healthy driver")
-            pub      = pubMaybe.get
-            subMaybeResult <- Abort.run[TopicTransportException] {
-                Topic.addSubscriptionDeadline(transport, ipcUri, regressionAddStreamId, 10.seconds)
-            }
-            _ = assert(
-                subMaybeResult.isSuccess,
-                s"addSubscriptionDeadline failed on a healthy driver: ${describeAddFailure(subMaybeResult)}"
-            )
-            subMaybe = subMaybeResult.getOrThrow
-            _        = assert(subMaybe.isDefined, "addSubscriptionDeadline returned Absent on a healthy driver")
-            sub      = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
-            _ = assert(pos > 0, s"offer did not succeed; pos=$pos")
-            received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
-            _ = assert(received.isDefined, "no message received within 5000 poll attempts")
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield assert(
-            java.util.Arrays.equals(received.get, payload),
-            s"round-trip payload mismatch: got ${received.get.toList}"
-        )
-        end for
+            end for
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -929,32 +1063,31 @@ class AeronTransportTest extends Test:
     // faulting. Raw transport.offer avoids Topic.publish, which would re-add a publication first.
     "UAF-sentinel: an offer on a publication after a concurrent client close returns the safe sentinel" in {
         val payload = Array[Byte](1, 2, 3, 4)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubMaybeResult <- Abort.run[TopicTransportException] {
-                Topic.addPublicationDeadline(transport, "aeron:ipc", uafSentinelStreamId, 10.seconds)
-            }
-            _ = assert(
-                pubMaybeResult.isSuccess,
-                s"addPublicationDeadline failed on a healthy driver: ${describeAddFailure(pubMaybeResult)}"
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubMaybeResult <- Abort.run[TopicTransportException] {
+                    Topic.addPublicationDeadline(transport, "aeron:ipc", uafSentinelStreamId, 10.seconds)
+                }
+                _ = assert(
+                    pubMaybeResult.isSuccess,
+                    s"addPublicationDeadline failed on a healthy driver: ${describeAddFailure(pubMaybeResult)}"
+                )
+                pubMaybe = pubMaybeResult.getOrThrow
+                _        = assert(pubMaybe.isDefined, "addPublicationDeadline returned Absent on a healthy driver")
+                pub      = pubMaybe.get
+                _ <- Sync.Unsafe.defer(rt.close())
+                // Offer on the freed-inner-handle publication.
+                offerResult <- Sync.Unsafe.defer(transport.offer(pub, payload))
+                // Release the publication bundle's client-bundle ref (closing=1, so it skips the freed
+                // handle and frees the bundle).
+                _ <- Sync.Unsafe.defer(transport.closePublication(pub))
+            yield assert(
+                offerResult == AeronSentinels.Closed,
+                s"expected offer on a closed-client publication to return AeronSentinels.Closed (-4); got $offerResult"
             )
-            pubMaybe = pubMaybeResult.getOrThrow
-            _        = assert(pubMaybe.isDefined, "addPublicationDeadline returned Absent on a healthy driver")
-            pub      = pubMaybe.get
-            _ <- Sync.Unsafe.defer(rt.close())
-            // Offer on the freed-inner-handle publication.
-            offerResult <- Sync.Unsafe.defer(transport.offer(pub, payload))
-            // Release the publication bundle's client-bundle ref (closing=1, so it skips the freed
-            // handle and frees the bundle).
-            _ <- Sync.Unsafe.defer(transport.closePublication(pub))
-            _ <- Path.run(dir.removeAll)
-        yield assert(
-            offerResult == AeronSentinels.Closed,
-            s"expected offer on a closed-client publication to return AeronSentinels.Closed (-4); got $offerResult"
-        )
-        end for
+            end for
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -969,80 +1102,76 @@ class AeronTransportTest extends Test:
     "oversize offer on term-length=65536 returns -6, does not throw" in {
         val oversizeUri = "aeron:ipc?term-length=65536"
         val oversize    = Array.fill[Byte](8193)(0)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(oversizeUri, oversizeJvmStreamId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(oversizeUri, oversizeJvmStreamId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
-            _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
-            pub = pubMaybe.get
-            sub = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            result <- Abort.run[Throwable](Sync.Unsafe.defer(transport.offer(pub, oversize)))
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield result match
-            case Result.Success(r) =>
-                assert(
-                    r == AeronSentinels.Error,
-                    s"Expected AeronSentinels.Error (-6) for oversize offer; got $r"
-                )
-            case Result.Panic(t) =>
-                fail(s"oversize offer threw ${t.getClass.getSimpleName} instead of returning -6: ${t.getMessage}")
-            case Result.Failure(t) =>
-                fail(s"oversize offer aborted with ${t.getClass.getSimpleName}: ${t.getMessage}")
-        end for
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(oversizeUri, oversizeJvmStreamId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(oversizeUri, oversizeJvmStreamId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
+                _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
+                pub = pubMaybe.get
+                sub = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                result <- Abort.run[Throwable](Sync.Unsafe.defer(transport.offer(pub, oversize)))
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield result match
+                case Result.Success(r) =>
+                    assert(
+                        r == AeronSentinels.Error,
+                        s"Expected AeronSentinels.Error (-6) for oversize offer; got $r"
+                    )
+                case Result.Panic(t) =>
+                    fail(s"oversize offer threw ${t.getClass.getSimpleName} instead of returning -6: ${t.getMessage}")
+                case Result.Failure(t) =>
+                    fail(s"oversize offer aborted with ${t.getClass.getSimpleName}: ${t.getMessage}")
+            end for
+        }
     }
 
     // Same subscriber+awaitConnected anti-flakiness pattern as the JVM oversize-offer leaf.
     "oversize offer on term-length=65536 returns -6 on every platform" in {
         val oversizeUri = "aeron:ipc?term-length=65536"
         val oversize    = Array.fill[Byte](8193)(0)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(oversizeUri, oversizeCrossStreamId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(oversizeUri, oversizeCrossStreamId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
-            _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
-            pub = pubMaybe.get
-            sub = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            result <- Abort.run[Throwable](Sync.Unsafe.defer(transport.offer(pub, oversize)))
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield result match
-            case Result.Success(r) =>
-                assert(
-                    r == AeronSentinels.Error,
-                    s"Expected AeronSentinels.Error (-6) for oversize offer on all platforms; got $r"
-                )
-            case Result.Panic(t) =>
-                fail(s"oversize offer threw ${t.getClass.getSimpleName} on a non-JVM platform: ${t.getMessage}")
-            case Result.Failure(t) =>
-                fail(s"oversize offer aborted with ${t.getClass.getSimpleName}: ${t.getMessage}")
-        end for
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(oversizeUri, oversizeCrossStreamId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(oversizeUri, oversizeCrossStreamId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done within 5000 attempts")
+                _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done within 5000 attempts")
+                pub = pubMaybe.get
+                sub = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                result <- Abort.run[Throwable](Sync.Unsafe.defer(transport.offer(pub, oversize)))
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield result match
+                case Result.Success(r) =>
+                    assert(
+                        r == AeronSentinels.Error,
+                        s"Expected AeronSentinels.Error (-6) for oversize offer on all platforms; got $r"
+                    )
+                case Result.Panic(t) =>
+                    fail(s"oversize offer threw ${t.getClass.getSimpleName} on a non-JVM platform: ${t.getMessage}")
+                case Result.Failure(t) =>
+                    fail(s"oversize offer aborted with ${t.getClass.getSimpleName}: ${t.getMessage}")
+            end for
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -1053,118 +1182,110 @@ class AeronTransportTest extends Test:
     // kyo_aeron_test_inject_error. Reaching the yield proves the recording error handler did not
     // exit() the process.
     "an injected fatal error is recorded in the slot and the process survives" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            _        <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
-            recorded <- Sync.Unsafe.defer(transport.fatalError)
-            _ = assert(
-                recorded == Present("driver timeout"),
-                s"fatalError expected Present('driver timeout') after inject; got $recorded"
-            )
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield succeed
-        end for
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                _        <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
+                recorded <- Sync.Unsafe.defer(transport.fatalError)
+                _ = assert(
+                    recorded == Present("driver timeout"),
+                    s"fatalError expected Present('driver timeout') after inject; got $recorded"
+                )
+            yield succeed
+            end for
+        }
     }
 
     // The next offer boundary checks fatalError and aborts, never exits the process.
     "a publish after a recorded fatal error aborts TopicTransportFailedException" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            _ <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
-            result <- Abort.run[TopicException] {
-                Topic.runWith(transport) {
-                    Topic.publish[Int](ipcUri, Schedule.never)(Stream.init(Seq(42)))
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                _ <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
+                result <- Abort.run[TopicException] {
+                    Topic.runWith(transport) {
+                        Topic.publish[Int](ipcUri, Schedule.never)(Stream.init(Seq(42)))
+                    }
                 }
-            }
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield result match
-            case Result.Failure(f: TopicTransportFailedException) =>
-                assert(
-                    f.detail == "driver timeout",
-                    s"TopicTransportFailedException carried wrong detail: '${f.detail}'"
-                )
-            case Result.Success(_) =>
-                fail("publish should have aborted with TopicTransportFailedException after fatal error inject")
-            case Result.Panic(t) =>
-                fail(s"unexpected panic: ${t.getClass.getSimpleName}: ${t.getMessage}")
-            case Result.Failure(other) =>
-                fail(s"expected TopicTransportFailedException, got ${other.getClass.getSimpleName}")
-        end for
+            yield result match
+                case Result.Failure(f: TopicTransportFailedException) =>
+                    assert(
+                        f.detail == "driver timeout",
+                        s"TopicTransportFailedException carried wrong detail: '${f.detail}'"
+                    )
+                case Result.Success(_) =>
+                    fail("publish should have aborted with TopicTransportFailedException after fatal error inject")
+                case Result.Panic(t) =>
+                    fail(s"unexpected panic: ${t.getClass.getSimpleName}: ${t.getMessage}")
+                case Result.Failure(other) =>
+                    fail(s"expected TopicTransportFailedException, got ${other.getClass.getSimpleName}")
+            end for
+        }
     }
 
     // Symmetric to the publish path, at the stream's poll boundary.
     "a stream after a recorded fatal error aborts TopicTransportFailedException" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            _ <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
-            result <- Abort.run[TopicException] {
-                Topic.runWith(transport) {
-                    Topic.stream[Int](ipcUri, Schedule.never).take(1).run
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                _ <- Sync.Unsafe.defer(transport.injectError(-1000, "driver timeout"))
+                result <- Abort.run[TopicException] {
+                    Topic.runWith(transport) {
+                        Topic.stream[Int](ipcUri, Schedule.never).take(1).run
+                    }
                 }
-            }
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield result match
-            case Result.Failure(f: TopicTransportFailedException) =>
-                assert(
-                    f.detail == "driver timeout",
-                    s"TopicTransportFailedException carried wrong detail: '${f.detail}'"
-                )
-            case Result.Success(_) =>
-                fail("stream should have aborted with TopicTransportFailedException after fatal error inject")
-            case Result.Panic(t) =>
-                fail(s"unexpected panic: ${t.getClass.getSimpleName}: ${t.getMessage}")
-            case Result.Failure(other) =>
-                fail(s"expected TopicTransportFailedException, got ${other.getClass.getSimpleName}")
-        end for
+            yield result match
+                case Result.Failure(f: TopicTransportFailedException) =>
+                    assert(
+                        f.detail == "driver timeout",
+                        s"TopicTransportFailedException carried wrong detail: '${f.detail}'"
+                    )
+                case Result.Success(_) =>
+                    fail("stream should have aborted with TopicTransportFailedException after fatal error inject")
+                case Result.Panic(t) =>
+                    fail(s"unexpected panic: ${t.getClass.getSimpleName}: ${t.getMessage}")
+                case Result.Failure(other) =>
+                    fail(s"expected TopicTransportFailedException, got ${other.getClass.getSimpleName}")
+            end for
+        }
     }
 
     // Regression guard: installing the error handler must not perturb the happy path.
     "no recorded error means normal operation, fatalError stays Absent" in {
         val payload = Array[Byte](10, 20, 30)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            beforeOp <- Sync.Unsafe.defer(transport.fatalError)
-            _ = assert(beforeOp.isEmpty, s"fatalError must be Absent on fresh transport; got $beforeOp")
-            pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, errorHandlerRegressionStreamId))
-            subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, errorHandlerRegressionStreamId))
-            _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
-            _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
-            pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
-            subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
-            _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done")
-            _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done")
-            pub = pubMaybe.get
-            sub = subMaybe.get
-            pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
-            _ = assert(pubConnected, "publication did not connect within 5s")
-            afterOp <- Sync.Unsafe.defer(transport.fatalError)
-            _ = assert(afterOp.isEmpty, s"fatalError must remain Absent after successful ops; got $afterOp")
-            pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
-            _ = assert(pos > 0, s"offer did not succeed; pos=$pos")
-            received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
-            _ = assert(received.isDefined, "no message received")
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                transport.closeSubscription(sub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield assert(
-            java.util.Arrays.equals(received.get, payload),
-            s"round-trip payload mismatch: got ${received.get.toList}"
-        )
-        end for
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                beforeOp <- Sync.Unsafe.defer(transport.fatalError)
+                _ = assert(beforeOp.isEmpty, s"fatalError must be Absent on fresh transport; got $beforeOp")
+                pubTokMaybe <- Sync.Unsafe.defer(transport.asyncAddPublication(ipcUri, errorHandlerRegressionStreamId))
+                subTokMaybe <- Sync.Unsafe.defer(transport.asyncAddSubscription(ipcUri, errorHandlerRegressionStreamId))
+                _ = assert(pubTokMaybe.isDefined, "asyncAddPublication returned Absent on a live client")
+                _ = assert(subTokMaybe.isDefined, "asyncAddSubscription returned Absent on a live client")
+                pubMaybe <- pollAddPubUntilDone(transport, pubTokMaybe.get, 5000)
+                subMaybe <- pollAddSubUntilDone(transport, subTokMaybe.get, 5000)
+                _   = assert(pubMaybe.isDefined, "pollAddPublication never returned Done")
+                _   = assert(subMaybe.isDefined, "pollAddSubscription never returned Done")
+                pub = pubMaybe.get
+                sub = subMaybe.get
+                pubConnected <- awaitTrue(5000)(Sync.Unsafe.defer(transport.publicationIsConnected(pub)))
+                _ = assert(pubConnected, "publication did not connect within 5s")
+                afterOp <- Sync.Unsafe.defer(transport.fatalError)
+                _ = assert(afterOp.isEmpty, s"fatalError must remain Absent after successful ops; got $afterOp")
+                pos <- offerUntil(5000)(Sync.Unsafe.defer(transport.offer(pub, payload)))
+                _ = assert(pos > 0, s"offer did not succeed; pos=$pos")
+                received <- pollUntil(5000)(Sync.Unsafe.defer(transport.pollOne(sub)))
+                _ = assert(received.isDefined, "no message received")
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                    transport.closeSubscription(sub)
+                }
+            yield assert(
+                java.util.Arrays.equals(received.get, payload),
+                s"round-trip payload mismatch: got ${received.get.toList}"
+            )
+            end for
+        }
     }
 
     // fatalError keys off the slot's presence flag, not msg.nonEmpty, so an empty message still surfaces
@@ -1172,42 +1293,40 @@ class AeronTransportTest extends Test:
     // 42)" on FFI; the throwable's toString on JVM, since getMessage is null for messageless throwables).
     // Were presence not the key, an empty-message fatal error would map to Absent and retry forever.
     "empty-message fatal error inject surfaces TopicTransportFailedException with non-empty detail" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            _        <- Sync.Unsafe.defer(transport.injectError(42, ""))
-            recorded <- Sync.Unsafe.defer(transport.fatalError)
-            _ = assert(
-                recorded.isDefined,
-                "fatalError must be Present after inject with empty message; the empty-message fatal error must surface as a typed failure"
-            )
-            _ = assert(
-                recorded.get.nonEmpty,
-                s"fatalError detail must be non-empty after inject with empty message; got '${recorded.get}'"
-            )
-            result <- Abort.run[TopicException] {
-                Topic.runWith(transport) {
-                    Topic.publish[Int](ipcUri, Schedule.never)(Stream.init(Seq(42)))
+        withEmbeddedRuntime() { rt =>
+            val transport = rt.transport
+            for
+                _        <- Sync.Unsafe.defer(transport.injectError(42, ""))
+                recorded <- Sync.Unsafe.defer(transport.fatalError)
+                _ = assert(
+                    recorded.isDefined,
+                    "fatalError must be Present after inject with empty message; the empty-message fatal error must surface as a typed failure"
+                )
+                _ = assert(
+                    recorded.get.nonEmpty,
+                    s"fatalError detail must be non-empty after inject with empty message; got '${recorded.get}'"
+                )
+                result <- Abort.run[TopicException] {
+                    Topic.runWith(transport) {
+                        Topic.publish[Int](ipcUri, Schedule.never)(Stream.init(Seq(42)))
+                    }
                 }
-            }
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield result match
-            case Result.Failure(f: TopicTransportFailedException) =>
-                assert(
-                    f.detail.nonEmpty,
-                    s"TopicTransportFailedException.detail must be non-empty for empty-message inject; got '${f.detail}'"
-                )
-            case Result.Success(_) =>
-                fail(
-                    "publish should have aborted with TopicTransportFailedException after empty-message fatal error inject; the empty-message fatal error must surface as a typed failure"
-                )
-            case Result.Panic(t) =>
-                fail(s"unexpected panic: ${t.getClass.getSimpleName}: ${t.getMessage}")
-            case Result.Failure(other) =>
-                fail(s"expected TopicTransportFailedException, got ${other.getClass.getSimpleName}")
-        end for
+            yield result match
+                case Result.Failure(f: TopicTransportFailedException) =>
+                    assert(
+                        f.detail.nonEmpty,
+                        s"TopicTransportFailedException.detail must be non-empty for empty-message inject; got '${f.detail}'"
+                    )
+                case Result.Success(_) =>
+                    fail(
+                        "publish should have aborted with TopicTransportFailedException after empty-message fatal error inject; the empty-message fatal error must surface as a typed failure"
+                    )
+                case Result.Panic(t) =>
+                    fail(s"unexpected panic: ${t.getClass.getSimpleName}: ${t.getMessage}")
+                case Result.Failure(other) =>
+                    fail(s"expected TopicTransportFailedException, got ${other.getClass.getSimpleName}")
+            end for
+        }
     }
 
 end AeronTransportTest

--- a/kyo-aeron/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,45 @@
 package kyo
 
+import kyo.internal.AeronPlatform
+import kyo.internal.AeronRuntime
+
 /** kyo-aeron test base on the kyo-test V3 framework.
   *
   * Leaves use the V3 DSL (`"name" in { ... }`); platform gating uses `.onlyJvm`/`.notJvm`/`.onlyJs`/`.onlyNative`.
   */
-abstract class Test extends kyo.test.Test[Any]
+abstract class Test extends kyo.test.Test[Any]:
+
+    /** Counts drivers actually released by [[withEmbeddedRuntime]]'s finalizer.
+      *
+      * The point of routing the close through a scope is that it runs whether or not the body finishes, and
+      * that is a claim about what executes rather than about what the code says. This counter is what lets a
+      * leaf assert the finalizer ran on a body that threw, instead of trusting the shape of the helper.
+      */
+    val embeddedRuntimeReleases = new java.util.concurrent.atomic.AtomicInteger(0)
+
+    /** Runs `body` against an embedded driver whose teardown cannot be skipped.
+      *
+      * The driver is a real C media driver reached through FFI on every platform, so a runtime that is
+      * never closed leaves its conductor thread running for the rest of the JVM's life. Closing it as an
+      * ordinary step of a for-comprehension makes that teardown conditional on the body finishing: a failed
+      * assert, an abort, or an interrupt anywhere in between skips it. Registering the close as a scope
+      * finalizer instead makes it unconditional, which is what a native resource needs.
+      */
+    def withEmbeddedRuntime[A, S](prefix: String = "kyo-aeron-embedded-test")(body: AeronRuntime => A < (Async & S))(using
+        Frame
+    ): A < (Async & Abort[FileSystemException] & S) =
+        Scope.run {
+            for
+                dir <- Path.run(Path.tempDir(prefix))
+                rt  <- AeronPlatform.embedded(dir.unsafe.show)
+                _ <- Scope.ensure(
+                    Sync.Unsafe.defer {
+                        rt.close()
+                        discard(embeddedRuntimeReleases.incrementAndGet())
+                    }.andThen(Path.run(dir.removeAll))
+                )
+                out <- body(rt)
+            yield out
+        }
+
+end Test

--- a/kyo-aeron/shared/src/test/scala/kyo/TopicInvariantsTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/TopicInvariantsTest.scala
@@ -111,17 +111,13 @@ class TopicInvariantsTest extends Test:
     // dlopens the shim via koffi). Pins that kyo_aeron_* symbols are linked into the Native binary
     // (aeron_driver_static) and resolve at runtime with no system libaeron.
     "runtime: symbols resolve and driver starts without system libaeron".onlyNative in {
-        for
-            dir     <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            runtime <- AeronPlatform.embedded(dir.unsafe.show)
-            result <- Sync.Unsafe.defer {
+        withEmbeddedRuntime() { runtime =>
+            Sync.Unsafe.defer {
                 assert(runtime.transport != null, "runtime.transport is null after embedded()")
                 runtime.close()
                 succeed
             }
-            _ <- Path.run(dir.removeAll)
-        yield result
-        end for
+        }
     }
 
     // The offer-sentinel classification itself is cross-platform and lives in AeronTransportTest
@@ -172,38 +168,36 @@ class TopicInvariantsTest extends Test:
     // generated binding converts via .toString.toLong, so a negative sentinel like NotConnected (-1L)
     // must survive with its sign intact; JVM/Native never exercise that path (primitive long / C long).
     "JS koffi int64 sentinel marshalling: negative offer sentinel survives BigInt round-trip".onlyJs in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-embedded-test"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pubMaybeR <- Abort.run[TopicTransportException] {
-                Topic.addPublicationDeadline(transport, "aeron:ipc", 78, 10.seconds)
-            }
-            // Do NOT interpolate pubMaybeR: on Scala.js a Result holding an FFI Handle (an opaque
-            // koffi pointer) throws "TypeError: Cannot convert object to primitive value" on string
-            // coercion. Report only the failure's class name.
-            _ = assert(
-                pubMaybeR.isSuccess,
-                s"addPublicationDeadline failed: ${pubMaybeR.failure.map(_.getClass.getSimpleName)}"
-            )
-            pubMaybe = pubMaybeR.getOrThrow
-            _        = assert(pubMaybe.isDefined, "addPublicationDeadline returned Absent on a live client")
-            pub      = pubMaybe.get
-            payload  = Array[Byte](0)
-            result <- Sync.Unsafe.defer(transport.offer(pub, payload))
-            _ <- Sync.Unsafe.defer {
-                transport.closePublication(pub)
-                rt.close()
-            }
-            _ <- Path.run(dir.removeAll)
-        yield
-            assert(result < 0, s"Expected a negative sentinel from a not-connected JS FFI publication; got $result")
-            assert(
-                result == AeronSentinels.NotConnected || result == AeronSentinels.BackPressured,
-                s"Expected NotConnected (-1L) or BackPressured (-2L) but got $result; " +
-                    "this indicates the koffi BigInt->Long conversion does not preserve the sign of negative int64 values"
-            )
-        end for
+        withEmbeddedRuntime("kyo-aeron-embedded-test") { rt =>
+            val transport = rt.transport
+            for
+                pubMaybeR <- Abort.run[TopicTransportException] {
+                    Topic.addPublicationDeadline(transport, "aeron:ipc", 78, 10.seconds)
+                }
+                // Do NOT interpolate pubMaybeR: on Scala.js a Result holding an FFI Handle (an opaque
+                // koffi pointer) throws "TypeError: Cannot convert object to primitive value" on string
+                // coercion. Report only the failure's class name.
+                _ = assert(
+                    pubMaybeR.isSuccess,
+                    s"addPublicationDeadline failed: ${pubMaybeR.failure.map(_.getClass.getSimpleName)}"
+                )
+                pubMaybe = pubMaybeR.getOrThrow
+                _        = assert(pubMaybe.isDefined, "addPublicationDeadline returned Absent on a live client")
+                pub      = pubMaybe.get
+                payload  = Array[Byte](0)
+                result <- Sync.Unsafe.defer(transport.offer(pub, payload))
+                _ <- Sync.Unsafe.defer {
+                    transport.closePublication(pub)
+                }
+            yield
+                assert(result < 0, s"Expected a negative sentinel from a not-connected JS FFI publication; got $result")
+                assert(
+                    result == AeronSentinels.NotConnected || result == AeronSentinels.BackPressured,
+                    s"Expected NotConnected (-1L) or BackPressured (-2L) but got $result; " +
+                        "this indicates the koffi BigInt->Long conversion does not preserve the sign of negative int64 values"
+                )
+            end for
+        }
     }
 
     // Behavioral guard: an Envelope with empty payload still encodes to a non-empty byte sequence, since

--- a/kyo-aeron/shared/src/test/scala/kyo/TopicRuntimeReleaseTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/TopicRuntimeReleaseTest.scala
@@ -1,0 +1,129 @@
+package kyo
+
+import kyo.internal.AeronTransport
+
+/** Whether `Topic.run` releases its media driver when the body fails.
+  *
+  * `Topic.run` owns an embedded driver for the duration of the body and shuts it down on the way out. A
+  * driver that is not shut down leaves its conductor threads running for the rest of the process, which is
+  * the one resource in this module whose escape is invisible: the computation returns the caller's error
+  * perfectly well and nothing else reports it.
+  *
+  * The runtime names its directory in the diagnostics registry, so the check is on the entry that appeared
+  * while the body ran. Comparing against the entries present beforehand keeps it specific while other
+  * suites run in parallel, and asserting the fixture saw its own runtime keeps a vacuous pass from reading
+  * as a release.
+  */
+class TopicRuntimeReleaseTest extends Test:
+
+    private def aeronDirs()(using AllowUnsafe): Set[String] =
+        kyo.internal.Diagnostics.dumpAll().linesIterator
+            .filter(_.contains("dir=")).map(_.trim).toSet
+
+    "a body that fails with a typed error still releases the driver"
+        .pendingUntilFixed(
+            "Sync.ensure does not run its finalizer when the guarded body short-circuits via Abort, so Topic.run's "
+                + "runtime close is skipped on a typed failure"
+        ) in {
+        Sync.Unsafe.defer(aeronDirs()).flatMap { before =>
+            Sync.Unsafe.defer(new java.util.concurrent.atomic.AtomicReference(Set.empty[String])).flatMap { seen =>
+                Abort.run[String] {
+                    Topic.run {
+                        Sync.Unsafe.defer(seen.set(aeronDirs() -- before))
+                            .andThen(Abort.fail("the body fails after the driver is up"))
+                    }
+                }.map { result =>
+                    Sync.Unsafe.defer {
+                        val mine  = seen.get()
+                        val after = aeronDirs()
+                        assert(result.isFailure, s"the fixture must fail typed for this to prove anything, got $result")
+                        assert(mine.nonEmpty, "the fixture never saw a live runtime, so a clean dump proves nothing")
+                        val survivors = mine.intersect(after)
+                        assert(
+                            survivors.isEmpty,
+                            s"the driver outlived a typed abort: ${survivors.mkString(", ")}"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /** Transport that hands out a publication and then reports a fatal error.
+      *
+      * The fatal slot is only armed once a publication has been added, so the body under test acquires the
+      * resource first and fails afterwards, which is the ordering that decides whether the release runs.
+      * Counting the close is the whole point: a leaked publication holds a client-bundle refcount, so it
+      * keeps the client alive too, and nothing above the transport reports either.
+      */
+    final private class FatalAfterAddTransport extends AeronTransport:
+        type Publication  = Int
+        type Subscription = Int
+        type AsyncPub     = Int
+        type AsyncSub     = Int
+
+        @volatile private var added = false
+        val closedPublications      = new java.util.concurrent.atomic.AtomicInteger(0)
+        val closedSubscriptions     = new java.util.concurrent.atomic.AtomicInteger(0)
+
+        def asyncAddPublication(uri: String, streamId: Int)(using AllowUnsafe): Maybe[AsyncPub] = Present(streamId)
+        def pollAddPublication(async: AsyncPub)(using AllowUnsafe): AeronTransport.AddPoll[Publication] =
+            added = true
+            AeronTransport.AddPoll.Done(async)
+        def freeAsyncPub(async: AsyncPub)(using AllowUnsafe): Unit                 = ()
+        def publicationIsConnected(pub: Publication)(using AllowUnsafe): Boolean   = true
+        def offer(pub: Publication, message: Array[Byte])(using AllowUnsafe): Long = 1L
+        def maxMessageLength(pub: Publication)(using AllowUnsafe): Int             = 1 << 20
+        def closePublication(pub: Publication)(using AllowUnsafe): Unit            = discard(closedPublications.incrementAndGet())
+        def asyncAddSubscription(uri: String, streamId: Int)(using AllowUnsafe): Maybe[AsyncSub] = Present(streamId)
+        def pollAddSubscription(async: AsyncSub)(using AllowUnsafe): AeronTransport.AddPoll[Subscription] =
+            added = true
+            AeronTransport.AddPoll.Done(async)
+        def freeAsyncSub(async: AsyncSub)(using AllowUnsafe): Unit                 = ()
+        def subscriptionIsConnected(sub: Subscription)(using AllowUnsafe): Boolean = false
+        def pollOne(sub: Subscription)(using AllowUnsafe): Maybe[Array[Byte]]      = Absent
+        def closeSubscription(sub: Subscription)(using AllowUnsafe): Unit          = discard(closedSubscriptions.incrementAndGet())
+
+        def fatalError(using AllowUnsafe): Maybe[String] =
+            if added then Present("injected after the publication was added") else Absent
+    end FatalAfterAddTransport
+
+    "a publish that fails with a typed error still closes its publication"
+        .pendingUntilFixed(
+            "Sync.ensure does not run its finalizer when the guarded body short-circuits via Abort, so the "
+                + "publication close is skipped when publish aborts typed"
+        ) in {
+        val transport = new FatalAfterAddTransport
+        Abort.run[TopicTransportException] {
+            Topic.runWith(transport) {
+                Topic.publish[Int]("aeron:ipc", streamId = Present(4242))(Stream.init(Seq(1, 2, 3)))
+            }
+        }.map { result =>
+            assert(result.isFailure, s"the fixture must fail typed for this to prove anything, got $result")
+            assert(
+                transport.closedPublications.get() == 1,
+                s"the publication was not closed: closePublication ran ${transport.closedPublications.get()} time(s)"
+            )
+        }
+    }
+
+    "a stream that fails with a typed error still closes its subscription"
+        .pendingUntilFixed(
+            "Sync.ensure does not run its finalizer when the guarded body short-circuits via Abort, so the "
+                + "subscription close is skipped when stream aborts typed"
+        ) in {
+        val transport = new FatalAfterAddTransport
+        Abort.run[TopicTransportException] {
+            Topic.runWith(transport) {
+                Topic.stream[Int]("aeron:ipc", streamId = Present(4343)).take(1).run
+            }
+        }.map { result =>
+            assert(result.isFailure, s"the fixture must fail typed for this to prove anything, got $result")
+            assert(
+                transport.closedSubscriptions.get() == 1,
+                s"the subscription was not closed: closeSubscription ran ${transport.closedSubscriptions.get()} time(s)"
+            )
+        }
+    }
+
+end TopicRuntimeReleaseTest

--- a/kyo-aeron/shared/src/test/scala/kyo/TopicUniformInvariantsTest.scala
+++ b/kyo-aeron/shared/src/test/scala/kyo/TopicUniformInvariantsTest.scala
@@ -350,53 +350,49 @@ class TopicUniformInvariantsTest extends Test:
     // immediately and the next offer would dereference freed memory on Native/JS.
     "offer after the caller's own closePublication returns the safe Closed sentinel, no UAF (JVM/JS/Native)" in {
         val payload = Array[Byte](1, 2, 3, 4)
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-offer-after-close"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            offerResult <- Abort.run[TopicTransportException] {
-                addPublication(transport, offerAfterOwnCloseStreamId).map { pub =>
-                    Sync.Unsafe.defer {
-                        // The caller's own close: marks the bundle closed, defers the free.
-                        transport.closePublication(pub)
-                        // The three guarded reads on the same, now-closed handle.
-                        val offered   = transport.offer(pub, payload)
-                        val connected = transport.publicationIsConnected(pub)
-                        val maxMsgLen = transport.maxMessageLength(pub)
-                        (offered, connected, maxMsgLen)
+        withEmbeddedRuntime("kyo-aeron-offer-after-close") { rt =>
+            val transport = rt.transport
+            for
+                offerResult <- Abort.run[TopicTransportException] {
+                    addPublication(transport, offerAfterOwnCloseStreamId).map { pub =>
+                        Sync.Unsafe.defer {
+                            // The caller's own close: marks the bundle closed, defers the free.
+                            transport.closePublication(pub)
+                            // The three guarded reads on the same, now-closed handle.
+                            val offered   = transport.offer(pub, payload)
+                            val connected = transport.publicationIsConnected(pub)
+                            val maxMsgLen = transport.maxMessageLength(pub)
+                            (offered, connected, maxMsgLen)
+                        }
                     }
                 }
-            }
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield offerResult match
-            case Result.Success((offered, connected, maxMsgLen)) =>
-                assert(
-                    offered == AeronSentinels.Closed,
-                    s"expected offer after the caller's own closePublication to return AeronSentinels.Closed (-4); got $offered"
-                )
-                assert(
-                    !connected,
-                    s"expected publicationIsConnected after own close to be false; got $connected"
-                )
-                assert(
-                    maxMsgLen == 0,
-                    s"expected maxMessageLength after own close to be 0 (the shim's closed-guard returns 0 on every platform); got $maxMsgLen"
-                )
-            case other =>
-                fail(s"add/offer round-trip failed before the assertion: $other")
-        end for
+            yield offerResult match
+                case Result.Success((offered, connected, maxMsgLen)) =>
+                    assert(
+                        offered == AeronSentinels.Closed,
+                        s"expected offer after the caller's own closePublication to return AeronSentinels.Closed (-4); got $offered"
+                    )
+                    assert(
+                        !connected,
+                        s"expected publicationIsConnected after own close to be false; got $connected"
+                    )
+                    assert(
+                        maxMsgLen == 0,
+                        s"expected maxMessageLength after own close to be 0 (the shim's closed-guard returns 0 on every platform); got $maxMsgLen"
+                    )
+                case other =>
+                    fail(s"add/offer round-trip failed before the assertion: $other")
+            end for
+        }
     }
 
     // Proves the per-client sweep is the sole free-owner of the deferred bundle: a double-free or
     // use-after-free would crash the process before the assertion. fatalError is read before the runtime
     // closes, since the runtime owns the transport's client handle.
     "client-close after a caller-closed publication is clean: no double-free, fatalError Absent (JVM/JS/Native)" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-client-close"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            fatalAfterClose <- Abort.run[TopicTransportException] {
+        withEmbeddedRuntime("kyo-aeron-client-close") { rt =>
+            val transport = rt.transport
+            for fatalAfterClose <- Abort.run[TopicTransportException] {
                 addPublication(transport, clientCloseStreamId).map { pub =>
                     Sync.Unsafe.defer {
                         transport.closePublication(pub)
@@ -406,17 +402,16 @@ class TopicUniformInvariantsTest extends Test:
             }
             // Close the client: the sweep frees the deferred bundle. A double-free would
             // crash here; reaching the assertion proves it did not.
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield fatalAfterClose match
-            case Result.Success(fatal) =>
-                assert(
-                    fatal.isEmpty,
-                    s"expected fatalError to be Absent after a clean caller-close; got $fatal"
-                )
-            case other =>
-                fail(s"add/close round-trip failed before the assertion: $other")
-        end for
+            yield fatalAfterClose match
+                case Result.Success(fatal) =>
+                    assert(
+                        fatal.isEmpty,
+                        s"expected fatalError to be Absent after a clean caller-close; got $fatal"
+                    )
+                case other =>
+                    fail(s"add/close round-trip failed before the assertion: $other")
+            end for
+        }
     }
 
     private val pollAfterOwnCloseStreamId = 202
@@ -436,43 +431,39 @@ class TopicUniformInvariantsTest extends Test:
     // close a no-op. Two guards meet here: the shim keeps the freed handle inert, and SubscriptionState
     // reports itself closed so the poll never hands the shim the receive buffer closeSubscription released.
     "poll after the caller's own closeSubscription returns no fragment and a second close is a no-op, no UAF (JVM/JS/Native)" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-poll-after-close"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            pollResult <- Abort.run[TopicTransportException] {
-                addSubscription(transport, pollAfterOwnCloseStreamId).map { sub =>
-                    Sync.Unsafe.defer {
-                        // The caller's own close: marks the bundle closed, defers the free.
-                        transport.closeSubscription(sub)
-                        // Guarded poll on the same, now-closed handle.
-                        val polled = transport.pollOne(sub)
-                        // Second close: must be an idempotent no-op.
-                        transport.closeSubscription(sub)
-                        polled
+        withEmbeddedRuntime("kyo-aeron-poll-after-close") { rt =>
+            val transport = rt.transport
+            for
+                pollResult <- Abort.run[TopicTransportException] {
+                    addSubscription(transport, pollAfterOwnCloseStreamId).map { sub =>
+                        Sync.Unsafe.defer {
+                            // The caller's own close: marks the bundle closed, defers the free.
+                            transport.closeSubscription(sub)
+                            // Guarded poll on the same, now-closed handle.
+                            val polled = transport.pollOne(sub)
+                            // Second close: must be an idempotent no-op.
+                            transport.closeSubscription(sub)
+                            polled
+                        }
                     }
                 }
-            }
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield pollResult match
-            case Result.Success(polled) =>
-                assert(
-                    polled.isEmpty,
-                    s"expected pollOne after the caller's own closeSubscription to return Absent; got $polled"
-                )
-            case other =>
-                fail(s"add/poll round-trip failed before the assertion: $other")
-        end for
+            yield pollResult match
+                case Result.Success(polled) =>
+                    assert(
+                        polled.isEmpty,
+                        s"expected pollOne after the caller's own closeSubscription to return Absent; got $polled"
+                    )
+                case other =>
+                    fail(s"add/poll round-trip failed before the assertion: $other")
+            end for
+        }
     }
 
     // Mirror of the publication client-close leaf above, for the subscription sweep.
     "client-close after a caller-closed subscription is clean: no double-free, fatalError Absent (JVM/JS/Native)" in {
-        for
-            dir <- Path.run(Path.tempDir("kyo-aeron-sub-client-close"))
-            rt  <- AeronPlatform.embedded(dir.unsafe.show)
-            transport = rt.transport
-            fatalAfterClose <- Abort.run[TopicTransportException] {
+        withEmbeddedRuntime("kyo-aeron-sub-client-close") { rt =>
+            val transport = rt.transport
+            for fatalAfterClose <- Abort.run[TopicTransportException] {
                 addSubscription(transport, subClientCloseStreamId).map { sub =>
                     Sync.Unsafe.defer {
                         transport.closeSubscription(sub)
@@ -482,17 +473,16 @@ class TopicUniformInvariantsTest extends Test:
             }
             // Close the client: the subscription sweep frees the deferred bundle. A double-free
             // would crash here; reaching the assertion proves it did not.
-            _ <- Sync.Unsafe.defer(rt.close())
-            _ <- Path.run(dir.removeAll)
-        yield fatalAfterClose match
-            case Result.Success(fatal) =>
-                assert(
-                    fatal.isEmpty,
-                    s"expected fatalError to be Absent after a clean caller-close; got $fatal"
-                )
-            case other =>
-                fail(s"add/close round-trip failed before the assertion: $other")
-        end for
+            yield fatalAfterClose match
+                case Result.Success(fatal) =>
+                    assert(
+                        fatal.isEmpty,
+                        s"expected fatalError to be Absent after a clean caller-close; got $fatal"
+                    )
+                case other =>
+                    fail(s"add/close round-trip failed before the assertion: $other")
+            end for
+        }
     }
 
     // aeron_errcode() reports AERON_CLIENT_ERRORED_MEDIA_DRIVER as a negated driver code; math.abs at both

--- a/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
@@ -539,6 +539,34 @@ class SignalTest extends kyo.test.Test[Any]:
             yield assert(v1 == (0, 1) && v2 == (0, 2))
         }
 
+        /** Each barrier below reports itself while it waits.
+          *
+          * This leaf has hung to its budget on a loaded CI leg, and the harness's hang dump names the leaf but carries no fiber trace, so
+          * the run said only "stuck" and not WHICH barrier nor what it observed. `assertEventually` retries on a fixed interval with no
+          * message, so an unreachable condition is indistinguishable from a slow one in the log. Reporting the label and the live counts
+          * while waiting turns the next sighting into a diagnosis: a barrier pinned at a count that never moves says the condition became
+          * unreachable, and a barrier that never appears says the leaf hung somewhere else entirely.
+          *
+          * The reporting is on the retry path only, so a passing run prints nothing and the assertion is unchanged. Nothing here waits on
+          * the clock: the harness budget remains the only failure detector.
+          */
+        def awaitBarrier(label: String, refA: SignalRef[Int], refB: SignalRef[Int])(cond: (Int, Int) => Boolean)(using
+            Frame,
+            kyo.test.AssertScope
+        ) =
+            val attempts = new java.util.concurrent.atomic.AtomicInteger(0)
+            assertEventually {
+                Kyo.zip(refA.waiters, refB.waiters).map { (a, b) =>
+                    val ok = cond(a, b)
+                    // Roughly every two seconds at the retry interval, often enough to be unmissable in a hung leg and rare enough not to
+                    // flood a log that is already large.
+                    if !ok && (attempts.incrementAndGet() % 200) == 0 then
+                        println(s"SIGNAL-BARRIER: waiting on $label, refA.waiters=$a refB.waiters=$b")
+                    ok
+                }
+            }
+        end awaitBarrier
+
         "interleaved self,other,self,other produces four emits" in {
             for
                 refA <- Signal.initRef(0)
@@ -547,15 +575,15 @@ class SignalTest extends kyo.test.Test[Any]:
                 f <- Fiber.initUnscoped(cl.streamChanges.take(5).run)
                 // streamChanges re-subscribes by racing refA.next and refB.next, so fire each change only after its waiter
                 // re-arms (a set in the re-arm gap is dropped, hanging the take). The first re-subscription is clean, so both refs arm to exactly 1.
-                _ <- assertEventually(Kyo.zip(refA.waiters, refB.waiters).map { case (a, b) => a == 1 && b == 1 })
+                _ <- awaitBarrier("initial-arm", refA, refB)((a, b) => a == 1 && b == 1)
                 _ <- refA.set(1)
                 // awaitAny cancels its losing branch without unregistering, leaving a ghost waiter; the next re-subscription
                 // arms that signal to 2 (ghost + live), so >= 2 proves the live re-arm landed, not a match on the stale ghost.
-                _  <- assertEventually(refB.waiters.map(_ >= 2))
+                _  <- awaitBarrier("after-setA-1", refA, refB)((_, b) => b >= 2)
                 _  <- refB.set(1)
-                _  <- assertEventually(refA.waiters.map(_ >= 2))
+                _  <- awaitBarrier("after-setB-1", refA, refB)((a, _) => a >= 2)
                 _  <- refA.set(2)
-                _  <- assertEventually(refB.waiters.map(_ >= 2))
+                _  <- awaitBarrier("after-setA-2", refA, refB)((_, b) => b >= 2)
                 _  <- refB.set(2)
                 vs <- f.get
             yield assert(vs == Chunk((0, 0), (1, 0), (1, 1), (2, 1), (2, 2)))

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -92,9 +92,17 @@ final private[kyo] class HttpClientBackend private (
                         val isDefaultPort   = if url.ssl then port == 443 else port == 80
                         val hostHeaderValue = if isDefaultPort || host.isEmpty then host else s"$host:$port"
                         val conn            = new HttpConnection(transportConn, http1, host, port, url.ssl, hostHeaderValue)
-                        resultPromise.completeDiscard(Result.succeed(conn))
+                        // The handoff is at-most-once, so a caller that already settled (a request timeout or any other
+                        // interrupt of `resultPromise`) leaves this connection undelivered. Nobody will ever use it and
+                        // nobody else holds it, so dropping the outcome would strand its socket for the life of the
+                        // process. Closing on a lost handoff is the same posture the transport takes when its own
+                        // connect completes after the caller has gone.
+                        if !resultPromise.complete(Result.succeed(conn)) then transportConn.close()
                     catch
                         case t: Throwable =>
+                            // The connection was established; only the wrapping failed. It is owned by nothing at this
+                            // point, so it has to be closed here or its descriptor outlives the process's interest in it.
+                            transportConn.close()
                             resultPromise.completeDiscard(Result.panic(t))
                     end try
                 case Result.Failure(netEx) =>

--- a/kyo-http/shared/src/test/scala/kyo/internal/HttpClientBackendTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/HttpClientBackendTest.scala
@@ -5,6 +5,9 @@ import kyo.*
 import kyo.internal.client.*
 import kyo.internal.http1.*
 import kyo.internal.util.*
+import kyo.net.DeferredConnectTransport
+import kyo.net.RecordingConnection
+import kyo.net.internal.transport.Connection as TransportConnection
 
 /** Integration and unit tests for HttpClientBackend.
   *
@@ -702,6 +705,36 @@ class HttpClientBackendTest extends kyo.BaseHttpTest:
       * A kyo server cannot produce these responses: its own serializer rejects a non-ASCII header value, so a peer writing
       * canned bytes is the only way to drive the client with what a foreign server can legally send.
       */
+    /** A connect whose caller has already gone must not strand the connection it establishes.
+      *
+      * The handoff to the caller is at-most-once. When the caller settles first, through a request timeout or any other interrupt, the
+      * connect still completes and builds a connection that nobody will ever read and nobody else holds; discarding the outcome of that
+      * handoff therefore strands its socket for the life of the process. The transport takes the opposite posture for its own connect,
+      * closing what it cannot deliver, and this pins the client to the same rule.
+      *
+      * The ordering is staged rather than raced: `DeferredConnectTransport` parks the connect until `release()`, so the caller's promise
+      * is settled FIRST and the connect lands SECOND, which is exactly the interleaving an interrupted caller produces. Nothing here
+      * depends on timing.
+      */
+    "a connect whose caller already settled closes the connection it established" in {
+        val (clientConn, _) = TransportConnection.inMemoryPair()
+        val recording       = new RecordingConnection(clientConn)
+        val transport       = new DeferredConnectTransport(recording)
+        val backend         = HttpClientBackend.init(transport, 2, 60.seconds)
+        val connectFiber    = backend.connect(HttpUrl.parse("http://test.invalid/").getOrThrow, 60.seconds, HttpTlsConfig.default)
+        // Settle the caller before the connect can hand anything over: from here the handoff is guaranteed to fail.
+        connectFiber.safe.interrupt.andThen {
+            Sync.Unsafe.defer(transport.release()).andThen {
+                Abort.run[Any](connectFiber.safe.getResult).andThen {
+                    assert(
+                        recording.wasClosed,
+                        "a connection established after its caller settled has no owner, so the connect must close it"
+                    )
+                }
+            }
+        }
+    }
+
     private def withRawPeer[A](response: String)(
         test: Int => A < (Async & Abort[Any] & Scope)
     )(using Frame): A < (Async & Abort[Any] & Scope) =

--- a/kyo-http/shared/src/test/scala/kyo/net/TestChannelTransport.scala
+++ b/kyo-http/shared/src/test/scala/kyo/net/TestChannelTransport.scala
@@ -67,3 +67,88 @@ final class TestChannelTransport(conns: Seq[Connection]) extends Transport:
     private[net] def capabilities: TransportCapabilities = TransportCapabilities(Set.empty, unixSockets = false)
 
 end TestChannelTransport
+
+/** Wraps a connection and records whether anything closed it. Delegation is total, so the wrapped connection behaves exactly as it would
+  * unwrapped; the only added behaviour is the flag. Lives here rather than in a test file because `Connection.start` is `private[net]`.
+  */
+final class RecordingConnection(underlying: Connection) extends Connection:
+    private val closed = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+    /** Whether `close()` has been called on this connection. */
+    def wasClosed: Boolean = closed.get()
+
+    def inbound: Channel.Unsafe[Span[Byte]]  = underlying.inbound
+    def outbound: Channel.Unsafe[Span[Byte]] = underlying.outbound
+
+    def isOpen(using AllowUnsafe): Boolean = underlying.isOpen
+
+    def close()(using AllowUnsafe, Frame): Unit =
+        closed.set(true)
+        underlying.close()
+
+    private[kyo] def onClosing: Fiber.Unsafe[Unit, Any] = underlying.onClosing
+
+    def detachForUpgrade()(using AllowUnsafe, Frame): Fiber.Unsafe[Maybe[Chunk[Span[Byte]]], Any] = underlying.detachForUpgrade()
+
+    private[net] def start()(using AllowUnsafe, Frame): Boolean = underlying.start()
+
+    def serverCertificateHash: Maybe[Span[Byte]] = underlying.serverCertificateHash
+
+    def status: Connection.Status = underlying.status
+end RecordingConnection
+
+/** Test transport whose `connect` parks until the test releases it, so a test can settle the caller's own promise FIRST and then let the
+  * connect succeed. That ordering is what an interrupted caller produces in production, and it cannot be staged with a transport that
+  * hands back an already-completed fiber.
+  */
+final class DeferredConnectTransport(conn: Connection)(using AllowUnsafe) extends Transport:
+    private val gate = Promise.Unsafe.init[Connection, Abort[NetException]]()
+
+    /** Let the pending connect succeed with the prepared connection. */
+    def release()(using AllowUnsafe, Frame): Unit = discard(gate.complete(Result.succeed(conn)))
+
+    def connect(host: String, port: Int, connectTimeout: Duration, config: NetConfig)(using
+        AllowUnsafe,
+        Frame
+    ): Fiber.Unsafe[Connection, Abort[NetException]] = gate
+
+    private def unsupported[A](op: String)(using AllowUnsafe): Fiber.Unsafe[A, Abort[NetException]] =
+        Fiber.Unsafe.fromResult(Result.panic(new UnsupportedOperationException(s"DeferredConnectTransport: $op not supported")))
+
+    def connectTls(host: String, port: Int, tls: NetTlsConfig, connectTimeout: Duration, config: NetConfig)(using
+        AllowUnsafe,
+        Frame
+    ): Fiber.Unsafe[Connection, Abort[NetException]] = unsupported("connectTls")
+
+    def connectUnix(path: String, connectTimeout: Duration, config: NetConfig)(using
+        AllowUnsafe,
+        Frame
+    ): Fiber.Unsafe[Connection, Abort[NetException]] = unsupported("connectUnix")
+
+    def stdio(channelCapacity: Int, readChunkSize: Int)(using
+        AllowUnsafe,
+        Frame
+    ): Fiber.Unsafe[Connection, Abort[NetException]] = unsupported("stdio")
+
+    def listen(host: String, port: Int, backlog: Int, config: NetConfig)(handler: Connection => Unit)(using
+        AllowUnsafe,
+        Frame
+    ): Fiber.Unsafe[Listener, Abort[NetException]] = unsupported("listen")
+
+    def listenTls(host: String, port: Int, backlog: Int, tls: NetTlsConfig, config: NetConfig)(handler: Connection => Unit)(using
+        AllowUnsafe,
+        Frame
+    ): Fiber.Unsafe[Listener, Abort[NetException]] = unsupported("listenTls")
+
+    def listenUnix(path: String, backlog: Int, config: NetConfig)(handler: Connection => Unit)(using
+        AllowUnsafe,
+        Frame
+    ): Fiber.Unsafe[Listener, Abort[NetException]] = unsupported("listenUnix")
+
+    def upgradeToTls(conn: Connection, tls: NetTlsConfig, channelCapacity: Int)(using
+        AllowUnsafe,
+        Frame
+    ): Fiber.Unsafe[Connection, Abort[NetException]] = unsupported("upgradeToTls")
+
+    private[net] def capabilities: TransportCapabilities = TransportCapabilities(Set.empty, unixSockets = false)
+end DeferredConnectTransport

--- a/kyo-net/js-wasm/src/main/scala/kyo/net/internal/JsTransport.scala
+++ b/kyo-net/js-wasm/src/main/scala/kyo/net/internal/JsTransport.scala
@@ -16,6 +16,7 @@ import kyo.net.NetNotUpgradableException
 import kyo.net.NetSocketOptionUnsupportedException
 import kyo.net.NetStdioAlreadyOpenException
 import kyo.net.NetTlsConfig
+import kyo.net.NetTlsConfigException
 import kyo.net.NetTlsHandshakeException
 import kyo.net.NetTlsHandshakeTimeoutException
 import kyo.net.NetUnixConnectException
@@ -24,6 +25,7 @@ import kyo.net.TransportCapabilities
 import kyo.net.internal.transport.*
 import kyo.scheduler.IOPromise
 import scala.scalajs.js
+import scala.util.control.NonFatal
 
 /** JS TCP transport delegating to Node.js `net` and `tls` modules.
   *
@@ -152,6 +154,12 @@ final private[kyo] class JsTransport private (
                     "hostnameVerification = false to opt out of name verification)"
             )))
         else
+            // Read every configured PEM before building the Node option object, so an unreadable path is reported on this method's declared
+            // failure channel like the two rejections above, instead of throwing out of the method as a Panic. See readConfiguredPems.
+            val pems = readConfiguredPems(tls, isServer = false) match
+                case Result.Success(p)  => p
+                case Result.Failure(ex) => return Fiber.Unsafe.fromResult(Result.fail(ex))
+                case Result.Panic(ex)   => return Fiber.Unsafe.fromResult(Result.panic(ex))
             val opts = js.Dynamic.literal(host = host, port = port)
             // rejectUnauthorized drives certificate-chain validation only; hostname check is a
             // separate concern routed through checkServerIdentity.
@@ -168,17 +176,12 @@ final private[kyo] class JsTransport private (
                 case Present(sni) => opts.servername = sni
                 case Absent       => opts.servername = host
             // Custom CA: Node's tls.connect loads this as the only trust anchor when present.
-            tls.caCertPath match
-                case Present(path) =>
-                    opts.ca = NodeFs.asInstanceOf[js.Dynamic].readFileSync(path, "utf8")
-                case Absent => ()
-            end match
+            pems.anchor.foreach(ca => opts.ca = ca)
             // Client certificate for mutual TLS: present it when the server requests one. A no-op for the common (no client cert) client.
-            (tls.certChainPath, tls.privateKeyPath) match
-                case (Present(certPath), Present(keyPath)) =>
-                    val fs = NodeFs.asInstanceOf[js.Dynamic]
-                    opts.cert = fs.readFileSync(certPath, "utf8")
-                    opts.key = fs.readFileSync(keyPath, "utf8")
+            (pems.cert, pems.key) match
+                case (Present(cert), Present(key)) =>
+                    opts.cert = cert
+                    opts.key = key
                 case _ => ()
             end match
             val socket = NodeTls.asInstanceOf[js.Dynamic].connect(opts)
@@ -203,16 +206,18 @@ final private[kyo] class JsTransport private (
         // closed rather than silently serving with Node under another provider's name (config truthfulness).
         if tls.tlsProvider.exists(_ != "node") then
             return Fiber.Unsafe.fromResult(Result.fail(NetTlsHandshakeException(host, port, rejectNonNodeProvider(tls))))
+        // As in connectTls: read the configured material first so an unreadable path is reported on the declared failure channel rather than
+        // thrown out of the method.
+        val pems = readConfiguredPems(tls, isServer = true) match
+            case Result.Success(p)  => p
+            case Result.Failure(ex) => return Fiber.Unsafe.fromResult(Result.fail(ex))
+            case Result.Panic(ex)   => return Fiber.Unsafe.fromResult(Result.panic(ex))
         val serverOpts = js.Dynamic.literal()
         // Constrain the negotiated TLS version on the server side too: a server pinned to TLS1.3 must reject a TLS1.2 client (CWE-326).
         applyVersionBounds(serverOpts, tls)
-        tls.certChainPath match
-            case Present(p) => serverOpts.cert = NodeFs.asInstanceOf[js.Dynamic].readFileSync(p, "utf8")
-            case Absent     => ()
-        tls.privateKeyPath match
-            case Present(p) => serverOpts.key = NodeFs.asInstanceOf[js.Dynamic].readFileSync(p, "utf8")
-            case Absent     => ()
-        applyServerClientAuth(serverOpts, tls)
+        pems.cert.foreach(cert => serverOpts.cert = cert)
+        pems.key.foreach(key => serverOpts.key = key)
+        applyServerClientAuth(serverOpts, tls, pems)
         val server = NodeTls.asInstanceOf[js.Dynamic].createServer(serverOpts)
         // One deadline per accepted connection: a client that completed the TCP accept but stalls the TLS handshake (sends nothing / a partial
         // ClientHello and never finishes) never fires "secureConnection", so the accepted Node socket would linger indefinitely, pinning the fd
@@ -239,6 +244,55 @@ final private[kyo] class JsTransport private (
 
     // -- shared helpers --
 
+    // Read a configured PEM file, reporting a read failure as NetTlsConfigException instead of letting Node's raw error escape.
+    //
+    // Every TLS tier owes the caller the same type for the same misconfiguration, because which tier runs is a property of the HOST rather
+    // than of the caller: the native providers raise NetTlsConfigException, the JVM Nio floor converts the JDK's exceptions to it, and Node
+    // here would otherwise surface a raw JavaScriptException ("ENOENT: no such file or directory"). Left unconverted, one NetTlsConfig and one
+    // operator typo are catchable on one platform and escape the same catch on another.
+    //
+    // `material` and `path` are named because the message is the only place the failure stays attributable to the setting that caused it. Only
+    // NonFatal failures convert: a fatal error is not a configuration problem and must keep propagating as itself.
+    private def readConfiguredPem(material: String, path: String)(using Frame): String =
+        try NodeFs.asInstanceOf[js.Dynamic].readFileSync(path, "utf8").asInstanceOf[String]
+        catch
+            case ex: Throwable if NonFatal(ex) =>
+                throw NetTlsConfigException(s"configured $material at $path could not be read: ${ex.getMessage}")
+    end readConfiguredPem
+
+    // Every configured PEM a TLS role needs, read up front as a Result.
+    //
+    // Reading here rather than at each option assignment is what puts a misconfigured path on the method's declared failure channel. These
+    // methods return a Fiber whose failure channel is Abort[NetException], and their sibling config rejections (a non-node provider pin, a
+    // verifying client with no reference identity) both report through it. A read that throws from inside the option-building instead escapes
+    // the method synchronously and reaches the caller as a Panic, which Abort.run[NetException] does not catch, so the caller who correctly
+    // folds the declared channel would see nothing. Uniform typing across the tiers is only worth anything if the failure arrives on the same
+    // channel too.
+    /** Reads exactly the material the given ROLE consumes, and no more. A client verifies the server chain against `caCertPath`; a server
+      * verifies a presented client certificate against `trustStorePath`, falling back to `caCertPath`. Reading the union instead would fail
+      * a client on an unreadable `trustStorePath` it never opens, and fail a server on an unreadable `caCertPath` that a present
+      * `trustStorePath` shadows, so Node would reject configurations the other tiers accept. The whole point of the typed failure is that
+      * one config behaves the same everywhere, and over-reading here would break that in the opposite direction.
+      */
+    private def readConfiguredPems(tls: NetTlsConfig, isServer: Boolean)(using Frame): Result[NetTlsConfigException, TlsPems] =
+        val anchorPath = if isServer then tls.trustStorePath.orElse(tls.caCertPath) else tls.caCertPath
+        val anchorName = if isServer then "trust store" else "CA certificate"
+        try
+            Result.succeed(TlsPems(
+                anchor = anchorPath.map(readConfiguredPem(anchorName, _)),
+                cert = tls.certChainPath.map(readConfiguredPem("certificate chain", _)),
+                key = tls.privateKeyPath.map(readConfiguredPem("private key", _))
+            ))
+        catch case ex: NetTlsConfigException => Result.fail(ex)
+        end try
+    end readConfiguredPems
+
+    /** The PEM contents for one TLS role, already read off disk. `anchor` is the resolved verification anchor for that role, so the
+      * trust-store-over-CA precedence is applied once at read time rather than at each use. `Absent` means the path was never configured,
+      * which is distinct from a configured path that could not be read (that fails in [[readConfiguredPems]] and never reaches here).
+      */
+    private case class TlsPems(anchor: Maybe[String], cert: Maybe[String], key: Maybe[String])
+
     // Map NetTlsConfig.minVersion/maxVersion onto Node's tls minVersion/maxVersion option keys. Node accepts the protocol strings
     // "TLSv1.2"/"TLSv1.3"; setting both bounds means the negotiated version is constrained to the configured range, so a TLS1.3-only config
     // cannot fall back to TLS1.2 (CWE-326). Applied to every Node tls option object the transport builds (connect, listen, both upgrade arms).
@@ -254,7 +308,7 @@ final private[kyo] class JsTransport private (
     // asks the client for a certificate; rejectUnauthorized rejects a client that presents none or one the trust store + ca does not validate.
     // Required rejects; Optional requests but does not reject; None leaves the defaults (no client cert requested). The presented client
     // certificate is validated against trustStorePath, falling back to caCertPath.
-    private def applyServerClientAuth(opts: js.Dynamic, tls: NetTlsConfig): Unit =
+    private def applyServerClientAuth(opts: js.Dynamic, tls: NetTlsConfig, pems: TlsPems): Unit =
         tls.clientAuth match
             case NetTlsConfig.ClientAuth.Required =>
                 opts.requestCert = true
@@ -264,9 +318,7 @@ final private[kyo] class JsTransport private (
                 opts.rejectUnauthorized = false
             case NetTlsConfig.ClientAuth.None => ()
         end match
-        tls.trustStorePath.orElse(tls.caCertPath).foreach { p =>
-            opts.ca = NodeFs.asInstanceOf[js.Dynamic].readFileSync(p, "utf8")
-        }
+        pems.anchor.foreach(ca => opts.ca = ca)
     end applyServerClientAuth
 
     // Property name under which each accepted raw socket carries a one-shot "handshake settled" guard, so the deadline timer and the
@@ -871,6 +923,13 @@ final private[kyo] class JsTransport private (
         // verify peer identity, so this guard is client-side only.
         // Safe: the guard above already confirmed conn.isInstanceOf[Connection[?]] && ....handle.isInstanceOf[JsHandle] before this point
         // (the guard's return is the only path past it), so this narrowing to Connection[JsHandle] cannot fail.
+        // As in connectTls / listenTls, read the configured material so an unreadable path is reported on the declared failure channel. It
+        // sits after the upgradability guard because the ROLE is only knowable here, and the role decides which material is even consumed:
+        // an upgrade inherits its direction from the connection's TCP origin.
+        val pems = readConfiguredPems(tls, isServer = conn.asInstanceOf[Connection[JsHandle]].isServerOrigin) match
+            case Result.Success(p)  => p
+            case Result.Failure(ex) => return Fiber.Unsafe.fromResult(Result.fail(ex))
+            case Result.Panic(ex)   => return Fiber.Unsafe.fromResult(Result.panic(ex))
         val clientUpgradeNoIdentity =
             !conn.asInstanceOf[Connection[JsHandle]].isServerOrigin && !tls.trustAll && tls.hostnameVerification &&
                 tls.sniHostname.getOrElse("").isEmpty
@@ -989,7 +1048,6 @@ final private[kyo] class JsTransport private (
             discard(socket.resume())
 
             val tlsModule = NodeTls.asInstanceOf[js.Dynamic]
-            val fsModule  = NodeFs.asInstanceOf[js.Dynamic]
 
             // The TLS role follows the connection's TCP origin: an accepted connection (isServerOrigin) upgrades as the TLS server, a connected one
             // as the client (STARTTLS initiate). The origin is authoritative: a config heuristic ("has a cert+key therefore server") would
@@ -1004,14 +1062,10 @@ final private[kyo] class JsTransport private (
                     opts.isServer = true
                     // Constrain the negotiated TLS version on the upgraded server socket (CWE-326).
                     applyVersionBounds(opts, tls)
-                    tls.certChainPath match
-                        case Present(p) => opts.cert = fsModule.readFileSync(p, "utf8")
-                        case Absent     => ()
-                    tls.privateKeyPath match
-                        case Present(p) => opts.key = fsModule.readFileSync(p, "utf8")
-                        case Absent     => ()
+                    pems.cert.foreach(cert => opts.cert = cert)
+                    pems.key.foreach(key => opts.key = key)
                     // Mutual TLS: honor clientAuth on the upgraded server socket, matching listen(tls) and the posix/NIO server STARTTLS path.
-                    applyServerClientAuth(opts, tls)
+                    applyServerClientAuth(opts, tls, pems)
                     // Construct TLSSocket directly with the existing socket and server opts
                     js.Dynamic.newInstance(tlsModule.selectDynamic("TLSSocket"))(socket, opts)
                 else
@@ -1031,16 +1085,12 @@ final private[kyo] class JsTransport private (
                         // but SAN/CN vs servername mismatch is ignored (verify-ca semantics).
                         opts.checkServerIdentity = ({ (_: js.Any, _: js.Any) => js.undefined }: js.Function2[js.Any, js.Any, js.Any])
                     end if
-                    tls.caCertPath match
-                        case Present(path) =>
-                            opts.ca = fsModule.readFileSync(path, "utf8")
-                        case Absent => ()
-                    end match
+                    pems.anchor.foreach(ca => opts.ca = ca)
                     // Client certificate for mutual TLS: present it when the server requests one. A no-op for the common (no client cert) client.
-                    (tls.certChainPath, tls.privateKeyPath) match
-                        case (Present(certPath), Present(keyPath)) =>
-                            opts.cert = fsModule.readFileSync(certPath, "utf8")
-                            opts.key = fsModule.readFileSync(keyPath, "utf8")
+                    (pems.cert, pems.key) match
+                        case (Present(cert), Present(key)) =>
+                            opts.cert = cert
+                            opts.key = key
                         case _ => ()
                     end match
                     tlsModule.connect(opts)

--- a/kyo-net/js-wasm/src/test/scala/kyo/net/internal/JsTransportTlsConfigTest.scala
+++ b/kyo-net/js-wasm/src/test/scala/kyo/net/internal/JsTransportTlsConfigTest.scala
@@ -1,0 +1,84 @@
+package kyo.net.internal
+
+import kyo.*
+import kyo.net.NetException
+import kyo.net.NetTlsConfig
+import kyo.net.NetTlsConfigException
+import kyo.net.Test
+import scala.scalajs.js as sjs
+
+/** Reproduce-first tests pinning the Node TLS path's configuration failure to [[NetTlsConfigException]], delivered on the failure channel
+  * `connectTls` / `listenTls` declare.
+  *
+  * Two things are under test, and the second is the one a caller actually feels:
+  *   - TYPE. The native providers and the JVM Nio floor report an unreadable configured PEM as `NetTlsConfigException`. Node's `readFileSync`
+  *     raises its own error ("ENOENT: no such file or directory"), so the same [[NetTlsConfig]] and the same operator typo produced a
+  *     different type on this platform than on the others.
+  *   - CHANNEL. Both methods return a `Fiber` whose failure channel is `Abort[NetException]`, and their sibling config rejections (a non-node
+  *     provider pin, a verifying client with no reference identity) both report through it. A read that throws from inside the option-building
+  *     escapes the method instead and reaches the caller as a Panic, which `Abort.run[NetException]` does not catch. So each leaf asserts
+  *     `Result.Failure` specifically, never merely "it failed": a Panic here would mean the caller who correctly folds the declared channel
+  *     still sees nothing.
+  *
+  * Anti-flakiness: no leaf reaches a socket. The configured material is read before any Node option object is built, so `listenTls` never
+  * binds and `connectTls` never dials; there is no peer, no handshake and no timing. The unreadable path is a fresh temp name that is never
+  * created, so the read fails deterministically.
+  */
+class JsTransportTlsConfigTest extends Test:
+
+    import AllowUnsafe.embrace.danger
+
+    private val fs       = sjs.Dynamic.global.require("fs")
+    private val os       = sjs.Dynamic.global.require("os")
+    private val nodePath = sjs.Dynamic.global.require("path")
+
+    /** An absolute path that does not exist, so any read of it fails deterministically. */
+    private def unreadablePath(): String =
+        nodePath.join(os.tmpdir().asInstanceOf[String], "kyo-net-js-tls-missing.pem").asInstanceOf[String] + "-does-not-exist"
+
+    private def writeTempPem(content: String, name: String): String =
+        val path = nodePath.join(os.tmpdir().asInstanceOf[String], name).asInstanceOf[String]
+        fs.writeFileSync(path, content)
+        path
+    end writeTempPem
+
+    private lazy val certPath: String = writeTempPem(kyo.net.TlsTestCertShared.certPem, "kyo-js-tlscfg-cert.pem")
+    private lazy val keyPath: String  = writeTempPem(kyo.net.TlsTestCertShared.keyPem, "kyo-js-tlscfg-key.pem")
+
+    "a server with an unreadable configured certChainPath fails the listen with NetTlsConfigException" in {
+        val transport = JsTransport.init(poolSize = 1)
+        val tls       = NetTlsConfig(certChainPath = Present(unreadablePath()), privateKeyPath = Present(keyPath))
+        Abort.run[NetException](transport.listenTls("127.0.0.1", 0, 128, tls)(_ => ()).safe.get).map {
+            case Result.Failure(_: NetTlsConfigException) => succeed
+            case Result.Success(listener) =>
+                listener.close()
+                fail("a listen with an unreadable configured certChainPath must not bind")
+            case other => fail(s"expected Failure(NetTlsConfigException) on the declared channel, got: $other")
+        }
+    }
+
+    "a verifying client with an unreadable configured caCertPath fails the connect with NetTlsConfigException" in {
+        val transport = JsTransport.init(poolSize = 1)
+        val tls       = NetTlsConfig(caCertPath = Present(unreadablePath()))
+        Abort.run[NetException](transport.connectTls("127.0.0.1", 1, tls).safe.get).map {
+            case Result.Failure(_: NetTlsConfigException) => succeed
+            case Result.Success(conn) =>
+                conn.close()
+                fail("a connect with an unreadable configured caCertPath must not succeed")
+            case other => fail(s"expected Failure(NetTlsConfigException) on the declared channel, got: $other")
+        }
+    }
+
+    // Boundary control: configured material that reads fine must still bind, so the guard above cannot be satisfied by rejecting every TLS
+    // listen. This is what separates "configured but unreadable" from "configured and usable".
+    "a server with readable configured material still binds" in {
+        val transport = JsTransport.init(poolSize = 1)
+        val tls       = NetTlsConfig(certChainPath = Present(certPath), privateKeyPath = Present(keyPath))
+        transport.listenTls("127.0.0.1", 0, 128, tls)(_ => ()).safe.get.map { listener =>
+            val bound = listener.port
+            listener.close()
+            assert(bound > 0, "a listener with readable configured material must bind to a real port")
+        }
+    }
+
+end JsTransportTlsConfigTest

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/BoringSslProviderConfiguredPemTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/BoringSslProviderConfiguredPemTest.scala
@@ -13,8 +13,8 @@ import kyo.net.Test
   *
   * The control is RFC 9525 / CWE-295 fail-closed: a verifying client that points `caCertPath` at a file it cannot read has had its pinned
   * private CA dropped. Falling back to the system trust store in that case silently weakens validation (the operator's pin is gone without
-  * notice), so `createEngine` MUST reject. The JDK floor already converges to this posture: `NioTransport.loadCaCertTrustManagers` opens the
-  * configured CA with a plain `FileInputStream` and lets the resulting exception propagate out of `createSslContext` rather than swallowing it.
+  * notice), so `createEngine` MUST reject. The JDK floor holds the same posture and reports the same type: `NioTransport` wraps an unreadable
+  * configured path as `NetTlsConfigException` rather than swallowing it or letting a raw JDK exception escape.
   *
   * The distinction drawn is between "path never configured" (`Absent`, keep the system-trust default, the non-verifying / no-CA cases)
   * and "path configured but unreadable / unparseable" (fail closed). The `Absent` boundary is pinned by a positive control: a verifying client
@@ -35,11 +35,55 @@ class BoringSslProviderConfiguredPemTest extends Test:
         f.getAbsolutePath + "-does-not-exist"
     end unreadablePath
 
+    /** A path that EXISTS and is readable but holds no certificate. Distinct from [[unreadablePath]]: that one fails at the read, this one
+      * reads fine and fails inside the library, which is the case the loader's return code is the only witness to.
+      */
+    private def certificateFreePath(): String =
+        val f = java.io.File.createTempFile("kyo-net-tls-noncert", ".pem")
+        java.nio.file.Files.write(f.toPath, "NOT A CERTIFICATE\n".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+        f.deleteOnExit()
+        f.getAbsolutePath
+    end certificateFreePath
+
+    /** Drive the readable-but-certificate-free CA against one provider. The PEM read SUCCEEDS here, so the only signal that the trust anchor
+      * did not take is the loader's return code. Left unchecked, the engine builds with an EMPTY trust store and every verification decision
+      * afterwards is made against trust the caller never configured, which surfaces later as an opaque handshake failure.
+      */
+    private def assertCertificateFreeCaFailsClosed(create: (NetTlsConfig, String, Boolean) => TlsEngine)(using
+        Frame,
+        kyo.test.AssertScope
+    ): Unit =
+        val config = NetTlsConfig(caCertPath = Present(certificateFreePath()))
+        val ex = intercept[NetTlsConfigException] {
+            val engine = create(config, "localhost", false)
+            // Defensive, as above: a regression returns a live engine over an empty store rather than throwing.
+            engine.free()
+        }
+        discard(ex)
+    end assertCertificateFreeCaFailsClosed
+
+    /** Drive a server whose certificate chain READS fine but holds no certificate. The unreadable-path leaves stop at `readPem`, so they never
+      * reach the cert/key loader at all; only a readable-but-invalid pair gets that far, which makes `ctxSetCert`'s return code the sole
+      * witness. Unchecked, the server builds with no identity to present and every handshake fails opaquely rather than naming the config.
+      */
+    private def assertCertificateFreeServerMaterialFailsClosed(create: (NetTlsConfig, String, Boolean) => TlsEngine)(using
+        Frame,
+        kyo.test.AssertScope
+    ): Unit =
+        val config = NetTlsConfig(certChainPath = Present(certificateFreePath()), privateKeyPath = Present(TlsTestCert.keyPath))
+        val ex = intercept[NetTlsConfigException] {
+            val engine = create(config, "localhost", true)
+            // Defensive, as above: a regression returns a live engine carrying no usable identity rather than throwing.
+            engine.free()
+        }
+        discard(ex)
+    end assertCertificateFreeServerMaterialFailsClosed
+
     private def boringSsl(using Frame): (NetTlsConfig, String, Boolean) => TlsEngine = BoringSslProvider.createEngine(_, _, _)
     private def openSsl(using Frame): (NetTlsConfig, String, Boolean) => TlsEngine   = SystemOpenSslProvider.createEngine(_, _, _)
 
     /** Drive the configured-but-unreadable-CA repro against one provider's `createEngine`. A verifying client (the two defaults,
-      * `trustAll = false` and `hostnameVerification = true`) with `caCertPath` set to a nonexistent file must FAIL CLOSED (`Closed`) instead of
+      * `trustAll = false` and `hostnameVerification = true`) with `caCertPath` set to a nonexistent file must FAIL CLOSED (`NetTlsConfigException`) instead of
       * silently building an engine that falls back to the system trust store.
       */
     private def assertCaFailsClosed(create: (NetTlsConfig, String, Boolean) => TlsEngine)(using Frame, kyo.test.AssertScope): Unit =
@@ -81,8 +125,8 @@ class BoringSslProviderConfiguredPemTest extends Test:
 
     // The bug (CWE-295 silent weakening) this guards: a verifying client whose configured caCertPath is unreadable must not fall back to the
     // system trust store. If readPem swallowed the read error to Absent and applyConfig treated Absent as "no CA configured, use system trust",
-    // createEngine would SUCCEED (the pin silently dropped); the CORRECT behavior is to reject (the JDK loadCaCertTrustManagers posture), so this
-    // asserts a Closed is thrown.
+    // createEngine would SUCCEED (the pin silently dropped); the CORRECT behavior is to reject (the same posture the JDK floor holds), so this
+    // asserts a NetTlsConfigException is thrown.
     "BoringSSL: a verifying client with an unreadable configured caCertPath fails closed instead of falling back to system trust" in {
         if !TlsRealEngines.boringSslAvailable() then cancel("BoringSSL not staged for this host")
         Sync.defer(assertCaFailsClosed(boringSsl))
@@ -91,6 +135,30 @@ class BoringSslProviderConfiguredPemTest extends Test:
     "OpenSSL: a verifying client with an unreadable configured caCertPath fails closed instead of falling back to system trust" in {
         if !TlsRealEngines.openSslAvailable() then cancel("system OpenSSL not available for this host")
         Sync.defer(assertCaFailsClosed(openSsl))
+    }
+
+    // The unreadable-path leaves above cover a CA that cannot be READ. A CA that reads fine and contains no certificate is a separate case:
+    // the read succeeds, so only the loader's return code says the anchor did not take, and discarding it leaves an empty trust store.
+    "BoringSSL: a readable caCertPath holding no certificate fails closed instead of building over an empty trust store" in {
+        if !TlsRealEngines.boringSslAvailable() then cancel("BoringSSL not staged for this host")
+        Sync.defer(assertCertificateFreeCaFailsClosed(boringSsl))
+    }
+
+    "OpenSSL: a readable caCertPath holding no certificate fails closed instead of building over an empty trust store" in {
+        if !TlsRealEngines.openSslAvailable() then cancel("system OpenSSL not available for this host")
+        Sync.defer(assertCertificateFreeCaFailsClosed(openSsl))
+    }
+
+    // The server cert/key loader needs its own readable-but-invalid case. The unreadable-path server leaves above fail at the READ, so they
+    // never reach the loader and would pass with its return code discarded; only material that reads successfully exercises it.
+    "BoringSSL: a server whose readable certificate chain holds no certificate fails closed instead of starting with no identity" in {
+        if !TlsRealEngines.boringSslAvailable() then cancel("BoringSSL not staged for this host")
+        Sync.defer(assertCertificateFreeServerMaterialFailsClosed(boringSsl))
+    }
+
+    "OpenSSL: a server whose readable certificate chain holds no certificate fails closed instead of starting with no identity" in {
+        if !TlsRealEngines.openSslAvailable() then cancel("system OpenSSL not available for this host")
+        Sync.defer(assertCertificateFreeServerMaterialFailsClosed(openSsl))
     }
 
     // The same swallow path backs the server cert/key material: an unreadable certChainPath or privateKeyPath is dropped to Absent and the

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/IoUringDriverConnectCloseRaceTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/IoUringDriverConnectCloseRaceTest.scala
@@ -1,0 +1,86 @@
+package kyo.net.internal.posix
+
+import kyo.*
+import kyo.ffi.Buffer
+import kyo.net.NetException
+import kyo.net.Test
+
+/** Ghost-connect regression guard for [[IoUringDriver]]: a connect arm belonging to a handle whose close has already run must never reach the
+  * ring.
+  *
+  * `awaitConnect` only ENQUEUES the arm on the engine FIFO; the SQE is prepped later, on the reap carrier. The connect-phase close in
+  * `PosixTransport.closeUnwiredHandle` closes the fd IMMEDIATELY on the caller's carrier rather than through the driver's deferred path, so a
+  * close that lands between the enqueue and the drain frees the fd number while the arm is still queued. The kernel is free to hand that
+  * number to the next socket, and a late-draining arm would then prep `IORING_OP_CONNECT` against a socket belonging to somebody else. The
+  * same window opens a second way: on a full submission queue the arm parks in `stalledSubmits` and `reArmStalledSubmits` re-enters the
+  * submit later, by which point the handle may be long closed.
+  *
+  * `submitAccept` already rejects a closing handle for exactly this reason. This pins the connect side of that invariant.
+  *
+  * The ordering is structural rather than timed: the engine FIFO is ordered, so a second arm on a healthy handle enqueued behind the closing
+  * one is a barrier. When the healthy fd reaches `kyo_uring_prep_connect`, the closing arm has already drained, and what it did is then a
+  * settled fact. Waiting on the closing arm's own promise would not work, since an unguarded submit leaves that promise pending forever.
+  *
+  * Runs over the ringless [[StubIoUringBindings]], so it exercises the real submit path on every platform rather than only where a kernel
+  * io_uring is available.
+  */
+class IoUringDriverConnectCloseRaceTest extends Test:
+
+    import AllowUnsafe.embrace.danger
+
+    private val ClosingFd = 7
+    private val HealthyFd = 9
+
+    "a connect arm for a handle whose close already ran never preps an SQE on its freed fd" in {
+        val stub = new StubIoUringBindings
+        val ring = Buffer.alloc[Byte](stub.kyo_uring_sizeof().toInt)
+        val drv  = TestDrivers.forBindings(stub, ring, StubSocketBindings)
+        discard(drv.start())
+        Sync.ensure(Sync.defer(drv.close())) {
+            val closingAddr = Buffer.alloc[Byte](16)
+            val healthyAddr = Buffer.alloc[Byte](16)
+            val closing =
+                PosixHandle.socket(ClosingFd, PosixHandle.DefaultReadBufferSize, Present((closingAddr, 16)), Frame.internal)
+            val healthy =
+                PosixHandle.socket(HealthyFd, PosixHandle.DefaultReadBufferSize, Present((healthyAddr, 16)), Frame.internal)
+            // Reproduce the production shape exactly, which is what makes this leaf load-bearing. The connect-phase close in
+            // `PosixTransport.closeUnwiredHandle` wins `claimFdClose()` and closes the fd on the CALLER's carrier; it never calls
+            // `requestClose()`, because on a connection handle that would free buffers a kernel-owned recv may still reference. So the
+            // handle's guard bit stays unset here, and a guard keyed on `isClosing()` would read false at exactly the moment the fd number
+            // has already been handed back to the kernel. The claim is the only state that moves when the fd does.
+            assert(closing.claimFdClose(), "the leaf must be the one that claims the fd close")
+            stub.setConnectBarrierFd(HealthyFd)
+            val closingPromise = Promise.Unsafe.init[Unit, Abort[Closed | NetException]]()
+            val healthyPromise = Promise.Unsafe.init[Unit, Abort[Closed | NetException]]()
+            drv.awaitConnect(closing, closingPromise)
+            drv.awaitConnect(healthy, healthyPromise)
+            stub.connectBarrierP.safe.get.andThen {
+                val armed = stub.prepConnectFds
+                assert(
+                    !armed.contains(ClosingFd),
+                    s"a closing handle's connect arm must not reach the ring, fds armed: $armed"
+                )
+                assert(
+                    armed.size == 1 && armed.head == HealthyFd,
+                    s"only the healthy handle's connect may be armed, fds armed: $armed"
+                )
+                // Rejecting the arm has to settle its promise too. A rejection that merely skips the submit leaves the caller parked on a
+                // connect that no completion will ever arrive for, which trades a misdirected connect for a hang.
+                closingPromise.safe.getResult.map { result =>
+                    assert(
+                        result.isFailure,
+                        s"a rejected connect arm must fail its promise rather than strand the caller, got $result"
+                    )
+                    closingAddr.close()
+                    healthyAddr.close()
+                    // The real deferred discharge would free these; nothing armed a recv here, so releasing them directly is safe and
+                    // keeps the fork's descriptor accounting clean.
+                    closing.requestClose()
+                    healthy.requestClose()
+                    succeed
+                }
+            }
+        }
+    }
+
+end IoUringDriverConnectCloseRaceTest

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/IoUringDriverConnectInterruptTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/IoUringDriverConnectInterruptTest.scala
@@ -1,0 +1,132 @@
+package kyo.net.internal.posix
+
+import kyo.*
+import kyo.ffi.Buffer
+import kyo.ffi.Ffi
+import kyo.net.Test
+
+/** Descriptor reclamation for a connect interrupted while the kernel still owns its submission.
+  *
+  * A connect that never completes still owns a socket. `PosixTransport`'s completion arm creates the fd, hands the connect to the driver, and
+  * parks the caller on a promise; nothing else holds that fd. So when the caller is interrupted, the connect-failure arm is the only thing
+  * that can give the descriptor back. `awaitConnectThen` forwards an external interrupt onto the connect arm precisely so that arm's
+  * `onComplete` reaches `closeUnwiredHandle`, and nothing exercised that forwarding, so it could stop reclaiming and no test would notice
+  * until a workload that interrupts connects ran out of descriptors.
+  *
+  * The reclamation is deliberately SYNCHRONOUS on the caller's carrier, and that asymmetry against its non-connect sibling is what this pins.
+  * The driver's deferred close discharges only once the handle's in-flight count drains, and it forces an in-flight RECV to reap by shutting
+  * the read half; there is no equivalent forcing for an in-flight CONNECT, a gap the driver's own teardown comment states outright. Route the
+  * connect-phase close through the deferred path and the count never reaches zero, the credit never discharges, and every interrupted connect
+  * leaks rather than a rare few.
+  *
+  * THE DRIVER IS A REAL [[IoUringDriver]], which is the only reason this leaf can see that. The deferral lives in the driver's own
+  * `submitEngineOp` and the reap-carrier FIFO behind it. A backend without a submission ring runs engine ops inline, so the same scenario over
+  * one cannot distinguish a close deferred forever from a close that ran, and a leaf built that way passes against the regression it was
+  * written to catch. What makes the real driver usable here is the ringless stub: it supplies no completion for the connect, so the SQE is
+  * prepped and can never reap, which is the substrate's equivalent of a black-holed handshake with no kernel required. The socket bindings are
+  * REAL, so the fd is a real non-stdio descriptor and its close is a real close; the driver leaves fds 0 and 1 alone as process-owned stdio,
+  * so a stubbed socket layer handing out 0 would report a leak that is an artifact of the fixture.
+  *
+  * The connect is armed for real rather than stalled at the decorator. A stalled arm registers nothing, so the handle's in-flight count is
+  * zero, `registerDeferredClose` takes its immediate branch, and the deferred path under test never runs at all.
+  *
+  * Two barriers, both events. `onAwaitConnect` fires before the arm is enqueued, which is what makes it safe to install the stub's prep
+  * barrier there, and `connectBarrierP` then reports that the SQE is genuinely prepped and in flight before the interrupt is issued. The
+  * second barrier is the close itself: the reclamation runs after the caller's own promise has already completed, so the interrupted fiber's
+  * result is NOT a barrier on it, and asserting there reads the close count before the close can have run and reports a leak that is not
+  * there. `closed(fd)` completes on the real `close(fd)`, so a descriptor that is never returned leaves this leaf pending and the harness
+  * budget reports it. Nothing measures elapsed time.
+  */
+class IoUringDriverConnectInterruptTest extends Test:
+
+    import AllowUnsafe.embrace.danger
+
+    /** The RING is stubbed here, but the SOCKETS are real, and that is what bounds the platforms this can run on:
+      * `SocketBindingsImpl` has no Windows implementation, so on Windows the leaf dies in class initialization inside the very first
+      * `socket()` call, before a connect is ever issued. Cancel there rather than fail, the same way the sibling posix leaves gate
+      * themselves off a platform that cannot provide their substrate. Linux and macOS/BSD both supply real POSIX sockets, and the driver
+      * under test is ordinary Scala over the bindings, so a stubbed ring exercises it identically on either.
+      */
+    private def assumePosixSockets(): Unit =
+        if !(PosixConstants.isLinux || PosixConstants.isMacOrBsd) then
+            cancel("real POSIX sockets are needed here and SocketBindingsImpl has no Windows implementation")
+
+    "an interrupted in-flight connect closes its socket exactly once" in {
+        assumePosixSockets()
+        given Frame = Frame.internal
+        val spy     = RecordingSocketBindings(Ffi.load[SocketBindings])
+        val stub    = new StubIoUringBindings
+        val ring    = Buffer.alloc[Byte](stub.kyo_uring_sizeof().toInt)
+        // Decorated only for the connect hook; the label still resolves to the real driver's, so the transport selects the completion arm
+        // on the driver's own identity rather than on an override.
+        val driver = RecordingIoDriver(TestDrivers.forBindings(stub, ring, spy))
+        discard(driver.start())
+        val transport = TestTransports.forTesting(driver, spy, backendIsEpoll = false)
+
+        val connectFd = new java.util.concurrent.atomic.AtomicInteger(-1)
+        driver.onAwaitConnect = handle =>
+            connectFd.set(handle.writeFd)
+            // Installed before the arm reaches the engine queue, so the prep can never precede the barrier that watches for it.
+            stub.setConnectBarrierFd(handle.writeFd)
+
+        Fiber.initUnscoped(
+            Abort.run[kyo.net.NetException | Closed](
+                transport.connect("127.0.0.1", 9, 1.minute, kyo.net.NetConfig.default).safe.get
+            )
+        ).flatMap { fiber =>
+            stub.connectBarrierP.safe.get.andThen {
+                val fd = connectFd.get()
+                // Registered before the interrupt so the close cannot land ahead of the barrier that waits for it.
+                val reclaimed = spy.closed(fd)
+                fiber.interrupt.andThen {
+                    reclaimed.safe.get.andThen {
+                        val closes = Maybe(spy.closeCounts.get(fd)).getOrElse(0)
+                        driver.close()
+                        assert(
+                            closes == 1,
+                            s"an interrupted connect must return its descriptor exactly once, fd=$fd saw $closes close(s): " +
+                                "2 closes a number the kernel may have already reassigned to an unrelated socket"
+                        )
+                        succeed
+                    }
+                }
+            }
+        }
+    }
+
+    /** A connect whose submission cannot be prepared must fail its caller, not sit in the driver forever.
+      *
+      * `io_uring_get_sqe` advances the submission tail as it hands the entry out, so by the time the prep runs the slot is already committed
+      * to the kernel and cannot be given back. The op is registered before that, which is what makes a raising prep so much worse than a
+      * failing one: the pending entry and the in-flight count it holds stay behind, the handle's deferred close waits on a completion for an
+      * op the kernel never received, and the descriptor is owed for the life of the process. Nothing above the driver learns, because the
+      * engine FIFO's backstop catches the throw so one connection's failure cannot stop the others draining.
+      *
+      * That is the descriptor leak this pins, and it is why the assertion is on the CALLER rather than on any driver internal: a withdrawn op
+      * is one whose caller was told. The stub raises out of the connect prep the way marshalling a released buffer does on JVM; without the
+      * withdrawal the connect promise is never completed at all and this leaf runs to the harness budget rather than failing an assertion.
+      * Nothing measures elapsed time.
+      */
+    "a connect whose submission cannot be prepared fails its caller" in {
+        assumePosixSockets()
+        given Frame = Frame.internal
+        val spy     = RecordingSocketBindings(Ffi.load[SocketBindings])
+        val stub    = new StubIoUringBindings
+        stub.failPrepConnect = true
+        val ring   = Buffer.alloc[Byte](stub.kyo_uring_sizeof().toInt)
+        val driver = RecordingIoDriver(TestDrivers.forBindings(stub, ring, spy))
+        discard(driver.start())
+        val transport = TestTransports.forTesting(driver, spy, backendIsEpoll = false)
+
+        Abort.run[kyo.net.NetException | Closed](
+            transport.connect("127.0.0.1", 9, 1.minute, kyo.net.NetConfig.default).safe.get
+        ).map { result =>
+            driver.close()
+            assert(
+                result.isFailure || result.isPanic,
+                s"a connect whose prep raised must be reported to the caller, got $result"
+            )
+        }
+    }
+
+end IoUringDriverConnectInterruptTest

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/IoUringProbeDepthTest.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/IoUringProbeDepthTest.scala
@@ -36,6 +36,8 @@ class IoUringProbeDepthTest extends Test:
             AllowUnsafe
         ): Unit = ()
         def kyo_uring_prep_connect(sqe: Ffi.Handle[IoUringSqe], fd: Int, addr: Buffer[Byte], addrlen: Int)(using AllowUnsafe): Unit = ()
+        def kyo_uring_prep_cancel64(sqe: Ffi.Handle[IoUringSqe], userData: Long, flags: Int)(using AllowUnsafe): Unit               = ()
+        def kyo_uring_prep_nop(sqe: Ffi.Handle[IoUringSqe])(using AllowUnsafe): Unit                                                = ()
         def kyo_uring_sqe_set_data64(sqe: Ffi.Handle[IoUringSqe], data: Long)(using AllowUnsafe): Unit                              = ()
         def kyo_uring_wait_cqe_timeout(ring: Buffer[Byte], cqePtr: Buffer[Long], timeoutNs: Long)(using
             AllowUnsafe

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/RecordingDecorators.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/RecordingDecorators.scala
@@ -356,6 +356,12 @@ class RecordingIoUringBindings(real: IoUringBindings, realRing: Buffer[Byte]) ex
     def kyo_uring_prep_connect(sqe: Ffi.Handle[IoUringSqe], fd: Int, addr: Buffer[Byte], addrlen: Int)(using AllowUnsafe): Unit =
         real.kyo_uring_prep_connect(sqe, fd, addr, addrlen)
 
+    def kyo_uring_prep_cancel64(sqe: Ffi.Handle[IoUringSqe], userData: Long, flags: Int)(using AllowUnsafe): Unit =
+        real.kyo_uring_prep_cancel64(sqe, userData, flags)
+
+    def kyo_uring_prep_nop(sqe: Ffi.Handle[IoUringSqe])(using AllowUnsafe): Unit =
+        real.kyo_uring_prep_nop(sqe)
+
     def kyo_uring_sqe_set_data64(sqe: Ffi.Handle[IoUringSqe], data: Long)(using AllowUnsafe): Unit =
         discard(submittedKeys.add(data))
         real.kyo_uring_sqe_set_data64(sqe, data)
@@ -960,6 +966,13 @@ final class RecordingIoDriver(real: IoDriver[PosixHandle]) extends IoDriver[Posi
     def handleLabel(handle: PosixHandle): String =
         real.handleLabel(handle)
 
+    // Delegate rather than inherit the trait default. The default runs the op INLINE, which is right only for a backend that is already
+    // single-owner; a decorated IoUringDriver owns a submission ring whose ops must run on its reap carrier. Inheriting the default here
+    // silently replaces the wrapped driver's ordering with a different one, so a deferral this decorator is meant to observe would never
+    // happen and a leaf written to catch it would pass against the very regression it targets.
+    override def submitEngineOp(op: () => Unit)(using AllowUnsafe, Frame): Unit =
+        real.submitEngineOp(op)
+
     def start()(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any] =
         if throwOnStart then throw new RuntimeException(s"driver start failed (throwOnStart=true)")
         real.start()
@@ -992,9 +1005,17 @@ final class RecordingIoDriver(real: IoDriver[PosixHandle]) extends IoDriver[Posi
     // and a driver carrier that never gets scheduled.
     @volatile var stallConnect: Boolean = false
 
+    // Callback fired with the connecting handle, before the stall decision and before any delegation, on the caller's thread. A connect
+    // handle's fd is otherwise invisible to a test driving the public transport surface, and asserting on that fd's disposition is the
+    // only way to tell a reclaimed connect from a leaked one. null means no hook set.
+    @volatile var onAwaitConnect: PosixHandle => Unit = null
+
     def awaitConnect(handle: PosixHandle, promise: Promise.Unsafe[Unit, Abort[Closed | NetException]])(using AllowUnsafe, Frame): Unit =
+        val hook = onAwaitConnect
+        if hook ne null then hook(handle)
         if stallConnect then ()
         else real.awaitConnect(handle, promise)
+    end awaitConnect
 
     def awaitAccept(handle: PosixHandle, promise: Promise.Unsafe[Int, Abort[Closed | NetException]])(using AllowUnsafe, Frame): Unit =
         real.awaitAccept(handle, promise)

--- a/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/StubIoUringHarness.scala
+++ b/kyo-net/jvm-native/src/test/scala/kyo/net/internal/posix/StubIoUringHarness.scala
@@ -76,6 +76,28 @@ class StubIoUringBindings extends IoUringBindings:
     @volatile private var sendBarrierTarget     = Int.MaxValue
     val sendBarrierP: Promise.Unsafe[Unit, Any] = Promise.Unsafe.init[Unit, Any]()
 
+    private val prepConnectFdQueue = new java.util.concurrent.ConcurrentLinkedQueue[Integer]
+
+    /** Every fd a connect SQE was prepped against, in submission order. */
+    private val prepCancelKeyQueue = new java.util.concurrent.ConcurrentLinkedQueue[java.lang.Long]
+
+    /** Keys a cancel SQE was prepped against, in submission order. */
+    def prepCancelKeys: Chunk[Long] = Chunk.from(prepCancelKeyQueue.toArray(Array.empty[java.lang.Long]).toSeq).map(_.longValue)
+
+    def prepConnectFds: Chunk[Int] = Chunk.from(prepConnectFdQueue.toArray(Array.empty[Integer]).toSeq).map(_.intValue)
+
+    /** Make the next connect prep raise, the way marshalling a released buffer does. */
+    @volatile var failPrepConnect: Boolean = false
+
+    @volatile private var connectBarrierFd         = Int.MinValue
+    val connectBarrierP: Promise.Unsafe[Unit, Any] = Promise.Unsafe.init[Unit, Any]()
+
+    /** Complete [[connectBarrierP]] when a connect SQE is prepped against `fd`. The engine FIFO is ordered, so awaiting a LATER arm's fd is
+      * how a test observes that an EARLIER arm has already drained, without a sleep and without waiting on a promise the earlier arm may
+      * deliberately never complete.
+      */
+    def setConnectBarrierFd(fd: Int): Unit = connectBarrierFd = fd
+
     // When true, the next kyo_uring_submit_and_wait_timeout throws instead of parking. CAS to false on use so it fires exactly once.
     // The authorized injection for the crash-containment guard: a reap cycle must contain a Throwable from anywhere in its body, run its
     // terminal teardown, and complete its done-fiber as a panic, rather than dying silently and leaving the ring held.
@@ -147,9 +169,25 @@ class StubIoUringBindings extends IoUringBindings:
         AllowUnsafe
     ): Unit = ()
 
+    // Record every connect SQE's fd and fire the barrier when the awaited one is prepped. The fd is what the observation needs: a connect
+    // arm that reaches the ring against a handle whose fd was already closed would prep against a number the kernel may have handed to
+    // another socket, so which fd was armed is the whole question, not how many were.
     override def kyo_uring_prep_connect(sqe: Ffi.Handle[IoUringSqe], fd: Int, addr: Buffer[Byte], addrlen: Int)(using
         AllowUnsafe
-    ): Unit = ()
+    ): Unit =
+        discard(prepConnectFdQueue.add(fd))
+        if fd == connectBarrierFd then connectBarrierP.completeDiscard(Result.succeed(()))
+        // Stands in for marshalling a connect target whose owner has already released it, which on JVM raises out of the Panama
+        // downcall rather than returning a code. The SQE is acquired by then, so this is the one way a test can put the driver in
+        // the state where a slot is committed to the ring and the op it was acquired for does not exist.
+        if failPrepConnect then throw new IllegalStateException("Already closed")
+    end kyo_uring_prep_connect
+
+    // Keys a cancel SQE was prepped against, in order. A cancel is the only way an in-flight connect is ever retired, so a test asserting
+    // that a stranded connect gets reclaimed has to be able to see whether the cancel was actually submitted and for which op.
+    override def kyo_uring_prep_cancel64(sqe: Ffi.Handle[IoUringSqe], userData: Long, flags: Int)(using AllowUnsafe): Unit =
+        discard(prepCancelKeyQueue.add(userData))
+    end kyo_uring_prep_cancel64
 
     override def kyo_uring_prep_poll_multishot(sqe: Ffi.Handle[IoUringSqe], fd: Int, pollMask: Int)(using AllowUnsafe): Unit = ()
 
@@ -157,6 +195,8 @@ class StubIoUringBindings extends IoUringBindings:
 
     // armWake calls set_data64(sqe, WakeKey=-1L); filter it so the raw-send key in lastDataKey
     // is not overwritten before the KICK test captures it.
+    override def kyo_uring_prep_nop(sqe: Ffi.Handle[IoUringSqe])(using AllowUnsafe): Unit = ()
+
     override def kyo_uring_sqe_set_data64(sqe: Ffi.Handle[IoUringSqe], data: Long)(using AllowUnsafe): Unit =
         if data != WakeKeyConst then lastDataKey = data
 

--- a/kyo-net/jvm/src/main/scala/kyo/net/internal/NioTransport.scala
+++ b/kyo-net/jvm/src/main/scala/kyo/net/internal/NioTransport.scala
@@ -38,6 +38,7 @@ import kyo.net.TransportCapabilities
 import kyo.net.internal.transport.*
 import kyo.scheduler.IOPromise
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 
 /** JVM TCP transport using a non-blocking NIO `Selector`.
   *
@@ -1569,7 +1570,7 @@ private[kyo] object NioTransport:
       * For client: uses trustAll, a custom CA cert from `caCertPath`, or the default trust store. For server: loads key managers from PEM
       * cert/key paths.
       */
-    private[kyo] def createSslContext(config: NetTlsConfig, isServer: Boolean)(using AllowUnsafe): SSLContext =
+    private[kyo] def createSslContext(config: NetTlsConfig, isServer: Boolean)(using AllowUnsafe, Frame): SSLContext =
         val ctx = SSLContext.getInstance("TLS")
         // The server verifies client certs against trustStorePath, falling back to caCertPath; the client verifies the server chain against
         // caCertPath.
@@ -1605,30 +1606,52 @@ private[kyo] object NioTransport:
         if lo <= hi then all.slice(lo, hi + 1) else Array.empty[String]
     end enabledProtocols
 
+    /** Report a failure to load configured TLS material as [[NetTlsConfigException]], the type the native providers raise for the same
+      * misconfiguration (`SslLibProvider.applyConfig`).
+      *
+      * Both tiers already fail closed, so this is about the TYPE a caller catches, not about a silent weakening. The JDK raises four different
+      * exceptions across these paths (`FileNotFoundException` on a missing CA or cert, `NoSuchFileException` on a missing key,
+      * `CertificateException` on a file holding no certificate, `InvalidKeySpecException` on an unusable key), and which tier runs at all is a
+      * property of the HOST rather than of the caller: a posix host reaches BoringSSL while one without it falls to this floor. Left
+      * unconverted, one `NetTlsConfig` and one operator typo are catchable on one machine and escape the same catch on another.
+      *
+      * `material` and `path` are named because the message is the only place the failure stays attributable to the setting that caused it; the
+      * JDK reason is kept as the cause, wrapped the way `SslLibProvider.readPem` wraps its own read failure, so nothing is lost. Only NonFatal
+      * failures convert: a fatal error is not a configuration problem and must keep propagating as itself.
+      */
+    private def loadConfigured[A](material: String, path: String)(load: => A)(using Frame): A =
+        try load
+        catch
+            case ex: Throwable if NonFatal(ex) =>
+                throw NetTlsConfigException(new IOException(s"configured $material at $path could not be loaded", ex))
+    end loadConfigured
+
     /** Load a PEM-encoded CA certificate and build TrustManagers that validate against it.
       *
       * Used for `sslmode=verify-ca` and `sslmode=verify-full` to pin server cert validation to a specific CA instead of the JDK default
       * trust store.
       */
-    private def loadCaCertTrustManagers(caPath: String)(using AllowUnsafe): Array[javax.net.ssl.TrustManager] =
+    private def loadCaCertTrustManagers(caPath: String)(using AllowUnsafe, Frame): Array[javax.net.ssl.TrustManager] =
         import java.io.FileInputStream
         import java.security.KeyStore
         import java.security.cert.CertificateFactory
         import javax.net.ssl.TrustManagerFactory
 
-        val cf       = CertificateFactory.getInstance("X.509")
-        val caStream = new FileInputStream(caPath)
-        val caCert =
-            try cf.generateCertificate(caStream)
-            finally caStream.close()
+        loadConfigured("CA certificate", caPath) {
+            val cf       = CertificateFactory.getInstance("X.509")
+            val caStream = new FileInputStream(caPath)
+            val caCert =
+                try cf.generateCertificate(caStream)
+                finally caStream.close()
 
-        val ks = KeyStore.getInstance(KeyStore.getDefaultType)
-        ks.load(null, null)
-        ks.setCertificateEntry("ca", caCert)
+            val ks = KeyStore.getInstance(KeyStore.getDefaultType)
+            ks.load(null, null)
+            ks.setCertificateEntry("ca", caCert)
 
-        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
-        tmf.init(ks)
-        tmf.getTrustManagers
+            val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+            tmf.init(ks)
+            tmf.getTrustManagers
+        }
     end loadCaCertTrustManagers
 
     /** Load PEM certificate chain and private key into KeyManagers for SSLContext.
@@ -1636,7 +1659,7 @@ private[kyo] object NioTransport:
       * Reads PEM-encoded X.509 certificate chain and PKCS#8 private key, loads them into an in-memory PKCS12 keystore, and returns
       * KeyManagers.
       */
-    private def loadPemKeyManagers(certPath: String, keyPath: String)(using AllowUnsafe): Array[javax.net.ssl.KeyManager] =
+    private def loadPemKeyManagers(certPath: String, keyPath: String)(using AllowUnsafe, Frame): Array[javax.net.ssl.KeyManager] =
         import java.io.FileInputStream
         import java.security.KeyFactory
         import java.security.KeyStore
@@ -1644,36 +1667,45 @@ private[kyo] object NioTransport:
         import java.security.spec.PKCS8EncodedKeySpec
         import javax.net.ssl.KeyManagerFactory
 
+        // Each half is wrapped against the path it actually reads, so a failure names the one setting that caused it rather than the pair.
         // Load certificate chain
-        val certFactory = CertificateFactory.getInstance("X.509")
-        val certStream  = new FileInputStream(certPath)
-        val certs =
-            try certFactory.generateCertificates(certStream)
-            finally certStream.close()
-        val certArray = new Array[java.security.cert.Certificate](certs.size())
-        certs.toArray(certArray)
+        val certArray = loadConfigured("certificate chain", certPath) {
+            val certFactory = CertificateFactory.getInstance("X.509")
+            val certStream  = new FileInputStream(certPath)
+            val certs =
+                try certFactory.generateCertificates(certStream)
+                finally certStream.close()
+            val array = new Array[java.security.cert.Certificate](certs.size())
+            certs.toArray(array)
+            array
+        }
 
         // Load private key (PKCS#8 PEM)
-        val keyBytes = java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(keyPath))
-        val keyPem   = new String(keyBytes, java.nio.charset.StandardCharsets.UTF_8)
-        val keyBase64 = keyPem
-            .replace("-----BEGIN PRIVATE KEY-----", "")
-            .replace("-----END PRIVATE KEY-----", "")
-            .replaceAll("\\s", "")
-        val keyDer  = java.util.Base64.getDecoder.decode(keyBase64)
-        val keySpec = new PKCS8EncodedKeySpec(keyDer)
-        val kf      = KeyFactory.getInstance("RSA")
-        val privKey = kf.generatePrivate(keySpec)
+        val privKey = loadConfigured("private key", keyPath) {
+            val keyBytes = java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(keyPath))
+            val keyPem   = new String(keyBytes, java.nio.charset.StandardCharsets.UTF_8)
+            val keyBase64 = keyPem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "")
+            val keyDer  = java.util.Base64.getDecoder.decode(keyBase64)
+            val keySpec = new PKCS8EncodedKeySpec(keyDer)
+            val kf      = KeyFactory.getInstance("RSA")
+            kf.generatePrivate(keySpec)
+        }
 
-        // Build in-memory PKCS12 keystore
-        val ks       = KeyStore.getInstance("PKCS12")
-        val password = "".toCharArray
-        ks.load(null, password)
-        ks.setKeyEntry("server", privKey, password, certArray)
+        // Build in-memory PKCS12 keystore. This is where a key that parses but does not match the certificate is rejected, so the failure
+        // belongs to the pair rather than to either path alone.
+        loadConfigured("certificate chain and private key", s"$certPath / $keyPath") {
+            val ks       = KeyStore.getInstance("PKCS12")
+            val password = "".toCharArray
+            ks.load(null, password)
+            ks.setKeyEntry("server", privKey, password, certArray)
 
-        val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
-        kmf.init(ks, password)
-        kmf.getKeyManagers
+            val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+            kmf.init(ks, password)
+            kmf.getKeyManagers
+        }
     end loadPemKeyManagers
 
     /** Returns the SHA-256 hash of the server's leaf certificate DER bytes per RFC 5929 tls-server-end-point.

--- a/kyo-net/jvm/src/test/scala/kyo/net/internal/NioTransportTlsConfigTest.scala
+++ b/kyo-net/jvm/src/test/scala/kyo/net/internal/NioTransportTlsConfigTest.scala
@@ -1,0 +1,170 @@
+package kyo.net.internal
+
+import kyo.*
+import kyo.net.NetException
+import kyo.net.NetTlsConfig
+import kyo.net.NetTlsConfigException
+import kyo.net.Test
+
+/** Reproduce-first tests pinning the JDK floor's TLS configuration failure to [[NetTlsConfigException]], the same type the native providers
+  * report ([[SslLibProvider]], covered by [[BoringSslProviderConfiguredPemTest]]).
+  *
+  * The control is the EXCEPTION TYPE, not fail-closed posture. Both tiers already fail closed: `NioTransport.createSslContext` opens the
+  * configured CA with a plain `FileInputStream` and lets the failure propagate rather than degrading to the system trust store. What diverged
+  * is what a caller catches. For one identical [[NetTlsConfig]] and one identical operator typo, the native providers raise
+  * `NetTlsConfigException` while the JDK floor raised whatever the JDK threw: `FileNotFoundException` for a missing path,
+  * `CertificateException` for a file holding no certificate, `InvalidKeySpecException` for an unusable key.
+  *
+  * That makes the failure type depend on which provider the HOST selected, which no caller controls: the posix hosts reach BoringSSL while a
+  * host without it falls to the Nio floor, so the same misconfiguration is catchable on one machine and escapes the same `catch` on another.
+  * `NetTlsConfigException` documents itself as covering exactly these cases ("a PEM file could not be read, the SSL context/engine could not
+  * be initialized"), so the floor owes that type too.
+  *
+  * Anti-flakiness: the `createSslContext` leaves are synchronous and in-memory (no socket, no handshake, no clock), and the unreadable path is
+  * a fresh temp name that is never created, so the read fails deterministically rather than racing a cleanup. The connect leaf binds a real
+  * loopback listener, but it never reaches a handshake: the engine build fails first, so the outcome does not depend on timing or on the peer
+  * speaking TLS, and nothing waits on a duration.
+  */
+class NioTransportTlsConfigTest extends Test:
+
+    import AllowUnsafe.embrace.danger
+
+    /** An absolute path that does not exist (a fresh temp name that is never created), so any read of it fails deterministically. */
+    private def unreadablePath(): String =
+        val f = java.io.File.createTempFile("kyo-net-nio-tls-missing", ".pem")
+        discard(f.delete())
+        f.getAbsolutePath + "-does-not-exist"
+    end unreadablePath
+
+    /** A path that EXISTS and is readable but holds no certificate. Distinct from [[unreadablePath]]: that one fails at the file open, this one
+      * opens fine and fails inside the certificate factory, which is a different JDK exception and so a separate leaf.
+      */
+    private def certificateFreePath(): String =
+        val f = java.io.File.createTempFile("kyo-net-nio-tls-noncert", ".pem")
+        java.nio.file.Files.write(f.toPath, "NOT A CERTIFICATE\n".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+        f.deleteOnExit()
+        f.getAbsolutePath
+    end certificateFreePath
+
+    "a verifying client with an unreadable configured caCertPath fails with NetTlsConfigException" in {
+        Sync.defer {
+            val path = unreadablePath()
+            val ex = intercept[NetTlsConfigException](discard(NioTransport.createSslContext(
+                NetTlsConfig(caCertPath = Present(path)),
+                isServer = false
+            )))
+            assert(
+                ex.getMessage.contains(path),
+                s"the failure must name the configured path that could not be loaded; got: ${ex.getMessage}"
+            )
+        }
+    }
+
+    // Separate from the unreadable-path leaf: the file opens, so the JDK raises CertificateException from the factory rather than
+    // FileNotFoundException from the open. Both are config errors and both must reach the caller as the same type.
+    "a verifying client with a readable caCertPath holding no certificate fails with NetTlsConfigException" in {
+        Sync.defer {
+            val path = certificateFreePath()
+            val ex = intercept[NetTlsConfigException](discard(NioTransport.createSslContext(
+                NetTlsConfig(caCertPath = Present(path)),
+                isServer = false
+            )))
+            assert(
+                ex.getMessage.contains(path),
+                s"the failure must name the configured path that could not be loaded; got: ${ex.getMessage}"
+            )
+        }
+    }
+
+    "a server with an unreadable configured certChainPath fails with NetTlsConfigException" in {
+        Sync.defer {
+            val path   = unreadablePath()
+            val config = NetTlsConfig(certChainPath = Present(path), privateKeyPath = Present(TlsTestCert.keyPath))
+            val ex     = intercept[NetTlsConfigException](discard(NioTransport.createSslContext(config, isServer = true)))
+            assert(
+                ex.getMessage.contains(path),
+                s"the failure must name the configured path that could not be loaded; got: ${ex.getMessage}"
+            )
+        }
+    }
+
+    "a server with an unreadable configured privateKeyPath fails with NetTlsConfigException" in {
+        Sync.defer {
+            val path   = unreadablePath()
+            val config = NetTlsConfig(certChainPath = Present(TlsTestCert.certPath), privateKeyPath = Present(path))
+            val ex     = intercept[NetTlsConfigException](discard(NioTransport.createSslContext(config, isServer = true)))
+            assert(
+                ex.getMessage.contains(path),
+                s"the failure must name the configured path that could not be loaded; got: ${ex.getMessage}"
+            )
+        }
+    }
+
+    // The key is read as PKCS#8 and parsed by a fixed RSA KeyFactory, so a readable key file that is not a usable PKCS#8 RSA key fails inside
+    // the parse (InvalidKeySpecException or a Base64 IllegalArgumentException) rather than at the open. Same config error, same type owed.
+    "a server with a readable but unparseable privateKeyPath fails with NetTlsConfigException" in {
+        Sync.defer {
+            val path   = certificateFreePath()
+            val config = NetTlsConfig(certChainPath = Present(TlsTestCert.certPath), privateKeyPath = Present(path))
+            val ex     = intercept[NetTlsConfigException](discard(NioTransport.createSslContext(config, isServer = true)))
+            assert(
+                ex.getMessage.contains(path),
+                s"the failure must name the configured path that could not be loaded; got: ${ex.getMessage}"
+            )
+        }
+    }
+
+    // Boundary control: a NOT-configured path keeps the JDK default trust store. "No CA configured" must never become a rejection, which is
+    // what separates this from the fail-closed cases above.
+    "a verifying client with no configured caCertPath still builds a context on the JDK default trust store" in {
+        Sync.defer {
+            val ctx = NioTransport.createSslContext(NetTlsConfig(), isServer = false)
+            assert(ctx != null, "a verifying client with no caCertPath must still build a context")
+        }
+    }
+
+    // Positive control on the server path: valid material must still load, so the wrapping above cannot be satisfied by rejecting everything.
+    "a server with a valid configured cert and key still builds a context" in {
+        Sync.defer {
+            val config = NetTlsConfig(certChainPath = Present(TlsTestCert.certPath), privateKeyPath = Present(TlsTestCert.keyPath))
+            val ctx    = NioTransport.createSslContext(config, isServer = true)
+            assert(ctx != null, "valid configured server material must still build a context")
+        }
+    }
+
+    /** Create a transport and register its driver to close at leaf-scope exit. An owned transport (unlike the process-shared one) must be
+      * closed, or its never-exiting selector poll loop keeps a scheduler worker busy and the suite fails the end-of-run leak check.
+      */
+    private def mkTransport()(using Frame): NioTransport < (Sync & Scope) =
+        Sync.defer(NioTransport.init()).map { t =>
+            Scope.ensure(Sync.defer(t.pool.next().close())).andThen(t)
+        }
+
+    // The connect path carries the same divergence one level up, and it is the half a caller actually sees. `startTlsHandshake` catches
+    // `NetTlsException` and reports it as-is, but reports every other Exception as NetTlsHandshakeException. A raw FileNotFoundException from
+    // the CA load took that second branch, so a misconfigured path was reported as a HANDSHAKE failure for a handshake that never started,
+    // pointing the operator at the network instead of at their own config. This mirrors the invariant PosixTransportTlsConfigTest already pins
+    // for the posix backend: a config failure propagates as-is and is never re-wrapped as a handshake failure.
+    "a TLS connect with an unreadable configured caCertPath reports a config failure, not a handshake failure" in {
+        given Frame = Frame.internal
+        mkTransport().map { transport =>
+            // A PLAIN listener is enough: the connect fails while building the engine, before any handshake byte is exchanged, so the peer
+            // never has to speak TLS. It exists only so the TCP connect completes and the TLS setup is actually reached.
+            transport.listen("127.0.0.1", 0, 50)(_ => ()).safe.get.map { listener =>
+                val badTls = NetTlsConfig(caCertPath = Present(unreadablePath()))
+                Abort.run[NetException](transport.connectTls("127.0.0.1", listener.port, badTls).safe.get).map { result =>
+                    listener.close()
+                    result match
+                        case Result.Failure(_: NetTlsConfigException) => succeed
+                        case Result.Success(conn) =>
+                            conn.close()
+                            fail("a connect with an unreadable configured caCertPath must not succeed")
+                        case other =>
+                            fail(s"expected NetTlsConfigException, got: $other")
+                    end match
+                }
+            }
+        }
+    }
+
+end NioTransportTlsConfigTest

--- a/kyo-net/shared/src/main/c/kyo_uring.c
+++ b/kyo-net/shared/src/main/c/kyo_uring.c
@@ -213,6 +213,32 @@ void kyo_uring_prep_connect(struct io_uring_sqe* sqe, int fd, void* addr, int ad
     io_uring_prep_connect(sqe, fd, (struct sockaddr*)addr, (socklen_t)addrlen);
 }
 
+/*
+ * io_uring_prep_cancel64: ask the kernel to cancel the in-flight op carrying user_data.
+ * The submission this targets is identified by its key, not by its fd, because a connect
+ * SQE is backed by an internal poll wait that close(2) alone does not complete: without
+ * this the op never reaps, so no completion ever decrements the caller's in-flight count.
+ */
+void kyo_uring_prep_cancel64(struct io_uring_sqe* sqe, long user_data, int flags) {
+    io_uring_prep_cancel64(sqe, (__u64)user_data, flags);
+}
+
+/*
+ * io_uring_prep_nop: make an already-acquired SQE into a no-op.
+ *
+ * io_uring_get_sqe advances the submission tail as it hands the entry out, so the
+ * slot is committed to the kernel from that moment: there is no way to give it back.
+ * A caller that acquires an SQE and then cannot use it (a marshalling failure, a
+ * rejected length) must therefore leave something WELL-DEFINED in the slot. liburing
+ * does not clear a reused SQE, so an abandoned one carries whatever the previous
+ * occupant wrote and would re-issue that stale opcode against a stale fd. Preparing
+ * a nop is what makes abandonment safe; the caller still has to set a user_data the
+ * completion side recognises and drops.
+ */
+void kyo_uring_prep_nop(struct io_uring_sqe* sqe) {
+    io_uring_prep_nop(sqe);
+}
+
 /* io_uring_sqe_set_data64: store the per-op key the completion is matched against. */
 void kyo_uring_sqe_set_data64(struct io_uring_sqe* sqe, long data) {
     io_uring_sqe_set_data64(sqe, (__u64)data);
@@ -402,6 +428,12 @@ int kyo_uring_poll_peer_closed(int fd) { (void)fd; return 0; }
 void kyo_uring_prep_connect(void* sqe, int fd, void* addr, int addrlen) {
     (void)sqe; (void)fd; (void)addr; (void)addrlen;
 }
+
+void kyo_uring_prep_cancel64(void* sqe, long user_data, int flags) {
+    (void)sqe; (void)user_data; (void)flags;
+}
+
+void kyo_uring_prep_nop(void* sqe) { (void)sqe; }
 
 void kyo_uring_sqe_set_data64(void* sqe, long data) { (void)sqe; (void)data; }
 

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/SslLibProvider.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/SslLibProvider.scala
@@ -36,9 +36,12 @@ abstract private[net] class SslLibProvider extends TlsEngineProvider:
         val l   = lib
         val ctx = l.ctxNew(if isServer then 1 else 0)
         if ctx == 0L then throw NetTlsConfigException("SSL_CTX_new failed")
+        // Held outside the try so the failure path can tell "no SSL yet" from "an SSL that now owns two memory BIOs and a
+        // malloc'd state struct", which are reclaimed only by sslFree.
+        var ssl = 0L
         try
             applyConfig(l, ctx, config, isServer)
-            val ssl = l.sslNew(ctx, hostname)
+            ssl = l.sslNew(ctx, hostname)
             if ssl == 0L then throw NetTlsConfigException("SSL_new failed")
             bindClientIdentity(l, ssl, config, hostname, isServer)
             if isServer then l.sslSetAcceptState(ssl)
@@ -46,9 +49,17 @@ abstract private[net] class SslLibProvider extends TlsEngineProvider:
             new NativeSslEngine(l, ssl)
         catch
             case t: Throwable =>
-                // SSL_new failed (or config threw) before the SSL took a reference on the context: free it so the context does not leak.
-                l.ctxFree(ctx)
+                // Config application and the identity binding both throw, and the second of those runs with the SSL already
+                // built, so the SSL is freed here whenever one exists. The context is not freed here: the finally below owns
+                // that on every path.
+                if ssl != 0L then l.sslFree(ssl)
                 throw t
+        finally
+            // SSL_CTX is refcounted and SSL_new took its own reference, so this drops only the reference this method created.
+            // On success the engine's SSL keeps the context alive until NativeSslEngine.free runs SSL_free; on failure the
+            // reference taken by SSL_new was already released above, so this is the one that reclaims it. Dropping it here
+            // rather than only on the failure path is what stops a context, with its chains and keys, leaking per engine.
+            l.ctxFree(ctx)
         end try
     end createEngine
 
@@ -57,22 +68,40 @@ abstract private[net] class SslLibProvider extends TlsEngineProvider:
         // caCertPath.
         val serverCa = if isServer then config.trustStorePath.orElse(config.caCertPath) else config.caCertPath
         readPem(serverCa) match
-            case Present(ca) => discard(lib.ctxLoadCa(ctx, ca))
-            case Absent      =>
+            case Present(ca) =>
+                // Returns the number of CAs added, or -1. A configured trust anchor that did not load is not a degraded mode: the store is
+                // empty or short, and every verification decision from here on is made against trust the caller never chose. Failing the
+                // engine build is the only place that failure is still attributable to the setting that caused it.
+                if lib.ctxLoadCa(ctx, ca) < 1 then
+                    throw NetTlsConfigException(s"the configured CA at ${serverCa.getOrElse("<unset>")} loaded no certificates")
+            case Absent =>
                 // A verifying CLIENT with no configured caCertPath validates the server chain against the platform default trust store,
                 // converging with the JDK floor (NioTransport: `Absent => JDK default trust store`). Without this a bundled BoringSSL client has
                 // an EMPTY X509 store, so every public-internet handshake fails with EngineError. NOT applied to a server: a server verifies the
                 // peer's CLIENT certificate and must anchor on an explicit trust store, never the public CA set.
-                if !isServer && !config.trustAll then discard(lib.ctxLoadSystemCa(ctx))
+                if !isServer && !config.trustAll then
+                    // Returns 1 when any trust source loaded, 0 otherwise. A verifying client that loaded none has no anchors at all, so it
+                    // would reject every peer; that is safe but indistinguishable from a certificate problem at the handshake, which is where
+                    // this used to surface.
+                    if lib.ctxLoadSystemCa(ctx) != 1 then
+                        throw NetTlsConfigException("no platform trust store could be loaded for a verifying client with no configured CA")
         end match
         lib.ctxSetVerifyMode(ctx, verifyMode(config, isServer))
-        discard(lib.ctxSetMinMaxVersion(ctx, versionCode(config.minVersion), versionCode(config.maxVersion)))
+        // Returns 0, or -1 when a bound is rejected. Discarding it leaves the version window UNSET while the config says otherwise, so a
+        // caller who pinned a floor of TLS 1.3 could negotiate 1.2 and never learn the pin did not take.
+        if lib.ctxSetMinMaxVersion(ctx, versionCode(config.minVersion), versionCode(config.maxVersion)) != 0 then
+            throw NetTlsConfigException(s"the TLS version window ${config.minVersion} to ${config.maxVersion} was rejected")
         // Load the certificate + key whenever both are configured, for the client too: a mutual-TLS client presents its own client certificate
         // when the server sends a CertificateRequest. A plaintext client leaves both Absent, so this is a no-op for the common (no client cert)
         // client, and a server still always loads its termination cert.
         (readPem(config.certChainPath), readPem(config.privateKeyPath)) match
-            case (Present(cert), Present(key)) => discard(lib.ctxSetCert(ctx, cert, key))
-            case _                             => ()
+            case (Present(cert), Present(key)) =>
+                // Returns 0, or -1 on bad PEM or a key that does not match the certificate. A server whose termination cert did not load has
+                // no identity to present and fails every handshake opaquely; naming it here points at the config instead.
+                if lib.ctxSetCert(ctx, cert, key) != 0 then
+                    throw NetTlsConfigException("the configured certificate and private key could not be loaded, or do not match")
+            case _ => ()
+        end match
     end applyConfig
 
     /** Bind the client reference identity so chain validation is accompanied by RFC 9525 name checking, and fail closed when a verifying
@@ -90,12 +119,23 @@ abstract private[net] class SslLibProvider extends TlsEngineProvider:
       *     accepting any chain-valid cert.
       */
     private def bindClientIdentity(lib: SslLibBindings, ssl: Long, config: NetTlsConfig, hostname: String, isServer: Boolean)(using
-        AllowUnsafe
+        AllowUnsafe,
+        Frame
     ): Unit =
+        // Returns 1 when the unmatchable identity was set, 0 on error. This is the one return code on this path whose failure
+        // ACCEPTS rather than rejects: it is reached only when the client is verifying and has no usable reference identity, so an
+        // unbound name means the handshake runs with no name check at all and takes any chain-valid certificate. Discarding it turns
+        // the fail-closed rule (RFC 9525 6.1) into fail-open, silently, which is the outcome the whole path exists to prevent.
+        def requireUnmatchable(): Unit =
+            if lib.sslRequireUnmatchableIdentity(ssl) != 1 then
+                throw NetTlsConfigException(
+                    "a verifying client could not be given an unmatchable reference identity, so the handshake would accept any " +
+                        "chain-valid certificate"
+                )
+
         if isServer || config.trustAll || !config.hostnameVerification then ()
-        else if hostname.isEmpty then discard(lib.sslRequireUnmatchableIdentity(ssl))
-        else if lib.sslSetVerifyName(ssl, hostname) != 1 then
-            discard(lib.sslRequireUnmatchableIdentity(ssl))
+        else if hostname.isEmpty then requireUnmatchable()
+        else if lib.sslSetVerifyName(ssl, hostname) != 1 then requireUnmatchable()
     end bindClientIdentity
 
     /** Map the config to the shim's verify mode (0 none, 1 optional, 2 required): a `trustAll` client skips verification; a server uses its
@@ -118,8 +158,8 @@ abstract private[net] class SslLibProvider extends TlsEngineProvider:
     /** Read a configured PEM file. A `path` that was never set stays `Absent` so the caller keeps the system-trust default; a `Present` path that
       * cannot be read or decoded FAILS CLOSED with [[NetTlsConfigException]] rather than degrading to `Absent`. Swallowing the read error would silently drop an
       * operator's pinned private CA (or a server's configured cert/key) and fall back to the system trust store, the CWE-295 silent-weakening
-      * the JDK floor avoids (`NioTransport.loadCaCertTrustManagers` lets the file-open exception propagate). Distinguishing not-configured from
-      * configured-but-unreadable is the whole fix.
+      * the JDK floor also refuses (`NioTransport` reports the same [[NetTlsConfigException]] for an unreadable configured path). Distinguishing
+      * not-configured from configured-but-unreadable is the whole fix.
       */
     private def readPem(path: Maybe[String])(using AllowUnsafe, Frame): Maybe[String] =
         path.map { p =>

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/backend/IoBackend.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/backend/IoBackend.scala
@@ -52,11 +52,13 @@ private[net] object IoBackend:
     /** The single selection function for BOTH registries (generic on the descriptor type and the failure leaf). Selection logic never
       * changes; adding an entry is a list edit, never a `select` edit.
       *
-      * Resolution order: `forced` (a name the caller resolved, typically from a `-D` property) is honored if its candidate is available, and
-      * fails with `onUnavailable` if not (never a silent fall-through). With no forced name, the highest-priority available candidate wins,
-      * walking the priority gradient; if nothing is available, the result fails with `onUnavailable(Absent, ...)`. Both failure paths log a
-      * warning via `log` before failing, and every path logs the [[SelectionReport]], which `onUnavailable` renders into the terminal
-      * failure's cause.
+      * Resolution order: `forced` (a name the caller resolved, typically from a `-D` property) is honored when it names a REGISTERED
+      * candidate that is available, and fails with `onUnavailable` when that candidate is unavailable. A forced name matching no registered
+      * candidate is a third case and does NOT fail: it resolves as if unforced, so a misspelled name selects the gradient's winner silently.
+      * That is deliberate (`IoBackendRegistryTest` pins it) and it differs from the pinned-provider path in `TlsProvider.selectFor`, which
+      * reports an unregistered id as unavailable. With no forced name, the highest-priority available candidate wins, walking the priority
+      * gradient; if nothing is available, the result fails with `onUnavailable(Absent, ...)`. Both failure paths log a warning via `log`
+      * before failing, and every path logs the [[SelectionReport]], which `onUnavailable` renders into the terminal failure's cause.
       */
     def select[D <: CapabilityDescriptor, E](
         registered: Chunk[D],

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/IoUringBindings.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/IoUringBindings.scala
@@ -90,6 +90,18 @@ private[net] trait IoUringBindings extends Ffi:
     /** `io_uring_prep_connect(sqe, fd, addr, addrlen)`. */
     def kyo_uring_prep_connect(sqe: Ffi.Handle[IoUringSqe], fd: Int, addr: Buffer[Byte], addrlen: Int)(using AllowUnsafe): Unit
 
+    /** `io_uring_prep_cancel64(sqe, userData, flags)`: ask the kernel to cancel the in-flight op registered under `userData`.
+      *
+      * Targets the op by KEY rather than by descriptor, which is what makes it the only way to retire a connect. A connect submission is
+      * backed by an internal poll wait that neither `close(2)` nor a `shutdown(2)` on a socket still in SYN-SENT completes, so without a
+      * cancel its completion never arrives and any bookkeeping waiting on that completion waits forever.
+      *
+      * The cancel reports one of three outcomes and all of them are normal: success, `-ENOENT` when the target already completed and its
+      * completion is reaped or on its way, and `-EALREADY` when it is completing. In every case the target's OWN completion still arrives,
+      * so a caller must retire the target on that completion and never on this one.
+      */
+    def kyo_uring_prep_cancel64(sqe: Ffi.Handle[IoUringSqe], userData: Long, flags: Int)(using AllowUnsafe): Unit
+
     /** Multishot poll: `IORING_OP_POLL_ADD | IORING_POLL_ADD_MULTI`. One submission re-fires a CQE every time `fd` becomes ready for
       * `pollMask` (e.g. `POLLIN`), staying armed across completions (each carries `IORING_CQE_F_MORE`). Armed on the driver's wake eventfd so a
       * cross-carrier `kyo_uring_eventfd_write` returns the parked reap wait promptly instead of leaving the reap loop parked indefinitely.
@@ -98,6 +110,15 @@ private[net] trait IoUringBindings extends Ffi:
 
     /** Non-blocking `poll(2)` peer-close probe, off the ring (see kyo_uring.c for the POLLRDHUP rationale). Returns 1 peer gone, 0 open, -1 error. */
     def kyo_uring_poll_peer_closed(fd: Int)(using AllowUnsafe): Int
+
+    /** `io_uring_prep_nop(sqe)`. Turns an already-acquired SQE into a no-op.
+      *
+      * `io_uring_get_sqe` advances the submission tail as it hands the entry out, so the slot goes to the kernel whether or not the caller
+      * fills it in: acquiring is a commitment, not a reservation that can be released. liburing does not clear a reused SQE, so a slot left
+      * untouched still carries the previous occupant's opcode and would re-issue it against a stale descriptor. A caller that acquires an SQE
+      * and then cannot use it prepares a nop here and gives it a key the reap side recognises and discards.
+      */
+    def kyo_uring_prep_nop(sqe: Ffi.Handle[IoUringSqe])(using AllowUnsafe): Unit
 
     /** `io_uring_sqe_set_data64(sqe, data)`. Stores the per-op key the completion is matched against. */
     def kyo_uring_sqe_set_data64(sqe: Ffi.Handle[IoUringSqe], data: Long)(using AllowUnsafe): Unit

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/IoUringDriver.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/IoUringDriver.scala
@@ -141,7 +141,7 @@ final private[net] class IoUringDriver private[posix] (
 
     // Handles whose pending SEND tail could not flush because the SUBMISSION queue was full (the flush's get_sqe returned Absent), so the remainder
     // is buffered with no send in flight. SQ-full has no per-handle send CQE to re-drive the flush, so the reap loop re-flushes these (on the
-    // engine FIFO worker) after each CQE batch, which freed at least one SQ slot. Backpressures rather than busy-spinning: at most one re-flush per
+    // engine FIFO worker) once per reap turn, after submit freed at least one SQ slot. Backpressures rather than busy-spinning: at most one re-flush per
     // drained batch per handle, and a re-flush that hits SQ-full again re-adds the handle. A set so a handle re-flushed once is not queued twice.
     //
     // Covers BOTH send tails, the raw one ([[flushRaw]]) and the TLS one ([[flushTls]]). A TLS flush that cannot submit strands its ciphertext
@@ -151,14 +151,39 @@ final private[net] class IoUringDriver private[posix] (
     private val stalledSends = ConcurrentHashMap.newKeySet[PosixHandle]()
 
     // Promise-bearing arms (recv, accept, connect) that could not submit because the SUBMISSION queue was full (their get_sqe returned Absent): no
-    // SQE is in flight, so no CQE will re-drive them. The reap loop re-arms these after each CQE batch frees an SQ slot (reArmStalledSubmits in
-    // drainReady), mirroring stalledSends for sends: a transient SQ-full BACKPRESSURES the operation (its promise stays pending) instead of failing
+    // SQE is in flight, so no CQE will re-drive them. The reap loop re-arms these once per turn (reArmStalledSubmits, via reArmStalled), mirroring
+    // stalledSends for sends: a transient SQ-full BACKPRESSURES the operation (its promise stays pending) instead of failing
     // it. A failed accept would wedge the accept loop (its onComplete reads Failure as "listener closed" and stops re-arming), and a failed connect
     // would drop a connection that would otherwise succeed; parking removes both. Each entry is the PendingOp (Read/Accept/Connect) carrying the
     // fields to re-submit; it is NOT registered (no key) while parked here, and a parked Accept keeps its addr/len buffers alive for the re-submit.
-    // Single-owner on the reap carrier (the submit helpers run there via submitEngineOp; reArmStalledSubmits runs in drainReady), so a plain
+    // The re-arm is deliberately NOT tied to a CQE batch: SQ space is freed by submitting, not by reaping, so an op parked on an otherwise-idle
+    // ring would otherwise wait forever for a CQE that only it could have produced. See reArmStalled for why every turn re-arms, timeout included.
+    // Single-owner on the reap carrier (the submit helpers run there via submitEngineOp; reArmStalledSubmits runs on the reap turn), so a plain
     // ArrayDeque is safe. Bounded: each batch is snapshotted and the queue cleared, so a re-arm that hits SQ-full again is retried only on the NEXT batch.
     private val stalledSubmits = new java.util.ArrayDeque[PendingOp]()
+
+    // Op keys whose forced-connect cancel could not reach the ring because the SQ was full. A cancel has no op of its own to re-arm, so it
+    // cannot ride [[stalledSubmits]]; it is the TARGET's key that must be retried. Dropping these is what left one descriptor stranded on a
+    // loaded leg: 66 deferred closes were owed at once, the SQ filled, and the connects that never got a cancel never reaped.
+    private val stalledCancels = new java.util.ArrayDeque[Long]()
+
+    // The target each in-flight cancel was issued against, so its completion can be judged. A cancel carries a key of its own (allocated
+    // below) rather than one shared sentinel, because a shared key cannot say WHICH target a reaped cancel belongs to, and that is exactly
+    // what deciding whether to re-issue requires.
+    private val cancelTargets = new java.util.concurrent.ConcurrentHashMap[java.lang.Long, java.lang.Long]()
+
+    // Cancel keys descend from -2, below the wake eventfd's -1 and far from the op generator, which counts up from 1.
+    private val cancelKeyGen = new java.util.concurrent.atomic.AtomicLong(-2L)
+
+    // A cancel is only observable through its completion, so a cancel that never reached the kernel and one that reaped normally are
+    // indistinguishable from the outside. These counters ride the driver's Diagnostics dump so the two can be told apart there.
+    private val diagCancelSubmitted = new java.util.concurrent.atomic.AtomicLong(0L)
+    private val diagCancelParked    = new java.util.concurrent.atomic.AtomicLong(0L)
+    private val diagCancelReaped    = new java.util.concurrent.atomic.AtomicLong(0L)
+
+    // Reap turns between re-forcing sweeps of the owed deferred closes. Coarse on purpose: the sweep exists to make a LOST forcing
+    // eventually consistent, not to drive the common path, which the single pass at close time already handles.
+    private val ReForceInterval = 2048L
 
     // Per-handle count of consecutive `-EINTR` send CQE completions for that handle's outstanding send (TLS or raw). A send CQE that reaps
     // `-EINTR` (a signal interrupted the send before any byte moved; POSIX send(2) says to retry) re-flushes the SAME unsent region instead of
@@ -341,6 +366,7 @@ final private[net] class IoUringDriver private[posix] (
                     // flags=0: single-shot recv. IORING_RECV_MULTISHOT requires provided buffer rings (IORING_OP_PROVIDE_BUFFERS) to be set up
                     // before submission, or the kernel returns -EINVAL. Provided buffer rings are deferred; each recv re-arms after its CQE.
                     if uring.kyo_uring_prep_recv(sqe, handle.readFd, recvTarget, handle.readBufferSize.toLong, 0) != 0 then
+                        discardSqe(sqe)
                         unregister(key)
                         promise.completeDiscard(Result.Panic(NetConnectionIoException(
                             s"connection ${handleLabel(handle)}",
@@ -356,7 +382,7 @@ final private[net] class IoUringDriver private[posix] (
                     end if
                 case Absent =>
                     // SUBMISSION queue full: no recv SQE is in flight, so no CQE will re-drive this read. Park it (the promise stays pending) and
-                    // re-arm after the next CQE batch frees a slot (reArmStalledSubmits), mirroring stalledSends for sends so a transient SQ-full
+                    // re-arm on the next reap turn (reArmStalledSubmits), mirroring stalledSends for sends so a transient SQ-full
                     // backpressures the read instead of failing the connection. unregister first: the key is re-assigned on re-submit. recvInFlight
                     // stays false: nothing kernel-owned touches the buffer yet, so the later re-arm (reArmStalledSubmits, calling submitRecv
                     // directly) must not itself trip the exclusive-use guard above.
@@ -416,7 +442,7 @@ final private[net] class IoUringDriver private[posix] (
     end awaitConnect
 
     /** Submit one connect SQE for `promise`, reading the stashed `connectTarget` off the handle. The public [[awaitConnect]] enters via the engine
-      * queue; [[reArmStalledSubmits]] re-enters here directly after a CQE batch freed a slot. On a full SQ the connect parks in [[stalledSubmits]]
+      * queue; [[reArmStalledSubmits]] re-enters here directly on the next reap turn, after submit freed a slot. On a full SQ the connect parks in [[stalledSubmits]]
       * (its promise stays pending) instead of failing, so a transient SQ-full does not drop a connection that would otherwise complete.
       */
     private def submitConnect(promise: Promise.Unsafe[Unit, Abort[Closed | NetException]], handle: PosixHandle)(using
@@ -430,14 +456,52 @@ final private[net] class IoUringDriver private[posix] (
                 if closedFlag.get() then
                     unregister(key)
                     promise.completeDiscard(Result.fail(Closed(label, Frame.internal, "driver closed")))
+                else if handle.isClosing() then
+                    // The handle's close was REQUESTED, which happens strictly before any closer takes the fd claim below. Arming a connect
+                    // in that gap dials out on a descriptor already committed to being closed and recycled, which is the same hazard the
+                    // accept path rejects on for its listener. Checking only the claim leaves the gap open, because `isClosing` is set at
+                    // the request and `fdCloseClaimed` only at the CAS a closer wins later.
+                    unregister(key)
+                    promise.completeDiscard(Result.fail(Closed(handleLabel(handle), handle.createdAt, "handle closing")))
+                else if handle.fdCloseIsClaimed then
+                    // The fd close has already been claimed, so `close(fd)` has either run or is owed, and the number may already name a
+                    // different socket: prepping a connect here would dial out on somebody else's connection. Two paths reach this check
+                    // with the claim already taken. `awaitConnect` only enqueues this submit on the engine FIFO, so a connect-phase teardown
+                    // that closes the fd on the caller's carrier can land before the arm drains; and a full SQ parks the arm in
+                    // `stalledSubmits`, where `reArmStalledSubmits` re-enters this submit long after. Reject instead, and fail the promise
+                    // rather than merely skipping the submit, which would park the caller on a completion that can never arrive.
+                    //
+                    // This narrows the window rather than closing it. The claim is taken on the CALLER's carrier
+                    // (`PosixTransport.closeUnwiredHandle`'s connect-phase arm claims, shuts down and closes the raw fd directly; only
+                    // `driver.closeHandle` goes through the FIFO), while this read and the `kyo_uring_prep_connect` below run on the reap
+                    // carrier, so a claim landing between them still arms against a just-freed fd. Closing that would mean routing the
+                    // connect-phase claim through `submitEngineOp` so it serializes with this submit on the one carrier that owns the ring.
+                    unregister(key)
+                    promise.completeDiscard(Result.fail(Closed(handleLabel(handle), handle.createdAt, "handle closed")))
                 else
                     uring.kyo_uring_get_sqe(ring) match
                         case Present(sqe) =>
-                            uring.kyo_uring_prep_connect(sqe, handle.writeFd, addr, len)
-                            uring.kyo_uring_sqe_set_data64(sqe, key)
-                            submitBatched()
+                            try
+                                uring.kyo_uring_prep_connect(sqe, handle.writeFd, addr, len)
+                                uring.kyo_uring_sqe_set_data64(sqe, key)
+                                submitBatched()
+                            catch
+                                case ex: Throwable =>
+                                    // Marshalling the connect target can fail on a buffer whose owner released it. The slot is already
+                                    // committed to the submission ring, so it has to be left well-defined; and this connect never reached
+                                    // the kernel, so its pending entry has to come back out or the in-flight count it holds keeps the
+                                    // handle's deferred close waiting on a completion that cannot arrive. Reporting it to the caller as a
+                                    // panic is what turns a silent stranded descriptor into a failed connect.
+                                    discardSqe(sqe)
+                                    unregister(key)
+                                    promise.completeDiscard(Result.Panic(ex))
+                                    Log.live.unsafe.error(
+                                        s"$label connect submission failed for ${handleLabel(handle)}; the op was withdrawn",
+                                        ex
+                                    )
+                            end try
                         case Absent =>
-                            // SQ full: nothing in flight to re-drive the connect. Park it and re-arm after the next CQE batch frees a slot
+                            // SQ full: nothing in flight to re-drive the connect. Park it and re-arm on the next reap turn, once submit frees a slot
                             // (reArmStalledSubmits), mirroring the recv path so a transient SQ-full backpressures rather than failing the connect.
                             unregister(key)
                             discard(stalledSubmits.add(PendingOp.Connect(promise, handle)))
@@ -467,7 +531,7 @@ final private[net] class IoUringDriver private[posix] (
     end awaitAccept
 
     /** Submit one accept SQE for `promise` over the supplied (already-allocated) addr/len placeholder buffers. The public [[awaitAccept]]
-      * enters via the engine queue; [[reArmStalledSubmits]] re-enters here directly after a CQE batch freed a slot. On a full SQ the accept
+      * enters via the engine queue; [[reArmStalledSubmits]] re-enters here directly on the next reap turn, after submit freed a slot. On a full SQ the accept
       * parks in [[stalledSubmits]] keeping its buffers (re-armed later), never failed, so a transient SQ-full cannot wedge the listener's
       * accept loop.
       */
@@ -498,7 +562,7 @@ final private[net] class IoUringDriver private[posix] (
                     uring.kyo_uring_sqe_set_data64(sqe, key)
                     submitBatched()
                 case Absent =>
-                    // SQ full: park the accept (keeping its buffers) and re-arm after the next CQE batch frees a slot (reArmStalledSubmits) instead
+                    // SQ full: park the accept (keeping its buffers) and re-arm on the next reap turn (reArmStalledSubmits) instead
                     // of failing it, which the accept loop would misread as "listener closed" and stop re-arming. unregister first: the key is
                     // re-assigned on re-submit.
                     unregister(key)
@@ -626,6 +690,7 @@ final private[net] class IoUringDriver private[posix] (
                                         PosixConstants.MSG_NOSIGNAL
                                     ) != 0
                                 then
+                                    discardSqe(sqe)
                                     unregister(key)
                                     sendBuf.close()
                                     discard(stalledSends.add(handle))
@@ -769,6 +834,7 @@ final private[net] class IoUringDriver private[posix] (
                                         PosixConstants.MSG_NOSIGNAL
                                     ) != 0
                                 then
+                                    discardSqe(sqe)
                                     unregister(key)
                                     discard(stalledSends.add(handle))
                                 else
@@ -1039,6 +1105,64 @@ final private[net] class IoUringDriver private[posix] (
         end if
     end closeHandle
 
+    /** Submit an `IORING_OP_ASYNC_CANCEL` for every connect this handle still has in flight, so the kernel completes it and the handle's
+      * in-flight count can reach zero. Without this a connect against a peer that never answers pins its deferred close forever.
+      *
+      * Runs on the reap carrier: every caller reaches it through [[closeHandle]]'s `submitEngineOp`, which is the single `get_sqe`
+      * producer. A full SQ is left alone rather than parked in [[stalledSubmits]]: the entry there is keyed by the op it re-arms, and a
+      * cancel has no op of its own to re-arm, so the TARGET's key is parked in [[stalledCancels]] and retried on the next reap turn once
+      * submit has freed a slot. Dropping it instead is not good enough: a loaded leg owed 66 deferred closes at once, the SQ filled, and the
+      * connects that never received a cancel never reaped, stranding a descriptor until teardown.
+      */
+    private def forceInFlightConnects(handle: PosixHandle)(using AllowUnsafe, Frame): Unit =
+        val id = handle.id.packed
+        pending.forEach { (key, op) =>
+            op match
+                case PendingOp.Connect(_, h) if h.id.packed == id =>
+                    uring.kyo_uring_get_sqe(ring) match
+                        case Present(sqe) =>
+                            val cancelKey = cancelKeyGen.getAndDecrement()
+                            discard(cancelTargets.put(java.lang.Long.valueOf(cancelKey), java.lang.Long.valueOf(key)))
+                            uring.kyo_uring_prep_cancel64(sqe, key, 0)
+                            uring.kyo_uring_sqe_set_data64(sqe, cancelKey)
+                            discard(diagCancelSubmitted.incrementAndGet())
+                            submitBatched()
+                        case Absent =>
+                            discard(diagCancelParked.incrementAndGet())
+                            discard(stalledCancels.add(key))
+                    end match
+                case _ => ()
+            end match
+        }
+    end forceInFlightConnects
+
+    /** Retry the cancels that could not reach a full submission queue, once per reap turn from [[reArmStalledSubmits]], after submit has freed
+      * SQ slots. A key whose target has since completed on its own is dropped rather than re-submitted: `pending` no longer holds it, so there
+      * is nothing left to cancel and the deferred close it was blocking has already discharged.
+      */
+    private def retryStalledCancels()(using AllowUnsafe, Frame): Unit =
+        if !stalledCancels.isEmpty then
+            val batch = new java.util.ArrayDeque[Long](stalledCancels)
+            stalledCancels.clear()
+            while !batch.isEmpty do
+                val key = batch.poll()
+                if pending.containsKey(key) then
+                    uring.kyo_uring_get_sqe(ring) match
+                        case Present(sqe) =>
+                            val cancelKey = cancelKeyGen.getAndDecrement()
+                            discard(cancelTargets.put(java.lang.Long.valueOf(cancelKey), java.lang.Long.valueOf(key)))
+                            uring.kyo_uring_prep_cancel64(sqe, key, 0)
+                            uring.kyo_uring_sqe_set_data64(sqe, cancelKey)
+                            discard(diagCancelSubmitted.incrementAndGet())
+                            submitBatched()
+                        case Absent =>
+                            discard(diagCancelParked.incrementAndGet())
+                            discard(stalledCancels.add(key))
+                    end match
+                end if
+            end while
+    end retryStalledCancels
+
     /** Register the handle for the deferred close, or close now when nothing is in flight. Factored so the plaintext close and the post-
       * close_notify TLS close share the same close-vs-reap race handling.
       */
@@ -1074,6 +1198,17 @@ final private[net] class IoUringDriver private[posix] (
                     handle.markDeferredFdClose()
                     discard(sockets.shutdown(handle.readFd, PosixConstants.SHUT_RD))
                 end if
+                // The SHUT_RD above forces an in-flight RECV to reap, but it does nothing for an in-flight CONNECT: shutdown(2) has no
+                // effect on a socket that is not yet established, and `cancel` fails only the local promise. So the in-flight count for a
+                // connect the peer never answers can never reach zero, this deferred close never discharges, and the descriptor is held
+                // until the ring tears down (teardownRing's closeAfterDrain sweep is the only thing that has ever reclaimed it). In a
+                // long-lived process that sweep never comes. Ask the kernel to complete the connect instead.
+                //
+                // Deliberately NOT gated on `claimedHere`: a cancel names the op by its user_data, never by a descriptor, so it is
+                // correct even when a racing transport-path closer owns the fd and even if that fd number has already been recycled. The
+                // target is either still in flight (reaped as -ECANCELED) or already complete (-ENOENT), and neither outcome touches a
+                // descriptor this driver no longer owns. Gating it on the claim is what left the previous attempt short.
+                forceInFlightConnects(handle)
                 // Register the deferred close, then re-check: if the reap loop drained the count between the read above and this put, it already
                 // ran (and removed) nothing, so claim the registration back and close here. This closes the close-vs-reap race either way.
                 // putIfAbsent, not put: a SECOND closeHandle for this same handle (production pair: an onFatal closeHandle plus the
@@ -1402,7 +1537,9 @@ final private[net] class IoUringDriver private[posix] (
                 closeAfterDrain.forEach((k, _) => discard(cad.append(k).append(' ')))
                 s"closed=${closedFlag.get()} reapExited=${reapExited.get()} ringExited=${ringExited.get()} reapCycles=$diagReapCycles " +
                     s"pending(${pending.size})=[$pend] inFlight=[$infl] closeAfterDrain(${closeAfterDrain.size})=[$cad] " +
-                    s"pendingCloses=${pendingCloses.size} stalledSends=${stalledSends.size}"
+                    s"pendingCloses=${pendingCloses.size} stalledSends=${stalledSends.size} " +
+                    s"cancelSubmitted=${diagCancelSubmitted.get()} cancelParked=${diagCancelParked.get()} " +
+                    s"cancelReaped=${diagCancelReaped.get()} stalledCancels=${stalledCancels.size}"
             ,
             probe = () =>
                 kyo.internal.Diagnostics.Probe(
@@ -1434,7 +1571,8 @@ final private[net] class IoUringDriver private[posix] (
     private val ReapTimeoutNs =
         100_000_000L // 100ms bounded fallback (only used when the wake eventfd is unavailable); otherwise the wait is indefinite
 
-    private val WakeKey = IoUringDriver.WakeKey
+    private val WakeKey    = IoUringDriver.WakeKey
+    private val DiscardKey = IoUringDriver.DiscardKey
 
     /** Arm (or re-arm) the multishot `IORING_OP_POLL_ADD` watch on the wake eventfd. Reap-carrier-only (the SQ is single-producer). On SQ-full
       * (`get_sqe` Absent) it leaves `wakePollArmed` false; the reap loop then parks with the bounded fallback (never indefinitely without an armed
@@ -1565,7 +1703,16 @@ final private[net] class IoUringDriver private[posix] (
                 // Park INDEFINITELY only when all three conditions hold: the wake multishot is armed, no op is stalled on a full SQ (a stalled
                 // op has no pending CQE to re-drive it, so it needs a bounded turn to reach reArmStalled), and IORING_FEAT_NODROP is confirmed
                 // (the kernel never drops the wake CQE). Bounded otherwise, so a missing wake can never hang the chain.
-                val hasStalled = !stalledSends.isEmpty || !stalledSubmits.isEmpty
+                // `stalledCancels` counts too, and leaving it out was a deadlock: a cancel parks here only when the submission queue was
+                // full, its retry runs once per reap turn, and an indefinite park produces no turns. On an otherwise idle driver the loop
+                // would sleep waiting for a completion that only the un-submitted cancel could force, which is exactly the situation the
+                // cancel exists to break.
+                // An owed close counts too. The re-force sweep that recovers a lost forcing runs once per reap turn, and an indefinite park
+                // produces no turns, so a ring that goes quiet while still owing a close is exactly where the backstop is needed and
+                // exactly where it could not run. The bounded park costs a periodic wakeup while any close is outstanding; a close whose
+                // operation will genuinely reap resolves on that completion and stops counting immediately.
+                val hasStalled =
+                    !stalledSends.isEmpty || !stalledSubmits.isEmpty || !stalledCancels.isEmpty || !closeAfterDrain.isEmpty
                 // On JS the wait runs on a libuv worker; force the already-existing bounded branch (`ReapTimeoutNs`) so the worker is
                 // released periodically and cannot be held for the process lifetime (the J libuv-budget design). This uses the same finite
                 // path the wake-poll/stall logic already handles, so it does not defeat that machinery; JVM/Native keep the indefinite park.
@@ -1783,7 +1930,28 @@ final private[net] class IoUringDriver private[posix] (
                         () // sends park in stalledSends / the in-flight send tail, never here
                 end match
             end while
+        end if
+        retryStalledCancels()
+        reForceStaleDeferredCloses()
     end reArmStalledSubmits
+
+    /** Re-issue the forcing cancel for handles whose deferred close has been owed for a long time.
+      *
+      * [[forceInFlightConnects]] runs ONCE, when the close is first deferred. A cancel that never reaches the kernel at all leaves nothing to
+      * judge and nothing to retry: [[retryStalledCancels]] only sees a cancel the submission queue rejected, and the result-based re-arm only
+      * sees a cancel that actually reaped. Anything lost between those two, and any op that became stuck after the single forcing pass, is
+      * owed until the ring tears down, which in a long-lived process never happens.
+      *
+      * Runs on the reap carrier, on a coarse interval so a busy ring pays a map scan rarely rather than every turn. Re-forcing a handle whose
+      * connects have since completed costs nothing: the scan finds no matching pending op and submits no cancel.
+      */
+    private def reForceStaleDeferredCloses()(using AllowUnsafe, Frame): Unit =
+        if !closeAfterDrain.isEmpty && (diagReapCycles % ReForceInterval) == 0L then
+            val it = closeAfterDrain.values().iterator()
+            while it.hasNext do
+                forceInFlightConnects(it.next())
+        end if
+    end reForceStaleDeferredCloses
 
     /** Map one reaped CQE back to its pending op and complete it. Releases the op's pinned memory and decrements the handle's in-flight
       * count (which may trigger a deferred close). `res >= 0` is the byte count or accepted fd; `res < 0` is `-errno`.
@@ -2174,7 +2342,11 @@ final private[net] class IoUringDriver private[posix] (
                 if backoffReArmAccept then ()
                 else if deferredDecrement then submitEngineOp { () => decrementInFlight(op.handle) } else decrementInFlight(op.handle)
             case Absent =>
-                Log.live.unsafe.warn(s"$label CQE for unknown key=$key")
+                // The result is half the evidence and the key alone is nearly useless: a completion nobody can attribute is only
+                // identifiable by what it carries. A negative value is an errno and names the failure; a non-negative one is an accepted
+                // descriptor or a byte count, which distinguishes an op that ran from one the kernel rejected. Without it, an unknown key is
+                // an unfalsifiable observation.
+                Log.live.unsafe.warn(s"$label CQE for unknown key=$key res=$res")
         end match
     end complete
 
@@ -2184,7 +2356,8 @@ final private[net] class IoUringDriver private[posix] (
       */
     private def completeMultishot(key: Long, res: Int, more: Boolean)(using AllowUnsafe): Unit =
         given Frame = Frame.internal
-        if key == WakeKey then
+        if key == DiscardKey then ()
+        else if key == WakeKey then
             // The wake eventfd's multishot poll fired: a cross-carrier submitEngineOp / close wrote the eventfd to return this parked wait. It
             // carries no connection work; the enqueued op is drained by the loop's next drainEngineOps. Drain the counter so the level-readable
             // eventfd does not immediately re-fire the poll. The multishot stays armed across completions (F_MORE); on a non-F_MORE completion
@@ -2192,6 +2365,20 @@ final private[net] class IoUringDriver private[posix] (
             // before the next park (and parks bounded until it does, never indefinitely without an armed wake).
             discard(uring.kyo_uring_eventfd_read(wakeFd))
             if !more then wakePollArmed = false
+        else if cancelTargets.containsKey(java.lang.Long.valueOf(key)) then
+            // A cancel issued by [[forceInFlightConnects]] reaped. Its own result decides whether the forcing actually happened: 0 means the
+            // kernel cancelled the target and -ENOENT means the target had already completed, and in both the deferred close is discharged
+            // by the TARGET's completion rather than this one. ANY OTHER RESULT MEANS THE FORCING DID NOT TAKE. -EALREADY is the case that
+            // matters under load: the target was already executing (mid-issue, or punted to a worker), so the kernel declines to cancel it
+            // and the connect runs to its natural end, which for a peer that never answers is the SYN-retransmit schedule, minutes long and
+            // far past any leaf budget. Discarding this result was a claim about kernel behaviour that had never been executed.
+            discard(diagCancelReaped.incrementAndGet())
+            val target       = cancelTargets.remove(java.lang.Long.valueOf(key)).longValue()
+            val stillPending = pending.containsKey(target)
+            if res != 0 && res != -PosixConstants.ENOENT && stillPending then
+                Log.live.unsafe.warn(s"$label cancel for op $target did not take (res=$res); re-arming")
+                discard(stalledCancels.add(target))
+            end if
         else if more then
             // Single-shot accept and recv do not set F_MORE. If the kernel sets it unexpectedly (future op or kernel behavior change),
             // treat the CQE as single-shot: complete and remove the entry so no stale pending key accumulates.
@@ -2313,6 +2500,16 @@ final private[net] class IoUringDriver private[posix] (
             Maybe(closeAfterDrain.remove(handle.id.packed)).foreach(dischargeDeferredClose)
         end if
     end decrementInFlight
+
+    /** Leave an acquired-but-unusable SQE in a well-defined state. The slot cannot be given back (see [[IoUringDriver.DiscardKey]]), and
+      * liburing does not clear a reused one, so leaving it alone re-issues the previous occupant's opcode against a stale descriptor. Prepare
+      * a nop and key it so the completion is dropped silently rather than logged as an unattributable CQE.
+      */
+    private def discardSqe(sqe: Ffi.Handle[IoUringSqe])(using AllowUnsafe): Unit =
+        uring.kyo_uring_prep_nop(sqe)
+        uring.kyo_uring_sqe_set_data64(sqe, DiscardKey)
+        submitBatched()
+    end discardSqe
 
     private def submitBatched()(using AllowUnsafe): Unit = discard(pendingSubmits.incrementAndGet())
 
@@ -2489,6 +2686,13 @@ private[net] object IoUringDriver:
       * which is pure reap-loop infrastructure, not a connection-op completion.
       */
     private[posix] val WakeKey: Long = -1L
+
+    /** user_data for an SQE that was acquired and then could not be used. `io_uring_get_sqe` advances the submission tail as it hands the
+      * entry out, so the slot reaches the kernel whether or not the caller fills it: acquiring is a commitment. The slot is prepared as a nop
+      * and given this key, which the reap side recognises and drops. Distinct from every other key space by construction: op keys count up
+      * from 1, the wake eventfd is -1, and cancel keys count down from -2.
+      */
+    private[posix] val DiscardKey: Long = Long.MinValue
 
     /** Build a driver over a freshly initialized io_uring ring. The ring lives in a caller-owned `Buffer[Byte]` of `kyo_uring_sizeof()` bytes
       * (the SQ/CQ mmaps are owned internally by liburing). Throws `NetBackendUnavailableException` if `io_uring_queue_init` fails (e.g. the

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixConstants.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixConstants.scala
@@ -88,6 +88,10 @@ private[net] object PosixConstants:
     val ECONNABORTED: Int = if isMacOrBsd then 53 else 103
     // EBUSY is 16 on both Linux and macOS/BSD; the io_uring reap loop treats it as a transient retry condition.
     val EBUSY: Int = 16
+
+    // ENOENT is 2 on both Linux and macOS/BSD. IORING_OP_ASYNC_CANCEL answers -ENOENT when it cannot find the target, which for a cancel
+    // issued against an in-flight op means the op completed on its own between the submit and the kernel's lookup.
+    val ENOENT: Int = 2
     // ENOSYS is what kyo_epoll.c's off-Linux stubs report: the epoll and eventfd syscalls do not exist on this platform. It names the
     // one outcome that distinguishes "the shim is present and says no" from "the symbol was never linked", which is the difference a
     // published Native artifact has to preserve across build hosts. Unlike every other errno here, this one is read on Windows too,

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixHandle.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixHandle.scala
@@ -180,6 +180,16 @@ final private[net] class PosixHandle private (
     /** Claim the socket-fd close: returns `true` for the single caller that should issue `close(fd)`, `false` for every later caller. */
     private[posix] def claimFdClose()(using AllowUnsafe): Boolean = fdCloseClaimed.compareAndSet(false, true)
 
+    /** Whether some path has already taken responsibility for closing this handle's fd, without consuming the claim the way
+      * [[claimFdClose]] does.
+      *
+      * This is the state that moves at the same instant the fd number does, which is what makes it the right thing to test before arming a
+      * new operation against [[writeFd]]. [[isClosing]] is not: a connection handle's guard bit is set by the driver's deferred discharge,
+      * on a different carrier and strictly after the close-phase paths have already issued `close(fd)` on the caller's, so a check against it
+      * reads `false` for exactly the window in which the number may already name somebody else's socket.
+      */
+    private[posix] def fdCloseIsClaimed(using AllowUnsafe): Boolean = fdCloseClaimed.get()
+
     /** Record that a [[claimFdClose]] win was spent guarding [[IoUringDriver.registerDeferredClose]]'s deferred `shutdown(SHUT_RD)`, not the
       * real `close(fd)` syscall: that call still owes the actual close once the in-flight recv drains, but its own `claimFdClose()` attempt
       * would lose (the claim is already spent). Set by the winner right after winning; consumed exactly once via [[consumeDeferredFdClose]].
@@ -652,10 +662,11 @@ private[net] object PosixHandle:
     def socket(fd: Int, bufSize: Int, connectTarget: Maybe[(Buffer[Byte], Int)], createdAt: Frame)(using
         AllowUnsafe
     ): PosixHandle =
+        val hid = HandleId.next(fd)
         new PosixHandle(
             fd,
             fd,
-            HandleId.next(fd),
+            hid,
             Buffer.alloc[Byte](bufSize),
             bufSize,
             Absent,
@@ -668,6 +679,7 @@ private[net] object PosixHandle:
             lastPlaintextRead = AtomicRef.Unsafe.init(Absent),
             createdAt = createdAt
         )
+    end socket
 
     /** stdio handle: split fds, read end 0 and write end 1 (the split-fd case). */
     def stdio(bufSize: Int, createdAt: Frame)(using AllowUnsafe): PosixHandle =

--- a/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixTransport.scala
+++ b/kyo-net/shared/src/main/scala/kyo/net/internal/posix/PosixTransport.scala
@@ -584,24 +584,33 @@ final private[net] class PosixTransport private[posix] (
         config: kyo.net.NetConfig
     )(using allow: AllowUnsafe, frame: Frame): Unit =
         val writablePromise = new IOPromise[Closed | NetException, Unit]
+        // Release the connect's resources on the carrier that owns the submission ring, never on whichever carrier happens to resolve this
+        // promise. The completion driver stashes `addr` on the handle as its connectTarget and marshals it when it preps the connect SQE, and
+        // that prep runs on the reap carrier from an op this method has ALREADY enqueued. Freeing `addr` here directly raced that prep: the
+        // buffer's memory session closed underneath it, the prep threw, and because an SQE had already been acquired (io_uring_get_sqe advances
+        // the submission tail, so the slot is committed the moment it is handed out) the connect went to the kernel as a zeroed SQE while its
+        // pending entry, and the in-flight count holding the handle's deferred close, stayed behind forever. Going through the engine FIFO
+        // orders this strictly after that prep, so the submit either ran with a live buffer or is rejected by the isClosing check it sets.
+        // The raw fd close is deferred with it for the same reason: closing the descriptor under a prepared connect lets the number be
+        // recycled before the SQE reaches the kernel. On the poller and the inline drivers this is the same FIFO their other engine ops use.
+        def releaseConnect(complete: () => Unit): Unit =
+            driver.submitEngineOp { () =>
+                addr.close()
+                closeUnwiredHandle(handle, driver, connectPhase = true)
+                complete()
+            }
         writablePromise.onComplete { result =>
             result match
                 case Result.Success(_) =>
                     val err = if checkSoError then soError(handle.writeFd) else 0
                     if err != 0 then
-                        addr.close()
-                        closeUnwiredHandle(handle, driver, connectPhase = true)
-                        promise.completeDiscard(Result.fail(connectFail(host, port, new NetErrno(err))))
+                        releaseConnect(() => promise.completeDiscard(Result.fail(connectFail(host, port, new NetErrno(err)))))
                     else completeOrTls(handle, addr, driver, target, port, tls, promise, config)
                     end if
                 case Result.Failure(cause) =>
-                    addr.close()
-                    closeUnwiredHandle(handle, driver, connectPhase = true)
-                    promise.completeDiscard(Result.fail(connectFail(host, port, cause)))
+                    releaseConnect(() => promise.completeDiscard(Result.fail(connectFail(host, port, cause))))
                 case Result.Panic(e) =>
-                    addr.close()
-                    closeUnwiredHandle(handle, driver, connectPhase = true)
-                    promise.completeDiscard(Result.panic(e))
+                    releaseConnect(() => promise.completeDiscard(Result.panic(e)))
             end match
         }
         // Promise.Unsafe[A, S] is an opaque alias over IOPromise[Any, A < S] (kyo.Fiber.scala), structurally different from this
@@ -1191,6 +1200,7 @@ final private[net] class PosixTransport private[posix] (
                         if handle.claimFdClose() then
                             discard(sockets.shutdown(clientFd, PosixConstants.SHUT_RDWR))
                             handle.fdCloseSink = Present(() => closeRawFd(clientFd))
+                        end if
                         engine.free()
                     end teardown
                     // One deadline per accepted connection: when handshakeTimeout is finite, a client that completed the TCP accept but stalls
@@ -1488,6 +1498,7 @@ final private[net] class PosixTransport private[posix] (
             if handle.claimFdClose() then
                 discard(sockets.shutdown(handle.writeFd, PosixConstants.SHUT_RDWR))
                 handle.fdCloseSink = Present(() => closeRawFd(handle.writeFd))
+            end if
             driver.closeHandle(handle)
             if held then discard(handle.endDeferredClose())
         end if

--- a/kyo-net/shared/src/test/scala/kyo/net/internal/SslLibProviderOwnershipTest.scala
+++ b/kyo-net/shared/src/test/scala/kyo/net/internal/SslLibProviderOwnershipTest.scala
@@ -1,0 +1,133 @@
+package kyo.net.internal
+
+import kyo.*
+import kyo.ffi.Buffer
+import kyo.net.NetTlsConfig
+import kyo.net.NetTlsConfigException
+import kyo.net.Test
+
+/** Engine construction over recording bindings instead of a real TLS library.
+  *
+  * What this covers is native OWNERSHIP, which no end-to-end TLS suite can see: an `SSL_CTX` is refcounted, `SSL_new` takes its own reference,
+  * and only `SSL_free` releases that one, so a context whose creation reference is never dropped leaks silently along with the chains and keys
+  * loaded into it. A leak has no observable behaviour, so counting the calls is the only way to assert it, and driving the provider over stub
+  * bindings does that without crypto, without staged libraries, and on every platform.
+  *
+  * It also reaches the fail-closed identity path, which real material cannot: `SSL_set1_host` on a fresh SSL essentially cannot fail, so the
+  * second-level failure (the unmatchable identity itself failing to bind) is unreachable with a real library and reachable here.
+  */
+class SslLibProviderOwnershipTest extends Test:
+
+    import AllowUnsafe.embrace.danger
+    given Frame = Frame.internal
+
+    /** Records the allocation and release calls, and lets a leaf choose which of them reports failure. Handles are plain integers: nothing
+      * dereferences them, so the provider cannot tell them from real pointers.
+      */
+    private class StubBindings(
+        ctxNewResult: Long = 10L,
+        sslNewResult: Long = 100L,
+        minMaxVersionResult: Int = 0,
+        systemCaResult: Int = 1,
+        verifyNameResult: Int = 1,
+        unmatchableResult: Int = 1
+    ) extends SslLibBindings:
+        var ctxNewCalls       = 0
+        var ctxFreeCalls      = 0
+        var sslNewCalls       = 0
+        var sslFreeCalls      = 0
+        var unmatchableCalls  = 0
+        var connectStateCalls = 0
+
+        def ctxNew(isServer: Int)(using AllowUnsafe): Long =
+            ctxNewCalls += 1; ctxNewResult
+        def ctxFree(ctx: Long)(using AllowUnsafe): Unit = ctxFreeCalls += 1
+        def sslNew(ctx: Long, hostname: String)(using AllowUnsafe): Long =
+            sslNewCalls += 1; sslNewResult
+        def sslFree(ssl: Long)(using AllowUnsafe): Unit = sslFreeCalls += 1
+
+        def sslSetVerifyName(ssl: Long, hostname: String)(using AllowUnsafe): Int = verifyNameResult
+        def sslRequireUnmatchableIdentity(ssl: Long)(using AllowUnsafe): Int =
+            unmatchableCalls += 1; unmatchableResult
+        def sslSetConnectState(ssl: Long)(using AllowUnsafe): Unit = connectStateCalls += 1
+        def sslSetAcceptState(ssl: Long)(using AllowUnsafe): Unit  = ()
+
+        def ctxSetCert(ctx: Long, certPem: String, keyPem: String)(using AllowUnsafe): Int = 0
+        def ctxSetVerifyMode(ctx: Long, mode: Int)(using AllowUnsafe): Unit                = ()
+        def ctxLoadCa(ctx: Long, caPem: String)(using AllowUnsafe): Int                    = 1
+        def ctxLoadSystemCa(ctx: Long)(using AllowUnsafe): Int                             = systemCaResult
+        def ctxSetMinMaxVersion(ctx: Long, min: Int, max: Int)(using AllowUnsafe): Int     = minMaxVersionResult
+
+        def doHandshakeStep(ssl: Long)(using AllowUnsafe): Int                                   = 1
+        def feedCiphertext(ssl: Long, buf: Buffer[Byte], len: Int)(using AllowUnsafe): Int       = len
+        def drainCiphertext(ssl: Long, buf: Buffer[Byte], len: Int)(using AllowUnsafe): Int      = 0
+        def readPlain(ssl: Long, buf: Buffer[Byte], len: Int)(using AllowUnsafe): Int            = 0
+        def writePlain(ssl: Long, buf: Buffer[Byte], len: Int)(using AllowUnsafe): Int           = len
+        def pending(ssl: Long)(using AllowUnsafe): Int                                           = 0
+        def shutdownStep(ssl: Long)(using AllowUnsafe): Int                                      = 1
+        def peerCertSha256(ssl: Long, outBuf: Buffer[Byte], outLen: Int)(using AllowUnsafe): Int = -1
+        def probeAvailable()(using AllowUnsafe): Boolean                                         = true
+    end StubBindings
+
+    private class StubProvider(bindings: StubBindings) extends SslLibProvider:
+        def name                                                     = "stub"
+        def priority                                                 = 0
+        def libraryIds: Chunk[String]                                = Chunk("stub")
+        private[internal] def lib(using AllowUnsafe): SslLibBindings = bindings
+    end StubProvider
+
+    private def build(bindings: StubBindings, config: NetTlsConfig = NetTlsConfig(), hostname: String = "example.com") =
+        StubProvider(bindings).createEngine(config, hostname, isServer = false)
+
+    "a built engine leaves the context's creation reference released" in {
+        // The engine's SSL holds its own reference, so releasing the creation reference here is what lets the context go when the engine is
+        // freed. Skipping it leaks a context per engine, which is invisible at every layer above this one.
+        val bindings = StubBindings()
+        val engine   = build(bindings)
+        assert(
+            bindings.ctxNewCalls == 1 && bindings.ctxFreeCalls == 1,
+            s"context: new=${bindings.ctxNewCalls} free=${bindings.ctxFreeCalls}"
+        )
+        assert(bindings.sslFreeCalls == 0, "the SSL belongs to the engine and must outlive construction")
+        engine.free()
+        assert(bindings.sslFreeCalls == 1, s"the engine must release its SSL exactly once; got ${bindings.sslFreeCalls}")
+    }
+
+    "a context whose SSL could not be created is released" in {
+        val bindings = StubBindings(sslNewResult = 0L)
+        val ex       = intercept[NetTlsConfigException](build(bindings))
+        discard(ex)
+        assert(bindings.ctxFreeCalls == 1, s"expected the context released; got ${bindings.ctxFreeCalls}")
+        assert(bindings.sslFreeCalls == 0, "no SSL was created, so none may be freed")
+    }
+
+    "a context rejected during configuration is released before any SSL exists" in {
+        val bindings = StubBindings(minMaxVersionResult = -1)
+        val ex       = intercept[NetTlsConfigException](build(bindings))
+        discard(ex)
+        assert(bindings.sslNewCalls == 0, "configuration failed, so no SSL should have been created")
+        assert(bindings.ctxFreeCalls == 1, s"expected the context released; got ${bindings.ctxFreeCalls}")
+    }
+
+    "an identity that cannot be bound fails closed and releases both the SSL and the context" in {
+        // A verifying client with no reference identity binds an unmatchable one so the handshake rejects every peer. When THAT fails there is
+        // no name bound at all and the handshake would take any chain-valid certificate, so the engine build must fail rather than proceed.
+        // It fails after the SSL exists, which is the path that would otherwise strand the SSL and its two memory BIOs.
+        val bindings = StubBindings(unmatchableResult = 0)
+        val ex       = intercept[NetTlsConfigException](build(bindings, hostname = ""))
+        discard(ex)
+        assert(bindings.unmatchableCalls == 1, "the unmatchable identity should have been attempted")
+        assert(bindings.sslFreeCalls == 1, s"expected the SSL released on the failure path; got ${bindings.sslFreeCalls}")
+        assert(bindings.ctxFreeCalls == 1, s"expected the context released; got ${bindings.ctxFreeCalls}")
+        assert(bindings.connectStateCalls == 0, "the engine must not reach role selection after a failed identity bind")
+    }
+
+    "a verifying client whose reference identity binds keeps the unmatchable fallback unused" in {
+        val bindings = StubBindings()
+        val engine   = build(bindings)
+        assert(bindings.unmatchableCalls == 0, "a host that bound needs no unmatchable fallback")
+        assert(bindings.connectStateCalls == 1, "the client role should have been selected")
+        engine.free()
+    }
+
+end SslLibProviderOwnershipTest

--- a/kyo-pod/shared/src/main/scala/kyo/ContainerPredef.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/ContainerPredef.scala
@@ -32,6 +32,59 @@ object ContainerPredef:
         s"""end=$$(($$(date +%s)+${budget.toSeconds})); while [ "$$(date +%s)" -lt "$$end" ]; do $quoted >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1"""
     end readinessScript
 
+    /** Whether a readiness exec that the daemon failed is worth one more attempt.
+      *
+      * Retryable means two things at once, and both matter. The container must still be RUNNING, because a container that died mid-boot
+      * will fail every subsequent exec for the same reason and retrying only delays the report; and there must be budget left, because an
+      * unbounded retry reintroduces the cost the single in-container poll loop exists to avoid, every host exec leaving a conmon lingering
+      * for minutes on rootless podman.
+      *
+      * A probe that RAN and reported the service down never reaches here. That is the service's own verdict and is terminal, and retrying
+      * it would mask exactly the failure this health check exists to report.
+      */
+    private[kyo] def retryableExecFailure(state: Result[ContainerException, Container.State], retriesLeft: Int): Boolean =
+        retriesLeft > 0 && (state match
+            case Result.Success(Container.State.Running) => true
+            case _                                       => false)
+
+    /** One readiness attempt and the retry decision after it, over the two effects it actually depends on rather than over a `Container`.
+      *
+      * An exec that FAILED is a different thing from a probe that RAN and reported the service down. The second is the service's own
+      * verdict and is terminal. This one is the daemon's, and under load it can be transient against a container that is perfectly
+      * healthy: a fork that hit EAGAIN, an API blip. So ask the container which happened. No longer running means it died mid-boot and no
+      * retry can help; still running means the exec itself faltered and is worth one more attempt.
+      *
+      * The retry is deliberately narrow, and both bounds carry weight. Retrying the ran-and-failed case would mask a service that never
+      * comes up, which is the failure this check exists to report. An unbounded retry would reintroduce the cost the single in-container
+      * poll loop exists to avoid, since every host exec leaves a conmon lingering for minutes on rootless podman. One extra attempt covers
+      * a transient without turning a health check into a poll.
+      *
+      * Taking `runProbe` and `readState` as parameters is what makes that policy assertable end to end: a caller can drive the loop with
+      * scripted outcomes and observe how many attempts it makes, which a `Container` cannot supply (its backend is a 51-member contract).
+      */
+    private[kyo] def readinessAttempt(
+        runProbe: () => Result[ContainerException, Container.ExecResult] < Async,
+        readState: () => Result[ContainerException, Container.State] < Async,
+        onProbeReportedDown: String => Unit < (Async & Abort[ContainerException]),
+        onExecFailed: ContainerException => Unit < (Async & Abort[ContainerException]),
+        retriesLeft: Int
+    )(using Frame): Unit < (Async & Abort[ContainerException]) =
+        runProbe().map {
+            case Result.Success(r) if r.isSuccess => Kyo.unit
+            case Result.Success(r)                => onProbeReportedDown(r.stderr.trim)
+            case Result.Failure(cause) =>
+                readState().map {
+                    case st if retryableExecFailure(st, retriesLeft) =>
+                        readinessAttempt(runProbe, readState, onProbeReportedDown, onExecFailed, retriesLeft - 1)
+                    // A defect while ASKING the daemon what happened is not the exec's failure, and reporting it as one would
+                    // attribute a bug in the state query to the service under test. Propagated like the probe's own panic below.
+                    case Result.Panic(t) => Abort.panic(t)
+                    case _               => onExecFailed(cause)
+                }
+            case Result.Panic(t) => Abort.panic(t)
+        }
+    end readinessAttempt
+
     /** A readiness [[Container.HealthCheck]] that runs `probe` in one bounded poll loop *inside* the container, not a
       * fresh host `exec` per retry. Each host `exec` leaves a `conmon` lingering ~300s on rootless podman, so a
       * sub-second host-side poll across a fixture suite accumulates orphaned `conmon`; the in-container loop collapses
@@ -46,16 +99,13 @@ object ContainerPredef:
                 // caller's ambient HttpClient timeout (often the 5s default; predef fixtures are reused beyond kyo-pod).
                 // Give it its own budget-covering timeout; the shell backend ignores the HttpClient config.
                 HttpClient.withConfig(_.timeout(budget + 15.seconds)) {
-                    Abort.run[ContainerException](container.exec(cmd)).map {
-                        case Result.Success(r) if r.isSuccess => Kyo.unit
-                        case Result.Success(r) =>
-                            healthFailure(container, s"readiness probe did not pass within ${budget.toSeconds}s", r.stderr.trim)
-                        case Result.Failure(cause) =>
-                            // The readiness exec failed: usually the service's own container exited mid-boot (OOM or
-                            // failed init), which the daemon reports as a not-running container. Capture why.
-                            healthFailure(container, s"readiness exec failed: ${cause.getMessage}", "")
-                        case Result.Panic(t) => Abort.panic(t)
-                    }
+                    readinessAttempt(
+                        () => Abort.run[ContainerException](container.exec(cmd)),
+                        () => Abort.run[ContainerException](container.state),
+                        stderr => healthFailure(container, s"readiness probe did not pass within ${budget.toSeconds}s", stderr),
+                        cause => healthFailure(container, s"readiness exec failed: ${cause.getMessage}", ""),
+                        1
+                    )
                 }
             end check
             def schedule: Schedule = Schedule.done

--- a/kyo-pod/shared/src/main/scala/kyo/internal/HttpContainerBackend.scala
+++ b/kyo-pod/shared/src/main/scala/kyo/internal/HttpContainerBackend.scala
@@ -1449,7 +1449,10 @@ final private[kyo] class HttpContainerBackend(
       * were rejected; a 404 still means missing.
       *
       * Transport-level failures (no `HttpStatusException`) still go through `mapHttpError` regardless — they aren't registry denials,
-      * they're connection / protocol errors and shouldn't be silently relabelled as missing image.
+      * they're connection / protocol errors and shouldn't be silently relabelled as missing image. A registry that answers 5xx is in that
+      * same category and is excluded for the same reason: the conflation this branch exists to paper over is between "absent" and "needs
+      * credentials", and a server error asserts neither. Calling it missing is worse than unhelpful, because a missing image is the one
+      * classification callers treat as permanent, so a transient upstream fault lands in the bucket that is never retried.
       */
     private def normalizePullError(
         httpEx: HttpException,
@@ -1457,7 +1460,7 @@ final private[kyo] class HttpContainerBackend(
         auth: Maybe[ContainerImage.RegistryAuth]
     )(using Frame): Unit < (Sync & Abort[ContainerException]) =
         httpEx match
-            case _: HttpStatusException if auth.isEmpty =>
+            case e: HttpStatusException if auth.isEmpty && !isRegistryUnavailable(e) =>
                 Abort.fail(ContainerImageMissingException(image))
             case e: HttpStatusException if auth.isDefined && isAuthDenialBody(e) =>
                 // With auth supplied, a daemon response carrying registry-denial wording is
@@ -1472,6 +1475,22 @@ final private[kyo] class HttpContainerBackend(
             case _ =>
                 mapHttpError(httpEx, ResourceContext.Image(image.reference)).unit
     end normalizePullError
+
+    /** True when the daemon reports the registry itself as failing rather than answering about the image.
+      *
+      * A 5xx is the upstream saying it could not serve the request at all, which is transient and carries no claim about whether the image
+      * exists or whether credentials would help. A body naming a server-side status is treated the same way, since the daemon proxies the
+      * registry's own wording and reports it under its own status.
+      */
+    private def isRegistryUnavailable(e: HttpStatusException): Boolean =
+        e.status.code >= 500 ||
+            e.body.exists { body =>
+                val lower = body.toLowerCase
+                lower.contains("500 internal server error") ||
+                lower.contains("502 bad gateway") ||
+                lower.contains("503 service unavailable") ||
+                lower.contains("504 gateway timeout")
+            }
 
     /** True when the response status code OR body carries a registry-level auth-denial signal.
       *

--- a/kyo-pod/shared/src/test/scala/kyo/ContainerPredefTest.scala
+++ b/kyo-pod/shared/src/test/scala/kyo/ContainerPredefTest.scala
@@ -179,6 +179,127 @@ class ContainerPredefTest extends BasePodTest:
         }
     }
 
+    "retryableExecFailure" - {
+
+        // A daemon that failed the exec is a different signal from a probe that ran and reported the service down.
+        // Only the first is worth another attempt, and only while the container is still alive to answer it.
+        "a running container with budget left is retried" in {
+            assert(ContainerPredef.retryableExecFailure(Result.Success(Container.State.Running), 1))
+        }
+
+        // A container that died mid-boot fails every later exec for the same reason, so retrying only delays the report.
+        "a container that is no longer running is terminal" in {
+            assert(ContainerPredef.retryableExecFailure(Result.Success(Container.State.Dead), 1) == false)
+            assert(ContainerPredef.retryableExecFailure(Result.Success(Container.State.Stopped), 1) == false)
+            assert(ContainerPredef.retryableExecFailure(Result.Success(Container.State.Created), 1) == false)
+        }
+
+        // The bound is what keeps a health check from becoming a poll; every host exec leaves a conmon behind for minutes.
+        "a running container with no budget left is terminal" in {
+            assert(ContainerPredef.retryableExecFailure(Result.Success(Container.State.Running), 0) == false)
+        }
+    }
+
+    // The leaves above pin the POLICY in isolation; these pin that the loop obeys it. Driving `readinessAttempt` with scripted outcomes
+    // counts the attempts it actually makes, which asserting the predicate alone cannot: a loop that never consulted it would still leave
+    // those leaves green.
+    "readinessAttempt" - {
+
+        val ok     = Container.ExecResult(ExitCode(0), "", "")
+        val notOk  = Container.ExecResult(ExitCode(1), "", "service down")
+        val daemon = ContainerBackendException("exec failed")
+
+        /** Runs the loop over a scripted sequence of probe outcomes, reporting how many attempts were consumed and which terminal branch
+          * (if any) the loop took.
+          */
+        def drive(
+            probes: Seq[Result[ContainerException, Container.ExecResult]],
+            state: Result[ContainerException, Container.State],
+            retries: Int = 1
+        )(using Frame) =
+            for
+                attempts <- AtomicInt.init(0)
+                down     <- AtomicInt.init(0)
+                failed   <- AtomicInt.init(0)
+                _ <- Abort.run[ContainerException](ContainerPredef.readinessAttempt(
+                    () => attempts.getAndIncrement.map(i => probes(math.min(i, probes.size - 1))),
+                    () => state,
+                    _ => down.incrementAndGet.unit,
+                    _ => failed.incrementAndGet.unit,
+                    retries
+                ))
+                a <- attempts.get
+                d <- down.get
+                f <- failed.get
+            yield (a, d, f)
+
+        "a probe that passes runs once and reports nothing" in {
+            drive(Seq(Result.succeed(ok)), Result.Success(Container.State.Running)).map { case (a, d, f) =>
+                assert((a, d, f) == (1, 0, 0), s"expected one attempt and no failure report; got attempts=$a down=$d failed=$f")
+            }
+        }
+
+        // The retry the policy allows must actually be taken: a daemon-failed exec against a live container gets a second attempt.
+        "a daemon-failed exec against a running container is retried once, then succeeds" in {
+            drive(Seq(Result.fail(daemon), Result.succeed(ok)), Result.Success(Container.State.Running)).map { case (a, d, f) =>
+                assert((a, d, f) == (2, 0, 0), s"expected the retry to be taken and to succeed; got attempts=$a down=$d failed=$f")
+            }
+        }
+
+        // And it must stop there rather than becoming a poll.
+        "a daemon-failed exec is retried at most once, then reported" in {
+            drive(Seq(Result.fail(daemon)), Result.Success(Container.State.Running)).map { case (a, d, f) =>
+                assert(
+                    (a, d, f) == (2, 0, 1),
+                    s"expected exactly two attempts then an exec-failed report; got attempts=$a down=$d failed=$f"
+                )
+            }
+        }
+
+        // A container that died mid-boot fails every later exec for the same reason, so the loop must not spend the retry on it.
+        "a daemon-failed exec against a dead container is not retried" in {
+            drive(Seq(Result.fail(daemon)), Result.Success(Container.State.Dead)).map { case (a, d, f) =>
+                assert((a, d, f) == (1, 0, 1), s"expected no retry for a dead container; got attempts=$a down=$d failed=$f")
+            }
+        }
+
+        // The service's own verdict is terminal: a probe that RAN and said "down" must never be retried, or the loop would mask exactly
+        // the failure the health check exists to report.
+        "a probe that ran and reported the service down is never retried" in {
+            drive(Seq(Result.succeed(notOk)), Result.Success(Container.State.Running)).map { case (a, d, f) =>
+                assert((a, d, f) == (1, 1, 0), s"expected one attempt and a probe-down report; got attempts=$a down=$d failed=$f")
+            }
+        }
+
+        // Asking the daemon what happened is itself code that can be defective. That defect belongs to the state query, so reporting it
+        // as the exec's failure would blame the service under test for a bug in the machinery inspecting it.
+        "a panic from the state query propagates instead of being reported as an exec failure" in {
+            val boom = new RuntimeException("state query defect")
+            for
+                attempts <- AtomicInt.init(0)
+                failed   <- AtomicInt.init(0)
+                outcome <- Abort.run[ContainerException](ContainerPredef.readinessAttempt(
+                    () => attempts.getAndIncrement.andThen(Result.fail(daemon)),
+                    () => Result.panic(boom),
+                    _ => Kyo.unit,
+                    _ => failed.incrementAndGet.unit,
+                    1
+                ))
+                a <- attempts.get
+                f <- failed.get
+            yield
+                assert(
+                    outcome match
+                        case Result.Panic(t) => t eq boom
+                        case _               => false
+                    ,
+                    s"expected the state-query panic to propagate unchanged; got $outcome"
+                )
+                assert((a, f) == (1, 0), s"expected one attempt and no exec-failed report; got attempts=$a failed=$f")
+            end for
+        }
+    }
+
     "readinessScript" - {
         "embeds the configured budget as the loop deadline" in {
             // The generated shell loop computes its end as `date +%s` plus the budget in seconds, so a fixture's

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
@@ -54,8 +54,22 @@ object StreamPublisher:
                 channel.stream().foreach: subscriber =>
                     for
                         subscription <- publisher.getSubscription(subscriber)
-                        fiber        <- subscription.subscribe.andThen(subscription.consume)
-                        _            <- supervisor.onInterrupt(_ => fiber.interrupt(Result.Panic(Interrupted(summon[Frame]))))
+                        _            <- subscription.subscribe
+                        // Registered BEFORE the consuming fiber exists. Cancelling a subscription closes its request
+                        // channel, which is what ends that fiber, so a teardown arriving between here and the fiber's
+                        // creation still stops the subscription rather than stranding it with nothing to interrupt it.
+                        _     <- supervisor.onInterrupt(_ => Sync.defer(subscription.stopForPublisherTeardown()))
+                        fiber <- subscription.consume
+                        _     <- supervisor.onInterrupt(_ => fiber.interrupt(Result.Panic(Interrupted(summon[Frame]))))
+                        // Registering on an ALREADY-completed promise is silently dropped, so for a subscriber accepted
+                        // while the publisher was being torn down neither registration above ever runs. Re-read the
+                        // supervisor and stop this subscription directly when that is what happened. Both calls are
+                        // idempotent, so the ordinary path costs a single completed-promise read.
+                        _ <- supervisor.done.map: settled =>
+                            if !settled then Kyo.unit
+                            else
+                                Sync.defer(subscription.stopForPublisherTeardown())
+                                    .andThen(fiber.interrupt(Result.Panic(Interrupted(summon[Frame]))).unit)
                     yield ()
             )
 

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -17,6 +17,11 @@ final private[kyo] class StreamSubscription[V, S](
 
     private val requestChannel = Channel.Unsafe.init[Long](Int.MaxValue)
 
+    // Whether the publisher stopped this subscription rather than the subscriber cancelling it. The two look identical downstream, since
+    // both close the request channel, but they owe the subscriber opposite things: a subscriber that cancelled has asked not to be
+    // signalled again, while one the publisher stopped never asked for anything and is still waiting for a terminal event.
+    private val stoppedByPublisher = new java.util.concurrent.atomic.AtomicBoolean(false)
+
     override def request(n: Long): Unit =
         if n <= 0 then subscriber.onError(new IllegalArgumentException("non-positive subscription request"))
         discard(requestChannel.offer(n))
@@ -25,6 +30,17 @@ final private[kyo] class StreamSubscription[V, S](
     override def cancel(): Unit =
         discard(requestChannel.close())
     end cancel
+
+    /** Stop this subscription because the publisher is going away, not because the subscriber asked.
+      *
+      * Ends the drain the same way `cancel` does, and records why, so the completion handler delivers the terminal error a subscriber that
+      * never cancelled is owed. Publisher teardown previously reused `cancel` and therefore inherited its silence, leaving such a
+      * subscriber waiting for an event nobody would send.
+      */
+    private[interop] def stopForPublisherTeardown(): Unit =
+        stoppedByPublisher.set(true)
+        discard(requestChannel.close())
+    end stopForPublisherTeardown
 
     private[interop] def subscribe(using Frame): Unit < Sync = Sync.defer(subscriber.onSubscribe(this))
 
@@ -78,7 +94,12 @@ final private[kyo] class StreamSubscription[V, S](
                     x match
                         case Result.Success(StreamComplete) => Sync.defer(subscriber.onComplete())
                         case Result.Panic(e)                => Sync.defer(subscriber.onError(e))
-                        case Result.Failure(StreamCanceled) => Kyo.unit
+                        case Result.Failure(StreamCanceled) =>
+                            // Silence is correct only when the SUBSCRIBER cancelled: it asked not to be signalled again. A subscription the
+                            // publisher stopped owes its subscriber a terminal event, and nothing else will send one.
+                            if stoppedByPublisher.get() then
+                                Sync.defer(subscriber.onError(StreamSubscription.PublisherStopped()))
+                            else Kyo.unit
                     end match
                 }.andThen(fiber)
             }
@@ -92,6 +113,13 @@ object StreamSubscription:
     case object StreamComplete
     type StreamCanceled = StreamCanceled.type
     case object StreamCanceled
+
+    /** Delivered to a subscriber whose publisher went away while it was still subscribed.
+      *
+      * The subscriber did not cancel, so the specification's allowance for going silent after a cancellation does not apply to it: it is
+      * owed a terminal event, and this is that event.
+      */
+    final class PublisherStopped extends RuntimeException("the publisher was torn down while this subscription was active")
 
     def subscribe[V, S](
         using Isolate[S, Sync, Any]

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -1,5 +1,7 @@
 package kyo.interop.flow
 
+import java.util.concurrent.Flow.Subscriber
+import java.util.concurrent.Flow.Subscription
 import kyo.*
 import kyo.Result.Failure
 import kyo.Result.Panic
@@ -209,6 +211,47 @@ abstract private class PublisherToSubscriberTest extends kyo.test.Test[Any]:
                 _ <- fiber3.getResult
                 _ <- fiber4.getResult
             yield succeed("publisher interruption ended all subscribed parties without hanging")
+            end for
+        }
+
+        /** A subscriber the publisher tears down under is entitled to a terminal signal.
+          *
+          * The specification lets a publisher stop signalling once the SUBSCRIBER cancels, and the subscription's `cancel` is written for
+          * exactly that: it closes the request channel and deliberately delivers no terminal event. Publisher-initiated teardown reuses that
+          * same verb, so a subscriber that never cancelled is stopped the silent way and waits for an event that never comes.
+          *
+          * This pins the property directly rather than through the interrupt-propagation leaf, which needs four subscribers racing and only
+          * fails under load. One subscriber, established before the teardown, and the assertion is simply that something terminal arrived.
+          * Nothing here waits on the clock.
+          */
+        "a subscriber the publisher tears down under receives a terminal signal" in {
+            for
+                subscribed <- Promise.init[Unit, Any]
+                terminated <- Promise.init[String, Any]
+                sub = new Subscriber[Int]:
+                    import AllowUnsafe.embrace.danger
+                    def onSubscribe(s: Subscription): Unit =
+                        s.request(Long.MaxValue)
+                        discard(Sync.Unsafe.evalOrThrow(subscribed.unsafe.completeDiscard(Result.succeed(()))))
+                    def onNext(v: Int): Unit = ()
+                    def onComplete(): Unit =
+                        discard(Sync.Unsafe.evalOrThrow(terminated.unsafe.completeDiscard(Result.succeed("onComplete"))))
+                    def onError(e: Throwable): Unit =
+                        discard(Sync.Unsafe.evalOrThrow(terminated.unsafe.completeDiscard(Result.succeed("onError"))))
+                publisherFiber <- Fiber.initUnscoped(Scope.run(
+                    Stream.range(0, 1000000, 1).toPublisher
+                        .map(_.subscribe(sub))
+                        .andThen(Async.never)
+                ))
+                // Established before teardown, so this tests what teardown delivers rather than racing setup.
+                _ <- subscribed.get
+                _ <- publisherFiber.interrupt.unit
+                // The harness budget is the failure detector: a teardown that signals nothing never completes this.
+                signal <- terminated.get
+            yield assert(
+                signal == "onComplete" || signal == "onError",
+                s"publisher teardown must tell its subscriber something terminal, got $signal"
+            )
             end for
         }
 

--- a/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/MysqlSqlConfigTlsModeIntegrationTest.scala
+++ b/kyo-sql-mysql/shared/src/test/scala/kyo/mysql/MysqlSqlConfigTlsModeIntegrationTest.scala
@@ -110,7 +110,19 @@ class MysqlSqlConfigTlsModeIntegrationTest extends SqlContainerTest:
             SqlTestContainers.initScoped(requireSslConfig, "mysql-require-secure-transport").flatMap { requireSslContainer =>
                 val mysql = new ContainerPredef.MySQL(requireSslContainer, requireSslPredef)
                 mysql.container.mappedPort(mysql.config.port).flatMap { port =>
-                    val url = s"mysql://${mysql.username}:${mysql.password}@${mysql.container.host}:$port/${mysql.database}?sslmode=allow"
+                    // No establish budget (`connectTimeout=0` reads back as `Duration.Infinity`), because this leaf is
+                    // shaped differently from every other one here. The pool applies ONE budget to the whole of
+                    // `factory.open`, and `allow` against a `--require-secure-transport=ON` server performs TWO
+                    // connect-plus-handshake rounds inside it: a plaintext connect and auth far enough to draw error
+                    // 3159, then a full TLS reconnect. Its siblings pay one, so the default is sized for one and this
+                    // leaf is the first to cross it on a loaded runner with a server still cold from its own container
+                    // start.
+                    // Any finite value here would be a second wall clock racing the first: too low and a slow runner is
+                    // indistinguishable from a broken upgrade, too high and it bounds nothing. The property under test
+                    // is that the upgrade COMPLETES, so the suite timeout is the failure detector and the Ssl_cipher
+                    // assertion below is the pass condition.
+                    val url =
+                        s"mysql://${mysql.username}:${mysql.password}@${mysql.container.host}:$port/${mysql.database}?sslmode=allow&connectTimeout=0"
                     MysqlClient.init(url).flatMap { client =>
                         DB.run(client) {
                             // The allow reconnect path fired and the connection is now over TLS.

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/SqlClientInterruptTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/SqlClientInterruptTest.scala
@@ -60,4 +60,39 @@ class SqlClientInterruptTest extends SqlContainerTest:
         }
     }
 
+    /** A caller interrupted out of a connect must not strand the socket that connect owns.
+      *
+      * `transport.connect` returns a fiber owning a descriptor from the instant it is called, so the finalizer that closes it has to be
+      * registered BEFORE the launch. While it was registered after, an interrupt landing in that window left nobody owning the socket:
+      * the connect still succeeded, handed its connection to a promise the interrupted computation never read, and the descriptor stayed
+      * ESTABLISHED for the life of the process along with the server-side peer it was connected to.
+      *
+      * The window is narrow, so ONE interrupt proves nothing: eight of 192 connects took it. The scenario is repeated until the failure
+      * is reliable rather than probabilistic, which is what makes this a guard instead of a coin flip.
+      *
+      * Each cycle runs in its OWN `Scope.run`. Without that, the fake server and the client accumulate for the whole leaf and the
+      * harness's descriptor check reports the fixture's own growth rather than anything about the interrupt path. Asserting that every
+      * interrupt actually landed is what keeps the loop honest, since a cycle whose statement was never in flight exercises nothing;
+      * the descriptor check is what catches the leak itself.
+      */
+    "an interrupted connect strands no descriptor" in {
+        Kyo.foreachDiscard(Chunk.from(1 to 100)) { _ =>
+            Scope.run {
+                withSilentClient { client =>
+                    Latch.initWith(1) { started =>
+                        Fiber.initUnscoped(
+                            started.release.andThen(Abort.run[SqlException](client.query("SELECT 1")))
+                        ).flatMap { queryFiber =>
+                            started.await.andThen {
+                                queryFiber.interrupt.map { interrupted =>
+                                    assert(interrupted, "each cycle must genuinely interrupt an in-flight statement")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }.andThen(succeed)
+    }
+
 end SqlClientInterruptTest

--- a/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/SqlConfigTlsModeIntegrationTest.scala
+++ b/kyo-sql-postgres/shared/src/test/scala/kyo/postgres/SqlConfigTlsModeIntegrationTest.scala
@@ -399,7 +399,15 @@ class SqlConfigTlsModeIntegrationTest extends SqlContainerTest:
         withRequireSslContainer { ctx =>
             // sslmode=allow: tries plaintext first → gets SQLSTATE 28000 → retries with TLS.
             // The reconnect succeeds because the container also has TLS certs (same as the main fixture).
-            val url = s"postgres://${ctx.user}:${ctx.password}@${ctx.host}:${ctx.port}/${ctx.db}?sslmode=allow"
+            // No establish budget (`connectTimeout=0` reads back as `Duration.Infinity`), for the same reason as the
+            // MySQL twin of this leaf. The pool applies ONE budget to the whole of `factory.open`, and `allow` against
+            // a server that refuses plaintext performs TWO connect-plus-handshake rounds inside it: a plaintext
+            // attempt far enough to draw SQLSTATE 28000, then a full TLS reconnect. Every sibling leaf pays one, so the
+            // default is sized for one and this is the first leaf to cross it under runner load.
+            // Any finite value here would be a second wall clock racing the first: too low and a slow runner is
+            // indistinguishable from a broken upgrade, too high and it bounds nothing. The property under test is that
+            // the upgrade COMPLETES, so the suite timeout is the failure detector.
+            val url = s"postgres://${ctx.user}:${ctx.password}@${ctx.host}:${ctx.port}/${ctx.db}?sslmode=allow&connectTimeout=0"
             Scope.run {
                 SqlClient.init(url).flatMap { client =>
                     DB.run(client) {
@@ -486,7 +494,10 @@ class SqlConfigTlsModeIntegrationTest extends SqlContainerTest:
         withRequireSslContainer { ctx =>
             // hostssl-only pg_hba.conf forces the allow upgrade.
             // After reconnect with TLS, every subsequent query on the connection is encrypted.
-            val url = s"postgres://${ctx.user}:${ctx.password}@${ctx.host}:${ctx.port}/${ctx.db}?sslmode=allow"
+            // No establish budget, for the reason given at the `sslmode=allow upgrades to TLS` leaf above: the forced upgrade spends TWO
+            // connect-plus-handshake rounds inside the ONE budget the pool applies to `factory.open`. This leaf is the more exposed of the
+            // two, because its three queries draw connections from the pool and each one that is established pays those two rounds again.
+            val url = s"postgres://${ctx.user}:${ctx.password}@${ctx.host}:${ctx.port}/${ctx.db}?sslmode=allow&connectTimeout=0"
             Scope.run {
                 SqlClient.init(url).flatMap { client =>
                     DB.run(client) {

--- a/kyo-sql/shared/src/main/scala/kyo/db/Connection.scala
+++ b/kyo-sql/shared/src/main/scala/kyo/db/Connection.scala
@@ -384,33 +384,54 @@ object Connection:
         // A finalizer on the connect fiber closes a connection an interrupt drops before `body` runs; after `body`, engine `a` is claimed
         // into `custodyLocal` (orphan finalizer closes it if the handover drops). Claim `a`, not the raw socket, whose close a TLS upgrade no-ops.
         Scope.run {
-            Sync.Unsafe.defer(kyo.net.NetPlatform.transport.connect(host, port).safe).map { connFiber =>
-                Scope.ensure { error =>
-                    if error.isDefined then
-                        connFiber.interrupt.andThen(connFiber.getResult).map {
-                            case Result.Success(rawConn) => Sync.Unsafe.defer(if rawConn.isOpen then rawConn.close() else ())
-                            case _                       => ()
+            // The close is registered BEFORE the connect is launched, and the ordering is the whole point. `transport.connect` returns a
+            // fiber that owns a socket from the instant it is called, so registering the finalizer on the far side of a `map` leaves a
+            // window in which an interrupt lands with nobody holding the obligation to close it: the connect still succeeds, hands its
+            // connection to a promise the interrupted computation never reads, and the descriptor stays ESTABLISHED for the life of the
+            // process. Measured over a 100-cycle interrupt stress, 8 of 192 connects took that window. `Scope.acquireRelease` is not a
+            // substitute; it has the same shape (`acquire.map(r => ensure(release(r)))`) and the same window.
+            //
+            // The cell is what breaks the ordering cycle, since the finalizer needs a fiber the connect has not produced yet. It is
+            // filled in the same unsafe block that launches, so nothing suspends between owning the socket and being able to close it,
+            // and a finalizer that runs before the launch simply finds `Absent` and has nothing to do.
+            Sync.Unsafe.defer(AtomicRef.Unsafe.init(Maybe.empty[kyo.Fiber[kyo.net.Connection, Abort[kyo.net.NetException]]])).map {
+                connCell =>
+                    Scope.ensure { error =>
+                        if error.isDefined then
+                            Sync.Unsafe.defer(connCell.get()).map {
+                                case Present(connFiber) =>
+                                    connFiber.interrupt.andThen(connFiber.getResult).map {
+                                        case Result.Success(rawConn) => Sync.Unsafe.defer(if rawConn.isOpen then rawConn.close() else ())
+                                        case _                       => ()
+                                    }
+                                case Absent => ()
+                            }
+                        else ()
+                    }.andThen {
+                        Sync.Unsafe.defer {
+                            val f = kyo.net.NetPlatform.transport.connect(host, port).safe
+                            connCell.set(Maybe(f))
+                            f
+                        }.map { connFiber =>
+                            Abort.run[kyo.net.NetException](connFiber.get).map {
+                                case Result.Failure(cause) =>
+                                    // Carry the NetException through as the cause rather than substituting a placeholder. The placeholder this
+                                    // replaces, `new Exception("connect refused")`, read as the socket's own answer while discarding it: a DNS
+                                    // failure, a refused connect, an unavailable I/O backend and a connect timeout all arrived as the same four
+                                    // words with no cause attached, and a report built on that message named the wrong layer.
+                                    Abort.fail(SqlConnectionConnectFailedException(host, port, cause))
+                                case Result.Panic(t) =>
+                                    onPanic(t).map(Abort.fail(_))
+                                case Result.Success(rawConn) =>
+                                    closingOnFailure(rawConn)(body(rawConn).map { a =>
+                                        custodyLocal.use {
+                                            case Present(custody) => Sync.Unsafe.defer(custody.claim(() => ownerClose(a)))
+                                            case Absent           => ()
+                                        }.andThen(a)
+                                    })
+                            }
                         }
-                    else ()
-                }.andThen {
-                    Abort.run[kyo.net.NetException](connFiber.get).map {
-                        case Result.Failure(cause) =>
-                            // Carry the NetException through as the cause rather than substituting a placeholder. The placeholder this
-                            // replaces, `new Exception("connect refused")`, read as the socket's own answer while discarding it: a DNS
-                            // failure, a refused connect, an unavailable I/O backend and a connect timeout all arrived as the same four
-                            // words with no cause attached, and a report built on that message named the wrong layer.
-                            Abort.fail(SqlConnectionConnectFailedException(host, port, cause))
-                        case Result.Panic(t) =>
-                            onPanic(t).map(Abort.fail(_))
-                        case Result.Success(rawConn) =>
-                            closingOnFailure(rawConn)(body(rawConn).map { a =>
-                                custodyLocal.use {
-                                    case Present(custody) => Sync.Unsafe.defer(custody.claim(() => ownerClose(a)))
-                                    case Absent           => ()
-                                }.andThen(a)
-                            })
                     }
-                }
             }
         }
 

--- a/kyo-sql/shared/src/test/scala/kyo/internal/FakeServer.scala
+++ b/kyo-sql/shared/src/test/scala/kyo/internal/FakeServer.scala
@@ -35,9 +35,14 @@ private[kyo] object FakeServer:
                 val it = accepted.iterator()
                 while it.hasNext do
                     val conn = it.next()
-                    if conn.isOpen then
-                        try conn.close()
-                        catch case scala.util.control.NonFatal(_) => ()
+                    // Closed unconditionally. `Connection.close` is idempotent, so asking a connection that already
+                    // finished to close again costs nothing, while an `isOpen` guard here would skip precisely the
+                    // connections that most need this finalizer: `isOpen` reports false for `Upgrading` and `Closing`,
+                    // and a connection abandoned mid-upgrade holds an fd that `closeFn` deliberately cannot take, so
+                    // `close` is the only thing that releases it. Skipping those strands the descriptor for the rest
+                    // of the run.
+                    try conn.close()
+                    catch case scala.util.control.NonFatal(_) => ()
                 end while
             }).andThen(listener)
         }

--- a/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/LeakCheck.scala
+++ b/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/LeakCheck.scala
@@ -354,7 +354,14 @@ private[runner] object LeakCheck:
                     res
                 catch case _: Throwable => Maybe.empty
             scanTcp("/proc/net/tcp").orElse(scanTcp("/proc/net/tcp6")).orElse(scanUnix())
-                .getOrElse(" [no /proc/net row: CLOSED-state TCP fd or closed Unix-domain socket]")
+                // Say what the absence proves, which is only that no row matched. Three different sockets produce it: one that was
+                // connected and has since closed, one that was created and never dialed, and a closed Unix-domain socket. They have
+                // opposite diagnoses, since the first points at a close path that ran too late and the second at a connect that never
+                // happened, so a label naming just one of them sends the reader the wrong way. A socket still mid-handshake does NOT
+                // land here: SYN_SENT carries a row.
+                .getOrElse(
+                    " [no /proc/net row: closed after use, never dialed, or a closed Unix-domain socket; these are indistinguishable here]"
+                )
     end describeSocket
 
     /** Leak-debug attribution: descriptor target -> the leaf path that first left it open. Populated only in leak-debug mode (see

--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -1308,6 +1308,8 @@ Server-push deployment. Returns `Seq[HttpHandler[?, ?, ?]] < Sync`: two handlers
 
 The session is the WebSocket connection. The WS handler owns the reactive subscription via a `Scope`; closing the socket cascade-tears-down the whole subscription tree (leak-free by construction). Per-connection state resets on a real disconnect: a dropped socket starts a fresh session, so signal state is per-connection. The initial `ui` should be deterministic so the SSR page and the WebSocket's first render agree.
 
+The page reconnects on its own. A dropped or refused socket is retried under capped exponential backoff, events raised while it is down are buffered and flushed once it opens, and the fresh session's first emission carries every reactive region, so the reconnected page is current rather than merely connected. This is why the initial `ui` should be deterministic: a reconnect re-evaluates it, so signal state resets to that starting point unless the signals live outside the by-name block.
+
 ```scala
 import UI.*
 import kyo.*

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlOp.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlOp.scala
@@ -7,6 +7,17 @@ sealed private[kyo] trait HtmlOp derives CanEqual
 
 private[kyo] object HtmlOp:
 
+    // --- Session lifecycle ---
+
+    /** First frame of every session, sent before any render.
+      *
+      * The WebSocket handshake tells the client only that the transport is up, not that a session is reading the socket: a server can
+      * complete the upgrade and then end the session at once, during a restart window. The client holds events until it has seen a frame,
+      * so a session that renders nothing still has to announce itself. A tree with no reactive regions emits no render at all, and without
+      * this frame such a page would buffer every interaction forever.
+      */
+    final case class SessionReady() extends HtmlOp derives Schema
+
     // --- Rendering operations ---
 
     case class Replace(path: Seq[String], html: String)     extends HtmlOp derives Schema

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -1166,13 +1166,77 @@ private[kyo] object HtmlRenderer:
            |function kyoSetCaret(t,s,e){if(typeof t.setSelectionRange!=="function")return;
            |  try{t.setSelectionRange(s,e);}catch(er){if(er.name!=="InvalidStateError")throw er;}}
            |$reactiveRangesJs
-           |var ws=new WebSocket((location.protocol===\"https:\"?\"wss:\":\"ws:\")+"//"+location.host+base+"/_kyo/ws");
-           |ws.onopen=function(){__q.forEach(function(m){ws.send(m);});__q=[];};
            |${DragClientJs.script(basePath)}
-           |var __dragRt=installDragRuntime(function(m){post(m);},{onClose:function(c){__dragCleanup=c;}});
-           |var __dragCleanup=__dragRt.cleanup;
-           |ws.onclose=function(){if(__dragCleanup){__dragCleanup();__dragCleanup=null;}};
-           |ws.onmessage=function(e){
+           |var ws=null,__wsRetries=0,__wsGone=false,__live=false;
+           |var __dragRt=null,__dragCleanup=null;
+           |// One call site on purpose. The runtime wires document-level capture listeners and one pagehide listener it never removes, so
+           |// it must be installed once per session and never over a live one; the guard at the open handler is what keeps that true
+           |// across reconnects, and its own cleanup is idempotent.
+           |function kyoInstallDrag(){
+           |  __dragRt=installDragRuntime(function(m){post(m);},{onClose:function(c){__dragCleanup=c;}});
+           |  __dragCleanup=__dragRt.cleanup;
+           |}
+           |kyoInstallDrag();
+           |// A session is one socket, and reconnecting is not optional bookkeeping. post() buffers into __q whenever the session is not
+           |// live, and __q has exactly one drain point, so a page that never reconnects silently stops delivering every later
+           |// interaction while still looking healthy: the click reaches the document, nothing reaches the server, and the failure only
+           |// surfaces much later as an assertion against state that never arrived. The refusal that forced this is a connect denied for
+           |// want of buffer space (Windows WSAENOBUFS), which is transient, so backing off and retrying is what rides it out.
+           |//
+           |// LIVE means a frame has ARRIVED, not that the socket opened. Completing the upgrade proves the transport is up and nothing
+           |// more: a server can accept and then end the session at once, during a restart window, and draining on open would empty the
+           |// buffer into a connection nobody reads, losing exactly the events this exists to preserve. Every session announces itself
+           |// with SessionReady before it renders, so this resolves even for a tree that is entirely const and never renders. It is also
+           |// what makes the backoff real: resetting the counter on open would let an accept-then-close loop redial forever at the
+           |// shortest interval, which is the opposite of backing off.
+           |function kyoConnect(){
+           |  if(__wsGone)return;
+           |  // Never dial while one is already dialing or open. Two paths can call in at once: a page becomes eligible for the
+           |  // back/forward cache precisely when its socket is down, which is precisely when a retry is pending, so a restore
+           |  // races the resumed timer. The loser of that race would be superseded immediately and never closed, leaving a live
+           |  // connection with a session attached whose frames are all dropped.
+           |  if(ws&&ws.readyState<2)return;
+           |  __live=false;
+           |  var sock=new WebSocket((location.protocol===\"https:\"?\"wss:\":\"ws:\")+"//"+location.host+base+"/_kyo/ws");
+           |  ws=sock;
+           |  // Each handler serves ONE socket and stands down once a newer one has replaced it, closing itself on the way out so
+           |  // a superseded connection is torn down instead of lingering with a server session attached.
+           |  sock.onopen=function(){
+           |    if(sock!==ws){sock.close();return;}
+           |    if(!__dragCleanup)kyoInstallDrag();
+           |  };
+           |  sock.onmessage=function(e){
+           |    if(sock!==ws){sock.close();return;}
+           |    if(!__live){__live=true;__wsRetries=0;var pending=__q;__q=[];for(var i=0;i<pending.length;i++)sock.send(pending[i]);}
+           |    kyoOnMessage(e);
+           |  };
+           |  // A connect that never completes reports here and then closes, so recovery is driven from onclose alone;
+           |  // this handler exists so the failure does not surface as an unhandled error.
+           |  sock.onerror=function(){};
+           |  sock.onclose=function(){
+           |    if(sock!==ws)return;
+           |    __live=false;
+           |    if(__dragCleanup){__dragCleanup();__dragCleanup=null;}
+           |    if(__wsGone)return;
+           |    // Capped exponential backoff: quick enough that a transient refusal recovers within a page's useful
+           |    // lifetime, slow enough not to hammer a server that is genuinely down.
+           |    var wait=Math.min(250*Math.pow(2,__wsRetries),5000);
+           |    __wsRetries++;
+           |    setTimeout(kyoConnect,wait);
+           |  };
+           |}
+           |// A page being torn down is not a lost connection: stop redialing so an unloading page does not keep calling the server it is
+           |// leaving. A page becomes eligible for the back/forward cache precisely when its socket is DOWN, since an open one usually
+           |// blocks it, so a restored page has to redial and rebuild the range map the hide path cleared, or it returns permanently
+           |// inert, which is the exact failure this reconnect exists to prevent.
+           |window.addEventListener("pagehide",function(){__wsGone=true;});
+           |window.addEventListener("pageshow",function(e){
+           |  if(!e.persisted)return;
+           |  if(!__kyoRanges)__kyoRanges=kyoRangeScan(document.body);
+           |  __wsGone=false;__wsRetries=0;kyoConnect();
+           |});
+           |kyoConnect();
+           |function kyoOnMessage(e){
            |  var op=JSON.parse(e.data);
            |  if(op.ResolveDrag){
            |    try{__dragRt.resolve(op.ResolveDrag.sessionId,op.ResolveDrag.decision);}catch(error){kyoClientError(error);}
@@ -1238,12 +1302,14 @@ private[kyo] object HtmlRenderer:
            |  }
            |  return false;
            |}
-           |// Send each event over the single WebSocket. ws.send preserves send order on one socket, so the
-           |// explicit fetch-queue serialization is no longer needed. Events fired before the socket opens are
-           |// buffered in __q and flushed on ws.onopen.
+           |// Send each event over the session's WebSocket. ws.send preserves send order on one socket, so the
+           |// explicit fetch-queue serialization is no longer needed. Events raised before the session is live are
+           |// buffered in __q and flushed when its first frame arrives, which every reconnect reaches. Both an absent
+           |// socket and an open-but-unanswered one take the buffer, so nothing is handed to a connection that has
+           |// not proven a session is reading it.
            |function post(b){
            |  var m=JSON.stringify(b);
-           |  if(ws.readyState===1)ws.send(m);
+           |  if(ws&&__live&&ws.readyState===1)ws.send(m);
            |  else __q.push(m);
            |}
            |function pa(el){

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
@@ -41,6 +41,10 @@ private[kyo] object UIServer:
                 // redundantly re-inject a rule the page's initial <style> block already has.
                 (_, initialRules) <- HtmlRenderer.renderWithCss(uiTree, Seq.empty)
                 exchange = wsExchange(ws, initialRules.map(_._1).toSet)
+                // Announce the session before subscribing, so this is the first frame on every connection including one whose tree is
+                // entirely const and will never render. The client gates its outbound events on having seen a frame, because completing
+                // the upgrade proves only that the transport is up, not that anything is reading this socket.
+                _   <- ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](HtmlOp.SessionReady())))
                 sub <- ReactiveUI.subscribe(root, exchange)
                 // Session command sink: an event handler calling UI.scrollIntoView sends the op over this
                 // connection's socket, riding the same channel as the reactive updates. runPartial drops

--- a/kyo-ui/shared/src/test/scala/kyo/HtmlRendererReconnectTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/HtmlRendererReconnectTest.scala
@@ -1,0 +1,92 @@
+package kyo
+
+import kyo.Browser.*
+import kyo.internal.UIServer
+
+/** Regression guard for the reactive client's socket recovery (the Windows WSAENOBUFS / error 10055 click loss).
+  *
+  * The page opens one WebSocket back to the UI server and every event handler posts over it. While no session is live the client buffers the
+  * event instead, and that buffer has exactly one drain point. So a socket that never comes back leaves the page inert while still looking
+  * healthy, and the click surfaces later as an assertion failing on state that never arrived rather than as a transport failure.
+  *
+  * Driven here by serving the real page route beside a gated session route that ends each session immediately while the gate is shut. That
+  * reproduces the client state the socket exhaustion produces (nothing reading the socket, events buffered, no recovery) without needing the
+  * exhaustion itself, which is Windows-specific and rare. The gate then opens, and each leaf requires the page to catch up: recovery is the
+  * property under test, so the assertion is that the update EVENTUALLY lands, with a budget sized past the client's capped backoff so it
+  * detects a page that never recovers and never doubles as the thing being measured.
+  *
+  * These leaves bind their own server and so cannot use `withUI`, which is why they take its browser retry explicitly.
+  */
+class HtmlRendererReconnectTest extends UITest:
+
+    /** Serves `app`'s real page route beside a session route that is refused until `serving` is set. */
+    private def gatedServer(app: UI, serving: AtomicBoolean)(using Frame) =
+        for
+            routes <- UIServer.handlers("/")(app)
+            // routes.head is the page route; the session route is replaced by a gated one that accepts the upgrade and ends the session at
+            // once, which is the state the client is left in when its socket cannot be established.
+            gated = HttpHandler.webSocket("/_kyo/ws") { (_, socket) =>
+                serving.get.map {
+                    case true  => UIServer.serveSession(socket, app)
+                    case false => Kyo.unit
+                }
+            }
+            server <- HttpServer.init(0, "localhost")(routes.head, gated)
+        yield server
+
+    private val recovery = Present(Schedule.fixed(100.millis).maxDuration(30.seconds))
+
+    "a click posted while the reactive socket is down is delivered once it recovers" in {
+        withBrowserRetry {
+            cancelOnUnsupportedPlatform {
+                for
+                    ref     <- Signal.initRef("before")
+                    serving <- AtomicBoolean.init(false)
+                    app = UI.div(
+                        UI.button("Change").id("b").onClick(ref.set("after")),
+                        ref.map(value => UI.span(value).id("v"))
+                    )
+                    server <- gatedServer(app, serving)
+                    result <- Browser.runShared() {
+                        for
+                            _ <- Browser.goto(s"http://localhost:${server.port}/")
+                            _ <- Browser.assertText(Selector.id("v"), "before")
+                            // Posted with no session reading the socket, so the client buffers it. Nothing reaches the server yet.
+                            _ <- Browser.click(Selector.id("b"))
+                            _ <- serving.set(true)
+                            _ <- Browser.assertText(Selector.id("v"), "after", recovery)
+                        yield ()
+                    }
+                yield result
+            }
+        }
+    }
+
+    "a change made while the socket is down is on the page after it recovers" in {
+        // Recovery is only worth anything if the recovered page is CURRENT. A reconnected session subscribes with no record of what the client
+        // already has, so each region's first emission carries the whole region and the page catches up on everything it missed. That is what
+        // makes a dropped socket recoverable rather than merely reconnected, so it is asserted rather than assumed.
+        withBrowserRetry {
+            cancelOnUnsupportedPlatform {
+                for
+                    ref     <- Signal.initRef("before")
+                    serving <- AtomicBoolean.init(false)
+                    app = UI.div(ref.map(value => UI.span(value).id("v")))
+                    server <- gatedServer(app, serving)
+                    result <- Browser.runShared() {
+                        for
+                            _ <- Browser.goto(s"http://localhost:${server.port}/")
+                            _ <- Browser.assertText(Selector.id("v"), "before")
+                            // No session is observing this, so nothing is queued anywhere: the client can only learn it from the full region
+                            // the next session sends.
+                            _ <- ref.set("changed")
+                            _ <- serving.set(true)
+                            _ <- Browser.assertText(Selector.id("v"), "changed", recovery)
+                        yield ()
+                    }
+                yield result
+            }
+        }
+    }
+
+end HtmlRendererReconnectTest

--- a/kyo-ui/shared/src/test/scala/kyo/HtmlRendererTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/HtmlRendererTest.scala
@@ -844,12 +844,24 @@ class HtmlRendererTest extends UITest:
             assert(!page.contains("/_kyo/sse"))
         }
 
-        "rendered page buffers events until the socket opens" in {
+        "rendered page buffers events until the session is live" in {
             val page = kyo.internal.HtmlRenderer.renderPage("t", "<div></div>", "", "/app")
             assert(page.contains("__q=[]"))
-            assert(page.contains("__q.forEach"))
             assert(page.contains("__q.push"))
-            assert(page.contains("ws.readyState===1"))
+            // Deliverability is the session having answered, not merely the socket being open. A server can complete the
+            // upgrade and end the session at once, and handing the buffer to that connection loses every event in it.
+            assert(page.contains("__live&&ws.readyState===1"))
+            // The buffer is taken by value and replaced before anything is sent, so an event raised during the drain lands
+            // in the fresh buffer rather than being dropped by the clear that follows.
+            assert(page.contains("var pending=__q;__q=[]"))
+            // The one place the drain is reached: a frame arriving, which every session guarantees by announcing itself.
+            assert(page.contains("if(!__live){__live=true"))
+            // Only one socket may be dialing or open at a time. A back/forward-cache restore races the retry it left pending,
+            // and without this the loser is superseded but never closed, leaving a live connection whose session is stranded.
+            // Asserted structurally because a bfcache restore is not drivable from the browser harness.
+            assert(page.contains("if(ws&&ws.readyState<2)return;"))
+            // A superseded socket closes itself rather than lingering.
+            assert(page.contains("if(sock!==ws){sock.close();return;}"))
         }
 
         "rendered page boots one live range registry and parses replacements in parent context" in {
@@ -901,7 +913,9 @@ class HtmlRendererTest extends UITest:
             val rendered = page
             assert(rendered.contains("op.ResolveDrag"))
             assert(rendered.contains("__dragRt.resolve(op.ResolveDrag.sessionId,op.ResolveDrag.decision)"))
-            assert(rendered.contains("ws.onclose"))
+            // Handlers are bound to the socket they were installed on, so a superseded socket's close cannot tear down the
+            // runtime belonging to the connection that replaced it.
+            assert(rendered.contains("sock.onclose"))
             assert(rendered.contains("__dragCleanup()"))
         }
 

--- a/kyo-ui/shared/src/test/scala/kyo/UIServerWsTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIServerWsTest.scala
@@ -25,6 +25,12 @@ import kyo.internal.UIServer
   */
 class UIServerWsTest extends kyo.test.Test[Any]:
 
+    /** Consumes the frames every session opens with: the `SessionReady` announcement the server sends before it renders, then the
+      * initial render itself. A leaf starts its interaction after this, so the frame it later takes is the one its own event produced.
+      */
+    private def awaitSessionStart(clientWs: HttpWebSocket)(using Frame): Unit < (Async & Abort[Closed]) =
+        clientWs.take().andThen(clientWs.take()).unit
+
     private def mediaType(value: String): Drag.MediaType = Drag.MediaType.parse(value).get
 
     private def dragText(representations: (String, String)*): Drag.Item.Text =
@@ -113,8 +119,7 @@ class UIServerWsTest extends kyo.test.Test[Any]:
                     (serverWs: HttpWebSocket) => UIServer.serveSession(serverWs, app),
                     (clientWs: HttpWebSocket) =>
                         for
-                            // Await the initial render frame to confirm the subscription is live.
-                            _ <- clientWs.take()
+                            _ <- awaitSessionStart(clientWs)
                             // Dispatch a Click on the button (path Seq("0"): first child of the div).
                             clickEvent = UIEvent.Click(Seq("0"), MouseEventData(UI.Modifiers.none, Absent))
                             _ <- clientWs.put(HttpWebSocket.Payload.Text(Json.encode[UIEvent](clickEvent)))
@@ -154,9 +159,8 @@ class UIServerWsTest extends kyo.test.Test[Any]:
                     (serverWs: HttpWebSocket) => Sync.ensure(serverEnded.set(true))(UIServer.serveSession(serverWs, app)),
                     (clientWs: HttpWebSocket) =>
                         for
-                            // Await the initial render frame, then confirm the server subscription is live: it parks on
-                            // the test-held leaf, so leafRef has exactly one waiter.
-                            _ <- clientWs.take()
+                            // Confirm the server subscription is live: it parks on the test-held leaf, so leafRef has exactly one waiter.
+                            _ <- awaitSessionStart(clientWs)
                             _ <- assertEventually(leafRef.waiters.map(_ == 1))
                             // Close the client: fires ws.onPeerClose on the server, ending the race and closing the
                             // connection's subscription Scope (cascade teardown).
@@ -749,7 +753,7 @@ class UIServerWsTest extends kyo.test.Test[Any]:
                     serverWs => UIServer.serveSession(serverWs, app),
                     clientWs =>
                         for
-                            _     <- clientWs.take()
+                            _     <- awaitSessionStart(clientWs)
                             _     <- clientWs.put(HttpWebSocket.Payload.Text(Json.encode[UIEvent](start)))
                             _     <- clientWs.put(HttpWebSocket.Payload.Text(Json.encode[UIEvent](drop)))
                             frame <- clientWs.take()
@@ -791,7 +795,7 @@ class UIServerWsTest extends kyo.test.Test[Any]:
                     serverWs => UIServer.serveSession(serverWs, app),
                     clientWs =>
                         for
-                            _ <- clientWs.take()
+                            _ <- awaitSessionStart(clientWs)
                             _ <- clientWs.put(HttpWebSocket.Payload.Text(Json.encode[UIEvent](invalidStart)))
                             click = UIEvent.Click(Seq("1"), MouseEventData(UI.Modifiers.none, Absent))
                             _     <- clientWs.put(HttpWebSocket.Payload.Text(Json.encode[UIEvent](click)))
@@ -825,8 +829,7 @@ class UIServerWsTest extends kyo.test.Test[Any]:
                     (serverWs: HttpWebSocket) => UIServer.serveSession(serverWs, app),
                     (clientWs: HttpWebSocket) =>
                         for
-                            // Await the initial render frame to confirm the subscription is live.
-                            _ <- clientWs.take()
+                            _ <- awaitSessionStart(clientWs)
                             clickEvent = UIEvent.Click(Seq("0"), MouseEventData(UI.Modifiers.none, Absent))
                             _     <- clientWs.put(HttpWebSocket.Payload.Text(Json.encode[UIEvent](clickEvent)))
                             frame <- clientWs.take()

--- a/kyo-ui/shared/src/test/scala/kyo/UITest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UITest.scala
@@ -27,6 +27,16 @@ abstract class UITest extends kyo.test.Test[Any]:
     private val retrySchedule: Schedule =
         Schedule.exponentialBackoff(initial = 1.second, factor = 2, maxBackoff = 8.seconds).take(2)
 
+    /** The transient-browser-failure retry that [[withUI]] applies, for leaves that must bind their own server and so cannot go through it.
+      * Retry selects the two infrastructure failure types by their union, so assertion failures and every other BrowserException propagate
+      * immediately and are never masked. Without this a hand-rolled-server leaf turns a dropped CDP connection into a red where every sibling
+      * suite rides it out.
+      */
+    private[kyo] def withBrowserRetry[A, S](f: A < (Async & Abort[BrowserException] & S))(using
+        Frame
+    ): A < (Async & Abort[BrowserException] & S) =
+        Retry[BrowserConnectionLostException | BrowserSetupFailedException](retrySchedule)(f)
+
     /** Marker substring in the unsupported-platform setup failure (kyo.internal.ChromeDownloader). Keep in sync with kyo-browser's BrowserTest. */
     private val unsupportedPlatformMarker = "cannot auto-download chrome-headless-shell"
 
@@ -35,7 +45,7 @@ abstract class UITest extends kyo.test.Test[Any]:
       * canceled (skipped) rather than red failures that each burn the retry budget and push the job past its timeout. Mirrors kyo-browser's
       * BrowserTest.cancelOnUnsupportedPlatform; every other failure propagates unchanged.
       */
-    private def cancelOnUnsupportedPlatform[A, S](
+    private[kyo] def cancelOnUnsupportedPlatform[A, S](
         f: A < (Async & Scope & Abort[BrowserSetupException] & S)
     )(using Frame): A < (Async & Scope & Abort[BrowserSetupException] & S) =
         Abort.recover[BrowserSetupException] { (ex: BrowserSetupException) =>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,6 +40,7 @@ CI_MEMORY="${CI_MEMORY:-16g}"
 CI_CPUS="${CI_CPUS:-4}"
 CI_DRIVER_OPTS="-Xmx12G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
 CONTAINER_IMAGE="${KYO_BUILD_IMAGE:-ubuntu:noble}"
+apt_mirror="${KYO_APT_MIRROR:-}"
 
 ENV_KIND="direct"
 ARCH="native"
@@ -114,7 +115,17 @@ podman_platform() {
     case "$ARCH" in
         x86) echo "linux/amd64" ;;
         arm) echo "linux/arm64" ;;
-        *)   echo "" ;;
+        # A native run names the host's own platform rather than leaving the choice open. Without it podman resolves the image tag to
+        # whichever architecture happens to be cached, so a single cross-arch pull by anything on the machine silently turns every later
+        # native run into an emulated one. That failure is expensive to recognise: the run does not error, it slows down and then dies
+        # inside qemu on the JVM toolchain, far from the pull that caused it.
+        *)
+            case "$(host_arch)" in
+                x86) echo "linux/amd64" ;;
+                arm) echo "linux/arm64" ;;
+                *)   echo "" ;;
+            esac
+            ;;
     esac
 }
 
@@ -173,7 +184,11 @@ container_provision() {
     local platform="$1"
     # liburing-dev + libssl-dev: the kyo-net JVM FFI shims link the io_uring (-luring) and OpenSSL TLS data planes; without them
     # kyo-netJVM's ffiCompile fails (cannot find -luring). Small and always installed so any kyo-net command builds in the container.
-    local apt_pkgs="curl ca-certificates patch liburing-dev libssl-dev"
+    # openssl is the CLI, not the library libssl-dev provides, and the base image ships without it. The
+    # kyo-sql TLS suites generate their server cert and key by shelling out to it, so without it every
+    # such leaf fails as "SSL not ready" with a Postgres that started perfectly well and simply has no
+    # certificate, which reads like a TLS defect rather than a missing tool.
+    local apt_pkgs="curl ca-certificates patch liburing-dev libssl-dev openssl"
     local node_pkgs="" native_pkgs="" bssl_pkgs="" aeron_pkgs=""
     # "all" provisions the union (raw sbt mode may run any platform's command in the container).
     case "$platform" in
@@ -237,6 +252,16 @@ fi'
     cat <<PROVISION
 export DEBIAN_FRONTEND=noninteractive
 if command -v apt-get >/dev/null 2>&1; then
+    # Every run provisions from a bare image, so one unreachable Ubuntu mirror stalls the whole loop
+    # (ports.ubuntu.com has timed out for a stretch while the rest of the network was fine). KYO_APT_MIRROR
+    # points apt at a reachable mirror instead; unset, nothing changes. Both source formats are rewritten
+    # because noble ships deb822 while older images still use the one-line list.
+    if [ -n "${apt_mirror}" ]; then
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list; do
+            [ -f "\$f" ] || continue
+            sed -i -e "s#https\\?://[a-z0-9.-]*/\\(ubuntu-ports\\|ubuntu\\)\\b#${apt_mirror}#g" "\$f"
+        done
+    fi
     apt-get update -qq >/dev/null
     apt-get install -y -qq -o Acquire::Retries=3 $apt_pkgs $node_pkgs $native_pkgs $bssl_pkgs $aeron_pkgs >/dev/null
 fi
@@ -280,6 +305,16 @@ run_in_container() {
     if [ -n "${KYO_BUILD_OUT:-}" ]; then
         mkdir -p "$KYO_BUILD_OUT"
         args+=(-v "$KYO_BUILD_OUT:/output")
+    fi
+    # A container starts with no dependency cache, so every run re-fetches the JDK and the whole dependency set before it can compile
+    # anything. That is slow on every run and fragile on all of them: one refused connection to the JDK host leaves the container with no
+    # `java` at all, and the run dies having produced no test output, which reads as an empty result rather than as a failed download.
+    # Persisting the cache on the host removes both problems, and it is safe to share across runs because coursier's layout is
+    # content-addressed. KYO_BUILD_NO_CACHE forces the cold path for anyone who wants to reproduce a from-scratch fetch.
+    if [ -z "${KYO_BUILD_NO_CACHE:-}" ]; then
+        local cache="${KYO_BUILD_CACHE:-$HOME/.cache/kyo-build-container}"
+        mkdir -p "$cache/coursier" "$cache/sbt" "$cache/ivy"
+        args+=(-v "$cache/coursier:/root/.cache/coursier" -v "$cache/sbt:/root/.sbt" -v "$cache/ivy:/root/.ivy2")
     fi
     local envs=()
     # Forward the leak-debug flag so the forked test JVM (which inherits the container env) runs leaves serially and attributes each leaked

--- a/scripts/ci-logs.sh
+++ b/scripts/ci-logs.sh
@@ -13,6 +13,7 @@ set -uo pipefail
 #   runs   <branch> [n]             --full                entire cleaned log
 #   running [branch]                --tail <n>            last n lines (n=40)
 #   pr     <number>                  --steps               per-job step status
+#                                    --totals              per-leg suite totals, every job
 #   open-prs                         --metrics             ci-monitor.sh resource
 #                                                          lines (implies all-jobs)
 #                                    --all-jobs            apply to ALL jobs,
@@ -26,6 +27,8 @@ set -uo pipefail
 #   ci-logs.sh run 281...948 --grep 'OutOfMemory'  # grep failed jobs of a run
 #   ci-logs.sh run 281...948 --grep Timeout --all-jobs   # grep every job
 #   ci-logs.sh run 281...948 --steps               # which step failed, timings
+#   ci-logs.sh run 281...948 --totals              # read a GREEN run: per-leg suite totals and
+#                                                  # whether the two arch legs of each target agree
 #
 # WHY a dedicated "failures" view: both test frameworks here (ScalaTest and
 # kyo-test) print " *** FAILED ***" on every failing leaf, and kyo-test's runner
@@ -58,6 +61,7 @@ while [ $# -gt 0 ]; do
         --tail)     VIEW=tail; TAIL_N="${2:?--tail needs a count}"; shift ;;
         --steps)    VIEW=steps ;;
         --all-jobs) ALL_JOBS=1 ;;
+        --totals)   VIEW=totals; ALL_JOBS=1 ;;
         *)          POS+=("$1") ;;
     esac
     shift
@@ -71,7 +75,11 @@ set -- "${POS[@]:-}"
 export GH_REPO="$REPO"
 
 # Strip ANSI, CR, and the leading ISO-8601 job-log timestamp prefix.
-clean() { perl -pe 's/\e\[[0-9;]*m//g; s/\r$//; s/^\d{4}-\d{2}-\d{2}T[\d:.]+Z[ \t]*//'; }
+# The BOM strip comes first and is not optional: the log API emits a UTF-8 byte order mark at chunk
+# boundaries, mid-file, in front of a timestamp. Every pattern below anchors on the start of the line, so a
+# line that keeps its timestamp because the BOM blocked the strip matches nothing, and a genuine failure on
+# such a line is reported as no failure at all.
+clean() { perl -pe 's/^\x{EF}\x{BB}\x{BF}//; s/\e\[[0-9;]*m//g; s/\r$//; s/^\d{4}-\d{2}-\d{2}T[\d:.]+Z[ \t]*//'; }
 
 # --failures: print only sbt's authoritative real-failure lines. Exit 9 if none.
 extract() {
@@ -99,6 +107,22 @@ infra_tail() {
         | tail -6 | sed 's/^/  infra:       /'
 }
 
+# Per-suite totals for one job's cleaned log.
+#
+# The mandate this drive works under requires a green run to be read on its suite totals rather than its
+# conclusion field, and doing that by hand is how a UTF-8 BOM once turned one leg's count into a phantom
+# arch discrepancy. The match is deliberately NOT anchored to the start of the line, so a stray prefix
+# costs nothing even if the cleaner ever misses one.
+totals_of() {
+    perl -ne '
+        if (/(?:^|\s)--- \S+: (\d+) passed, (\d+) failed(?:, (\d+) cancelled)?/) {
+            $n++; $p += $1; $f += $2; $c += (defined $3 ? $3 : 0);
+        }
+        END { printf("  suites=%d passed=%d failed=%d cancelled=%d passed+cancelled=%d\n",
+                     $n, $p, $f, $c, $p + $c); }
+    '
+}
+
 # Apply the selected view to a job's cleaned log (read from a variable).
 show_log() {
     local log="$1"
@@ -108,6 +132,17 @@ show_log() {
         grep)     printf '%s\n' "$log" | grep -aiE "$GREP_RE" | sed 's/^/  /' || echo "  (no matches)" ;;
         full)     printf '%s\n' "$log" ;;
         tail)     printf '%s\n' "$log" | tail -n "$TAIL_N" | sed 's/^/  /' ;;
+        totals)
+            local tline
+            tline="$(printf '%s\n' "$log" | totals_of)"
+            printf '%s\n' "$tline"
+            if [ -n "${TOTALS_FILE:-}" ] && [ -n "${TOTALS_JOB:-}" ]; then
+                # "build (linux-x64) / build (Native)" reduces to "linux-x64/Native" so the pair is groupable.
+                printf '%s %s\n' \
+                    "$(printf '%s' "$TOTALS_JOB" | sed -E 's/build \(([^)]*)\) \/ build \(([^)]*)\)/\1\/\2/')" \
+                    "$(printf '%s' "$tline" | sed 's/^ *//')" >> "$TOTALS_FILE"
+            fi
+            ;;
     esac
 }
 
@@ -131,6 +166,35 @@ run_steps() {
             | "    step \(.number) \(.name): \(.status)/\(.conclusion // "running")")'
 }
 
+# The two arch legs of one target must agree on suites and on passed+cancelled. Their CANCELLED splits
+# differ legitimately (a leg that cannot host a browser cancels those leaves instead of running them), so
+# neither figure alone is comparable; the sum is. A disagreement means one arch silently skipped work that
+# the other ran, which no conclusion field ever reports.
+arch_check() {
+    local f="$1"
+    [ -s "$f" ] || return 0
+    echo "------------------------------------------------------------------"
+    echo "ARCH AGREEMENT (linux-x64 vs linux-arm64, per target)"
+    perl -ne '
+        next unless /^(\S+)\s+suites=(\d+).*passed\+cancelled=(\d+)/;
+        my ($job, $su, $pc) = ($1, $2, $3);
+        next unless $job =~ /^(linux-x64|linux-arm64)\/(\S+)$/;
+        $seen{$2}{$1} = "$su/$pc";
+        END {
+            my $bad = 0;
+            for my $t (sort keys %seen) {
+                my $x = $seen{$t}{"linux-x64"}; my $a = $seen{$t}{"linux-arm64"};
+                next unless defined $x && defined $a;
+                my $ok = ($x eq $a);
+                $bad++ unless $ok;
+                printf("  %-8s x64=%-14s arm64=%-14s %s\n", $t, $x, $a, $ok ? "AGREE" : "DISAGREE");
+            }
+            print "  (no arch pair present in this run)\n" unless keys %seen;
+            print "  a DISAGREE means one arch skipped suites the other ran; read that leg before trusting the run\n" if $bad;
+        }
+    ' "$f"
+}
+
 inspect_run() {
     local runid="$1" meta
     meta="$(gh run view "$runid" --json status,conclusion,displayTitle,headSha,workflowName 2>/dev/null)"
@@ -151,17 +215,33 @@ inspect_run() {
     running=$(gh run view "$runid" --json jobs \
         --jq '.jobs[] | select(.status=="in_progress" or .status=="queued") | .name' 2>/dev/null)
 
+    if [ "$VIEW" = totals ]; then
+        TOTALS_FILE="$(mktemp)"; export TOTALS_FILE
+        trap 'rm -f "$TOTALS_FILE"' RETURN
+    fi
+
     if [ -z "$jobs" ] && [ -z "$running" ]; then echo "  no failed jobs."; return; fi
     if [ -n "$jobs" ]; then
         while IFS=$'\t' read -r jid jname; do
             [ -z "$jid" ] && continue
             echo "------------------------------------------------------------------"
             echo "JOB: $jname  (db=$jid)"
-            inspect_job "$jid"
+            TOTALS_JOB="$jname" inspect_job "$jid"
         done <<< "$jobs"
     fi
     [ -n "$running" ] && { echo "------------------------------------------------------------------";
         echo "STILL RUNNING:"; printf '%s\n' "$running" | sed 's/^/  ... /'; }
+    # Only meaningful once every leg has finished: legs mid-run are simply at different points, and comparing
+    # them reports a disagreement that says nothing about what either leg will end up running.
+    if [ "$VIEW" = totals ]; then
+        if [ "$(jq -r .status <<<"$meta")" = completed ]; then
+            arch_check "$TOTALS_FILE"
+        else
+            echo "------------------------------------------------------------------"
+            echo "ARCH AGREEMENT: skipped, run still in progress (legs are at different points)"
+        fi
+    fi
+    return 0
 }
 
 as_id() { printf '%s' "$1" | grep -oE '[0-9]+' | tail -1; }


### PR DESCRIPTION
### Problem

Several paths discarded a failure together with the resource it stranded. A verifying client whose reference identity could not be bound carried on with no name bound at all, so the handshake accepted any chain valid certificate. Return codes from the TLS version window, the trust anchor load and the server certificate load were discarded, leaving a rejected setting indistinguishable from an applied one. Every successfully built TLS engine leaked the context holding its chains and keys, because the reference the builder created was released only on the failure path. A connect the caller was interrupted out of left its descriptor established for the life of the process. A reactive page whose socket failed to connect buffered every later event forever while still looking healthy, since nothing reconnected and nothing reported the failure. Closing a media driver runtime twice tore down an already freed bundle and killed the process.

### Solution

Report each failure on its declared channel, and release resources on the failing paths as well as the succeeding ones. A rejected TLS setting now fails the engine build and names the setting, identically on every tier. Connect finalizers are registered before a descriptor can exist rather than after. The reactive socket reinstalls its handlers and retries under capped backoff so its queue drains again. A driver close is granted to exactly one caller.

### Notes

Every change carries a test that was seen to fail without it.
