### PR TITLE
fix: forward JsonSchema constraints to OpenAPI SchemaObject

### DIFF
--- a/kyo-http/shared/src/main/scala/kyo/HttpOpenApi.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpOpenApi.scala
@@ -53,7 +53,18 @@ object HttpOpenApi:
         additionalProperties: Option[SchemaObject],
         oneOf: Option[List[SchemaObject]],
         `enum`: Option[List[String]],
-        `$ref`: Option[String]
+        `$ref`: Option[String],
+        minimum: Option[Double] = None,
+        exclusiveMinimum: Option[Double] = None,
+        maximum: Option[Double] = None,
+        exclusiveMaximum: Option[Double] = None,
+        minLength: Option[Int] = None,
+        maxLength: Option[Int] = None,
+        pattern: Option[String] = None,
+        minItems: Option[Int] = None,
+        maxItems: Option[Int] = None,
+        uniqueItems: Option[Boolean] = None,
+        description: Option[String] = None
     ) derives Schema, CanEqual
 
     case class Info(

--- a/kyo-http/shared/src/main/scala/kyo/internal/codec/OpenApiGenerator.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/codec/OpenApiGenerator.scala
@@ -226,9 +226,9 @@ private[kyo] object OpenApiGenerator:
       *   - Nullable(inner) → recurse on inner (optionality is captured in the parent's required list).
       *   - OneOf(variants) → if all variants map to an empty Obj, emit enum with variant names; otherwise emit oneOf.
       */
-    private def jsonSchemaToHttpOpenApi(js: JsonSchema): HttpOpenApi.SchemaObject =
+    private[kyo] def jsonSchemaToHttpOpenApi(js: JsonSchema): HttpOpenApi.SchemaObject =
         js match
-            case JsonSchema.Obj(properties, required, additionalProperties, _, _, _) =>
+            case JsonSchema.Obj(properties, required, additionalProperties, description, _, _) =>
                 val propsMap =
                     if properties.isEmpty then None
                     else
@@ -247,36 +247,93 @@ private[kyo] object OpenApiGenerator:
                     additionalProperties = addProps,
                     oneOf = None,
                     `enum` = None,
-                    `$ref` = None
+                    `$ref` = None,
+                    description = description.toOption
                 )
 
-            case JsonSchema.Arr(items, _, _, _, _) =>
-                HttpOpenApi.SchemaObject.array(jsonSchemaToHttpOpenApi(items))
+            case JsonSchema.Arr(items, minItems, maxItems, uniqueItems, description) =>
+                HttpOpenApi.SchemaObject(
+                    `type` = Some("array"),
+                    format = None,
+                    items = Some(jsonSchemaToHttpOpenApi(items)),
+                    properties = None,
+                    required = None,
+                    additionalProperties = None,
+                    oneOf = None,
+                    `enum` = None,
+                    `$ref` = None,
+                    minItems = minItems.toOption,
+                    maxItems = maxItems.toOption,
+                    uniqueItems = uniqueItems.toOption,
+                    description = description.toOption
+                )
 
-            case JsonSchema.Str(_, _, _, format, _) =>
-                format match
-                    case Present(f) =>
-                        HttpOpenApi.SchemaObject(
-                            `type` = Some("string"),
-                            format = Some(f),
-                            items = None,
-                            properties = None,
-                            required = None,
-                            additionalProperties = None,
-                            oneOf = None,
-                            `enum` = None,
-                            `$ref` = None
-                        )
-                    case Absent => HttpOpenApi.SchemaObject.string
+            case JsonSchema.Str(minLength, maxLength, pattern, format, description) =>
+                HttpOpenApi.SchemaObject(
+                    `type` = Some("string"),
+                    format = format.toOption,
+                    items = None,
+                    properties = None,
+                    required = None,
+                    additionalProperties = None,
+                    oneOf = None,
+                    `enum` = None,
+                    `$ref` = None,
+                    minLength = minLength.toOption,
+                    maxLength = maxLength.toOption,
+                    pattern = pattern.toOption,
+                    description = description.toOption
+                )
 
-            case JsonSchema.Num(_, _, _, _, _) =>
-                HttpOpenApi.SchemaObject.number
+            case JsonSchema.Num(minimum, exclusiveMinimum, maximum, exclusiveMaximum, description) =>
+                HttpOpenApi.SchemaObject(
+                    `type` = Some("number"),
+                    format = Some("double"),
+                    items = None,
+                    properties = None,
+                    required = None,
+                    additionalProperties = None,
+                    oneOf = None,
+                    `enum` = None,
+                    `$ref` = None,
+                    minimum = minimum.toOption,
+                    exclusiveMinimum = exclusiveMinimum.toOption,
+                    maximum = maximum.toOption,
+                    exclusiveMaximum = exclusiveMaximum.toOption,
+                    description = description.toOption
+                )
 
-            case JsonSchema.Integer(_, _, _, _, _) =>
-                HttpOpenApi.SchemaObject.integer
+            case JsonSchema.Integer(minimum, exclusiveMinimum, maximum, exclusiveMaximum, description) =>
+                HttpOpenApi.SchemaObject(
+                    `type` = Some("integer"),
+                    format = Some("int32"),
+                    items = None,
+                    properties = None,
+                    required = None,
+                    additionalProperties = None,
+                    oneOf = None,
+                    `enum` = None,
+                    `$ref` = None,
+                    minimum = minimum.toOption.map(_.toDouble),
+                    exclusiveMinimum = exclusiveMinimum.toOption.map(_.toDouble),
+                    maximum = maximum.toOption.map(_.toDouble),
+                    exclusiveMaximum = exclusiveMaximum.toOption.map(_.toDouble),
+                    description = description.toOption
+                )
 
-            case JsonSchema.Bool(_) =>
-                HttpOpenApi.SchemaObject.boolean
+            case JsonSchema.Bool(description) =>
+                HttpOpenApi.SchemaObject(
+                    `type` = Some("boolean"),
+                    format = None,
+                    items = None,
+                    properties = None,
+                    required = None,
+                    additionalProperties = None,
+                    oneOf = None,
+                    `enum` = None,
+                    `$ref` = None,
+                    description = description.toOption
+                )
 
             case JsonSchema.Null(_) =>
                 HttpOpenApi.SchemaObject(

--- a/kyo-http/shared/src/main/scala/kyo/internal/codec/OpenApiGenerator.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/codec/OpenApiGenerator.scala
@@ -335,7 +335,7 @@ private[kyo] object OpenApiGenerator:
                     description = description.toOption
                 )
 
-            case JsonSchema.Null(_) =>
+            case JsonSchema.Null(description) =>
                 HttpOpenApi.SchemaObject(
                     `type` = Some("null"),
                     format = None,
@@ -345,7 +345,8 @@ private[kyo] object OpenApiGenerator:
                     additionalProperties = None,
                     oneOf = None,
                     `enum` = None,
-                    `$ref` = None
+                    `$ref` = None,
+                    description = description.toOption
                 )
 
             case JsonSchema.Nullable(inner) =>

--- a/kyo-http/shared/src/test/scala/kyo/internal/OpenApiGeneratorTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/OpenApiGeneratorTest.scala
@@ -197,5 +197,114 @@ class OpenApiGeneratorTest extends kyo.BaseHttpTest:
             assert(json.contains("Pet API"))
             assert(json.contains("petId"))
         }
+
+        "constraint forwarding" - {
+
+            "Str: minLength, maxLength, and pattern" in {
+                val js  = Json.JsonSchema.Str(minLength = Present(2), maxLength = Present(50), pattern = Present("[a-z]+"))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.`type` == Some("string"))
+                assert(obj.minLength == Some(2))
+                assert(obj.maxLength == Some(50))
+                assert(obj.pattern == Some("[a-z]+"))
+                assert(obj.format == None)
+            }
+
+            "Str: format is still forwarded" in {
+                val js  = Json.JsonSchema.Str(format = Present("uuid"))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.format == Some("uuid"))
+            }
+
+            "Str: description is forwarded" in {
+                val js  = Json.JsonSchema.Str(description = Present("a name"))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.description == Some("a name"))
+            }
+
+            "Num: minimum and maximum" in {
+                val js  = Json.JsonSchema.Num(minimum = Present(0.0), maximum = Present(99.9))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.`type` == Some("number"))
+                assert(obj.minimum == Some(0.0))
+                assert(obj.maximum == Some(99.9))
+                assert(obj.exclusiveMinimum == None)
+                assert(obj.exclusiveMaximum == None)
+            }
+
+            "Num: exclusiveMinimum and exclusiveMaximum" in {
+                val js  = Json.JsonSchema.Num(exclusiveMinimum = Present(0.0), exclusiveMaximum = Present(1.0))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.exclusiveMinimum == Some(0.0))
+                assert(obj.exclusiveMaximum == Some(1.0))
+            }
+
+            "Integer: minimum and maximum forwarded as Double" in {
+                val js  = Json.JsonSchema.Integer(minimum = Present(0L), maximum = Present(100L))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.`type` == Some("integer"))
+                assert(obj.minimum == Some(0.0))
+                assert(obj.maximum == Some(100.0))
+            }
+
+            "Arr: minItems, maxItems, and uniqueItems" in {
+                val js =
+                    Json.JsonSchema.Arr(Json.JsonSchema.Str(), minItems = Present(1), maxItems = Present(10), uniqueItems = Present(true))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.`type` == Some("array"))
+                assert(obj.minItems == Some(1))
+                assert(obj.maxItems == Some(10))
+                assert(obj.uniqueItems == Some(true))
+            }
+
+            "Obj: description is forwarded" in {
+                val js  = Json.JsonSchema.Obj(List("x" -> Json.JsonSchema.Str()), List("x"), description = Present("my object"))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.`type` == Some("object"))
+                assert(obj.description == Some("my object"))
+            }
+
+            "Bool: description is forwarded" in {
+                val js  = Json.JsonSchema.Bool(description = Present("a flag"))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.`type` == Some("boolean"))
+                assert(obj.description == Some("a flag"))
+            }
+
+            "constraint fields are absent from JSON when empty" in {
+                val js  = Json.JsonSchema.Str()
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                val spec = HttpOpenApi(
+                    openapi = "3.0.0",
+                    info = HttpOpenApi.Info("T", "1", None),
+                    paths = Map.empty,
+                    components = Some(HttpOpenApi.Components(
+                        schemas = Some(Map("x" -> obj)),
+                        securitySchemes = None
+                    ))
+                )
+                val json = HttpOpenApi.toJson(spec)
+                assert(!json.contains("minLength"))
+                assert(!json.contains("maximum"))
+                assert(!json.contains("pattern"))
+            }
+
+            "constraint fields appear in serialized JSON when set" in {
+                val js  = Json.JsonSchema.Str(minLength = Present(1), pattern = Present("[a-z]+"))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                val spec = HttpOpenApi(
+                    openapi = "3.0.0",
+                    info = HttpOpenApi.Info("T", "1", None),
+                    paths = Map.empty,
+                    components = Some(HttpOpenApi.Components(
+                        schemas = Some(Map("x" -> obj)),
+                        securitySchemes = None
+                    ))
+                )
+                val json = HttpOpenApi.toJson(spec)
+                assert(json.contains("minLength"))
+                assert(json.contains("[a-z]+"))
+            }
+        }
     }
 end OpenApiGeneratorTest

--- a/kyo-http/shared/src/test/scala/kyo/internal/OpenApiGeneratorTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/OpenApiGeneratorTest.scala
@@ -271,6 +271,13 @@ class OpenApiGeneratorTest extends kyo.BaseHttpTest:
                 assert(obj.description == Some("a flag"))
             }
 
+            "Null: description is forwarded" in {
+                val js  = Json.JsonSchema.Null(description = Present("always null"))
+                val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)
+                assert(obj.`type` == Some("null"))
+                assert(obj.description == Some("always null"))
+            }
+
             "constraint fields are absent from JSON when empty" in {
                 val js  = Json.JsonSchema.Str()
                 val obj = OpenApiGenerator.jsonSchemaToHttpOpenApi(js)


### PR DESCRIPTION
Fixes a silent data loss in the OpenAPI generator: constraint information
recorded in `Json.JsonSchema` (via `Schema.Constraint` and
`JsonSchemaEnricher`) was always dropped when translating to
`HttpOpenApi.SchemaObject`, so generated specs never contained
`minLength`, `maxLength`, `pattern`, `minimum`, `maximum`,
`exclusiveMinimum`, `exclusiveMaximum`, `minItems`, `maxItems`,
`uniqueItems`, or `description` on any schema.

## Root cause

`HttpOpenApi.SchemaObject` was missing all constraint fields. The
translation function `jsonSchemaToHttpOpenApi` in `OpenApiGenerator`
discarded every `Json.JsonSchema` variant down to the bare primitive
helper (`SchemaObject.string`, `SchemaObject.number`, etc.) regardless
of what constraints were present on the source node.

## Changes

**`HttpOpenApi.SchemaObject`** (`kyo-http/shared/.../HttpOpenApi.scala`)

Adds the 11 missing constraint fields with `= None` defaults:
`minimum`, `exclusiveMinimum`, `maximum`, `exclusiveMaximum`,
`minLength`, `maxLength`, `pattern`, `minItems`, `maxItems`,
`uniqueItems`, `description`. All existing positional and named
call sites continue to compile unchanged.

**`OpenApiGenerator.jsonSchemaToHttpOpenApi`** (`kyo-http/shared/.../OpenApiGenerator.scala`)

Forwards all constraint fields from each `JsonSchema` variant:
- `Str`: `minLength`, `maxLength`, `pattern`, `format`, `description`
- `Num`: `minimum`, `exclusiveMinimum`, `maximum`, `exclusiveMaximum`, `description`
- `Integer`: same numeric constraints widened to `Double`, `description`
- `Arr`: `minItems`, `maxItems`, `uniqueItems`, `description`
- `Obj`: `description`
- `Bool`: `description`

Also widens the method from `private` to `private[kyo]` to allow
direct unit testing.

**`OpenApiGeneratorTest`** (`kyo-http/shared/.../OpenApiGeneratorTest.scala`)

11 new tests in a `constraint forwarding` group: one per variant and
constraint combination, plus round-trip JSON serialization checks
verifying fields are absent when empty and present when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)